### PR TITLE
Surface next non-done step on project cards

### DIFF
--- a/src/condash/assets/dashboard.html
+++ b/src/condash/assets/dashboard.html
@@ -723,6 +723,37 @@ body:not([data-single-term]) .term-side.is-active-side .term-mount {
 .card-header-right { display: flex; align-items: center; gap: 0.5rem; flex-shrink: 0; }
 .card.collapsed .card-body { display: none; }
 .card.collapsed .card-header { border-bottom: none; }
+/* Next-step row sits between header and body so it stays visible on
+   collapsed cards — answers "what's this project blocked on?" without
+   expanding each one. See #9. */
+.card-next-step {
+    display: flex; align-items: center; gap: 0.4rem;
+    padding: 0.3rem 1rem 0.45rem;
+    font-size: 0.8rem; color: var(--text-secondary);
+    cursor: pointer; user-select: none;
+    border-top: 1px dashed var(--border-light);
+}
+.card:not(.collapsed) .card-next-step { display: none; }
+.card-next-step:hover { color: var(--text); }
+.next-step-marker {
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 0.85rem; height: 0.85rem; border-radius: 3px;
+    border: 1px solid var(--text-muted); flex-shrink: 0;
+    font-size: 0.65rem; line-height: 1;
+}
+.next-step-marker.next-step-open {
+    background: transparent;
+}
+.next-step-marker.next-step-progress {
+    background: var(--pri-soon-bg); border-color: var(--pri-soon);
+}
+.next-step-marker.next-step-progress::before {
+    content: "~"; color: var(--pri-soon); font-weight: 700;
+}
+.next-step-text {
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+    min-width: 0;
+}
 .card-body { display: flex; }
 .card-left {
     width: 40%; padding: 0.75rem 1.2rem; border-right: 1px solid var(--border-light);

--- a/src/condash/render.py
+++ b/src/condash/render.py
@@ -313,6 +313,21 @@ def _render_deliverables(deliverables):
     )
 
 
+def _next_step(item):
+    """First pending step across all sections, or None.
+
+    "Pending" means status is ``open`` or ``progress`` — ``abandoned``
+    steps aren't "next", they're intentionally parked. Used on the
+    collapsed card so users can see what the project is blocked on
+    without expanding each one.
+    """
+    for sec in item["sections"]:
+        for step in sec["items"]:
+            if step["status"] in ("open", "progress"):
+                return step
+    return None
+
+
 def _render_card(item):
     from .parser import PRIORITIES
 
@@ -375,6 +390,20 @@ def _render_card(item):
         else ""
     )
 
+    next_step = _next_step(item)
+    if next_step is not None:
+        next_step_html = (
+            f'<div class="card-next-step" '
+            f"onclick=\"toggleCard(this.closest('.card'))\" "
+            f'title="Next pending step">'
+            f'<span class="next-step-marker next-step-{next_step["status"]}" '
+            f'aria-hidden="true"></span>'
+            f'<span class="next-step-text">{h(next_step["text"])}</span>'
+            f"</div>"
+        )
+    else:
+        next_step_html = ""
+
     node_id = f"projects/{pri}/{item['slug']}"
     card_actions_html = _render_card_actions(item)
     return (
@@ -389,6 +418,7 @@ def _render_card(item):
         f"{progress} {invalid_badge}{priority_select} "
         f'<span class="date">{h(item["date"])}</span>'
         f"{card_actions_html}</div></div>"
+        f"{next_step_html}"
         f'<div class="card-body">'
         f'<div class="card-left">'
         f"{apps_div}"


### PR DESCRIPTION
## Summary

- Closes #9.
- Each card now renders a compact "next step" row between the header and body showing the first step whose marker is not `[x]` — so `[ ]` (open) or `[~]` (progress). `[-]` (abandoned) is skipped because abandoned steps aren't "next".
- The row is visible on the collapsed card, and hidden once the card is expanded (expanded view already lists every step with its own marker).

## Changes

- `src/condash/render.py` — new `_next_step(item)` helper; `_render_card` emits `<div class="card-next-step">` with a marker span and the step text. Clicking the row toggles the card (same behaviour as the header).
- `src/condash/assets/dashboard.html` — CSS for `.card-next-step`, `.next-step-marker` (open = empty box, progress = filled box with `~`), and text-truncation on long step titles.

## Impact / Watchpoints

- Cards with no `## Steps` or with every step marked `[x]` / `[-]` get no next-step row (falls through to existing layout).
- Added row takes ~22px of vertical space on every card. Intentional — this is the signal the issue asked us to surface.
- Row is clickable and expands the card, so accidental clicks land on the same affordance as the header.