### PR TITLE
Narrow excepts, add logging, pin CDN assets with SRI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,13 +14,14 @@ The name is a contraction of *conception dashboard*. The package distributes on 
 
 - Python 3.11+, `uv`-managed
 - Typer (CLI) + NiceGUI + FastAPI (routes on NiceGUI's embedded FastAPI instance) + pywebview[qt] (native window) + tomlkit (config round-trip preserving comments)
-- No ORM, no async, no test suite yet
+- No ORM. `app.py` mixes sync (legacy rendering helpers) and async (FastAPI routes + the WebSocket pty session) — sync helpers must not call `asyncio.run`; async handlers must not block on subprocess without `run_in_executor`.
+- Smoke test suite under `tests/` (CLI + FastAPI integration); run via `make test`.
 
 ## Architecture
 
 ```
 condash/
-  cli.py       <- Typer app (default launches the window; subcommands: init, config show/edit, tidy, install-desktop, uninstall-desktop)
+  cli.py       <- Typer app (default launches the window; subcommands: init, tidy, install-desktop, uninstall-desktop, config show/path/edit)
   config.py    <- TOML loader + writer (tomlkit round-trip) + CondashConfig dataclass + DEFAULT_CONFIG_TEMPLATE
   app.py       <- NiceGUI bootstrap + FastAPI route registration (`/`, `/toggle`, `/add-step`, `/tidy`, `/config`, …). Holds _RUNTIME_CFG so the in-app editor can mutate config without a restart.
   legacy.py    <- Ported verbatim from conception/tools/dashboard.py: Markdown parser, HTML renderer, mutation helpers, tidy pass. `init()` injects BASE_DIR / workspace / worktrees / repo structure from CondashConfig. `app.py` calls the helpers directly instead of routing through a BaseHTTPRequestHandler.
@@ -49,23 +50,27 @@ Config file lives at `~/.config/condash/config.toml` (or `$XDG_CONFIG_HOME/conda
 ## Commands
 
 ```bash
-uv sync --all-extras            # install deps incl. dev
+make dev-install                # uv sync --all-extras (install runtime + dev deps)
+make test                       # uv run pytest
+make lint                       # uv run ruff check + format --check
+make format                     # uv run ruff check --fix + format
+make run                        # uv run condash (native window)
 uv run condash --version        # smoke test the entry point
-uv run condash                  # launch the native window using ~/.config/condash/config.toml
-uv run ruff check src           # lint
-uv run ruff format src          # format (no Makefile yet — invoke ruff directly)
 uv run condash init             # write a default config template
 uv run condash config show      # print the effective configuration
+uv run condash config path      # print the resolved config-file path
+uv run condash config edit      # open the config file in $VISUAL / $EDITOR
 uv run condash tidy             # move done items into YYYY-MM/ archive dirs
+uv run condash install-desktop  # register the XDG .desktop entry (Linux)
 ```
 
-There is **no `Makefile`** and **no `tests/` directory** yet — unlike quelle and knoten. When adding either, match their shape (`make dev-install / test / lint / format / tool-install` and `tests/test_cli_smoke.py` as the integration anchor) so the three vcoeur CLIs keep the same workflow shape.
+The CLI honours `CONDASH_LOG_LEVEL` (default `INFO`) for the root logger; set to `DEBUG` to surface the clipboard fallback chain and similar low-noise events.
 
 ## Workflow
 
-1. After any code change: `uv run ruff format src && uv run ruff check src` — matches the `make format` step the other vcoeur CLIs have.
-2. Manual smoke test: `uv run condash` against a throwaway `conception_path` (e.g. `/tmp/fake-conception/` with one project README) before committing changes that touch `app.py` or `legacy.py`.
-3. When adding a new FastAPI route in `app.py`: add the matching fetch call in `assets/dashboard.html` and verify it in the browser dev-tools network tab — there is no automated coverage yet.
+1. After any code change: `make format && make lint && make test` — matches the `make format` / `make test` rhythm the other vcoeur CLIs have.
+2. Manual smoke test: `make run` against a throwaway `conception_path` (e.g. `/tmp/fake-conception/` with one project README) before committing changes that touch `app.py` or `legacy.py` the automated smoke does not cover.
+3. When adding a new FastAPI route in `app.py`: add the matching fetch call in `assets/dashboard.html` and consider extending `tests/test_app_smoke.py` if the route is reachable from a `TestClient`.
 4. When porting more behaviour from `conception/tools/dashboard.py`: keep the helper in `legacy.py`, not in `app.py`. `legacy.py` is the "ported verbatim" layer; `app.py` is the NiceGUI/FastAPI wiring.
 5. When touching `config.py`: round-trip at least one fixture through `tomlkit` manually to confirm comments and key order survive the rewrite — the in-app editor depends on this.
 
@@ -73,7 +78,7 @@ There is **no `Makefile`** and **no `tests/` directory** yet — unlike quelle a
 
 - CLI entrypoint: `src/condash/cli.py` — Typer app with a root callback that launches the window and a `config` sub-app for `show / edit / path`.
 - FastAPI routes: `src/condash/app.py::_register_routes` — all the endpoints `dashboard.html` talks to, registered on NiceGUI's embedded FastAPI instance.
-- Markdown parser + renderer: `src/condash/legacy.py` — 1.3 kloc, ported from `conception/tools/dashboard.py`. Module-level globals (`BASE_DIR`, `_WORKSPACE`, `_WORKTREES`, `_REPO_STRUCTURE`) are populated by `legacy.init(cfg)`; **never read them before `init` runs**.
+- Markdown parser + renderer: `src/condash/legacy.py` — ~2.0 kloc. Originally ported from `conception/tools/dashboard.py` but has since grown well past the port (knowledge-tree rendering, wikilink resolver, sandbox-stub filtering, note preview dispatch, …). Module-level globals (`BASE_DIR`, `_WORKSPACE`, `_WORKTREES`, `_REPO_STRUCTURE`, `_OPEN_WITH`, `_PDF_VIEWER`) are populated by `legacy.init(cfg)`; **never read them before `init` runs**.
 - Config dataclass + loader: `src/condash/config.py::CondashConfig` and `config.load`. `ConfigNotFoundError` vs `ConfigIncompleteError` are distinct so the CLI can suggest `init` vs `config edit`.
 - Native window launcher: `src/condash/desktop.py` — writes `~/.local/share/applications/condash.desktop` and the SVG icon. Linux only.
 - Assets shipped in the wheel: `src/condash/assets/` — referenced via `importlib.resources.files("condash") / "assets"`, never via `__file__`, so the app works when installed from a wheel.

--- a/src/condash/app.py
+++ b/src/condash/app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import fcntl
 import json
+import logging
 import os
 import secrets
 import signal
@@ -33,6 +34,8 @@ from .config import (
     CondashConfig,
     OpenWithSlot,
 )
+
+log = logging.getLogger(__name__)
 
 # Holds the live runtime config so the in-app editor can mutate it after a
 # successful POST /config without forcing a process restart. Initialized by
@@ -455,11 +458,11 @@ def _register_routes() -> None:
                 await ws.send_text(
                     json.dumps({"type": "session-expired", "session_id": requested_id})
                 )
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, OSError):
                 pass
             try:
                 await ws.close()
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, OSError):
                 pass
             return
 
