### PR TITLE
Port step reorder from HTML5 drag to pointer events

### DIFF
--- a/src/condash/assets/dashboard.html
+++ b/src/condash/assets/dashboard.html
@@ -844,6 +844,10 @@ body:not([data-single-term]) .term-side.is-active-side .term-mount {
 .drag-handle {
     cursor: grab; color: var(--text-muted); font-size: 0.75rem; margin-right: 4px;
     flex-shrink: 0; padding: 0 2px; user-select: none; opacity: 0.3;
+    /* Pointer-event drag needs to own all pointer input on this span —
+       otherwise the browser turns a small vertical drag into a page
+       scroll and the reorder never starts. */
+    touch-action: none;
 }
 .drag-handle:active { cursor: grabbing; }
 .step:hover .drag-handle { opacity: 1; }
@@ -4396,15 +4400,12 @@ async function addStep(file, section, inputEl) {
     var data = await res.json();
     var step = document.createElement('div');
     step.className = 'step open';
-    step.draggable = true;
     step.setAttribute('data-file', file);
     step.setAttribute('data-line', data.line);
-    step.ondragstart = stepDragStart;
-    step.ondragend = stepDragEnd;
-    step.ondragover = stepDragOver;
     var handle = document.createElement('span');
     handle.className = 'drag-handle';
     handle.textContent = '\u283f';
+    handle.addEventListener('pointerdown', stepPointerDown);
     var dot = document.createElement('span');
     dot.className = 'status-dot';
     dot.onmousedown = function(e) { e.stopPropagation(); e.preventDefault(); };
@@ -4436,29 +4437,74 @@ async function addStep(file, section, inputEl) {
     updateBaseline();
 }
 
-var _dragEl = null;
-var _dragContainer = null;
+/* Step reorder — pointer-event based for the same reason the terminal tabs
+   use pointer events (see _termChipPointerDown): QtWebEngine segfaults
+   pywebview on HTML5 dragstart of any moderately complex DOM element.
+   Triggered from the drag handle only so click-to-edit on the text span
+   and the status-dot cycle both keep working.
+   See #8. */
+var _stepDrag = null;
+var _STEP_DRAG_THRESHOLD_PX = 4;
 
-function stepDragStart(e) {
-    _dragEl = e.target.closest('.step');
-    _dragContainer = _dragEl.closest('.sec-items');
-    _dragEl.classList.add('dragging');
-    e.dataTransfer.effectAllowed = 'move';
-    e.dataTransfer.setData('text/plain', '');
+function stepPointerDown(ev) {
+    if (ev.button !== undefined && ev.button !== 0) return;
+    var handle = ev.currentTarget;
+    var step = handle.closest('.step');
+    if (!step) return;
+    _stepDrag = {
+        step: step,
+        container: step.closest('.sec-items'),
+        pointerId: ev.pointerId,
+        startX: ev.clientX,
+        startY: ev.clientY,
+        active: false,
+        handle: handle,
+    };
+    try { handle.setPointerCapture(ev.pointerId); } catch (e) {}
+    handle.addEventListener('pointermove', stepPointerMove);
+    handle.addEventListener('pointerup', stepPointerUp);
+    handle.addEventListener('pointercancel', stepPointerCancel);
+    ev.preventDefault();
 }
 
-function stepDragEnd(e) {
-    if (_dragEl) _dragEl.classList.remove('dragging');
-    var container = _dragContainer;
-    _dragEl = null;
-    _dragContainer = null;
-    if (!container) return;
+function stepPointerMove(ev) {
+    if (!_stepDrag || ev.pointerId !== _stepDrag.pointerId) return;
+    if (!_stepDrag.active) {
+        var dx = ev.clientX - _stepDrag.startX;
+        var dy = ev.clientY - _stepDrag.startY;
+        if (Math.hypot(dx, dy) < _STEP_DRAG_THRESHOLD_PX) return;
+        _stepDrag.active = true;
+        _stepDrag.step.classList.add('dragging');
+    }
+    // Hit-test for another step to insert above/below. setPointerCapture
+    // routes events to the handle even when the cursor leaves it, so we
+    // consult elementFromPoint ourselves to find the hovered step.
+    var under = document.elementFromPoint(ev.clientX, ev.clientY);
+    if (!under) return;
+    var target = under.closest && under.closest('.step');
+    if (!target || target === _stepDrag.step) return;
+    if (target.closest('.sec-items') !== _stepDrag.container) return;
+    var rect = target.getBoundingClientRect();
+    var mid = rect.top + rect.height / 2;
+    if (ev.clientY < mid) {
+        _stepDrag.container.insertBefore(_stepDrag.step, target);
+    } else {
+        _stepDrag.container.insertBefore(_stepDrag.step, target.nextSibling);
+    }
+}
+
+function stepPointerUp(ev) {
+    if (!_stepDrag || ev.pointerId !== _stepDrag.pointerId) return;
+    var drag = _stepDrag;
+    _stepCleanupDrag();
+    if (!drag.active) return;  // Just a click on the handle — nothing to do.
+    var container = drag.container;
     var steps = container.querySelectorAll('.step');
     if (!steps.length) return;
     var file = steps[0].getAttribute('data-file');
     var lines = [].map.call(steps, function(s) { return parseInt(s.getAttribute('data-line')); });
-    var sorted = lines.slice().sort(function(a,b) { return a-b; });
-    if (lines.every(function(v,i) { return v === sorted[i]; })) return;
+    var sorted = lines.slice().sort(function(a, b) { return a - b; });
+    if (lines.every(function(v, i) { return v === sorted[i]; })) return;
     fetch('/reorder-all', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -4470,19 +4516,20 @@ function stepDragEnd(e) {
     });
 }
 
-function stepDragOver(e) {
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'move';
-    var target = e.target.closest('.step');
-    if (!target || !_dragEl || target === _dragEl) return;
-    var container = target.closest('.sec-items');
-    var rect = target.getBoundingClientRect();
-    var mid = rect.top + rect.height / 2;
-    if (e.clientY < mid) {
-        container.insertBefore(_dragEl, target);
-    } else {
-        container.insertBefore(_dragEl, target.nextSibling);
-    }
+function stepPointerCancel(ev) {
+    if (!_stepDrag || ev.pointerId !== _stepDrag.pointerId) return;
+    _stepCleanupDrag();
+}
+
+function _stepCleanupDrag() {
+    if (!_stepDrag) return;
+    var handle = _stepDrag.handle;
+    try { handle.releasePointerCapture(_stepDrag.pointerId); } catch (e) {}
+    handle.removeEventListener('pointermove', stepPointerMove);
+    handle.removeEventListener('pointerup', stepPointerUp);
+    handle.removeEventListener('pointercancel', stepPointerCancel);
+    _stepDrag.step.classList.remove('dragging');
+    _stepDrag = null;
 }
 
 function startEditText(el) {

--- a/src/condash/render.py
+++ b/src/condash/render.py
@@ -135,11 +135,10 @@ def _render_step(item, file_path):
         status, ""
     )
     return (
-        f'<div class="step {status}" draggable="true" '
-        f'data-file="{h(file_path)}" data-line="{item["line"]}" '
-        f'ondragstart="stepDragStart(event)" ondragend="stepDragEnd(event)" '
-        f'ondragover="stepDragOver(event)">'
-        f'<span class="drag-handle">\u283f</span>'
+        f'<div class="step {status}" '
+        f'data-file="{h(file_path)}" data-line="{item["line"]}">'
+        f'<span class="drag-handle" '
+        f'onpointerdown="stepPointerDown(event)">\u283f</span>'
         f'<span class="status-dot status-{status}" '
         f'onmousedown="event.stopPropagation();event.preventDefault()" '
         f"onclick=\"var s=this.closest('.step');cycle({js_file},+s.dataset.line,s)\">{dot_char}</span>"


### PR DESCRIPTION
## Summary

- Closes #8.
- Root cause: `.step` used the HTML5 drag-and-drop API (`draggable="true"` + `dragstart` / `dragover` / `dragend`). QtWebEngine's native drag-image snapshot segfaults pywebview on `dragstart` of any moderately complex DOM element — the exact trap the terminal-tab code worked around months ago (see comment at `dashboard.html` around line 5050 in main).
- Ports step reorder to the same pointer-event pattern the terminal tabs use: `pointerdown` on the drag handle, threshold-armed `pointermove` to reorder DOM via `elementFromPoint` + `insertBefore`, `pointerup` to commit the new order to `/reorder-all`.

## Changes

- `src/condash/render.py::_render_step` — drop `draggable="true"` + inline `ondragstart/ondragend/ondragover`. Move the pointer-event trigger onto the drag-handle span only (text span stays click-to-edit, status-dot still cycles).
- `src/condash/assets/dashboard.html`:
    - Replace `stepDragStart/stepDragOver/stepDragEnd` with `stepPointerDown/Move/Up/Cancel` + `_stepCleanupDrag`. Same 4-px threshold, same `.dragging` opacity hint.
    - `addStep` builds new steps with `pointerdown` listener on the handle instead of the old `ondrag*` properties.
    - `.drag-handle` gains `touch-action: none` so a small drag doesn't turn into a page scroll on trackpads and touch devices.

## Impact / Watchpoints

- Drag affordance is unchanged visually — grip glyph, `cursor: grab`, opacity dim on drag.
- Drag now initiates from the drag-handle span only (was: anywhere on the step). Click-to-edit on the text span and the status-dot cycle both still work.
- Works identically in pywebview (native window) and in-browser (port mode).
- 109 existing tests green. Smoke-verified that the app boots and serves `/` with the new step markup.