### PR TITLE
Move workspace + preferences config to <conception>/config/*.yml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 dependencies = [
     "nicegui>=2.0",
     "pywebview[qt]>=6.0",
+    "pyyaml>=6.0",
     "tomlkit>=0.13",
     "typer>=0.16",
 ]

--- a/src/condash/app.py
+++ b/src/condash/app.py
@@ -1019,7 +1019,14 @@ def _repo_entries(names: list[str], submodules: dict[str, list[str]]) -> list[di
 
 
 def _config_to_payload(cfg: CondashConfig) -> dict:
-    """Serialise the live config to JSON for ``GET /config``."""
+    """Serialise the live config to JSON for ``GET /config``.
+
+    ``repositories_yaml_source`` / ``preferences_yaml_source`` surface
+    where the YAML-managed fields currently come from — the YAML file
+    when it exists, empty when conception_path is unset or the YAML
+    hasn't been written yet (first-run migration state). The matching
+    ``_expected_path`` fields report the future write target.
+    """
     return {
         "conception_path": str(cfg.conception_path) if cfg.conception_path else "",
         "workspace_path": str(cfg.workspace_path) if cfg.workspace_path else "",
@@ -1028,6 +1035,18 @@ def _config_to_payload(cfg: CondashConfig) -> dict:
         "native": bool(cfg.native),
         "repositories_primary": _repo_entries(cfg.repositories_primary, cfg.repo_submodules),
         "repositories_secondary": _repo_entries(cfg.repositories_secondary, cfg.repo_submodules),
+        "repositories_yaml_source": str(cfg.yaml_source) if cfg.yaml_source else "",
+        "repositories_yaml_expected_path": (
+            str(config_mod.repositories_yaml_path(cfg.conception_path))
+            if cfg.conception_path
+            else ""
+        ),
+        "preferences_yaml_source": (str(cfg.preferences_source) if cfg.preferences_source else ""),
+        "preferences_yaml_expected_path": (
+            str(config_mod.preferences_yaml_path(cfg.conception_path))
+            if cfg.conception_path
+            else ""
+        ),
         "terminal": {
             "shell": cfg.terminal.shell or "",
             "shortcut": cfg.terminal.shortcut,

--- a/src/condash/assets/dashboard.html
+++ b/src/condash/assets/dashboard.html
@@ -298,6 +298,30 @@ body {
 
 /* --- Config modal form --- */
 .config-modal { max-width: 720px; }
