### PR TITLE
Soft-wrap long prose lines in rendered markdown note view

### DIFF
--- a/src/condash/assets/dashboard.html
+++ b/src/condash/assets/dashboard.html
@@ -1207,6 +1207,12 @@ body[data-term-open="1"] #note-modal.note-modal-backdrop {
 .note-modal[data-mode="view"] .note-pane-view {
     display: block; overflow: auto;
     padding: 1.2rem 1.6rem;
+    /* Match the edit pane's soft-wrap behaviour: long prose lines and
+       inline tokens (URLs, inline code) should break at the pane edge
+       instead of forcing a horizontal scrollbar. `<pre>` blocks keep
+       `white-space: pre` + their own `overflow: auto`, so code stays
+       on one line with its own local scroll. */
+    overflow-wrap: anywhere;
 }
 /* When the view pane hosts the PDF viewer, it fills the pane edge-to-edge
    and owns its own scrolling — strip the pane's padding + outer scrollbar


### PR DESCRIPTION
## Summary

- Closes #6.
- Adds `overflow-wrap: anywhere` to the rendered markdown view pane (`.note-modal[data-mode=\"view\"] .note-pane-view`) so long prose lines, URLs, and inline tokens break at the pane edge instead of forcing a horizontal scrollbar.
- `<pre>` blocks keep `white-space: pre` + their own `overflow: auto`, so code stays on one line with its own local scroll — matching the issue's stated expectation.

## Changes

- `src/condash/assets/dashboard.html` — one CSS rule added to the existing `.note-pane-view` selector, with a comment explaining the scope (prose wraps, code blocks still scroll).

## Impact / Watchpoints

- Long cell text in markdown tables will now wrap at any character inside a cell rather than stretching the table past the pane width. Acceptable — the alternative is the current horizontal scrollbar.
- No JS, no renderer change — CSS-only.