### PR TITLE
Seed pytest harness and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+PYTHONPATH := $(shell pwd)
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*## "}; {printf "%-16s %s\n", $$1, $$2}'
+
+install: ## Install dependencies into a uv-managed venv
+	uv sync
+
+dev-install: ## Install dev dependencies too
+	uv sync --all-extras
+
+run: ## Run the condash CLI (pass args after --, e.g. make run -- init)
+	uv run condash
+
+test: ## Run pytest
+	uv run pytest; RET=$$?; if [ $$RET -eq 5 ]; then exit 0; else exit $$RET; fi
+
+coverage: ## Run pytest with line-coverage report
+	uv run pytest --cov=condash --cov-report=term-missing --cov-report=html
+
+lint: ## Ruff lint + format check
+	uv run ruff check .
+	uv run ruff format --check .
+
+format: ## Ruff auto-fix + format
+	uv run ruff check --fix .
+	uv run ruff format .
+
+.PHONY: help install dev-install run test coverage lint format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "ruff>=0.5",
+    "httpx>=0.27",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+"""Shared fixtures for the condash smoke tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from condash.config import CondashConfig, OpenWithSlot
+
+
+@pytest.fixture
+def tmp_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect $HOME and $XDG_CONFIG_HOME to a clean temp dir."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    return tmp_path
+
+
+@pytest.fixture
+def tmp_conception(tmp_path: Path) -> Path:
+    """Create a minimal conception tree with one project containing one checkbox step."""
+    root = tmp_path / "conception"
+    project = root / "projects" / "2026-01-01-hello"
+    project.mkdir(parents=True)
+    (project / "README.md").write_text(
+        "# Hello\n\n**Date**: 2026-01-01\n**Status**: now\n\n## Steps\n\n- [ ] first task\n",
+        encoding="utf-8",
+    )
+    (root / "incidents").mkdir()
+    (root / "documents").mkdir()
+    return root
+
+
+@pytest.fixture
+def cfg(tmp_home: Path, tmp_conception: Path) -> CondashConfig:
+    """A CondashConfig pointing at the throwaway conception tree."""
+    return CondashConfig(
+        conception_path=tmp_conception,
+        port=0,
+        native=False,
+        open_with={
+            "main_ide": OpenWithSlot(label="Open in main IDE", commands=["idea {path}"]),
+            "secondary_ide": OpenWithSlot(label="Open in secondary IDE", commands=["code {path}"]),
+            "terminal": OpenWithSlot(label="Open terminal here", commands=["xterm"]),
+        },
+    )

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -1,0 +1,63 @@
+"""Integration smoke — FastAPI routes behave against a throwaway conception tree."""
+
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from nicegui import app as _ng_app
+
+from condash import app as app_mod
+from condash import legacy
+from condash.config import CondashConfig
+
+
+def _client(cfg: CondashConfig) -> TestClient:
+    """Wire up the FastAPI routes against ``cfg`` and return a TestClient."""
+    app_mod._RUNTIME_CFG = cfg
+    legacy.init(cfg)
+    app_mod._register_routes()
+    return TestClient(_ng_app)
+
+
+def test_root_renders(cfg: CondashConfig):
+    client = _client(cfg)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "2026-01-01-hello" in response.text
+
+
+def test_config_get(cfg: CondashConfig):
+    client = _client(cfg)
+    response = client.get("/config")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["conception_path"] == str(cfg.conception_path)
+    assert body["port"] == 0
+    assert body["native"] is False
+
+
+def test_toggle_flips_checkbox(cfg: CondashConfig):
+    client = _client(cfg)
+    target = cfg.conception_path / "projects" / "2026-01-01-hello" / "README.md"
+    lines = target.read_text(encoding="utf-8").splitlines()
+    step_line_index = lines.index("- [ ] first task")  # 0-based; matches legacy._toggle_checkbox
+
+    response = client.post(
+        "/toggle",
+        json={
+            "file": "projects/2026-01-01-hello/README.md",
+            "line": step_line_index,
+        },
+    )
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+    assert "- [x] first task" in target.read_text(encoding="utf-8")
+
+
+def test_download_rejects_traversal(cfg: CondashConfig):
+    client = _client(cfg)
+    # Path matches the /download/{rel_path:path} route so the handler runs
+    # and exercises its `..` + regex + resolve guard. A raw `../../etc/...`
+    # URL gets normalised before the router, so wedge the dot-dot inside a
+    # plausible-looking prefix to reach the handler.
+    response = client.get("/download/projects/2026-01-01-hello/../../etc/passwd")
+    assert response.status_code == 403

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,54 @@
+"""CLI smoke tests — cover the three subcommands every user runs on first install."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from condash.cli import app
+
+runner = CliRunner()
+
+
+def test_version_flag():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0, result.output
+    assert result.stdout.strip().startswith("condash ")
+
+
+def test_init_creates_config(tmp_home: Path):
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code == 0, result.output
+    cfg_path = tmp_home / ".config" / "condash" / "config.toml"
+    assert cfg_path.is_file()
+    assert "conception_path" in cfg_path.read_text(encoding="utf-8")
+
+
+def test_config_path_prints_path(tmp_home: Path):
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["config", "path"])
+    assert result.exit_code == 0, result.output
+    assert "config.toml" in result.stdout
+
+
+def test_config_path_json(tmp_home: Path):
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["config", "path", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["config_file"].endswith("config.toml")
+    assert payload["exists"] is True
+
+
+def test_config_show_json_is_valid(tmp_home: Path):
+    runner.invoke(app, ["init"])
+    result = runner.invoke(app, ["config", "show", "--json"])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    # A freshly-seeded config leaves every path field commented out — the
+    # CLI still renders them as keys with null values.
+    assert "conception_path" in parsed
+    assert "port" in parsed
+    assert "open_with" in parsed

--- a/uv.lock
+++ b/uv.lock
@@ -274,12 +274,14 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "pytest" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "nicegui", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pywebview", extras = ["qt"], specifier = ">=6.0" },


### PR DESCRIPTION
## Summary

- Adds a minimal pytest harness (CLI smoke + FastAPI integration smoke against a throwaway temp conception tree) so future refactors can land with a safety net.
- Adds a `Makefile` matching the shape of the other vcoeur CLIs (`dev-install`, `test`, `lint`, `format`, `coverage`, `run`).

## Changes

- New `Makefile` with `help / install / dev-install / run / test / coverage / lint / format` targets.
- `pyproject.toml` dev deps: add `httpx>=0.27` (required by `fastapi.testclient.TestClient`).
- New `tests/conftest.py` with `tmp_home`, `tmp_conception`, `cfg` fixtures.
- New `tests/test_cli_smoke.py` — 5 tests covering `--version`, `init`, `config path`, `config path --json`, `config show --json`.
- New `tests/test_app_smoke.py` — 4 tests covering `GET /` render, `GET /config` payload, `POST /toggle` (checkbox flip), `GET /download/...` traversal rejection.