@@ -472,7 +475,7 @@ def _register_routes() -> None:
             session.attached_ws = None
             try:
                 await old.close()
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, OSError):
                 pass
 
         if session is None:
@@ -483,15 +486,12 @@ def _register_routes() -> None:
                 if validated is not None:
                     override_cwd = str(validated)
                 else:
-                    print(
-                        f"[term] rejecting out-of-sandbox cwd: {requested_cwd!r}",
-                        file=sys.stderr,
-                    )
+                    log.warning("term: rejecting out-of-sandbox cwd: %r", requested_cwd)
             session = await _spawn_pty_session(override_cwd=override_cwd)
             if session is None:
                 try:
                     await ws.close()
-                except Exception:
+                except (WebSocketDisconnect, RuntimeError, OSError):
                     pass
                 return
 
@@ -507,7 +507,7 @@ def _register_routes() -> None:
                     }
                 )
             )
-        except Exception:
+        except (WebSocketDisconnect, RuntimeError, OSError):
             session.attached_ws = None
             return
 
@@ -517,7 +517,7 @@ def _register_routes() -> None:
         if session.buffer:
             try:
                 await ws.send_bytes(bytes(session.buffer))
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, OSError):
                 session.attached_ws = None
                 return
 
@@ -587,7 +587,7 @@ async def _spawn_pty_session(override_cwd: str | None = None) -> PtySession | No
             session.out_queue.put_nowait(None)
             try:
                 loop.remove_reader(fd)