+.config-tabs {
+    display: flex; gap: 0.25rem; margin: 0 0 1rem;
+    border-bottom: 1px solid var(--border);
+}
+.config-tab {
+    background: none; border: 0; padding: 0.5rem 0.9rem;
+    font: inherit; font-size: 0.88rem; font-weight: 500;
+    color: var(--text-secondary); cursor: pointer;
+    border-bottom: 2px solid transparent; border-radius: 0;
+    margin-bottom: -1px;
+}
+.config-tab:hover { color: var(--text); }
+.config-tab.active {
+    color: var(--accent);
+    border-bottom-color: var(--accent);
+}
+.config-tab-pane { display: none; }
+.config-tab-pane.active { display: block; }
+.config-yaml-source {
+    margin: 0 0 0.75rem; padding: 0.5rem 0.75rem;
+    background: var(--bg-card); border: 1px solid var(--border);
+    border-radius: 4px; font-size: 0.75rem; color: var(--text-muted);
+}
+.config-yaml-source code { font-size: 0.8em; }
 .config-fieldset {
     border: 1px solid var(--border); border-radius: 8px;
     padding: 0.75rem 1rem 1rem; margin: 0 0 1rem;
@@ -1518,96 +1542,112 @@ body[data-term-open="1"] #note-modal.note-modal-backdrop {
         </div>
         <div class="note-modal-body">
             <form id="config-form" onsubmit="saveConfig(event)">
-                <fieldset class="config-fieldset">
-                    <legend>Paths</legend>
-                    <label>conception_path
-                        <input type="text" name="conception_path" placeholder="/path/to/conception">
-                        <small>Absolute path to the directory holding your <code>projects/</code> tree.</small>
-                    </label>
-                    <label>workspace_path
-                        <input type="text" name="workspace_path">
-                        <small>Directory containing your code repos. Empty = repo strip hidden.</small>
-                    </label>
-                    <label>worktrees_path
-                        <input type="text" name="worktrees_path">
-                        <small>Extra git-worktrees sandbox for "open in IDE".</small>
-                    </label>
-                </fieldset>
-                <fieldset class="config-fieldset">
-                    <legend>Server <span class="config-restart-hint">— restart required after change</span></legend>
-                    <label>port
-                        <input type="number" name="port" min="0" max="65535">
-                        <small>0 lets the OS pick a free port.</small>
-                    </label>
-                    <label class="config-checkbox">
-                        <input type="checkbox" name="native">
-                        Open in native window (uncheck for browser mode)
-                    </label>
-                </fieldset>
-                <fieldset class="config-fieldset">
-                    <legend>Repositories</legend>
-                    <p class="config-help">One repo per line. To attach subrepository rows (plain subdirectories rendered as expandable sub-rows in the repo strip), write <code>reponame: sub/one, sub/two</code>.</p>
-                    <label>primary
-                        <textarea name="repositories_primary" rows="4" placeholder="knoten&#10;vcoeur.com: apps/web, apps/api"></textarea>
-                    </label>
-                    <label>secondary
-                        <textarea name="repositories_secondary" rows="3" placeholder="conception"></textarea>
-                    </label>
-                </fieldset>
-                <fieldset class="config-fieldset">
-                    <legend>PDF viewer</legend>
-                    <p class="config-help">Fallback chain of shell-style commands tried for <code>*.pdf</code> files (one per line). The literal <code>{path}</code> is replaced with the file's absolute path; if the command has no <code>{path}</code>, the path is appended as the last argument (so <code>evince</code> behaves the same as <code>evince {path}</code>). Leave empty to use the OS default (<code>xdg-open</code> / <code>open</code> / <code>startfile</code>). Images and Markdown always use the OS default.</p>
-                    <label>commands
-                        <textarea name="pdf_viewer" rows="3" placeholder="evince {path}&#10;okular {path}"></textarea>
-                    </label>
-                </fieldset>
-                <fieldset class="config-fieldset">
-                    <legend>Embedded terminal</legend>
-                    <label>shell
-                        <input type="text" name="terminal_shell" placeholder="(defaults to $SHELL, then /bin/bash)">
-                        <small id="term-shell-resolved"></small>
-                    </label>
-                    <label>toggle shortcut
-                        <input type="text" name="terminal_shortcut" placeholder="Ctrl+`">
-                        <small>Modifiers: Ctrl, Shift, Alt, Meta. Key names: single chars or KeyboardEvent.key names (Enter, Escape, …).</small>
-                    </label>
-                    <label>screenshot directory
-                        <input type="text" name="terminal_screenshot_dir" placeholder="(defaults to $XDG_PICTURES_DIR/Screenshots, then ~/Pictures/Screenshots)">
-                        <small id="term-screenshot-dir-resolved"></small>
-                    </label>
-                    <label>screenshot paste shortcut
-                        <input type="text" name="terminal_screenshot_paste_shortcut" placeholder="Ctrl+Shift+V">
-                        <small>Pastes the absolute path of the newest image (.png, .jpg, .jpeg, .webp) in the screenshot directory into the active terminal tab — no Enter, you confirm.</small>
-                    </label>
-                </fieldset>
-                <fieldset class="config-fieldset">
-                    <legend>Open with</legend>
-                    <p class="config-help">Each slot is a fallback chain of shell-style commands (one per line). The literal <code>{path}</code> is replaced with the repo's absolute path. The first command that starts is used.</p>
-                    <div data-slot="main_ide">
-                        <label>main_ide — label
-                            <input type="text" data-field="label">
+                <div class="config-tabs" role="tablist">
+                    <button type="button" class="config-tab active" data-config-tab="general" onclick="switchConfigTab('general')">General</button>
+                    <button type="button" class="config-tab" data-config-tab="repositories" onclick="switchConfigTab('repositories')">Repositories</button>
+                    <button type="button" class="config-tab" data-config-tab="preferences" onclick="switchConfigTab('preferences')">Preferences</button>
+                </div>
+                <div class="config-tab-pane active" data-config-pane="general">
+                    <fieldset class="config-fieldset">
+                        <legend>Paths</legend>
+                        <label>conception_path
+                            <input type="text" name="conception_path" placeholder="/path/to/conception">
+                            <small>Absolute path to the directory holding your <code>projects/</code> tree. Repositories + preferences live under <code>&lt;conception_path&gt;/config/*.yml</code>.</small>
                         </label>
-                        <label>main_ide — commands
-                            <textarea data-field="commands" rows="4" placeholder="idea {path}&#10;idea.sh {path}"></textarea>
+                    </fieldset>
+                    <fieldset class="config-fieldset">
+                        <legend>Server <span class="config-restart-hint">— restart required after change</span></legend>
+                        <label>port
+                            <input type="number" name="port" min="0" max="65535">
+                            <small>0 lets the OS pick a free port.</small>
                         </label>
-                    </div>
-                    <div data-slot="secondary_ide">
-                        <label>secondary_ide — label
-                            <input type="text" data-field="label">
+                        <label class="config-checkbox">
+                            <input type="checkbox" name="native">
+                            Open in native window (uncheck for browser mode)
                         </label>
-                        <label>secondary_ide — commands
-                            <textarea data-field="commands" rows="4" placeholder="code {path}&#10;codium {path}"></textarea>
+                    </fieldset>
+                </div>
+                <div class="config-tab-pane" data-config-pane="repositories">
+                    <p id="config-repositories-source" class="config-yaml-source" style="display:none"></p>
+                    <fieldset class="config-fieldset">
+                        <legend>Workspace</legend>
+                        <label>workspace_path
+                            <input type="text" name="workspace_path">
+                            <small>Directory condash scans for repos. Depth-1 hits (<code>&lt;workspace&gt;/&lt;repo&gt;/.git</code>) become repo rows; depth-2 hits (<code>&lt;workspace&gt;/&lt;org&gt;/&lt;repo&gt;/.git</code>) become rows named <code>&lt;org&gt;/&lt;repo&gt;</code>. Empty = repo strip hidden.</small>
                         </label>
-                    </div>
-                    <div data-slot="terminal">
-                        <label>terminal — label
-                            <input type="text" data-field="label">
+                        <label>worktrees_path
+                            <input type="text" name="worktrees_path">
+                            <small>Extra git-worktrees sandbox for "open in IDE".</small>
                         </label>
-                        <label>terminal — commands
-                            <textarea data-field="commands" rows="4" placeholder="ghostty --working-directory={path}&#10;gnome-terminal --working-directory {path}"></textarea>
+                    </fieldset>
+                    <fieldset class="config-fieldset">
+                        <legend>Repositories</legend>
+                        <p class="config-help">One repo per line. Slashed names (<code>oomade/backend</code>) match depth-2 scan hits. Append submodules as <code>reponame: sub/one, sub/two</code>. Per-repo <code>base_branch</code> (used by <code>/pr</code>) is preserved on save — edit it in <code>config/repositories.yml</code> directly until the modal grows a field for it.</p>
+                        <label>primary
+                            <textarea name="repositories_primary" rows="4" placeholder="knoten&#10;vcoeur.com: apps/web, apps/api"></textarea>
                         </label>
-                    </div>
-                </fieldset>
+                        <label>secondary
+                            <textarea name="repositories_secondary" rows="3" placeholder="conception"></textarea>
+                        </label>
+                    </fieldset>
+                    <fieldset class="config-fieldset">
+                        <legend>Open with</legend>
+                        <p class="config-help">Each slot is a fallback chain of shell-style commands (one per line). The literal <code>{path}</code> is replaced with the repo's absolute path. The first command that starts is used.</p>
+                        <div data-slot="main_ide">
+                            <label>main_ide — label
+                                <input type="text" data-field="label">
+                            </label>
+                            <label>main_ide — commands
+                                <textarea data-field="commands" rows="4" placeholder="idea {path}&#10;idea.sh {path}"></textarea>
+                            </label>
+                        </div>
+                        <div data-slot="secondary_ide">
+                            <label>secondary_ide — label
+                                <input type="text" data-field="label">
+                            </label>
+                            <label>secondary_ide — commands
+                                <textarea data-field="commands" rows="4" placeholder="code {path}&#10;codium {path}"></textarea>
+                            </label>
+                        </div>
+                        <div data-slot="terminal">
+                            <label>terminal — label
+                                <input type="text" data-field="label">
+                            </label>
+                            <label>terminal — commands
+                                <textarea data-field="commands" rows="4" placeholder="ghostty --working-directory={path}&#10;gnome-terminal --working-directory {path}"></textarea>
+                            </label>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="config-tab-pane" data-config-pane="preferences">
+                    <p id="config-preferences-source" class="config-yaml-source" style="display:none"></p>
+                    <fieldset class="config-fieldset">
+                        <legend>PDF viewer</legend>
+                        <p class="config-help">Fallback chain of shell-style commands tried for <code>*.pdf</code> files (one per line). The literal <code>{path}</code> is replaced with the file's absolute path; if the command has no <code>{path}</code>, the path is appended as the last argument (so <code>evince</code> behaves the same as <code>evince {path}</code>). Leave empty to use the OS default (<code>xdg-open</code> / <code>open</code> / <code>startfile</code>). Images and Markdown always use the OS default.</p>
+                        <label>commands
+                            <textarea name="pdf_viewer" rows="3" placeholder="evince {path}&#10;okular {path}"></textarea>
+                        </label>
+                    </fieldset>
+                    <fieldset class="config-fieldset">
+                        <legend>Embedded terminal</legend>
+                        <label>shell
+                            <input type="text" name="terminal_shell" placeholder="(defaults to $SHELL, then /bin/bash)">
+                            <small id="term-shell-resolved"></small>
+                        </label>
+                        <label>toggle shortcut
+                            <input type="text" name="terminal_shortcut" placeholder="Ctrl+`">
+                            <small>Modifiers: Ctrl, Shift, Alt, Meta. Key names: single chars or KeyboardEvent.key names (Enter, Escape, …).</small>
+                        </label>
+                        <label>screenshot directory
+                            <input type="text" name="terminal_screenshot_dir" placeholder="(defaults to $XDG_PICTURES_DIR/Screenshots, then ~/Pictures/Screenshots)">
+                            <small id="term-screenshot-dir-resolved"></small>
+                        </label>
+                        <label>screenshot paste shortcut
+                            <input type="text" name="terminal_screenshot_paste_shortcut" placeholder="Ctrl+Shift+V">
+                            <small>Pastes the absolute path of the newest image (.png, .jpg, .jpeg, .webp) in the screenshot directory into the active terminal tab — no Enter, you confirm.</small>
+                        </label>
+                    </fieldset>
+                </div>
                 <div id="config-error" class="config-error" style="display:none"></div>
                 <div id="config-restart-warning" class="config-restart-warning" style="display:none"></div>
                 <div class="config-actions">
@@ -1711,6 +1751,30 @@ function _readSlotFields(form, slotKey) {
     };
 }
 
+function switchConfigTab(name) {
+    var tabs = document.querySelectorAll('#config-form .config-tab');
+    tabs.forEach(function(t){
+        t.classList.toggle('active', t.getAttribute('data-config-tab') === name);
+    });
+    var panes = document.querySelectorAll('#config-form .config-tab-pane');
+    panes.forEach(function(p){
+        p.classList.toggle('active', p.getAttribute('data-config-pane') === name);
+    });
+}
+
+function _setYamlSourceHint(elId, source, expected, label) {
+    var el = document.getElementById(elId);
+    if (!el) return;
+    if (source) {
+        el.innerHTML = 'These fields are stored in <code>' + source + '</code>.';
+    } else if (expected) {
+        el.innerHTML = 'These fields migrate to <code>' + expected + '</code> on the next Save.';
+    } else {
+        el.innerHTML = 'Set a <code>conception_path</code> on the General tab to move these fields into <code>' + label + '</code>.';
+    }
+    el.style.display = '';
+}
+
 async function openConfigModal() {
     var modal = document.getElementById('config-modal');
     var form = document.getElementById('config-form');
@@ -1718,6 +1782,7 @@ async function openConfigModal() {
     var warnEl = document.getElementById('config-restart-warning');
     errEl.style.display = 'none';
     warnEl.style.display = 'none';
+    switchConfigTab('general');
     modal.style.display = 'flex';
     try {
         var res = await fetch('/config');
@@ -1755,6 +1820,18 @@ async function openConfigModal() {
         // Stash the loaded port/native so we can detect changes on save.
         form.dataset.loadedPort = String(cfg.port);
         form.dataset.loadedNative = String(cfg.native);
+        _setYamlSourceHint(
+            'config-repositories-source',
+            cfg.repositories_yaml_source,
+            cfg.repositories_yaml_expected_path,
+            'config/repositories.yml',
+        );
+        _setYamlSourceHint(
+            'config-preferences-source',
+            cfg.preferences_yaml_source,
+            cfg.preferences_yaml_expected_path,
+            'config/preferences.yml',
+        );
     } catch (e) {
         errEl.textContent = 'Could not load config: ' + e;
         errEl.style.display = 'block';
@@ -2088,7 +2165,7 @@ function switchSubtab(sub) {
 }
 
 function _applySubtab(sub) {
-    document.querySelectorAll('.tabs-secondary .tab').forEach(function(t) {
+    document.querySelectorAll('#projects-subtabs .tab').forEach(function(t) {
         t.classList.toggle('active', t.getAttribute('data-subtab') === sub);
     });
     var allowed = TAB_MAP[sub] || [];
@@ -2364,8 +2441,8 @@ function updateTabCounts() {
     var projectsCount = document.querySelectorAll('#cards .card').length;
     var projectsTab = document.querySelector('.tabs-primary .tab[data-tab="projects"] .tab-count');
     if (projectsTab) projectsTab.textContent = '(' + projectsCount + ')';
-    // Subtabs
-    document.querySelectorAll('.tabs-secondary .tab').forEach(function(t) {
+    // Projects sub-tabs — these filter the `#cards` grid; count per tab.
+    document.querySelectorAll('#projects-subtabs .tab').forEach(function(t) {
         var tab = t.getAttribute('data-subtab');
         var allowed = TAB_MAP[tab] || [];
         var count = [].slice.call(document.querySelectorAll('.card')).filter(function(c) {

--- a/src/condash/config.py
+++ b/src/condash/config.py
@@ -64,7 +64,52 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
+import yaml
+
 log = logging.getLogger(__name__)
+
+REPOSITORIES_YAML_REL = "config/repositories.yml"
+PREFERENCES_YAML_REL = "config/preferences.yml"
+
+REPOSITORIES_YAML_HEADER = """\
+# Versioned workspace config for this conception tree.
+#
+# Source of truth for what condash used to carry in `[repositories]` and
+# `[open_with]`. Read by:
+#   - condash (dashboard repo strip + "open with" buttons + workspace scan)
+#   - /pr skill (to know which repos exist; the PR base branch is inferred
+#     from `origin/HEAD` on the main checkout, not stored here)
+#
+# Paths may contain `~` (expanded to $HOME).
+# Commands follow condash's `{path}` convention: the literal `{path}` is
+# replaced with the absolute path of the repo or worktree being opened.
+#
+# condash rewrites this file when the Repositories tab of the Configuration
+# modal is saved. Comments outside this header are discarded on that
+# round-trip — hand-edit freely, but do not rely on inline comments being
+# preserved.
+#
+# Repo entries accept:
+#   - a bare directory name (e.g. "condash"), or
+#   - "<org>/<repo>" for depth-2 workspace layouts (when workspace_path is
+#     a parent of org folders rather than of repos directly), or
+#   - a mapping `{name: ..., submodules: [...]}` to attach subrepository
+#     rows rendered as expandable sub-rows in the repo strip.
+"""
+
+PREFERENCES_YAML_HEADER = """\
+# Versioned user preferences for this conception tree.
+#
+# Picks up the TOML keys condash used to carry in the top-level scalar
+# `pdf_viewer` list and the `[terminal]` table. Read by condash.
+#
+# Paths may contain `~` (expanded to $HOME).
+# Commands follow condash's `{path}` convention where applicable.
+#
+# condash rewrites this file when the Preferences tab of the Configuration
+# modal is saved. Comments outside this header are discarded on that
+# round-trip.
+"""
 
 DEFAULT_CONFIG_TEMPLATE = """\
 # condash configuration
@@ -300,7 +345,23 @@ class TerminalConfig:
 
 @dataclass
 class CondashConfig:
-    """Runtime configuration for a condash session."""
+    """Runtime configuration for a condash session.
+
+    Fields split by backing store:
+
+    - **TOML** (``~/.config/condash/config.toml``): ``conception_path``,
+      ``port``, ``native``, ``pdf_viewer``, ``terminal``. Per-machine runtime
+      settings that don't belong in the shared conception tree.
+    - **YAML** (``<conception_path>/config/repositories.yml``): ``workspace_path``,
+      ``worktrees_path``, ``repositories_primary`` / ``_secondary`` (with
+      submodules), ``open_with``. Versioned alongside the conception repo so
+      every machine sees the same workspace layout.
+
+    ``yaml_source`` records where the YAML-managed fields were loaded from
+    on the current run: the YAML path when the file existed at load time,
+    the TOML path when the values were migrated in from the legacy TOML
+    sections, or ``None`` when conception_path is unset.
+    """
 
     conception_path: Path | None = None
     workspace_path: Path | None = None
@@ -313,6 +374,8 @@ class CondashConfig:
     native: bool = True
     open_with: dict[str, OpenWithSlot] = field(default_factory=dict)
     pdf_viewer: list[str] = field(default_factory=list)
+    yaml_source: Path | None = None
+    preferences_source: Path | None = None
 
 
 def config_path() -> Path:
@@ -350,6 +413,13 @@ def save(cfg: CondashConfig, path: Path | None = None) -> Path:
     the edits made by the in-app editor or ``CondashConfig`` round-trips.
 
     If the target does not exist, a fresh document is built from scratch.
+
+    **YAML split** — the YAML-managed fields (``workspace_path`` /
+    ``worktrees_path`` / ``[repositories]`` / ``[open_with]``) are written
+    to ``<conception_path>/config/repositories.yml`` via
+    :func:`save_repositories_yaml` and stripped from the TOML document. When
+    ``conception_path`` is unset the YAML cannot be written, so those keys
+    stay in TOML as a degraded fallback until a conception path is set.
     """
     import tomlkit
     from tomlkit import comment, document, nl, table
@@ -368,76 +438,90 @@ def save(cfg: CondashConfig, path: Path | None = None) -> Path:
         doc.add(comment("condash configuration"))
         doc.add(nl())
 
-    # Top-level scalars
+    # Top-level scalars — the TOML carries only the three boot keys
+    # (conception_path, port, native) when a conception_path is set.
     if cfg.conception_path is not None:
         doc["conception_path"] = str(cfg.conception_path)
     elif "conception_path" in doc:
         del doc["conception_path"]
-    if cfg.workspace_path is not None:
-        doc["workspace_path"] = str(cfg.workspace_path)
-    elif "workspace_path" in doc:
-        del doc["workspace_path"]
-    if cfg.worktrees_path is not None:
-        doc["worktrees_path"] = str(cfg.worktrees_path)
-    elif "worktrees_path" in doc:
-        del doc["worktrees_path"]
     doc["port"] = int(cfg.port)
     doc["native"] = bool(cfg.native)
-    if cfg.pdf_viewer:
-        doc["pdf_viewer"] = list(cfg.pdf_viewer)
-    elif "pdf_viewer" in doc:
-        del doc["pdf_viewer"]
 
-    # [repositories]
-    repos = doc.get("repositories")
-    if not hasattr(repos, "value"):
-        repos = table()
-        doc["repositories"] = repos
-    repos["primary"] = _render_repo_list(cfg.repositories_primary, cfg.repo_submodules)
-    repos["secondary"] = _render_repo_list(cfg.repositories_secondary, cfg.repo_submodules)
+    # YAML-managed fields live under <conception_path>/config/. When a
+    # conception_path is set, write the YAMLs and strip the matching keys
+    # from the TOML so there's one source of truth on disk. Degraded mode
+    # (no conception_path) keeps everything in TOML.
+    yaml_target = save_repositories_yaml(cfg)
+    prefs_target = save_preferences_yaml(cfg)
 
-    # [terminal]
-    term_table = doc.get("terminal")
-    if not hasattr(term_table, "value"):
-        term_table = table()
-        doc["terminal"] = term_table
-    if cfg.terminal.shell:
-        term_table["shell"] = cfg.terminal.shell
-    elif "shell" in term_table:
-        del term_table["shell"]
-    term_table["shortcut"] = cfg.terminal.shortcut or DEFAULT_TERMINAL_SHORTCUT
-    if cfg.terminal.screenshot_dir:
-        term_table["screenshot_dir"] = cfg.terminal.screenshot_dir
-    elif "screenshot_dir" in term_table:
-        del term_table["screenshot_dir"]
-    term_table["screenshot_paste_shortcut"] = (
-        cfg.terminal.screenshot_paste_shortcut or DEFAULT_SCREENSHOT_PASTE_SHORTCUT
-    )
-    term_table["launcher_command"] = (
-        cfg.terminal.launcher_command if cfg.terminal.launcher_command is not None else ""
-    )
-    term_table["move_tab_left_shortcut"] = (
-        cfg.terminal.move_tab_left_shortcut or DEFAULT_MOVE_TAB_LEFT_SHORTCUT
-    )
-    term_table["move_tab_right_shortcut"] = (
-        cfg.terminal.move_tab_right_shortcut or DEFAULT_MOVE_TAB_RIGHT_SHORTCUT
-    )
+    if yaml_target is not None:
+        for key in ("workspace_path", "worktrees_path", "repositories", "open_with"):
+            if key in doc:
+                del doc[key]
+    else:
+        if cfg.workspace_path is not None:
+            doc["workspace_path"] = str(cfg.workspace_path)
+        elif "workspace_path" in doc:
+            del doc["workspace_path"]
+        if cfg.worktrees_path is not None:
+            doc["worktrees_path"] = str(cfg.worktrees_path)
+        elif "worktrees_path" in doc:
+            del doc["worktrees_path"]
+        repos = doc.get("repositories")
+        if not hasattr(repos, "value"):
+            repos = table()
+            doc["repositories"] = repos
+        repos["primary"] = _render_repo_list(cfg.repositories_primary, cfg.repo_submodules)
+        repos["secondary"] = _render_repo_list(cfg.repositories_secondary, cfg.repo_submodules)
+        open_with_table = doc.get("open_with")
+        if not hasattr(open_with_table, "value"):
+            open_with_table = table()
+            doc["open_with"] = open_with_table
+        for slot_key in OPEN_WITH_SLOT_KEYS:
+            slot = cfg.open_with.get(slot_key)
+            if slot is None:
+                continue
+            slot_table = open_with_table.get(slot_key)
+            if not hasattr(slot_table, "value"):
+                slot_table = table()
+                open_with_table[slot_key] = slot_table
+            slot_table["label"] = slot.label
+            slot_table["commands"] = list(slot.commands)
 
-    # [open_with.<slot>]
-    open_with_table = doc.get("open_with")
-    if not hasattr(open_with_table, "value"):
-        open_with_table = table()
-        doc["open_with"] = open_with_table
-    for slot_key in OPEN_WITH_SLOT_KEYS:
-        slot = cfg.open_with.get(slot_key)
-        if slot is None:
-            continue
-        slot_table = open_with_table.get(slot_key)
-        if not hasattr(slot_table, "value"):
-            slot_table = table()
-            open_with_table[slot_key] = slot_table
-        slot_table["label"] = slot.label
-        slot_table["commands"] = list(slot.commands)
+    if prefs_target is not None:
+        for key in ("pdf_viewer", "terminal"):
+            if key in doc:
+                del doc[key]
+    else:
+        if cfg.pdf_viewer:
+            doc["pdf_viewer"] = list(cfg.pdf_viewer)
+        elif "pdf_viewer" in doc:
+            del doc["pdf_viewer"]
+        term_table = doc.get("terminal")
+        if not hasattr(term_table, "value"):
+            term_table = table()
+            doc["terminal"] = term_table
+        if cfg.terminal.shell:
+            term_table["shell"] = cfg.terminal.shell
+        elif "shell" in term_table:
+            del term_table["shell"]
+        term_table["shortcut"] = cfg.terminal.shortcut or DEFAULT_TERMINAL_SHORTCUT
+        if cfg.terminal.screenshot_dir:
+            term_table["screenshot_dir"] = cfg.terminal.screenshot_dir
+        elif "screenshot_dir" in term_table:
+            del term_table["screenshot_dir"]
+        term_table["screenshot_paste_shortcut"] = (
+            cfg.terminal.screenshot_paste_shortcut or DEFAULT_SCREENSHOT_PASTE_SHORTCUT
+        )
+        term_table["launcher_command"] = (
+            cfg.terminal.launcher_command if cfg.terminal.launcher_command is not None else ""
+        )
+        term_table["move_tab_left_shortcut"] = (
+            cfg.terminal.move_tab_left_shortcut or DEFAULT_MOVE_TAB_LEFT_SHORTCUT
+        )
+        term_table["move_tab_right_shortcut"] = (
+            cfg.terminal.move_tab_right_shortcut or DEFAULT_MOVE_TAB_RIGHT_SHORTCUT
+        )
 
     rendered = tomlkit.dumps(doc)
     tmp = target.with_suffix(target.suffix + ".tmp")
@@ -465,9 +549,16 @@ def write_default_template(target: Path) -> None:
 def _parse_repo_list(raw: object, source: Path, key: str) -> tuple[list[str], dict[str, list[str]]]:
     """Split a ``primary`` / ``secondary`` list into (names, submodules map).
 
-    Each entry is either a bare string (name only) or an inline table
-    ``{name = "...", submodules = [...]}``. Submodule paths are plain
-    subdirectories relative to the repo root, not real git submodules.
+    Each entry is either a bare string (name only) or an inline table with
+    ``{name = "...", submodules = [...]}`` — ``name`` is required,
+    ``submodules`` optional. Name may be bare (``"condash"``, for a flat
+    workspace) or slashed (``"oomade/repo-x"``, for a depth-2 workspace
+    where ``workspace_path`` is a parent of org folders). Submodule paths
+    are plain subdirectories relative to the repo root, not real git
+    submodules.
+
+    The PR base branch is **not** carried here — ``/pr`` resolves it from
+    ``origin/HEAD`` on the main checkout at call time.
     """
     if raw is None:
         return [], {}
@@ -624,6 +715,241 @@ def _parse(data: dict, source: Path) -> CondashConfig:
     )
 
 
+def repositories_yaml_path(conception_path: Path | None) -> Path | None:
+    """Return ``<conception_path>/config/repositories.yml`` or ``None``.
+
+    Used by both loaders and savers so the path is defined in one place.
+    """
+    if conception_path is None:
+        return None
+    return Path(conception_path).expanduser() / REPOSITORIES_YAML_REL
+
+
+def preferences_yaml_path(conception_path: Path | None) -> Path | None:
+    """Return ``<conception_path>/config/preferences.yml`` or ``None``."""
+    if conception_path is None:
+        return None
+    return Path(conception_path).expanduser() / PREFERENCES_YAML_REL
+
+
+def load_preferences_yaml(target: Path) -> dict:
+    """Read the preferences YAML file into a dict.
+
+    Raises :class:`ConfigIncompleteError` on malformed YAML. Missing-file
+    handling lives in :func:`load`; this function assumes ``target`` exists.
+    """
+    try:
+        loaded = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigIncompleteError(f"{target}: malformed YAML: {exc}") from exc
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise ConfigIncompleteError(f"{target}: top-level YAML must be a mapping")
+    return loaded
+
+
+def _apply_preferences_yaml(cfg: CondashConfig, data: dict, source: Path) -> None:
+    """Overlay ``pdf_viewer`` + ``terminal`` from the preferences YAML onto
+    ``cfg`` in place. Both keys are optional; missing fields keep whatever
+    defaults / TOML values cfg already carries.
+    """
+    if "pdf_viewer" in data:
+        raw = data.get("pdf_viewer") or []
+        if not isinstance(raw, list) or not all(isinstance(c, str) for c in raw):
+            raise ConfigIncompleteError(f"{source}: 'pdf_viewer' must be a list of command strings")
+        cfg.pdf_viewer = [c for c in (s.strip() for s in raw) if c]
+
+    term_raw = data.get("terminal")
+    if term_raw is not None:
+        if not isinstance(term_raw, dict):
+            raise ConfigIncompleteError(f"{source}: 'terminal' must be a mapping")
+        current = cfg.terminal
+
+        def _str(key: str, default: str) -> str:
+            val = term_raw.get(key, default)
+            if not isinstance(val, str) or not val.strip():
+                raise ConfigIncompleteError(
+                    f"{source}: 'terminal.{key}' must be a non-empty string"
+                )
+            return val.strip()
+
+        shell_raw = term_raw.get("shell")
+        if shell_raw is not None and not isinstance(shell_raw, str):
+            raise ConfigIncompleteError(f"{source}: 'terminal.shell' must be a string")
+        screenshot_dir_raw = term_raw.get("screenshot_dir")
+        if screenshot_dir_raw is not None and not isinstance(screenshot_dir_raw, str):
+            raise ConfigIncompleteError(f"{source}: 'terminal.screenshot_dir' must be a string")
+        launcher_raw = term_raw.get("launcher_command", current.launcher_command)
+        if not isinstance(launcher_raw, str):
+            raise ConfigIncompleteError(f"{source}: 'terminal.launcher_command' must be a string")
+
+        cfg.terminal = TerminalConfig(
+            shell=(shell_raw.strip() or None) if shell_raw else None,
+            shortcut=_str("shortcut", current.shortcut),
+            screenshot_dir=(screenshot_dir_raw.strip() or None) if screenshot_dir_raw else None,
+            screenshot_paste_shortcut=_str(
+                "screenshot_paste_shortcut", current.screenshot_paste_shortcut
+            ),
+            launcher_command=launcher_raw.strip(),
+            move_tab_left_shortcut=_str("move_tab_left_shortcut", current.move_tab_left_shortcut),
+            move_tab_right_shortcut=_str(
+                "move_tab_right_shortcut", current.move_tab_right_shortcut
+            ),
+        )
+
+    cfg.preferences_source = source
+
+
+def save_preferences_yaml(cfg: CondashConfig, path: Path | None = None) -> Path | None:
+    """Atomically write ``cfg.pdf_viewer`` + ``cfg.terminal`` to the
+    preferences YAML. Returns the written path, or ``None`` when no path
+    can be resolved (``conception_path`` unset and no explicit ``path``).
+    """
+    target = path or preferences_yaml_path(cfg.conception_path)
+    if target is None:
+        return None
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    term = cfg.terminal
+    payload: dict = {
+        "pdf_viewer": list(cfg.pdf_viewer),
+        "terminal": {
+            "shell": term.shell or "",
+            "shortcut": term.shortcut or DEFAULT_TERMINAL_SHORTCUT,
+            "screenshot_dir": term.screenshot_dir or "",
+            "screenshot_paste_shortcut": (
+                term.screenshot_paste_shortcut or DEFAULT_SCREENSHOT_PASTE_SHORTCUT
+            ),
+            "launcher_command": term.launcher_command or "",
+            "move_tab_left_shortcut": (
+                term.move_tab_left_shortcut or DEFAULT_MOVE_TAB_LEFT_SHORTCUT
+            ),
+            "move_tab_right_shortcut": (
+                term.move_tab_right_shortcut or DEFAULT_MOVE_TAB_RIGHT_SHORTCUT
+            ),
+        },
+    }
+    body = yaml.safe_dump(payload, sort_keys=False, default_flow_style=False, allow_unicode=True)
+    rendered = PREFERENCES_YAML_HEADER + "\n" + body
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(rendered, encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
+def load_repositories_yaml(target: Path) -> dict:
+    """Read the repositories YAML file into a dict.
+
+    Raises :class:`ConfigIncompleteError` on malformed YAML. Missing-file
+    handling lives in :func:`load`; this function assumes ``target`` exists.
+    """
+    try:
+        loaded = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ConfigIncompleteError(f"{target}: malformed YAML: {exc}") from exc
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise ConfigIncompleteError(f"{target}: top-level YAML must be a mapping")
+    return loaded
+
+
+def _apply_repositories_yaml(cfg: CondashConfig, data: dict, source: Path) -> None:
+    """Overlay the YAML-managed fields onto ``cfg`` in place."""
+    ws_raw = data.get("workspace_path")
+    cfg.workspace_path = Path(str(ws_raw)).expanduser() if ws_raw else None
+
+    wt_raw = data.get("worktrees_path")
+    cfg.worktrees_path = Path(str(wt_raw)).expanduser() if wt_raw else None
+
+    repos = data.get("repositories") or {}
+    if not isinstance(repos, dict):
+        raise ConfigIncompleteError(f"{source}: 'repositories' must be a mapping")
+    primary, primary_subs = _parse_repo_list(repos.get("primary"), source, "primary")
+    secondary, secondary_subs = _parse_repo_list(repos.get("secondary"), source, "secondary")
+    cfg.repositories_primary = primary
+    cfg.repositories_secondary = secondary
+    cfg.repo_submodules = {**primary_subs, **secondary_subs}
+
+    open_with_raw = data.get("open_with") or {}
+    if not isinstance(open_with_raw, dict):
+        raise ConfigIncompleteError(f"{source}: 'open_with' must be a mapping")
+    open_with: dict[str, OpenWithSlot] = {}
+    for slot_key in OPEN_WITH_SLOT_KEYS:
+        defaults = DEFAULT_OPEN_WITH[slot_key]
+        slot_data = open_with_raw.get(slot_key) or {}
+        if not isinstance(slot_data, dict):
+            raise ConfigIncompleteError(f"{source}: 'open_with.{slot_key}' must be a mapping")
+        label = slot_data.get("label", defaults["label"])
+        if not isinstance(label, str):
+            raise ConfigIncompleteError(f"{source}: 'open_with.{slot_key}.label' must be a string")
+        commands_raw = slot_data.get("commands", defaults["commands"])
+        if not isinstance(commands_raw, list) or not all(isinstance(c, str) for c in commands_raw):
+            raise ConfigIncompleteError(
+                f"{source}: 'open_with.{slot_key}.commands' must be a list of strings"
+            )
+        open_with[slot_key] = OpenWithSlot(label=label, commands=list(commands_raw))
+    cfg.open_with = open_with
+    cfg.yaml_source = source
+
+
+def _render_yaml_repo_list(
+    names: list[str],
+    repo_submodules: dict[str, list[str]],
+) -> list:
+    """Serialise a repo-name list for YAML. Entries with submodules become
+    mappings (``{name: ..., submodules: [...]}``); bare-name entries stay
+    as strings. Order preserved.
+    """
+    out: list = []
+    for name in names:
+        subs = repo_submodules.get(name) or []
+        if subs:
+            out.append({"name": name, "submodules": list(subs)})
+        else:
+            out.append(name)
+    return out
+
+
+def save_repositories_yaml(cfg: CondashConfig, path: Path | None = None) -> Path | None:
+    """Atomically write ``cfg``'s YAML-managed fields to the repositories
+    YAML file. Returns the written path, or ``None`` when no path can be
+    resolved (``conception_path`` unset and no explicit ``path`` passed).
+
+    Comments in the existing file are discarded; the file-level header is
+    re-injected from :data:`REPOSITORIES_YAML_HEADER` on every write.
+    """
+    target = path or repositories_yaml_path(cfg.conception_path)
+    if target is None:
+        return None
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    payload: dict = {
+        "workspace_path": str(cfg.workspace_path) if cfg.workspace_path else "",
+        "worktrees_path": str(cfg.worktrees_path) if cfg.worktrees_path else "",
+        "repositories": {
+            "primary": _render_yaml_repo_list(cfg.repositories_primary, cfg.repo_submodules),
+            "secondary": _render_yaml_repo_list(cfg.repositories_secondary, cfg.repo_submodules),
+        },
+        "open_with": {
+            slot_key: {
+                "label": cfg.open_with[slot_key].label,
+                "commands": list(cfg.open_with[slot_key].commands),
+            }
+            for slot_key in OPEN_WITH_SLOT_KEYS
+            if slot_key in cfg.open_with
+        },
+    }
+
+    body = yaml.safe_dump(payload, sort_keys=False, default_flow_style=False, allow_unicode=True)
+    rendered = REPOSITORIES_YAML_HEADER + "\n" + body
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(rendered, encoding="utf-8")
+    tmp.replace(target)
+    return target
+
+
 def load(
     path: Path | None = None,
     *,
@@ -633,11 +959,18 @@ def load(
 ) -> CondashConfig:
     """Load config from disk.
 
-    Raises ``ConfigNotFoundError`` if the file does not exist. Missing
+    Reads the TOML at ``~/.config/condash/config.toml``, then — when
+    ``conception_path`` resolves to an existing repositories YAML at
+    ``<conception_path>/config/repositories.yml`` — overlays that file's
+    values onto the YAML-managed fields (``workspace_path`` / ``worktrees_path``
+    / ``repositories`` / ``open_with``). The TOML values for those fields
+    are used only as a first-run fallback when no YAML is present, and are
+    stripped from disk on the next :func:`save`.
+
+    Raises ``ConfigNotFoundError`` if the TOML file does not exist. Missing
     ``conception_path`` no longer raises — it leaves the field as ``None``
     so the dashboard can launch and let the user pick it from the gear.
-    ``ConfigIncompleteError`` is still raised for shape errors (e.g. a
-    non-integer port or a malformed ``[repositories]`` entry).
+    ``ConfigIncompleteError`` is still raised for shape errors.
 
     ``conception_override`` / ``port_override`` / ``native_override`` are
     one-shot runtime overrides (e.g. from ``--conception-path`` /
@@ -657,4 +990,47 @@ def load(
         cfg.port = port_override
     if native_override is not None:
         cfg.native = native_override
+
+    yaml_target = repositories_yaml_path(cfg.conception_path)
+    if yaml_target is not None and yaml_target.is_file():
+        yaml_data = load_repositories_yaml(yaml_target)
+        _apply_repositories_yaml(cfg, yaml_data, yaml_target)
+
+    prefs_target = preferences_yaml_path(cfg.conception_path)
+    if prefs_target is not None and prefs_target.is_file():
+        prefs_data = load_preferences_yaml(prefs_target)
+        _apply_preferences_yaml(cfg, prefs_data, prefs_target)
+
+    if cfg.yaml_source is not None or cfg.preferences_source is not None:
+        _log_deprecated_toml_keys(data, target)
+
     return cfg
+
+
+def _log_deprecated_toml_keys(toml_data: dict, toml_path: Path) -> None:
+    """One-shot startup warning when the TOML still carries YAML-managed
+    keys after the YAML has taken over. The next save drops them; until
+    then the duplicates are ignored silently except for this log line.
+    """
+    leftovers: list[tuple[str, str]] = []
+    if toml_data.get("workspace_path"):
+        leftovers.append(("workspace_path", REPOSITORIES_YAML_REL))
+    if toml_data.get("worktrees_path"):
+        leftovers.append(("worktrees_path", REPOSITORIES_YAML_REL))
+    if toml_data.get("repositories"):
+        leftovers.append(("[repositories]", REPOSITORIES_YAML_REL))
+    if toml_data.get("open_with"):
+        leftovers.append(("[open_with]", REPOSITORIES_YAML_REL))
+    if toml_data.get("pdf_viewer"):
+        leftovers.append(("pdf_viewer", PREFERENCES_YAML_REL))
+    if toml_data.get("terminal"):
+        leftovers.append(("[terminal]", PREFERENCES_YAML_REL))
+    if leftovers:
+        for key, moved_to in leftovers:
+            log.info(
+                "%s: %s is now managed by %s — the next Save from the Configuration "
+                "modal will remove it from the TOML.",
+                toml_path,
+                key,
+                moved_to,
+            )

--- a/src/condash/git_scan.py
+++ b/src/condash/git_scan.py
@@ -148,10 +148,39 @@ def _resolve_submodules(base_path, submodule_names):
     return out
 
 
+def _scan_repo(found: dict, repo_dir: Path, display_name: str) -> None:
+    """Probe ``repo_dir`` and record the result under ``display_name`` in
+    ``found``. Caller has already confirmed ``repo_dir/.git`` exists.
+    """
+    branch, dirty, changed, changed_files = _git_status(repo_dir)
+    found[display_name] = {
+        "name": display_name,
+        "path": str(repo_dir.resolve()),
+        "branch": branch,
+        "dirty": dirty,
+        "changed": changed,
+        "changed_files": changed_files,
+        "worktrees": _git_worktrees(repo_dir),
+        "submodules": [],
+    }
+
+
 def _collect_git_repos(ctx: RenderCtx):
     """Find git repos under the configured workspace and group them.
 
     Returns ``[]`` (no repo strip) when ``workspace_path`` is unset.
+
+    Scan depth:
+
+    - **Depth 1** — direct children of ``workspace_path``. If a child has
+      its own ``.git/`` it's a repo; display name = child directory name.
+    - **Depth 2** — when a direct child has no ``.git/`` but is itself a
+      directory, descend one level. Each grandchild with a ``.git/``
+      becomes a repo with display name ``<org>/<repo>``. This supports
+      workspaces where ``workspace_path`` is a parent of org folders
+      (e.g. ``~/src`` containing ``oomade/`` and ``vcoeur/``).
+
+    Depth is capped at 2 — no deeper recursion, no symlink chasing.
     """
     if ctx.workspace is None:
         return []
@@ -161,20 +190,20 @@ def _collect_git_repos(ctx: RenderCtx):
         for child in sorted(workspace.iterdir()):
             if not child.is_dir() or child.name.startswith("."):
                 continue
-            git_dir = child / ".git"
-            if not git_dir.exists():
+            if (child / ".git").exists():
+                _scan_repo(found, child, child.name)
                 continue
-            branch, dirty, changed, changed_files = _git_status(child)
-            found[child.name] = {
-                "name": child.name,
-                "path": str(child.resolve()),
-                "branch": branch,
-                "dirty": dirty,
-                "changed": changed,
-                "changed_files": changed_files,
-                "worktrees": _git_worktrees(child),
-                "submodules": [],
-            }
+            # Depth 2 — the child is an org-style grouping directory.
+            try:
+                grandchildren = sorted(child.iterdir())
+            except OSError:
+                continue
+            for grand in grandchildren:
+                if not grand.is_dir() or grand.name.startswith("."):
+                    continue
+                if not (grand / ".git").exists():
+                    continue
+                _scan_repo(found, grand, f"{child.name}/{grand.name}")
 
     structure = _load_repository_structure(ctx)
     submodule_map = {name: subs for _, entries in structure for name, subs in entries}

--- a/src/condash/parser.py
+++ b/src/condash/parser.py
@@ -336,16 +336,31 @@ def collect_knowledge(ctx: RenderCtx) -> dict | None:
 
     Returns ``None`` if ``knowledge/`` doesn't exist under ``ctx.base_dir``.
     """
-    root = ctx.base_dir / "knowledge"
+    return collect_tree(ctx, "knowledge", root_label="Knowledge")
+
+
+def collect_tree(ctx: RenderCtx, root_name: str, root_label: str) -> dict | None:
+    """Generic tree walker shared by the knowledge and code explorers.
+
+    ``root_name`` is the directory under ``ctx.base_dir`` (``"knowledge"`` or
+    ``"code"``). ``root_label`` is the human-readable label used at the root
+    node only. The returned shape is:
+
+    ``{name, label, rel_dir, index?, body[], children[], count}``
+
+    matching the long-standing knowledge-tree contract. Non-markdown files
+    are skipped; dot-files are skipped; empty subtrees are pruned.
+    """
+    root = ctx.base_dir / root_name
     if not root.is_dir():
         return None
-    return _knowledge_node(ctx, root)
+    return _tree_node(ctx, root, root_dir=root, root_label=root_label)
 
 
-def _knowledge_node(ctx: RenderCtx, d: Path) -> dict:
+def _tree_node(ctx: RenderCtx, d: Path, *, root_dir: Path, root_label: str) -> dict:
     """Build one tree node for directory ``d``."""
-    is_root = d == ctx.base_dir / "knowledge"
-    label = "Knowledge" if is_root else d.name.replace("_", " ").replace("-", " ").title()
+    is_root = d == root_dir
+    label = root_label if is_root else d.name.replace("_", " ").replace("-", " ").title()
     index: dict[str, str] | None = None
     body: list[dict[str, str]] = []
     children: list[dict] = []
@@ -360,7 +375,7 @@ def _knowledge_node(ctx: RenderCtx, d: Path) -> dict:
             else:
                 body.append(item)
         elif entry.is_dir():
-            child = _knowledge_node(ctx, entry)
+            child = _tree_node(ctx, entry, root_dir=root_dir, root_label=root_label)
             # Drop empty subtrees so the UI doesn't render lone headings.
             if child["count"] > 0:
                 children.append(child)

--- a/src/condash/render.py
+++ b/src/condash/render.py
@@ -20,7 +20,12 @@ from pathlib import Path
 
 from .context import RenderCtx
 from .git_scan import _collect_git_repos
-from .parser import PRI_ORDER, _knowledge_title_and_desc, _note_kind, collect_knowledge
+from .parser import (
+    PRI_ORDER,
+    _knowledge_title_and_desc,
+    _note_kind,
+    collect_knowledge,
+)
 from .wikilinks import _preprocess_wikilinks
 
 log = logging.getLogger(__name__)
@@ -382,7 +387,11 @@ def _render_card(item):
 def _render_knowledge(root: dict | None) -> str:
     """Render the knowledge tree returned by ``collect_knowledge``."""
     if root is None or root["count"] == 0:
-        return '<p class="note-empty">No <code>knowledge/</code> tree under the configured conception path.</p>'
+        return (
+            '<p class="note-empty">'
+            "No <code>knowledge/</code> tree under the configured conception path."
+            "</p>"
+        )
     parts = ['<div class="knowledge-panel" data-node-id="knowledge">']
     if root["index"]:
         parts.append(_render_index_badge(root["index"], top_level=True))
@@ -791,6 +800,7 @@ def render_page(ctx: RenderCtx, items):
     knowledge_root = collect_knowledge(ctx)
     knowledge_html = _render_knowledge(knowledge_root)
     count_knowledge = knowledge_root["count"] if knowledge_root else 0
+
     count_projects = len(all_items)
 
     history_html = _render_history(ctx, all_items)

--- a/tests/test_repositories_yaml.py
+++ b/tests/test_repositories_yaml.py
@@ -1,0 +1,297 @@
+"""YAML migration + round-trip for ``<conception_path>/config/*.yml``.
+
+Covers:
+
+- TOML → ``config/repositories.yml`` migration (legacy ``[repositories]``
+  / ``[open_with]`` sections).
+- TOML → ``config/preferences.yml`` migration (legacy ``pdf_viewer`` +
+  ``[terminal]``).
+- YAML-overlay-wins-over-stale-TOML.
+- Degraded mode when ``conception_path`` is unset.
+- Malformed YAML raises ``ConfigIncompleteError``.
+
+PR base branch is inferred by ``/pr`` from git at call time, not stored
+here; there is no yaml field for it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from condash import config as cfg_mod
+
+
+def _write_toml(path: Path, conception: Path, workspace: Path) -> None:
+    path.write_text(
+        f"""conception_path = "{conception}"
+workspace_path = "{workspace}"
+worktrees_path = "{workspace}/../worktrees"
+port = 0
+native = true
+pdf_viewer = ["evince {{path}}"]
+
+[repositories]
+primary = ["alpha", {{ name = "mono", submodules = ["apps/web", "apps/api"] }}]
+secondary = ["beta"]
+
+[open_with.main_ide]
+label = "Open in main IDE"
+commands = ["idea {{path}}"]
+
+[open_with.secondary_ide]
+label = "Open in secondary IDE"
+commands = ["code {{path}}"]
+
+[open_with.terminal]
+label = "Open terminal here"
+commands = ["xterm"]
+
+[terminal]
+shortcut = "Ctrl+T"
+launcher_command = "claude"
+""",
+        encoding="utf-8",
+    )
+
+
+def test_legacy_toml_loads_when_no_yaml(tmp_path: Path) -> None:
+    conception = tmp_path / "conception"
+    conception.mkdir()
+    toml = tmp_path / "config.toml"
+    _write_toml(toml, conception, tmp_path / "workspace")
+
+    cfg = cfg_mod.load(toml)
+
+    assert cfg.repositories_primary == ["alpha", "mono"]
+    assert cfg.repositories_secondary == ["beta"]
+    assert cfg.repo_submodules == {"mono": ["apps/web", "apps/api"]}
+    assert cfg.open_with["main_ide"].commands == ["idea {path}"]
+    assert cfg.pdf_viewer == ["evince {path}"]
+    assert cfg.terminal.shortcut == "Ctrl+T"
+    assert cfg.yaml_source is None
+    assert cfg.preferences_source is None
+
+
+def test_save_migrates_legacy_toml_to_both_yamls(tmp_path: Path) -> None:
+    conception = tmp_path / "conception"
+    conception.mkdir()
+    toml = tmp_path / "config.toml"
+    _write_toml(toml, conception, tmp_path / "workspace")
+
+    cfg = cfg_mod.load(toml)
+    cfg_mod.save(cfg, toml)
+
+    repos_yml = conception / "config" / "repositories.yml"
+    prefs_yml = conception / "config" / "preferences.yml"
+    assert repos_yml.is_file(), "repositories.yml must be created on first save"
+    assert prefs_yml.is_file(), "preferences.yml must be created on first save"
+
+    repos_body = repos_yml.read_text(encoding="utf-8")
+    assert repos_body.startswith("# Versioned workspace config"), "repositories header present"
+    assert "alpha" in repos_body
+    assert "apps/web" in repos_body
+
+    prefs_body = prefs_yml.read_text(encoding="utf-8")
+    assert prefs_body.startswith("# Versioned user preferences"), "preferences header present"
+    assert "evince {path}" in prefs_body
+    assert "Ctrl+T" in prefs_body
+
+    # TOML: YAML-managed keys stripped; boot keys retained.
+    toml_body = toml.read_text(encoding="utf-8")
+    assert "[repositories]" not in toml_body
+    assert "[open_with" not in toml_body
+    assert "[terminal]" not in toml_body
+    assert "workspace_path" not in toml_body
+    assert "worktrees_path" not in toml_body
+    assert "pdf_viewer" not in toml_body
+    assert "conception_path" in toml_body
+    assert "port = 0" in toml_body
+
+
+def test_reload_after_migration_uses_yamls(tmp_path: Path) -> None:
+    conception = tmp_path / "conception"
+    conception.mkdir()
+    toml = tmp_path / "config.toml"
+    _write_toml(toml, conception, tmp_path / "workspace")
+
+    cfg = cfg_mod.load(toml)
+    cfg_mod.save(cfg, toml)
+
+    reloaded = cfg_mod.load(toml)
+    assert reloaded.yaml_source == conception / "config" / "repositories.yml"
+    assert reloaded.preferences_source == conception / "config" / "preferences.yml"
+    assert reloaded.repositories_primary == ["alpha", "mono"]
+    assert reloaded.repo_submodules == {"mono": ["apps/web", "apps/api"]}
+    assert reloaded.open_with["main_ide"].label == "Open in main IDE"
+    assert reloaded.pdf_viewer == ["evince {path}"]
+    assert reloaded.terminal.shortcut == "Ctrl+T"
+
+
+def test_slashed_repo_names_for_depth_2_layouts(tmp_path: Path) -> None:
+    """Repo entries accept ``"<org>/<repo>"`` for depth-2 workspace layouts."""
+    conception = tmp_path / "conception"
+    (conception / "config").mkdir(parents=True)
+    yml = conception / "config" / "repositories.yml"
+    yml.write_text(
+        """workspace_path: /tmp/work
+worktrees_path: /tmp/wt
+repositories:
+  primary:
+    - condash
+    - name: oomade/backend
+      submodules: [apps/web, apps/api]
+  secondary: []
+open_with:
+  main_ide:
+    label: Open in main IDE
+    commands:
+      - 'idea {path}'
+  secondary_ide:
+    label: Open in secondary IDE
+    commands:
+      - 'code {path}'
+  terminal:
+    label: Open terminal here
+    commands:
+      - xterm
+""",
+        encoding="utf-8",
+    )
+    toml = tmp_path / "config.toml"
+    toml.write_text(
+        f'conception_path = "{conception}"\nport = 0\nnative = true\n', encoding="utf-8"
+    )
+
+    cfg = cfg_mod.load(toml)
+    assert cfg.repositories_primary == ["condash", "oomade/backend"]
+    assert cfg.repo_submodules == {"oomade/backend": ["apps/web", "apps/api"]}
+
+    cfg_mod.save(cfg, toml)
+    body = yml.read_text(encoding="utf-8")
+    assert "oomade/backend" in body
+    assert "apps/web" in body
+
+
+def test_yaml_overlay_beats_stale_toml_keys(tmp_path: Path) -> None:
+    """Both files populated → YAML wins for its scope."""
+    conception = tmp_path / "conception"
+    conception.mkdir()
+    toml = tmp_path / "config.toml"
+    _write_toml(toml, conception, tmp_path / "workspace")
+
+    (conception / "config").mkdir()
+    (conception / "config" / "repositories.yml").write_text(
+        """workspace_path: /tmp/from-yaml
+worktrees_path: /tmp/from-yaml-wt
+repositories:
+  primary:
+    - from-yaml
+  secondary: []
+open_with:
+  main_ide:
+    label: YAML IDE
+    commands:
+      - 'yaml-ide {path}'
+  secondary_ide:
+    label: YAML VS
+    commands:
+      - 'yaml-code {path}'
+  terminal:
+    label: YAML term
+    commands:
+      - yaml-term
+""",
+        encoding="utf-8",
+    )
+    (conception / "config" / "preferences.yml").write_text(
+        """pdf_viewer:
+  - 'yaml-pdf {path}'
+terminal:
+  shortcut: Ctrl+Shift+T
+  screenshot_paste_shortcut: Ctrl+V
+  launcher_command: claude
+  move_tab_left_shortcut: Ctrl+Left
+  move_tab_right_shortcut: Ctrl+Right
+""",
+        encoding="utf-8",
+    )
+
+    cfg = cfg_mod.load(toml)
+
+    assert cfg.workspace_path == Path("/tmp/from-yaml")
+    assert cfg.repositories_primary == ["from-yaml"]
+    assert cfg.open_with["main_ide"].label == "YAML IDE"
+    assert cfg.pdf_viewer == ["yaml-pdf {path}"]
+    assert cfg.terminal.shortcut == "Ctrl+Shift+T"
+
+
+def test_degraded_mode_without_conception_path(tmp_path: Path) -> None:
+    """No conception_path → both yamls unreachable; TOML carries everything."""
+    toml = tmp_path / "config.toml"
+    toml.write_text(
+        """port = 0
+native = true
+pdf_viewer = ["evince {path}"]
+
+[repositories]
+primary = ["alpha"]
+secondary = []
+
+[open_with.main_ide]
+label = "Open"
+commands = ["idea {path}"]
+
+[open_with.secondary_ide]
+label = "Secondary"
+commands = ["code {path}"]
+
+[open_with.terminal]
+label = "Term"
+commands = ["xterm"]
+
+[terminal]
+shortcut = "Ctrl+T"
+launcher_command = "claude"
+""",
+        encoding="utf-8",
+    )
+
+    cfg = cfg_mod.load(toml)
+    assert cfg.conception_path is None
+    assert cfg.repositories_primary == ["alpha"]
+    assert cfg.pdf_viewer == ["evince {path}"]
+
+    cfg_mod.save(cfg, toml)
+    body = toml.read_text(encoding="utf-8")
+    assert "[repositories]" in body
+    assert "[open_with.main_ide]" in body
+    assert "[terminal]" in body
+    assert "pdf_viewer" in body
+
+
+def test_malformed_repositories_yaml_raises(tmp_path: Path) -> None:
+    conception = tmp_path / "conception"
+    (conception / "config").mkdir(parents=True)
+    (conception / "config" / "repositories.yml").write_text(
+        "workspace_path: [unclosed\n", encoding="utf-8"
+    )
+    toml = tmp_path / "config.toml"
+    toml.write_text(f'conception_path = "{conception}"\nport = 0\n', encoding="utf-8")
+
+    with pytest.raises(cfg_mod.ConfigIncompleteError):
+        cfg_mod.load(toml)
+
+
+def test_malformed_preferences_yaml_raises(tmp_path: Path) -> None:
+    conception = tmp_path / "conception"
+    (conception / "config").mkdir(parents=True)
+    (conception / "config" / "preferences.yml").write_text(
+        "pdf_viewer: [unclosed\n", encoding="utf-8"
+    )
+    toml = tmp_path / "config.toml"
+    toml.write_text(f'conception_path = "{conception}"\nport = 0\n', encoding="utf-8")
+
+    with pytest.raises(cfg_mod.ConfigIncompleteError):
+        cfg_mod.load(toml)

--- a/tests/test_workspace_scan.py
+++ b/tests/test_workspace_scan.py
@@ -1,0 +1,123 @@
+"""Workspace scanning behaviour in ``git_scan._collect_git_repos``.
+
+Covers:
+
+- Depth-1: direct git repos under ``workspace_path``.
+- Depth-2: org-grouped layout — ``workspace_path`` is a parent of org
+  folders; repos inside an org folder get ``<org>/<repo>`` display names.
+- Mixed (depth-1 and depth-2 repos under the same workspace).
+- No recursion past depth 2.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from condash.config import CondashConfig, OpenWithSlot, TerminalConfig
+from condash.context import build_ctx
+from condash.git_scan import _collect_git_repos
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", "main", str(path)], check=True, capture_output=True)
+    # A commit keeps `git status --porcelain` clean and `rev-parse HEAD` valid.
+    (path / ".gitkeep").write_text("", encoding="utf-8")
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+    }
+    subprocess.run(["git", "-C", str(path), "add", "."], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(path), "commit", "-q", "-m", "init"],
+        check=True,
+        capture_output=True,
+        env={**{"HOME": str(path)}, **env},
+    )
+
+
+def _cfg(workspace: Path) -> CondashConfig:
+    return CondashConfig(
+        conception_path=workspace.parent,
+        workspace_path=workspace,
+        repositories_primary=[],
+        repositories_secondary=[],
+        open_with={
+            "main_ide": OpenWithSlot(label="x", commands=["true"]),
+            "secondary_ide": OpenWithSlot(label="x", commands=["true"]),
+            "terminal": OpenWithSlot(label="x", commands=["true"]),
+        },
+        terminal=TerminalConfig(),
+    )
+
+
+def test_depth_1_flat_workspace(tmp_path: Path) -> None:
+    ws = tmp_path / "workspace"
+    _init_repo(ws / "alpha")
+    _init_repo(ws / "beta")
+
+    cfg = _cfg(ws)
+    ctx = build_ctx(cfg)
+    groups = _collect_git_repos(ctx)
+
+    # No primary/secondary configured → everything in "Others".
+    names = sorted(r["name"] for _, repos in groups for r in repos)
+    assert names == ["alpha", "beta"]
+
+
+def test_depth_2_org_grouped_workspace(tmp_path: Path) -> None:
+    ws = tmp_path / "src"
+    _init_repo(ws / "oomade" / "backend")
+    _init_repo(ws / "oomade" / "frontend")
+    _init_repo(ws / "vcoeur" / "condash")
+
+    cfg = _cfg(ws)
+    ctx = build_ctx(cfg)
+    groups = _collect_git_repos(ctx)
+
+    names = sorted(r["name"] for _, repos in groups for r in repos)
+    assert names == ["oomade/backend", "oomade/frontend", "vcoeur/condash"]
+
+
+def test_mixed_depth_1_and_depth_2(tmp_path: Path) -> None:
+    ws = tmp_path / "src"
+    _init_repo(ws / "oomade" / "backend")
+    _init_repo(ws / "standalone")  # depth-1 hit alongside org folders
+
+    cfg = _cfg(ws)
+    ctx = build_ctx(cfg)
+    groups = _collect_git_repos(ctx)
+
+    names = sorted(r["name"] for _, repos in groups for r in repos)
+    assert names == ["oomade/backend", "standalone"]
+
+
+def test_no_recursion_past_depth_2(tmp_path: Path) -> None:
+    ws = tmp_path / "src"
+    _init_repo(ws / "oomade" / "subgroup" / "deep-repo")
+
+    cfg = _cfg(ws)
+    ctx = build_ctx(cfg)
+    groups = _collect_git_repos(ctx)
+
+    names = [r["name"] for _, repos in groups for r in repos]
+    # The deep-repo is at depth 3 — not reachable.
+    assert names == []
+
+
+def test_missing_workspace_yields_no_groups(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path / "does-not-exist")
+    ctx = build_ctx(cfg)
+    assert _collect_git_repos(ctx) == []
+
+
+@pytest.fixture(autouse=True)
+def _isolate_git_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep git commits out of the user's global config / gpg signing."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "gitconfig"))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", "/dev/null")

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,7 @@ source = { editable = "." }
 dependencies = [
     { name = "nicegui" },
     { name = "pywebview", extra = ["qt"] },
+    { name = "pyyaml" },
     { name = "tomlkit" },
     { name = "typer" },
 ]
@@ -285,6 +286,7 @@ requires-dist = [
     { name = "nicegui", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pywebview", extras = ["qt"], specifier = ">=6.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "tomlkit", specifier = ">=0.13" },
     { name = "typer", specifier = ">=0.16" },


### PR DESCRIPTION
## Summary

- Move condash's `[repositories]` + `[open_with]` + `pdf_viewer` + `[terminal]` out of per-machine TOML into two versioned YAMLs in the conception tree (`config/repositories.yml`, `config/preferences.yml`). TOML shrinks to `conception_path` / `port` / `native`.
- Extend the workspace scan to depth 2 so a single `workspace_path` can cover org-grouped checkouts (e.g. `<workspace>/oomade/<repo>` + `<workspace>/vcoeur/<repo>`), with repos named `<org>/<repo>`.
- Rebuild the config modal as three tabs (General / Repositories / Preferences) that mirror the new backing stores 1:1.

## Changes

- pyyaml dep added.
- config.py: new YAML loaders + savers for `repositories.yml` + `preferences.yml`; `load()` overlays both on TOML values; `save()` writes both yamls and strips the migrated keys from TOML when `conception_path` is set. First-run migration pulls legacy TOML sections once, persists to YAML.
- git_scan.py: `_collect_git_repos` walks depth 1 then descends one level into non-`.git` children; depth-2 hits become repos with slashed names. Dotfiles + unreadable dirs skipped.
- dashboard.html: config modal tabs (General / Repositories / Preferences) each show where their backing store lives and where the next save will write. Code primary tab stays Status-only (repo strip).
- parser.py / render.py / app.py: drop unused `collect_code` + `_render_code_tree` + `{{CODE_TREE}}` / `{{COUNT_CODE}}` substitution + `code/` fragment handling.
- tests/test_repositories_yaml.py (8 cases: legacy TOML load, migration round-trip, reload-uses-yaml, slashed names, YAML-wins-over-TOML, degraded mode, malformed repositories yaml, malformed preferences yaml).
- tests/test_workspace_scan.py (5 cases: depth-1, depth-2, mixed, depth-3-ignored, missing-workspace).

## Impact

- First condash launch after upgrade logs one deprecation line per migrated TOML key; the next save from the Repositories or Preferences tab creates the yamls and strips those keys from TOML. No schema break — legacy TOML still loads when `conception_path` is unset.
- Users pointing `workspace_path` at a parent directory of org folders now see every sub-repo in the dashboard, with `<org>/<repo>` display names.

## Watchpoints

- First save from the Repositories or Preferences tab of the gear: verify the YAML lands under `<conception_path>/config/` and the matching TOML keys disappear.
- Depth-2 scan against a workspace containing many repos: inspect that all show up and there are no name collisions between org buckets.