-            except Exception:
+            except (OSError, ValueError):
                 pass
             return
         session.out_queue.put_nowait(data)
@@ -615,11 +615,11 @@ async def _pump_session(session: PtySession) -> None:
             if ws is not None:
                 try:
                     await ws.send_text(json.dumps({"type": "exit"}))
-                except Exception:
+                except (WebSocketDisconnect, RuntimeError, OSError):
                     pass
                 try:
                     await ws.close()
-                except Exception:
+                except (WebSocketDisconnect, RuntimeError, OSError):
                     pass
             try:
                 os.close(session.fd)
@@ -643,7 +643,7 @@ async def _pump_session(session: PtySession) -> None:
         if ws is not None:
             try:
                 await ws.send_bytes(data)
-            except Exception:
+            except (WebSocketDisconnect, RuntimeError, OSError):
                 # Viewer went away (e.g. F5). Detach so the next attach
                 # replays from the buffer; keep pty running.
                 if session.attached_ws is ws:
@@ -691,8 +691,8 @@ async def _attach_ws(session: PtySession, ws: WebSocket) -> None:
                     )
                 except OSError:
                     pass
-    except Exception:
-        pass
+    except (WebSocketDisconnect, RuntimeError, OSError) as exc:
+        log.debug("attach_ws: receive loop ended: %s", exc)
     finally:
         # Detach only — pty stays alive for the next reconnect.
         if session.attached_ws is ws:
@@ -791,7 +791,7 @@ def _qt_clipboard():
         return None
     try:
         return app.clipboard()
-    except Exception:
+    except (RuntimeError, AttributeError):
         return None
 
 
@@ -802,8 +802,8 @@ def _clipboard_read() -> str:
     if cb is not None:
         try:
             return cb.text() or ""
-        except Exception:
-            pass
+        except RuntimeError as exc:
+            log.debug("clipboard_read: Qt clipboard unavailable: %s", exc)
     for argv in (
         ["wl-paste", "--no-newline"],
         ["xclip", "-selection", "clipboard", "-o"],
@@ -813,7 +813,8 @@ def _clipboard_read() -> str:
             out = _sp.run(argv, capture_output=True, timeout=2)
         except FileNotFoundError:
             continue
-        except Exception:
+        except (OSError, _sp.SubprocessError) as exc:
+            log.debug("clipboard_read: %s failed: %s", argv[0], exc)
             continue
         if out.returncode == 0:
             return out.stdout.decode("utf-8", errors="replace")
@@ -828,8 +829,8 @@ def _clipboard_write(text: str) -> bool:
         try:
             cb.setText(text)
             return True
-        except Exception:
-            pass
+        except RuntimeError as exc:
+            log.debug("clipboard_write: Qt clipboard unavailable: %s", exc)
     for argv in (
         ["wl-copy"],
         ["xclip", "-selection", "clipboard", "-i"],
@@ -839,14 +840,16 @@ def _clipboard_write(text: str) -> bool:
             proc = _sp.Popen(argv, stdin=_sp.PIPE)
         except FileNotFoundError:
             continue
-        except Exception:
+        except OSError as exc:
+            log.debug("clipboard_write: %s failed to spawn: %s", argv[0], exc)
             continue
         try:
             proc.communicate(text.encode("utf-8"), timeout=2)
-        except Exception:
+        except (OSError, _sp.SubprocessError) as exc:
+            log.debug("clipboard_write: %s communicate failed: %s", argv[0], exc)
             try:
                 proc.kill()
-            except Exception:
+            except OSError:
                 pass
             continue
         if proc.returncode == 0:

--- a/src/condash/assets/dashboard.html
+++ b/src/condash/assets/dashboard.html
@@ -20,10 +20,18 @@
     }
 })();
 </script>
-<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js" defer></script>
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css">
-<script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"
+        integrity="sha384-1CMXl090wj8Dd6YfnzSQUOgWbE6suWCaenYG7pox5AX7apTpY3PmJMeS2oPql4Gk"
+        crossorigin="anonymous" defer></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/xterm@5.3.0/css/xterm.min.css"
+      integrity="sha384-9ftsg11+LSxVUaknegCfeKvlkO9EdIPI2op725RqY87IvhyGjElmpjZlP3LhTQjn"
+      crossorigin="anonymous">
+<script src="https://cdn.jsdelivr.net/npm/xterm@5.3.0/lib/xterm.min.js"
+        integrity="sha384-xjfWUeCWdMtvpAb/SmM6lMzS6pQGcQa0loOl1d97j6Odw0vjK9nW3+dTb/bn/mwH"
+        crossorigin="anonymous" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/xterm-addon-fit@0.8.0/lib/xterm-addon-fit.min.js"
+        integrity="sha384-dpjGwSSISUTz2taP54Bor7qkyMR20sSO9oe11UVYnGs2/YdUBf7HW30XKQx9PCzn"
+        crossorigin="anonymous" defer></script>
 <style>
 :root, [data-theme="light"] {
     --bg: #f4f4f5;

--- a/src/condash/cli.py
+++ b/src/condash/cli.py
@@ -10,6 +10,7 @@ three vcoeur CLI tools present the same config UX to users.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import platform
 import subprocess
@@ -286,8 +287,16 @@ def _resolve_editor() -> str:
     return "xdg-open"
 
 
+log = logging.getLogger(__name__)
+
+
 def main() -> None:
     """Entry point used by the `condash` console script."""
+    logging.basicConfig(
+        level=os.environ.get("CONDASH_LOG_LEVEL", "INFO").upper(),
+        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
     app()
 
 

--- a/src/condash/config.py
+++ b/src/condash/config.py
@@ -57,11 +57,14 @@ before condash can launch the dashboard. The template is shipped as
 
 from __future__ import annotations
 
+import logging
 import os
 import shlex
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
+
+log = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_TEMPLATE = """\
 # condash configuration
@@ -300,7 +303,8 @@ def save(cfg: CondashConfig, path: Path | None = None) -> Path:
     if target.exists():
         try:
             doc = tomlkit.parse(target.read_text(encoding="utf-8"))
-        except Exception:
+        except (OSError, UnicodeDecodeError, tomlkit.exceptions.TOMLKitError) as exc:
+            log.warning("could not reparse %s (%s); rewriting from scratch", target, exc)
             doc = document()
     else:
         doc = document()

--- a/src/condash/desktop.py
+++ b/src/condash/desktop.py
@@ -14,6 +14,7 @@ binary called this command, so it survives venv / pipx isolation.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import subprocess
@@ -21,6 +22,8 @@ import sys
 from pathlib import Path
 
 from .app import icon_path
+
+log = logging.getLogger(__name__)
 
 APP_ID = "condash"
 DESKTOP_FILE_NAME = f"{APP_ID}.desktop"

--- a/src/condash/legacy.py
+++ b/src/condash/legacy.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import hashlib
 import html as html_mod
 import json
+import logging
 import os
 import re
 import shlex
@@ -34,6 +35,8 @@ from importlib.resources import files as _package_files
 from itertools import groupby
 from pathlib import Path
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 # Populated by init() before any rendering / mutation function is called.
 BASE_DIR: Path = Path("/nonexistent")
@@ -291,7 +294,8 @@ def parse_readme(path, kind):
     """Parse a single incident/project README."""
     try:
         text = path.read_text(encoding="utf-8")
-    except Exception:
+    except (OSError, UnicodeDecodeError) as exc:
+        log.warning("parse_readme: could not read %s: %s", path, exc)
         return None
     lines = text.split("\n")
     if not lines:
@@ -795,7 +799,7 @@ def _git_status(path):
             text=True,
             timeout=5,
         ).stdout
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return "?", False, 0, []
     changed_files = []
     for ln in status_out.splitlines():
@@ -819,7 +823,7 @@ def _git_worktrees(repo_path):
             text=True,
             timeout=5,
         ).stdout
-    except Exception:
+    except (OSError, subprocess.SubprocessError):
         return []
     main = str(Path(repo_path).resolve())
     worktrees = []
@@ -1342,7 +1346,8 @@ def _preprocess_wikilinks(text: str) -> str:
 def _render_markdown(full_path, note_dir_rel):
     try:
         text = full_path.read_text(encoding="utf-8")
-    except Exception:
+    except (OSError, UnicodeDecodeError) as exc:
+        log.warning("render_markdown: could not read %s: %s", full_path, exc)
         return '<p class="note-error">Unable to read note.</p>'
     text = _preprocess_wikilinks(text)
     try:
@@ -1355,8 +1360,8 @@ def _render_markdown(full_path, note_dir_rel):
         )
         if out.returncode == 0 and out.stdout.strip():
             return _rewrite_img_src(out.stdout, note_dir_rel)
-    except Exception:
-        pass
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("render_markdown: pandoc failed for %s: %s", full_path, exc)
     return f'<pre class="note-raw">{h(text)}</pre>'
 
 
@@ -1393,7 +1398,8 @@ def _render_note(full_path: Path) -> str:
     if kind == "text":
         try:
             text = full_path.read_text(encoding="utf-8", errors="replace")
-        except Exception:
+        except OSError as exc:
+            log.warning("render_note: could not read %s: %s", full_path, exc)
             return '<p class="note-error">Unable to read file.</p>'
         return f'<pre class="note-raw note-preview-text">{h(text)}</pre>'
 
@@ -1740,7 +1746,7 @@ def _git_fingerprint():
                     timeout=5,
                 ).stdout
                 parts.append(f"{child.name}:{head}:{status}")
-            except Exception:
+            except (OSError, subprocess.SubprocessError):
                 parts.append(f"{child.name}:error")
 
     fp = hashlib.md5("".join(parts).encode()).hexdigest()[:16]
@@ -1865,7 +1871,7 @@ def _validate_open_path(path_str):
         return None
     try:
         p = Path(path_str).resolve(strict=True)
-    except Exception:
+    except (OSError, RuntimeError):
         return None
     if not p.is_dir():
         return None
@@ -1893,11 +1899,11 @@ def _open_path(slot_key, path):
     path_str = str(path)
     slot = _OPEN_WITH.get(slot_key)
     if slot is None:
-        print(f"[open] unknown slot: {slot_key!r}", file=sys.stderr)
+        log.warning("unknown slot: %r", slot_key)
         return False
     candidates = slot.resolve(path_str)
     if not candidates:
-        print(f"[open] {slot_key}: no commands configured", file=sys.stderr)
+        log.warning("%s: no commands configured", slot_key)
         return False
     last_err = None
     for cmd in candidates:
@@ -1909,18 +1915,15 @@ def _open_path(slot_key, path):
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
-            print(f"[open] {slot_key}: launched {cmd[0]}", file=sys.stderr)
+            log.info("%s: launched %s", slot_key, cmd[0])
             return True
         except FileNotFoundError as exc:
             last_err = exc
             continue
-        except Exception as exc:
-            print(f"[open] {slot_key}: {cmd[0]} failed: {exc}", file=sys.stderr)
+        except OSError as exc:
+            log.warning("%s: %s failed: %s", slot_key, cmd[0], exc)
             return False
-    print(
-        f"[open] {slot_key}: no launcher found (last error: {last_err})",
-        file=sys.stderr,
-    )
+    log.warning("%s: no launcher found (last error: %s)", slot_key, last_err)
     return False
 
 
@@ -1953,7 +1956,7 @@ def _try_pdf_viewer(path_str: str) -> bool:
         try:
             argv = shlex.split(raw)
         except ValueError as exc:
-            print(f"[open-doc] pdf_viewer parse failed for {raw!r}: {exc}", file=sys.stderr)
+            log.warning("pdf_viewer parse failed for %r: %s", raw, exc)
             continue
         argv = [arg.replace("{path}", path_str) for arg in argv]
         if not argv:
@@ -1968,8 +1971,8 @@ def _try_pdf_viewer(path_str: str) -> bool:
             return True
         except FileNotFoundError:
             continue
-        except Exception as exc:
-            print(f"[open-doc] pdf_viewer {argv[0]!r} failed: {exc}", file=sys.stderr)
+        except OSError as exc:
+            log.warning("pdf_viewer %r failed: %s", argv[0], exc)
             continue
     return False
 
@@ -1997,8 +2000,8 @@ def _os_open(path: Path) -> bool:
                 start_new_session=True,
             )
         return True
-    except Exception as exc:
-        print(f"[open-doc] failed: {exc}", file=sys.stderr)
+    except OSError as exc:
+        log.warning("open-doc failed: %s", exc)
         return False
 
 
@@ -2019,8 +2022,8 @@ def _open_external(url: str) -> bool:
 
     try:
         return bool(webbrowser.open(url, new=2))
-    except Exception as exc:
-        print(f"[open-external] failed: {exc}", file=sys.stderr)
+    except (OSError, webbrowser.Error) as exc:
+        log.warning("open-external failed: %s", exc)
         return False
 
 


### PR DESCRIPTION
## Summary

- Narrow ~28 wide `except Exception:` blocks across `legacy.py`, `app.py`, `config.py`; silent swallowing of programmer errors stops. Clipboard fallback chain stays wide but now logs at DEBUG with the reason.
- Introduce structured logging: `logging.basicConfig` in `cli.main()` honoring `CONDASH_LOG_LEVEL`, per-module loggers, and seven stderr `print` calls in `legacy.py` converted to `log.info` / `log.warning`.
- Add SRI `integrity` + `crossorigin="anonymous"` on all four dashboard CDN assets; pin `mermaid@11` to `11.14.0` so the floating major can't silently break the hash.

## Changes

- `src/condash/cli.py` — `logging.basicConfig` in `main()`; `CONDASH_LOG_LEVEL` env override.
- `src/condash/app.py` — per-module logger; 18 wide excepts narrowed (WS send/close → `WebSocketDisconnect/RuntimeError/OSError`; clipboard fallbacks log at DEBUG).
- `src/condash/legacy.py` — per-module logger; 7 wide excepts narrowed; 7 stderr prints → `log.info`/`log.warning`.
- `src/condash/config.py` — per-module logger; `tomlkit.parse` except narrowed.
- `src/condash/desktop.py` — per-module logger.
- `src/condash/assets/dashboard.html` — SRI + `crossorigin="anonymous"` on mermaid / xterm css / xterm js / xterm-addon-fit; `mermaid@11` → `mermaid@11.14.0`.
- `CLAUDE.md` — subcommand list, async claim, post-init module globals, `legacy.py` size (~2.0 kloc), `make` commands, `CONDASH_LOG_LEVEL` env var.

## Impact

- New `CONDASH_LOG_LEVEL` env var (default `INFO`) — users who want verbose output can export it before launch.
- `mermaid@11` now pinned to exact `11.14.0`. Future CDN upgrades require editing both the URL and the SRI hash; not a transparent bump.