### PR TITLE
Unify workspace config + persist conception path

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+# Wrap rustc with sccache so every compilation unit is content-addressed
+# and reused across worktrees, branch switches, and `cargo clean` cycles.
+# The first build of a new worktree or a fresh `target/` still *links*,
+# but it no longer *compiles* crates it has seen before — a full Tauri
+# dep graph drops from ~3 min to seconds.
+#
+# Install once: `cargo install sccache` (or via a prebuilt binary).
+# Verify the cache is active with `sccache --show-stats` after a build.
+[build]
+rustc-wrapper = "sccache"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,11 +46,18 @@ Import direction: `cli` → `app` → `routes/*` → {`context`, `render`, `muta
 
 ## Config
 
-Config file lives at `~/.config/condash/config.toml` (or `$XDG_CONFIG_HOME/condash/config.toml`). Required key: `conception_path`. Everything else optional — see the `DEFAULT_CONFIG_TEMPLATE` string in `condash/config.py` for the full schema, and the top-of-file docstring for the canonical documentation.
+Two files, two layers:
 
-- **First-run flow**: `condash init` writes the template (fully commented out); `condash config edit` opens it in `$VISUAL` / `$EDITOR`. If the user runs `condash` before editing the template, `ConfigIncompleteError` is raised and the CLI prints a pointer to `condash config edit`.
-- **In-app editor**: the gear icon in the dashboard header posts to `/config`, which rewrites the TOML file atomically via tomlkit (comments and key order preserved) and rebuilds `_RUNTIME_CTX` via `build_ctx(new_cfg)`. Path / repository / `open_with` changes take effect on dashboard reload; `port` / `native` changes require a process restart and the modal tells the user so.
-- **`[open_with.*]` slots**: three vendor-neutral launcher keys — `main_ide`, `secondary_ide`, `terminal` — each with a `label` and a `commands` fallback chain. Commands are `shlex`-parsed; `{path}` is substituted with the absolute path of the repo / worktree being opened. Commands are tried in order until one starts. Built-in defaults reproduce the pre-0.2 hardcoded IntelliJ / VS Code / terminal behaviour, so the user only needs to override the slots they actually want to customise.
+- **Per-user**: `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Flat, today a single key: `conception_path`. Points condash at the conception tree it should render. Written atomically (temp + rename), `0600` on unix. Loader: `src-tauri/src/user_config.rs`.
+- **Per-tree**: `<conception_path>/configuration.yml`. Flat YAML merging the old `config/repositories.yml` + `config/preferences.yml` — carries `workspace_path`, `worktrees_path`, `repositories.{primary,secondary}`, `open_with`, `pdf_viewer`, `terminal`. Loader: `src-tauri/src/config.rs::build_ctx`.
+
+Precedence when resolving the conception tree (`src-tauri/src/lib.rs::resolve_conception_path`): `CONDASH_CONCEPTION_PATH` env var → `settings.yaml` → (GUI only) native folder picker → hard error. No hard-coded `~/src/vcoeur/conception` fallback — the picker replaces that.
+
+- **First-run flow** (GUI): if neither env nor settings.yaml supply a path, a native folder picker opens via `rfd`. Loose validation (directory exists + contains `configuration.yml` or `projects/`). On accept, the choice is persisted to `settings.yaml` before the dashboard loads. On cancel, the app exits cleanly.
+- **Headless** (`condash-serve`): env var → settings.yaml → hard error. No prompt.
+- **In-app editor**: the gear icon opens a plain-text YAML editor (`GET /configuration` returns the raw file; `POST /configuration` validates via `serde_yaml_ng::from_str::<ConfigurationYaml>` and atomically replaces the file). The current build does not hot-swap `RenderCtx` — the modal's success message tells the user to reopen condash for changes to take effect.
+- **`[open_with.*]` slots**: three vendor-neutral launcher keys — `main_ide`, `secondary_ide`, `terminal` — each with a `label` and a `commands` fallback chain. `{path}` is substituted with the absolute path of the repo / worktree being opened. Commands are tried in order until one starts.
+- **Split files** (`<conception_path>/config/repositories.yml` + `preferences.yml`): kept on disk for the retired Python build (`condash-python`). Condash no longer reads them. Edits via the modal land in `configuration.yml` and do not propagate to the split files — known drift hazard, accepted because condash-python is retired.
 
 ## Sandbox rules for "open in IDE"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,181 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ashpd"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.9.4",
+ "raw-window-handle",
+ "serde",
+ "serde_repr",
+ "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "zbus",
+]
+
+[[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +371,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -379,6 +567,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "condash"
 version = "0.20.1"
 dependencies = [
@@ -397,6 +594,7 @@ dependencies = [
  "portable-pty",
  "rand 0.8.6",
  "regex",
+ "rfd",
  "rust-embed",
  "serde",
  "serde_json",
@@ -748,6 +946,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlib"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +1064,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -881,6 +1115,27 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1039,6 +1294,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1424,6 +1692,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2448,6 +2722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "pango"
 version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2755,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2701,6 +2991,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2714,7 +3015,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2731,6 +3032,26 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-pty"
@@ -2866,6 +3187,15 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
 dependencies = [
  "memchr",
 ]
@@ -3111,6 +3441,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+dependencies = [
+ "ashpd",
+ "block2",
+ "dispatch2",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3244,6 +3598,12 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3586,6 +3946,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -4433,7 +4803,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4500,6 +4882,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -4584,6 +4977,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -4802,6 +5201,66 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "scoped-tls",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml 0.39.2",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "dlib",
+ "log",
+ "pkg-config",
 ]
 
 [[package]]
@@ -5345,6 +5804,9 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"
@@ -5563,6 +6025,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5641,3 +6164,44 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
+ "winnow 0.7.15",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "0.20.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/condash-render/src/bin/render_diff.rs
+++ b/crates/condash-render/src/bin/render_diff.rs
@@ -171,6 +171,8 @@ fn build_ctx_from_py(ctx_json: &Value, base: &Path) -> RenderCtx {
         open_with,
         repo_run_keys,
         repo_run_templates: Default::default(),
+        pdf_viewer: Vec::new(),
+        terminal: Default::default(),
         template: String::new(),
     }
 }

--- a/crates/condash-state/src/bin/state_diff.rs
+++ b/crates/condash-state/src/bin/state_diff.rs
@@ -164,6 +164,8 @@ fn build_ctx_from_py(ctx_json: &Value) -> RenderCtx {
         open_with: Default::default(),
         repo_run_keys,
         repo_run_templates: Default::default(),
+        pdf_viewer: Vec::new(),
+        terminal: Default::default(),
         template: String::new(),
     }
 }

--- a/crates/condash-state/src/ctx.rs
+++ b/crates/condash-state/src/ctx.rs
@@ -36,6 +36,22 @@ pub struct OpenWithSlot {
     pub label: String,
 }
 
+/// Embedded-terminal preferences. Carries the Python
+/// `TerminalConfig` fields verbatim, all optional so the YAML
+/// round-trip via the plain-text config modal preserves whatever
+/// the user wrote. The renderer applies built-in defaults when a
+/// field is `None`.
+#[derive(Debug, Clone, Default)]
+pub struct TerminalPrefs {
+    pub shell: Option<String>,
+    pub shortcut: Option<String>,
+    pub screenshot_dir: Option<String>,
+    pub screenshot_paste_shortcut: Option<String>,
+    pub launcher_command: Option<String>,
+    pub move_tab_left_shortcut: Option<String>,
+    pub move_tab_right_shortcut: Option<String>,
+}
+
 /// Immutable runtime context carried by every helper that needs config.
 ///
 /// Built once per effective config; rebuilt and swapped into the shared
@@ -74,6 +90,13 @@ pub struct RenderCtx {
     /// `/api/runner/start` handler treats that as "no command
     /// configured" and 404s, matching Python.
     pub repo_run_templates: HashMap<String, String>,
+    /// PDF-viewer command fallback chain (e.g. `["evince {path}",
+    /// "okular {path}"]`). Empty = use the built-in chain. Consumed by
+    /// the openers layer (Phase 3+).
+    pub pdf_viewer: Vec<String>,
+    /// Embedded-terminal preferences. All fields optional; absent ones
+    /// fall back to the renderer's built-in defaults.
+    pub terminal: TerminalPrefs,
     /// Dashboard HTML template shipped with the wheel. Loaded once at
     /// ctx-build time so render helpers don't re-read it per request.
     pub template: String,

--- a/crates/condash-state/src/lib.rs
+++ b/crates/condash-state/src/lib.rs
@@ -17,7 +17,7 @@ pub mod git;
 pub mod search;
 
 pub use cache::{Tab, WorkspaceCache};
-pub use ctx::{OpenWithSlot, RenderCtx, RepoEntry, RepoSection};
+pub use ctx::{OpenWithSlot, RenderCtx, RepoEntry, RepoSection, TerminalPrefs};
 pub use git::{
     collect_git_repos, compute_git_node_fingerprints, git_fingerprint, Checkout, Family, Group,
     Member,

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -208,159 +208,33 @@
     </div>
 </div>
 <div id="config-modal" class="note-modal-backdrop" onclick="if(event.target===this)closeConfigModal()">
-    <div class="note-modal config-modal">
+    <div class="note-modal config-modal config-modal-wide">
         <div class="note-modal-header">
             <span class="note-modal-title">Configuration</span>
             <button class="note-modal-close" onclick="closeConfigModal()" aria-label="Close">&times;</button>
         </div>
         <div class="note-modal-body">
             <form id="config-form" onsubmit="saveConfig(event)">
-                <div class="config-tabs" role="tablist">
-                    <button type="button" class="config-tab active" data-config-tab="general" onclick="switchConfigTab('general')">General</button>
-                    <button type="button" class="config-tab" data-config-tab="repositories" onclick="switchConfigTab('repositories')">Repositories</button>
-                    <button type="button" class="config-tab" data-config-tab="preferences" onclick="switchConfigTab('preferences')">Preferences</button>
-                </div>
-                <div class="config-tab-pane active" data-config-pane="general">
-                    <fieldset class="config-fieldset">
-                        <legend>Paths</legend>
-                        <label>conception_path
-                            <input type="text" name="conception_path" placeholder="/path/to/conception">
-                            <small>Absolute path to the directory holding your <code>projects/</code> tree. Repositories + preferences live under <code>&lt;conception_path&gt;/config/*.yml</code>.</small>
-                        </label>
-                    </fieldset>
-                    <fieldset class="config-fieldset">
-                        <legend>Server <span class="config-restart-hint">— restart required after change</span></legend>
-                        <label>port
-                            <input type="number" name="port" min="0" max="65535">
-                            <small>0 picks a free port in 11111–12111.</small>
-                        </label>
-                        <label class="config-checkbox">
-                            <input type="checkbox" name="native">
-                            Open in native window (uncheck for browser mode)
-                        </label>
-                    </fieldset>
-                </div>
-                <div class="config-tab-pane" data-config-pane="repositories">
-                    <p id="config-repositories-source" class="config-yaml-source" style="display:none"></p>
-                    <div class="config-split">
-                        <div class="config-split-pane">
-                            <div class="config-split-pane-head">
-                                <span>repositories.yml</span>
-                                <span class="config-split-status" data-yaml-status="repositories">synced</span>
-                            </div>
-                            <textarea class="config-yaml-editor"
-                                      data-yaml-file="repositories"
-                                      spellcheck="false"
-                                      aria-label="repositories.yml raw contents"></textarea>
-                            <small class="config-help">Edit the YAML directly and click <b>Save &amp; reload</b>. The form on the right stays in sync with the parsed content.</small>
-                        </div>
-                        <div class="config-split-pane">
-                    <fieldset class="config-fieldset">
-                        <legend>Workspace</legend>
-                        <label>workspace_path
-                            <input type="text" name="workspace_path">
-                            <small>Directory condash scans for repos. Depth-1 hits (<code>&lt;workspace&gt;/&lt;repo&gt;/.git</code>) become repo rows; depth-2 hits (<code>&lt;workspace&gt;/&lt;org&gt;/&lt;repo&gt;/.git</code>) become rows named <code>&lt;org&gt;/&lt;repo&gt;</code>. Empty = repo strip hidden.</small>
-                        </label>
-                        <label>worktrees_path
-                            <input type="text" name="worktrees_path">
-                            <small>Extra git-worktrees sandbox for "open in IDE".</small>
-                        </label>
-                    </fieldset>
-                    <fieldset class="config-fieldset">
-                        <legend>Repositories</legend>
-                        <p class="config-help">One repo per line. Slashed names (<code>myorg/backend</code>) match depth-2 scan hits. Append submodules as <code>reponame: sub/one, sub/two</code>. <code>/pr</code> resolves the default base branch from <code>origin/HEAD</code> on the main checkout at call time; no per-repo override is stored here.</p>
-                        <label>primary
-                            <textarea name="repositories_primary" rows="4" placeholder="knoten&#10;vcoeur.com: apps/web, apps/api"></textarea>
-                        </label>
-                        <label>secondary
-                            <textarea name="repositories_secondary" rows="3" placeholder="conception"></textarea>
-                        </label>
-                    </fieldset>
-                    <fieldset class="config-fieldset">
-                        <legend>Open with</legend>
-                        <p class="config-help">Each slot is a fallback chain of shell-style commands (one per line). The literal <code>{path}</code> is replaced with the repo's absolute path. The first command that starts is used.</p>
-                        <div data-slot="main_ide">
-                            <label>main_ide — label
-                                <input type="text" data-field="label">
-                            </label>
-                            <label>main_ide — commands
-                                <textarea data-field="commands" rows="4" placeholder="idea {path}&#10;idea.sh {path}"></textarea>
-                            </label>
-                        </div>
-                        <div data-slot="secondary_ide">
-                            <label>secondary_ide — label
-                                <input type="text" data-field="label">
-                            </label>
-                            <label>secondary_ide — commands
-                                <textarea data-field="commands" rows="4" placeholder="code {path}&#10;codium {path}"></textarea>
-                            </label>
-                        </div>
-                        <div data-slot="terminal">
-                            <label>terminal — label
-                                <input type="text" data-field="label">
-                            </label>
-                            <label>terminal — commands
-                                <textarea data-field="commands" rows="4" placeholder="ghostty --working-directory={path}&#10;gnome-terminal --working-directory {path}"></textarea>
-                            </label>
-                        </div>
-                    </fieldset>
-                        </div>
-                    </div>
-                </div>
-                <div class="config-tab-pane" data-config-pane="preferences">
-                    <p id="config-preferences-source" class="config-yaml-source" style="display:none"></p>
-                    <div class="config-split">
-                        <div class="config-split-pane">
-                            <div class="config-split-pane-head">
-                                <span>preferences.yml</span>
-                                <span class="config-split-status" data-yaml-status="preferences">synced</span>
-                            </div>
-                            <textarea class="config-yaml-editor"
-                                      data-yaml-file="preferences"
-                                      spellcheck="false"
-                                      aria-label="preferences.yml raw contents"></textarea>
-                            <small class="config-help">Edit the YAML directly and click <b>Save &amp; reload</b>. The form on the right stays in sync with the parsed content.</small>
-                        </div>
-                        <div class="config-split-pane">
-                    <fieldset class="config-fieldset">
-                        <legend>PDF viewer</legend>
-                        <p class="config-help">Fallback chain of shell-style commands tried for <code>*.pdf</code> files (one per line). The literal <code>{path}</code> is replaced with the file's absolute path; if the command has no <code>{path}</code>, the path is appended as the last argument (so <code>evince</code> behaves the same as <code>evince {path}</code>). Leave empty to use the OS default (<code>xdg-open</code> / <code>open</code> / <code>startfile</code>). Images and Markdown always use the OS default.</p>
-                        <label>commands
-                            <textarea name="pdf_viewer" rows="3" placeholder="evince {path}&#10;okular {path}"></textarea>
-                        </label>
-                    </fieldset>
-                    <fieldset class="config-fieldset">
-                        <legend>Embedded terminal</legend>
-                        <label>shell
-                            <input type="text" name="terminal_shell" placeholder="(defaults to $SHELL, then /bin/bash)">
-                            <small id="term-shell-resolved"></small>
-                        </label>
-                        <label>toggle shortcut
-                            <input type="text" name="terminal_shortcut" placeholder="Ctrl+`">
-                            <small>Modifiers: Ctrl, Shift, Alt, Meta. Key names: single chars or KeyboardEvent.key names (Enter, Escape, …).</small>
-                        </label>
-                        <label>screenshot directory
-                            <input type="text" name="terminal_screenshot_dir" placeholder="(defaults to $XDG_PICTURES_DIR/Screenshots, then ~/Pictures/Screenshots)">
-                            <small id="term-screenshot-dir-resolved"></small>
-                        </label>
-                        <label>screenshot paste shortcut
-                            <input type="text" name="terminal_screenshot_paste_shortcut" placeholder="Ctrl+Shift+V">
-                            <small>Pastes the absolute path of the newest image (.png, .jpg, .jpeg, .webp) in the screenshot directory into the active terminal tab — no Enter, you confirm.</small>
-                        </label>
-                    </fieldset>
-                        </div>
-                    </div>
-                </div>
+                <p class="config-help">
+                    Plain-text editor of <code id="config-file-path">&lt;conception&gt;/configuration.yml</code>.
+                    Save validates the YAML; changes take effect the next time condash launches.
+                </p>
+                <textarea id="config-yaml"
+                          spellcheck="false"
+                          rows="28"
+                          style="width:100%;font-family:ui-monospace,monospace;font-size:13px;"
+                          aria-label="configuration.yml raw contents"></textarea>
                 <div id="config-error" class="config-error" style="display:none"></div>
-                <div id="config-restart-warning" class="config-restart-warning" style="display:none"></div>
+                <div id="config-saved" class="config-saved" style="display:none;color:#2a7a2a;margin-top:8px"></div>
                 <div class="config-actions">
                     <button type="button" onclick="closeConfigModal()">Cancel</button>
-                    <button type="submit" class="config-save">Save &amp; reload</button>
+                    <button type="submit" class="config-save">Save</button>
                 </div>
             </form>
         </div>
     </div>
 </div>
+
 
 <div id="new-item-modal" class="note-modal-backdrop" onclick="if(event.target===this)closeNewItemModal()">
     <div class="note-modal config-modal" style="max-width:560px">

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -141,65 +141,23 @@ function _setYamlSourceHint(elId, source, expected, label) {
 
 async function openConfigModal() {
     var modal = document.getElementById('config-modal');
-    var form = document.getElementById('config-form');
+    var ta = document.getElementById('config-yaml');
     var errEl = document.getElementById('config-error');
-    var warnEl = document.getElementById('config-restart-warning');
+    var okEl = document.getElementById('config-saved');
+    var pathEl = document.getElementById('config-file-path');
     errEl.style.display = 'none';
-    warnEl.style.display = 'none';
-    switchConfigTab('general');
+    okEl.style.display = 'none';
     modal.style.display = 'flex';
     try {
-        var res = await fetch('/config');
+        var res = await fetch('/configuration');
         if (!res.ok) throw new Error('HTTP ' + res.status);
-        var cfg = await res.json();
-        _setField(form, 'conception_path', cfg.conception_path);
-        _setField(form, 'workspace_path', cfg.workspace_path);
-        _setField(form, 'worktrees_path', cfg.worktrees_path);
-        _setField(form, 'port', cfg.port);
-        _setField(form, 'native', cfg.native);
-        form.elements['repositories_primary'].value = _reposToLines(cfg.repositories_primary);
-        form.elements['repositories_secondary'].value = _reposToLines(cfg.repositories_secondary);
-        var ow = cfg.open_with || {};
-        _setSlotFields(form, 'main_ide', ow.main_ide);
-        _setSlotFields(form, 'secondary_ide', ow.secondary_ide);
-        _setSlotFields(form, 'terminal', ow.terminal);
-        form.elements['pdf_viewer'].value = _listToLines(cfg.pdf_viewer || []);
-        var term = cfg.terminal || {};
-        _setField(form, 'terminal_shell', term.shell);
-        _setField(form, 'terminal_shortcut', term.shortcut);
-        _setField(form, 'terminal_screenshot_dir', term.screenshot_dir);
-        _setField(form, 'terminal_screenshot_paste_shortcut', term.screenshot_paste_shortcut);
-        var resolvedNote = document.getElementById('term-shell-resolved');
-        if (resolvedNote) {
-            resolvedNote.textContent = term.resolved_shell
-                ? 'Currently resolved: ' + term.resolved_shell
-                : '';
-        }
-        var resolvedDirNote = document.getElementById('term-screenshot-dir-resolved');
-        if (resolvedDirNote) {
-            resolvedDirNote.textContent = term.resolved_screenshot_dir
-                ? 'Currently resolved: ' + term.resolved_screenshot_dir
-                : '';
-        }
-        // Stash the loaded port/native so we can detect changes on save.
-        form.dataset.loadedPort = String(cfg.port);
-        form.dataset.loadedNative = String(cfg.native);
-        _setYamlSourceHint(
-            'config-repositories-source',
-            cfg.repositories_yaml_source,
-            cfg.repositories_yaml_expected_path,
-            'config/repositories.yml',
-        );
-        _setYamlSourceHint(
-            'config-preferences-source',
-            cfg.preferences_yaml_source,
-            cfg.preferences_yaml_expected_path,
-            'config/preferences.yml',
-        );
-        _populateYamlEditor('repositories', cfg.repositories_yaml_body || '');
-        _populateYamlEditor('preferences', cfg.preferences_yaml_body || '');
+        ta.value = await res.text();
+        var path = res.headers.get('X-Condash-Config-Path');
+        if (path && pathEl) pathEl.textContent = path;
+        // Defer focus so the modal is laid out before we position the cursor.
+        setTimeout(function() { ta.focus(); ta.setSelectionRange(0, 0); }, 0);
     } catch (e) {
-        errEl.textContent = 'Could not load config: ' + e;
+        errEl.textContent = 'Could not load configuration.yml: ' + e;
         errEl.style.display = 'block';
     }
 }
@@ -502,92 +460,25 @@ function _expandCardBySlug(slug) {
 
 async function saveConfig(ev) {
     ev.preventDefault();
-    var form = document.getElementById('config-form');
+    var ta = document.getElementById('config-yaml');
     var errEl = document.getElementById('config-error');
-    var warnEl = document.getElementById('config-restart-warning');
+    var okEl = document.getElementById('config-saved');
     errEl.style.display = 'none';
-    warnEl.style.display = 'none';
-    // Prefer the raw-YAML path when the user has edited the YAML pane —
-    // it's the more honest "YAML is source of truth" route and preserves
-    // exact formatting / comments the form can't round-trip.
-    var dirtyYaml = _getDirtyYamlFile();
-    if (dirtyYaml) {
-        try {
-            var yres = await fetch('/config/yaml', {
-                method: 'POST',
-                headers: {'Content-Type': 'application/json'},
-                body: JSON.stringify(dirtyYaml),
-            });
-            var ybody = await yres.json().catch(function(){return {};});
-            if (!yres.ok) {
-                errEl.textContent = ybody.error || ('HTTP ' + yres.status);
-                errEl.style.display = 'block';
-                return;
-            }
-            _loadTermShortcuts();
-            closeConfigModal();
-            setTimeout(_reloadInPlace, 200);
-            return;
-        } catch (e) {
-            errEl.textContent = 'Save failed: ' + e;
-            errEl.style.display = 'block';
-            return;
-        }
-    }
-    var payload = {
-        conception_path: _getField(form, 'conception_path'),
-        workspace_path: _getField(form, 'workspace_path'),
-        worktrees_path: _getField(form, 'worktrees_path'),
-        port: _getField(form, 'port'),
-        native: _getField(form, 'native'),
-        repositories_primary: _linesToRepos(form.elements['repositories_primary'].value),
-        repositories_secondary: _linesToRepos(form.elements['repositories_secondary'].value),
-        pdf_viewer: _linesToList(form.elements['pdf_viewer'].value),
-        terminal: {
-            shell: _getField(form, 'terminal_shell'),
-            shortcut: _getField(form, 'terminal_shortcut'),
-            screenshot_dir: _getField(form, 'terminal_screenshot_dir'),
-            screenshot_paste_shortcut: _getField(form, 'terminal_screenshot_paste_shortcut'),
-        },
-        open_with: {
-            main_ide: _readSlotFields(form, 'main_ide'),
-            secondary_ide: _readSlotFields(form, 'secondary_ide'),
-            terminal: _readSlotFields(form, 'terminal'),
-        },
-    };
+    okEl.style.display = 'none';
     try {
-        var res = await fetch('/config', {
+        var res = await fetch('/configuration', {
             method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(payload),
+            headers: {'Content-Type': 'text/yaml; charset=utf-8'},
+            body: ta.value,
         });
-        var body = await res.json().catch(function(){return {};});
-        if (!res.ok) {
-            errEl.textContent = body.error || ('HTTP ' + res.status);
-            errEl.style.display = 'block';
-            return;
-        }
-        var restart = (body && body.restart_required) || [];
-        // Refresh the cached shortcut specs so terminal-toggle and
-        // screenshot-paste keybindings pick up the new config without a
-        // full reload (when no restart is required).
-        _loadTermShortcuts();
-        if (restart.length) {
-            warnEl.textContent = 'Saved. The following changes need a condash restart to take effect: ' + restart.join(', ') + '. Reloading…';
-            warnEl.style.display = 'block';
+        if (res.ok) {
+            okEl.textContent = 'Saved. Close and reopen condash for changes to take effect.';
+            okEl.style.display = 'block';
         } else {
-            // No restart needed → close the modal immediately so the user
-            // sees the refreshed dashboard, not a modal sitting in front
-            // of it. (_reloadInPlace swaps #dash-main, but modals are
-            // siblings and stay put otherwise.)
-            closeConfigModal();
+            var msg = await res.text();
+            errEl.textContent = 'Save rejected (' + res.status + '): ' + msg;
+            errEl.style.display = 'block';
         }
-        // Brief pause so the user sees the warning, then refresh. When a
-        // restart is required (port change, etc.) we need a real reload so
-        // the browser talks to the new process; otherwise an in-place
-        // swap is enough and preserves terminal state.
-        var refresh = restart.length ? function(){ location.reload(); } : _reloadInPlace;
-        setTimeout(refresh, restart.length ? 1500 : 200);
     } catch (e) {
         errEl.textContent = 'Save failed: ' + e;
         errEl.style.display = 'block';
@@ -3060,10 +2951,9 @@ function _startEventStream() {
         // existing staleness pipeline.
         var payload = null;
         try { payload = JSON.parse(ev.data || '{}'); } catch (e) { payload = {}; }
-        if (payload && payload.tab === 'config') {
-            _onConfigChanged(payload);
-            return;
-        }
+        // Config changes no longer stream over SSE — the watcher on
+        // config/*.yml was removed; the modal's Save path handles
+        // everything explicitly.
         // Any other non-typed message is a staleness hint. Debounced so
         // a burst of watcher events collapses into a single fetch + swap.
         _scheduleCheckUpdates();

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,6 +38,7 @@ anyhow = "1"
 once_cell = "1"
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+rfd = "0.15"
 
 condash-parser = { path = "../crates/condash-parser" }
 condash-state = { path = "../crates/condash-state" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "0.20.1"
+version = "1.1.0"
 description = "Conception dashboard — Tauri port (Phase 0 scaffold)"
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/bin/condash_serve.rs
+++ b/src-tauri/src/bin/condash_serve.rs
@@ -9,22 +9,17 @@
 //! `CONDASH_PORT` to pin the listen port — handy for Playwright
 //! fixtures that want a stable URL.
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use condash_lib::{assets, build_ctx_for_bin, load_template_for_bin};
+use condash_lib::{assets, build_ctx_for_bin, load_template_for_bin, resolve_conception_path};
 use condash_state::WorkspaceCache;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let conception_path = match std::env::var_os("CONDASH_CONCEPTION_PATH") {
-        Some(v) => PathBuf::from(v),
-        None => {
-            let home = std::env::var_os("HOME").context("HOME unset")?;
-            PathBuf::from(home).join("src/vcoeur/conception")
-        }
-    };
+    // Headless binary: env var → ~/.config/condash/settings.yaml →
+    // hard error. No folder picker, no hard-coded default.
+    let conception_path = resolve_conception_path().map_err(|e| anyhow::anyhow!("{e}"))?;
     let asset_source = assets::pick_from_env();
     let template = load_template_for_bin(&asset_source)?;
 

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -129,6 +129,36 @@ pub fn configuration_path(conception_path: &Path) -> PathBuf {
     conception_path.join("configuration.yml")
 }
 
+/// Parse `body` as a well-formed `configuration.yml`. Returns Ok on
+/// success. The config modal calls this before writing so invalid YAML
+/// never hits disk.
+pub fn validate_configuration_yaml(body: &str) -> Result<()> {
+    let _: ConfigurationYaml =
+        serde_yaml_ng::from_str(body).with_context(|| "parsing configuration.yml body")?;
+    Ok(())
+}
+
+/// Atomically write `body` as `<conception>/configuration.yml`. Rejects
+/// invalid YAML; on success, the file on disk is replaced in a single
+/// rename so a crash mid-write cannot truncate the user's config.
+pub fn write_configuration(conception_path: &Path, body: &str) -> Result<PathBuf> {
+    validate_configuration_yaml(body)?;
+    let path = configuration_path(conception_path);
+    let tmp = {
+        let mut p = path.to_path_buf();
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "configuration.yml".into());
+        p.set_file_name(format!(".{name}.tmp"));
+        p
+    };
+    fs::write(&tmp, body.as_bytes()).with_context(|| format!("writing {}", tmp.display()))?;
+    fs::rename(&tmp, &path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(path)
+}
+
 /// Build a [`RenderCtx`] for the conception tree at `conception_path`.
 ///
 /// Reads `<conception>/configuration.yml` when present; falls back to

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,23 +1,24 @@
-//! Minimal config loader — reads `<conception>/config/repositories.yml`
-//! into a [`RenderCtx`] suitable for the Phase 2 read-only routes.
+//! Config loader — reads `<conception>/configuration.yml` into a
+//! [`RenderCtx`].
 //!
-//! Scoped intentionally narrow: parses `workspace_path`, `worktrees_path`,
-//! `repositories.{primary,secondary}` (repo names + optional submodule
-//! lists + optional `run:` commands), and `open_with` labels. The
-//! Python build has a richer config.py with TOML layering, defaults,
-//! and preferences.yml — those belong in a later phase once the Rust
-//! app runs real user workflows.
+//! Flat YAML: the top level carries both the workspace layout
+//! (`workspace_path`, `worktrees_path`, `repositories`, `open_with`)
+//! and the user preferences (`pdf_viewer`, `terminal`). Replaces the
+//! old split between `config/repositories.yml` and
+//! `config/preferences.yml` — those split files are still written on
+//! disk for the retired Python build (`condash-python`) but condash no
+//! longer reads them.
 
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use condash_state::{OpenWithSlot, RenderCtx, RepoEntry, RepoSection};
+use condash_state::{OpenWithSlot, RenderCtx, RepoEntry, RepoSection, TerminalPrefs};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize, Default)]
-struct RepositoriesYaml {
+struct ConfigurationYaml {
     #[serde(default)]
     workspace_path: Option<String>,
     #[serde(default)]
@@ -26,6 +27,54 @@ struct RepositoriesYaml {
     repositories: Option<RepoBuckets>,
     #[serde(default)]
     open_with: Option<HashMap<String, OpenWithSlotYaml>>,
+    #[serde(default)]
+    pdf_viewer: Vec<String>,
+    #[serde(default)]
+    terminal: Option<TerminalYaml>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct TerminalYaml {
+    #[serde(default)]
+    shell: Option<String>,
+    #[serde(default)]
+    shortcut: Option<String>,
+    #[serde(default)]
+    screenshot_dir: Option<String>,
+    #[serde(default)]
+    screenshot_paste_shortcut: Option<String>,
+    #[serde(default)]
+    launcher_command: Option<String>,
+    #[serde(default)]
+    move_tab_left_shortcut: Option<String>,
+    #[serde(default)]
+    move_tab_right_shortcut: Option<String>,
+}
+
+impl TerminalYaml {
+    fn into_prefs(self) -> TerminalPrefs {
+        let TerminalYaml {
+            shell,
+            shortcut,
+            screenshot_dir,
+            screenshot_paste_shortcut,
+            launcher_command,
+            move_tab_left_shortcut,
+            move_tab_right_shortcut,
+        } = self;
+        // Treat empty strings as unset so the YAML idiom `shell: ''` —
+        // how the preferences file ships — round-trips as None.
+        let squash = |s: Option<String>| s.filter(|v| !v.is_empty());
+        TerminalPrefs {
+            shell: squash(shell),
+            shortcut: squash(shortcut),
+            screenshot_dir: squash(screenshot_dir),
+            screenshot_paste_shortcut: squash(screenshot_paste_shortcut),
+            launcher_command: squash(launcher_command),
+            move_tab_left_shortcut: squash(move_tab_left_shortcut),
+            move_tab_right_shortcut: squash(move_tab_right_shortcut),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -75,16 +124,19 @@ struct OpenWithSlotYaml {
     // commands: skipped for Phase 2 — consumed by the mutations layer.
 }
 
+/// Path to the merged configuration file inside a conception tree.
+pub fn configuration_path(conception_path: &Path) -> PathBuf {
+    conception_path.join("configuration.yml")
+}
+
 /// Build a [`RenderCtx`] for the conception tree at `conception_path`.
 ///
-/// Reads `<conception>/config/repositories.yml` when present; falls
-/// back to minimal state when absent (no workspace, no git strip).
-/// Also loads `<conception_path>/../<template>` — the dashboard shell —
-/// into `ctx.template`. The template itself lives next to the Python
-/// package's `assets/` directory; `template_path` points the loader at
-/// it explicitly so the Tauri binary can be launched from anywhere.
+/// Reads `<conception>/configuration.yml` when present; falls back to
+/// a minimal ctx when absent (no workspace, no git strip, no
+/// preferences). `template` is the dashboard shell HTML — loaded once
+/// by the caller so render helpers don't re-read the asset per request.
 pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> {
-    let yaml_path = conception_path.join("config").join("repositories.yml");
+    let yaml_path = configuration_path(conception_path);
     let mut ctx = RenderCtx {
         base_dir: conception_path.to_path_buf(),
         template,
@@ -92,13 +144,13 @@ pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> 
     };
 
     if !yaml_path.is_file() {
-        // No repositories.yml yet — return a minimal ctx; the dashboard
+        // No configuration.yml yet — return a minimal ctx; the dashboard
         // renders without the Code tab populated.
         return Ok(ctx);
     }
     let raw = fs::read_to_string(&yaml_path)
         .with_context(|| format!("reading {}", yaml_path.display()))?;
-    let parsed: RepositoriesYaml = serde_yaml_ng::from_str(&raw)
+    let parsed: ConfigurationYaml = serde_yaml_ng::from_str(&raw)
         .with_context(|| format!("parsing YAML at {}", yaml_path.display()))?;
 
     ctx.workspace = parsed.workspace_path.as_deref().map(expand_tilde);
@@ -141,6 +193,11 @@ pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> 
                 (key, OpenWithSlot { label })
             })
             .collect();
+    }
+
+    ctx.pdf_viewer = parsed.pdf_viewer;
+    if let Some(term) = parsed.terminal {
+        ctx.terminal = term.into_prefs();
     }
 
     Ok(ctx)

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,9 +1,14 @@
 //! Filesystem-driven staleness push — Rust port of `src/condash/events.py`.
 //!
 //! The watcher emits coarse per-tab events (`projects` / `knowledge` /
-//! `code` / `config`) whenever a watched path changes. The SSE handler in
+//! `code`) whenever a watched path changes. The SSE handler in
 //! `server.rs` subscribes to the bus and streams events to the browser;
 //! the frontend treats every event as a hint to re-poll `/check-updates`.
+//!
+//! The merged `configuration.yml` is intentionally *not* watched —
+//! edits come from the in-app YAML editor which explicitly triggers a
+//! `RenderCtx` rebuild on Save. Out-of-band edits (hand-edit from a
+//! different tool) require the user to reopen the modal or restart.
 //!
 //! Two differences from the Python original:
 //!
@@ -12,10 +17,9 @@
 //!    broadcast channel gives us lagging-subscriber semantics for free
 //!    (the client re-polls on lag, which is the same fall-back the
 //!    reconciler already provides).
-//! 2. Config hot-reload (the `on_config_reload` callback) is deferred —
-//!    the Rust build doesn't yet expose a `/config` HTTP endpoint, so
-//!    there's nothing to rebuild on config change. The config handler
-//!    still fires the `config` event so a future slice can hook it.
+//! 2. Config hot-reload is the config modal's responsibility — it
+//!    rebuilds the `RenderCtx` in-band after a successful save and the
+//!    event bus stays out of that path.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,11 +34,6 @@ use tokio::sync::broadcast;
 /// save often produces swap-file + metadata-touch events too. Matches
 /// Python's `_DEBOUNCE_SECONDS`.
 pub const DEBOUNCE: Duration = Duration::from_millis(750);
-
-/// Config-file debounce. Shorter than the default — just long enough to
-/// collapse the three-event storm an atomic write produces on Linux.
-/// Matches Python's `_ConfigHandler._DEBOUNCE`.
-pub const CONFIG_DEBOUNCE: Duration = Duration::from_millis(300);
 
 /// Payload emitted by the watcher. Wire format matches Python —
 /// `{"tab": <tab>, "ts": <seconds>, "file": <leaf>?}`.
@@ -147,18 +146,17 @@ fn leaf_of(path: &Path) -> String {
 pub struct WatchConfig {
     pub projects: Option<PathBuf>,
     pub knowledge: Option<PathBuf>,
-    pub config: Option<PathBuf>,
     pub git_dirs: Vec<PathBuf>,
 }
 
 impl WatchConfig {
     /// Derive a [`WatchConfig`] from a conception base dir + optional
-    /// workspace / worktrees roots. Mirrors Python's `start_watcher`
-    /// directory selection.
+    /// workspace / worktrees roots. `configuration.yml` is deliberately
+    /// *not* watched (see module docs); the config modal pushes rebuilds
+    /// explicitly.
     pub fn from_ctx(base_dir: &Path, workspace: Option<&Path>, worktrees: Option<&Path>) -> Self {
         let projects = base_dir.join("projects");
         let knowledge = base_dir.join("knowledge");
-        let config = base_dir.join("config");
 
         let mut git_dirs = Vec::new();
         if let Some(ws) = workspace {
@@ -180,7 +178,6 @@ impl WatchConfig {
         WatchConfig {
             projects: projects.is_dir().then_some(projects),
             knowledge: knowledge.is_dir().then_some(knowledge),
-            config: config.is_dir().then_some(config),
             git_dirs,
         }
     }
@@ -225,15 +222,9 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
     let projects_deb = Arc::new(Debouncer::new(DEBOUNCE));
     let knowledge_deb = Arc::new(Debouncer::new(DEBOUNCE));
     let code_deb = Arc::new(Debouncer::new(DEBOUNCE));
-    // Config has per-file debouncers keyed by leaf — build them upfront
-    // for the two files we care about.
-    let config_repos_deb = Arc::new(Debouncer::new(CONFIG_DEBOUNCE));
-    let config_prefs_deb = Arc::new(Debouncer::new(CONFIG_DEBOUNCE));
 
-    let nothing_to_watch = cfg.projects.is_none()
-        && cfg.knowledge.is_none()
-        && cfg.config.is_none()
-        && cfg.git_dirs.is_empty();
+    let nothing_to_watch =
+        cfg.projects.is_none() && cfg.knowledge.is_none() && cfg.git_dirs.is_empty();
     if nothing_to_watch {
         return None;
     }
@@ -241,7 +232,6 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
     let bus_clone = bus.clone();
     let projects_path = cfg.projects.clone();
     let knowledge_path = cfg.knowledge.clone();
-    let config_path = cfg.config.clone();
     let git_dirs = cfg.git_dirs.clone();
 
     let mut watcher = recommended_watcher(move |res: notify::Result<Event>| {
@@ -266,21 +256,6 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
                     continue;
                 }
             }
-            if let Some(root) = &config_path {
-                if src.starts_with(root) {
-                    let deb = match leaf.as_str() {
-                        "repositories.yml" => Some(&config_repos_deb),
-                        "preferences.yml" => Some(&config_prefs_deb),
-                        _ => None,
-                    };
-                    if let Some(deb) = deb {
-                        if deb.should_fire() {
-                            bus_clone.publish(EventPayload::new("config", Some(leaf.clone())));
-                            continue;
-                        }
-                    }
-                }
-            }
             for gitdir in &git_dirs {
                 if src.starts_with(gitdir)
                     && matches!(leaf.as_str(), "HEAD" | "index" | "packed-refs")
@@ -299,9 +274,6 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
     }
     if let Some(p) = &cfg.knowledge {
         let _ = watcher.watch(p, RecursiveMode::Recursive);
-    }
-    if let Some(p) = &cfg.config {
-        let _ = watcher.watch(p, RecursiveMode::NonRecursive);
     }
     for gitdir in &cfg.git_dirs {
         let _ = watcher.watch(gitdir, RecursiveMode::NonRecursive);
@@ -364,7 +336,6 @@ mod tests {
         let cfg = WatchConfig::from_ctx(base, None, None);
         assert!(cfg.projects.is_some());
         assert!(cfg.knowledge.is_none());
-        assert!(cfg.config.is_none());
         assert!(cfg.git_dirs.is_empty());
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@
 //! they all speak plain HTTP fetches, so pointing the webview at our
 //! axum server is the only integration delta.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use condash_state::WorkspaceCache;
@@ -52,7 +52,12 @@ pub fn load_template_for_bin(source: &assets::AssetSource) -> anyhow::Result<Str
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
-            let conception_path = resolve_conception_path().map_err(|e| e.to_string())?;
+            let conception_path = match resolve_conception_path() {
+                Ok(p) => p,
+                Err(unset) => prompt_for_conception_path(unset).ok_or_else(|| {
+                    "condash cancelled at the conception folder picker".to_string()
+                })?,
+            };
             let asset_source = assets::pick_from_env();
             let template =
                 load_template_for_bin(&asset_source).map_err(|e| format!("load template: {e}"))?;
@@ -181,6 +186,108 @@ pub fn resolve_from(
         }
     }
     Err(ConceptionPathUnset { settings_path })
+}
+
+/// Native folder picker shown at first run when no env var and no
+/// user config supply a conception path. Loops until the user picks a
+/// directory that looks like a conception tree or cancels.
+///
+/// On success, persists the choice to the on-disk settings file so the
+/// next launch skips the picker. Returns `None` when the user cancels
+/// (the caller should exit cleanly).
+fn prompt_for_conception_path(initial: ConceptionPathUnset) -> Option<PathBuf> {
+    // Title picks a friendlier form than the raw error.
+    let title = "Select your conception tree";
+    let message = format!(
+        "{}\n\nPick the root of your conception tree (the directory that \
+         contains configuration.yml and/or projects/).",
+        initial,
+    );
+    eprintln!("condash: {message}");
+
+    loop {
+        let Some(picked) = rfd::FileDialog::new().set_title(title).pick_folder() else {
+            // User hit Cancel — bail to the caller.
+            return None;
+        };
+
+        match validate_conception_candidate(&picked) {
+            Ok(()) => {
+                let cfg = user_config::UserConfig {
+                    conception_path: Some(picked.clone()),
+                };
+                if let Err(e) = user_config::save(&cfg) {
+                    // Don't fail the launch on a save failure — the
+                    // user still gets a working session with this path,
+                    // and they'll see the same picker on the next run.
+                    eprintln!("condash: warning — could not persist settings.yaml: {e}");
+                } else if let Some(path) = user_config::settings_file_path() {
+                    eprintln!("condash: saved conception path to {}", path.display());
+                }
+                return Some(picked);
+            }
+            Err(reason) => {
+                // Show a non-blocking error and loop back to the picker.
+                rfd::MessageDialog::new()
+                    .set_title("Not a conception tree")
+                    .set_description(&format!("{}\n\n{}", picked.display(), reason))
+                    .set_level(rfd::MessageLevel::Warning)
+                    .show();
+            }
+        }
+    }
+}
+
+/// Loose validation: the candidate must be a directory and contain
+/// either `configuration.yml` (a migrated tree) or `projects/` (a
+/// pre-migration or freshly-scaffolded tree). Stricter checks are
+/// deliberately avoided — we re-prompt rather than punish plausible
+/// picks.
+pub fn validate_conception_candidate(path: &Path) -> Result<(), String> {
+    if !path.is_dir() {
+        return Err(format!("{} is not a directory.", path.display()));
+    }
+    let has_config = path.join("configuration.yml").is_file();
+    let has_projects = path.join("projects").is_dir();
+    if has_config || has_projects {
+        return Ok(());
+    }
+    Err(
+        "This directory does not look like a conception tree — expected configuration.yml \
+         or projects/ inside it."
+            .into(),
+    )
+}
+
+#[cfg(test)]
+mod validate_tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_missing_directory() {
+        assert!(validate_conception_candidate(Path::new("/does/not/exist")).is_err());
+    }
+
+    #[test]
+    fn rejects_empty_directory() {
+        let tmp = tempdir().unwrap();
+        assert!(validate_conception_candidate(tmp.path()).is_err());
+    }
+
+    #[test]
+    fn accepts_directory_with_configuration_yml() {
+        let tmp = tempdir().unwrap();
+        std::fs::write(tmp.path().join("configuration.yml"), "").unwrap();
+        assert!(validate_conception_candidate(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn accepts_directory_with_projects_subdir() {
+        let tmp = tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("projects")).unwrap();
+        assert!(validate_conception_candidate(tmp.path()).is_ok());
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,14 +19,16 @@ pub mod paths;
 pub mod pty;
 pub mod runners;
 pub mod server;
+pub mod user_config;
 
 /// Re-exports for the standalone `condash-serve` binary (same config
 /// and asset resolution the Tauri host uses).
 pub use config::build_ctx as build_ctx_for_bin;
 
-/// Environment variable the dev build reads to locate the conception
-/// tree. Production builds will ship a richer config layer (Phase 5).
-const CONCEPTION_ENV: &str = "CONDASH_CONCEPTION_PATH";
+/// Environment variable that overrides every other source when
+/// resolving the conception tree. Primarily useful for tests and
+/// Playwright fixtures that want a stable path.
+pub const CONCEPTION_ENV: &str = "CONDASH_CONCEPTION_PATH";
 
 /// Load the dashboard HTML template from the configured asset source.
 /// Fails loudly when it's missing — the dashboard is unusable without
@@ -50,7 +52,7 @@ pub fn load_template_for_bin(source: &assets::AssetSource) -> anyhow::Result<Str
 pub fn run() {
     tauri::Builder::default()
         .setup(|app| {
-            let conception_path = resolve_conception_path()?;
+            let conception_path = resolve_conception_path().map_err(|e| e.to_string())?;
             let asset_source = assets::pick_from_env();
             let template =
                 load_template_for_bin(&asset_source).map_err(|e| format!("load template: {e}"))?;
@@ -123,16 +125,128 @@ pub fn run() {
         .expect("error while running condash Tauri application");
 }
 
-fn resolve_conception_path() -> Result<PathBuf, String> {
-    if let Some(path) = std::env::var_os(CONCEPTION_ENV) {
-        return Ok(PathBuf::from(path));
+/// Error returned when no source provides a conception path. The
+/// Tauri host upgrades this into a folder-picker prompt; `condash-serve`
+/// surfaces it as a fatal error.
+#[derive(Debug, Clone)]
+pub struct ConceptionPathUnset {
+    pub settings_path: Option<PathBuf>,
+}
+
+impl std::fmt::Display for ConceptionPathUnset {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let hint = self
+            .settings_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| "~/.config/condash/settings.yaml".into());
+        write!(
+            f,
+            "no conception path configured. Set {CONCEPTION_ENV}, \
+             or create {hint} with `conception_path: /path/to/conception`."
+        )
     }
-    // Dev default — the user's conception tree.
-    let fallback = std::env::var_os("HOME").map(|h| PathBuf::from(h).join("src/vcoeur/conception"));
-    match fallback {
-        Some(p) if p.is_dir() => Ok(p),
-        _ => Err(format!(
-            "no conception path configured. Set {CONCEPTION_ENV} or ensure ~/src/vcoeur/conception exists."
-        )),
+}
+
+impl std::error::Error for ConceptionPathUnset {}
+
+/// Resolve the conception tree from (in order): `CONDASH_CONCEPTION_PATH`
+/// env var → user config at `~/.config/condash/settings.yaml` → absent.
+///
+/// The GUI binary wraps `Err(ConceptionPathUnset)` into a folder picker
+/// (Phase 3); `condash-serve` and other headless callers surface the
+/// error verbatim.
+pub fn resolve_conception_path() -> Result<PathBuf, ConceptionPathUnset> {
+    resolve_from(
+        std::env::var_os(CONCEPTION_ENV).map(PathBuf::from),
+        user_config::load().ok().flatten(),
+        user_config::settings_file_path(),
+    )
+}
+
+/// Pure form of [`resolve_conception_path`] — every input is explicit
+/// so callers can unit-test the precedence rules without mutating
+/// process env or the real settings file.
+pub fn resolve_from(
+    env_var: Option<PathBuf>,
+    user_cfg: Option<user_config::UserConfig>,
+    settings_path: Option<PathBuf>,
+) -> Result<PathBuf, ConceptionPathUnset> {
+    if let Some(p) = env_var.filter(|p| !p.as_os_str().is_empty()) {
+        return Ok(p);
+    }
+    if let Some(cfg) = user_cfg {
+        if let Some(p) = cfg.conception_path.filter(|p| !p.as_os_str().is_empty()) {
+            return Ok(p);
+        }
+    }
+    Err(ConceptionPathUnset { settings_path })
+}
+
+#[cfg(test)]
+mod resolve_tests {
+    use super::*;
+    use user_config::UserConfig;
+
+    #[test]
+    fn env_var_wins_over_user_config() {
+        let got = resolve_from(
+            Some(PathBuf::from("/from-env")),
+            Some(UserConfig {
+                conception_path: Some(PathBuf::from("/from-file")),
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/from-env"));
+    }
+
+    #[test]
+    fn empty_env_var_falls_through_to_user_config() {
+        let got = resolve_from(
+            Some(PathBuf::from("")),
+            Some(UserConfig {
+                conception_path: Some(PathBuf::from("/from-file")),
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/from-file"));
+    }
+
+    #[test]
+    fn user_config_used_when_env_absent() {
+        let got = resolve_from(
+            None,
+            Some(UserConfig {
+                conception_path: Some(PathBuf::from("/from-file")),
+            }),
+            None,
+        )
+        .unwrap();
+        assert_eq!(got, PathBuf::from("/from-file"));
+    }
+
+    #[test]
+    fn no_sources_errors_with_unset() {
+        let err = resolve_from(None, None, Some(PathBuf::from("/x/settings.yaml"))).unwrap_err();
+        assert_eq!(err.settings_path, Some(PathBuf::from("/x/settings.yaml")));
+        let msg = err.to_string();
+        assert!(msg.contains(CONCEPTION_ENV));
+        assert!(msg.contains("/x/settings.yaml"));
+    }
+
+    #[test]
+    fn user_config_without_conception_path_is_unset() {
+        let err = resolve_from(
+            None,
+            Some(UserConfig {
+                conception_path: None,
+            }),
+            None,
+        )
+        .unwrap_err();
+        // Error path — we don't assert on the message beyond the type.
+        let _ = err;
     }
 }

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -184,6 +184,12 @@ pub fn build_router(state: AppState) -> Router {
         .route("/note/mkdir", post(post_note_mkdir))
         .route("/note/upload", post(post_note_upload))
         .route("/create-item", post(post_create_item))
+        // Configuration modal — plain-text YAML editor of
+        // <conception>/configuration.yml.
+        .route(
+            "/configuration",
+            get(get_configuration).post(post_configuration),
+        )
         .with_state(state)
 }
 
@@ -1455,4 +1461,47 @@ fn error(code: StatusCode, msg: &str) -> Response {
         .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
         .body(Body::from(format!("{code} — {msg}\n")))
         .unwrap()
+}
+
+// ---------------------------------------------------------------------
+// Configuration modal (GET/POST /configuration) — plain-text YAML editor
+// backed by <conception>/configuration.yml.
+//
+// GET returns the raw file contents so the modal populates a single
+// <textarea>. POST validates the body via serde (rejects invalid YAML
+// with 400 + parse error), then atomically replaces the file. Changes
+// take effect on the next launch — the RenderCtx is built once at
+// startup and not hot-swapped in this phase.
+
+async fn get_configuration(State(state): State<AppState>) -> Response {
+    let path = crate::config::configuration_path(&state.ctx.base_dir);
+    let body = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(e) => return error(StatusCode::INTERNAL_SERVER_ERROR, &format!("read: {e}")),
+    };
+    let mut r = Response::new(Body::from(body));
+    r.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("text/yaml; charset=utf-8"),
+    );
+    if let Ok(hv) = HeaderValue::from_str(&path.to_string_lossy()) {
+        r.headers_mut().insert("X-Condash-Config-Path", hv);
+    }
+    r
+}
+
+async fn post_configuration(State(state): State<AppState>, body: String) -> Response {
+    if let Err(e) = crate::config::validate_configuration_yaml(&body) {
+        return error(StatusCode::BAD_REQUEST, &format!("{e}"));
+    }
+    match crate::config::write_configuration(&state.ctx.base_dir, &body) {
+        Ok(_path) => (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+            "saved. Close and reopen condash for changes to take effect.\n",
+        )
+            .into_response(),
+        Err(e) => error(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e}")),
+    }
 }

--- a/src-tauri/src/user_config.rs
+++ b/src-tauri/src/user_config.rs
@@ -1,0 +1,155 @@
+//! Per-user persistent settings — the file condash writes after the
+//! first-run prompt so the next launch doesn't need the env var or a
+//! fresh GUI dialog.
+//!
+//! Stored at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` as a
+//! flat YAML document with a single key:
+//!
+//! ```yaml
+//! conception_path: /home/alice/src/vcoeur/conception
+//! ```
+//!
+//! Read order of precedence when resolving the conception tree lives in
+//! [`crate::resolve_conception_path`]: env var → this file → first-run
+//! prompt (Tauri only) → hard error.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct UserConfig {
+    /// Absolute path to the conception tree. Optional in the struct so a
+    /// future settings.yaml with other keys can still deserialize when
+    /// this one is missing — callers decide whether absence is fatal.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conception_path: Option<PathBuf>,
+}
+
+/// Resolve the on-disk settings file path. Returns `None` when neither
+/// `XDG_CONFIG_HOME` nor `HOME` is set (no sensible location to read
+/// or write to).
+pub fn settings_file_path() -> Option<PathBuf> {
+    let base = match std::env::var_os("XDG_CONFIG_HOME") {
+        Some(v) if !v.is_empty() => PathBuf::from(v),
+        _ => {
+            let home = std::env::var_os("HOME")?;
+            PathBuf::from(home).join(".config")
+        }
+    };
+    Some(base.join("condash").join("settings.yaml"))
+}
+
+/// Load the on-disk user config from the default settings path.
+/// Returns `Ok(None)` when the file doesn't exist; `Err` only on IO /
+/// parse failures.
+pub fn load() -> Result<Option<UserConfig>> {
+    let Some(path) = settings_file_path() else {
+        return Ok(None);
+    };
+    load_from(&path)
+}
+
+/// Testable variant of [`load`].
+pub fn load_from(path: &Path) -> Result<Option<UserConfig>> {
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let raw = fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let cfg: UserConfig =
+        serde_yaml_ng::from_str(&raw).with_context(|| format!("parsing {}", path.display()))?;
+    Ok(Some(cfg))
+}
+
+/// Persist `cfg` to the default settings path. Creates the parent
+/// directory if needed. Writes atomically (temp file + rename) and sets
+/// `0600` permissions on unix.
+pub fn save(cfg: &UserConfig) -> Result<PathBuf> {
+    let path = settings_file_path()
+        .context("neither XDG_CONFIG_HOME nor HOME is set; cannot locate settings.yaml")?;
+    save_to(&path, cfg)?;
+    Ok(path)
+}
+
+/// Testable variant of [`save`]. Writes to `path` with the same atomic
+/// semantics.
+pub fn save_to(path: &Path, cfg: &UserConfig) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+    let yaml = serde_yaml_ng::to_string(cfg).context("serialising UserConfig")?;
+    let tmp = {
+        let mut p = path.to_path_buf();
+        let file_name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "settings.yaml".into());
+        p.set_file_name(format!(".{file_name}.tmp"));
+        p
+    };
+    fs::write(&tmp, yaml.as_bytes()).with_context(|| format!("writing {}", tmp.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = fs::set_permissions(&tmp, fs::Permissions::from_mode(0o600));
+    }
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_missing_file_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.yaml");
+        assert!(matches!(load_from(&path), Ok(None)));
+    }
+
+    #[test]
+    fn roundtrip_preserves_conception_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nested").join("settings.yaml");
+        let cfg = UserConfig {
+            conception_path: Some(PathBuf::from("/tmp/conception")),
+        };
+        save_to(&path, &cfg).unwrap();
+        let loaded = load_from(&path).unwrap().unwrap();
+        assert_eq!(loaded, cfg);
+    }
+
+    #[test]
+    fn save_sets_0600_on_unix() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let tmp = tempfile::tempdir().unwrap();
+            let path = tmp.path().join("settings.yaml");
+            save_to(&path, &UserConfig::default()).unwrap();
+            let mode = fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "expected 0600, got {mode:o}");
+        }
+    }
+
+    #[test]
+    fn load_rejects_invalid_yaml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.yaml");
+        fs::write(&path, "conception_path: [not, a, path]").unwrap();
+        assert!(load_from(&path).is_err());
+    }
+
+    #[test]
+    fn load_accepts_empty_document() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("settings.yaml");
+        fs::write(&path, "{}\n").unwrap();
+        let cfg = load_from(&path).unwrap().unwrap();
+        assert_eq!(cfg.conception_path, None);
+    }
+}

--- a/src-tauri/tests/configuration_yml.rs
+++ b/src-tauri/tests/configuration_yml.rs
@@ -1,0 +1,173 @@
+//! build_ctx coverage — exercises the full `configuration.yml`
+//! deserialisation surface: workspace paths (incl. tilde expansion),
+//! primary + secondary repo buckets (bare string + mapping with
+//! submodules + `run:` commands at both levels), open_with slot
+//! labels, pdf_viewer chain, and terminal preferences (empty-string
+//! normalisation → None).
+
+use std::fs;
+use std::path::PathBuf;
+
+use condash_lib::config::{build_ctx, configuration_path};
+
+const FIXTURE: &str = r#"
+workspace_path: /tmp/vcoeur
+worktrees_path: ~/worktrees-test
+repositories:
+  primary:
+    - condash
+    - name: vcoeur.com
+      run: make dev
+    - name: PaintingManager
+      submodules:
+        - name: app
+          run: ls -al && pwd
+        - docs
+  secondary:
+    - conception
+open_with:
+  main_ide:
+    label: Open in main IDE
+    commands:
+      - idea {path}
+  secondary_ide:
+    label: Open in VS Code
+    commands:
+      - code {path}
+pdf_viewer:
+  - evince {path}
+  - okular {path}
+terminal:
+  shell: /bin/zsh
+  shortcut: Ctrl+T
+  screenshot_dir: ''
+  screenshot_paste_shortcut: Ctrl+Shift+V
+  launcher_command: claude
+  move_tab_left_shortcut: Ctrl+Left
+  move_tab_right_shortcut: Ctrl+Right
+"#;
+
+#[test]
+fn build_ctx_reads_every_top_level_field() {
+    let tmp = tempfile::tempdir().unwrap();
+    let base = tmp.path();
+    let yaml_path = configuration_path(base);
+    fs::write(&yaml_path, FIXTURE).unwrap();
+
+    let ctx = build_ctx(base, String::new()).expect("build_ctx");
+
+    assert_eq!(ctx.base_dir, base);
+    assert_eq!(ctx.workspace, Some(PathBuf::from("/tmp/vcoeur")));
+    // ~/ expansion hits whatever HOME is set to — just assert the
+    // suffix rather than the absolute path.
+    assert!(
+        ctx.worktrees
+            .as_ref()
+            .map(|p| p.ends_with("worktrees-test"))
+            .unwrap_or(false),
+        "expected worktrees to end in worktrees-test, got {:?}",
+        ctx.worktrees
+    );
+
+    // Two sections — primary + secondary.
+    assert_eq!(ctx.repo_structure.len(), 2);
+    let primary = &ctx.repo_structure[0];
+    assert_eq!(primary.label, "Primary");
+    let names: Vec<&str> = primary.repos.iter().map(|r| r.name.as_str()).collect();
+    assert_eq!(names, vec!["condash", "vcoeur.com", "PaintingManager"]);
+    let pm = primary
+        .repos
+        .iter()
+        .find(|r| r.name == "PaintingManager")
+        .unwrap();
+    assert_eq!(pm.submodules, vec!["app".to_string(), "docs".to_string()]);
+
+    let secondary = &ctx.repo_structure[1];
+    assert_eq!(secondary.label, "Secondary");
+    assert_eq!(
+        secondary
+            .repos
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>(),
+        vec!["conception"]
+    );
+
+    // Runner configuration: repo-level run + submodule-level run both
+    // land as keys; their templates carry the {path} placeholder for
+    // the runner layer to substitute.
+    assert!(ctx.repo_run_keys.contains("vcoeur.com"));
+    assert_eq!(
+        ctx.repo_run_templates.get("vcoeur.com").map(String::as_str),
+        Some("make dev")
+    );
+    assert!(ctx.repo_run_keys.contains("PaintingManager--app"));
+    assert_eq!(
+        ctx.repo_run_templates
+            .get("PaintingManager--app")
+            .map(String::as_str),
+        Some("ls -al && pwd")
+    );
+    // Bare submodule (`docs`) has no run command — must not appear.
+    assert!(!ctx.repo_run_keys.contains("PaintingManager--docs"));
+
+    // open_with — labels preserved, commands consumed by the mutations
+    // layer so not surfaced on the ctx.
+    assert_eq!(
+        ctx.open_with.get("main_ide").map(|s| s.label.as_str()),
+        Some("Open in main IDE")
+    );
+    assert_eq!(
+        ctx.open_with.get("secondary_ide").map(|s| s.label.as_str()),
+        Some("Open in VS Code")
+    );
+
+    // pdf_viewer — full fallback chain carried through.
+    assert_eq!(
+        ctx.pdf_viewer,
+        vec!["evince {path}".to_string(), "okular {path}".to_string()]
+    );
+
+    // terminal prefs — empty strings (e.g. `screenshot_dir: ''`)
+    // normalise to None so consumers fall back to their defaults.
+    assert_eq!(ctx.terminal.shell.as_deref(), Some("/bin/zsh"));
+    assert_eq!(ctx.terminal.shortcut.as_deref(), Some("Ctrl+T"));
+    assert_eq!(ctx.terminal.screenshot_dir, None);
+    assert_eq!(
+        ctx.terminal.screenshot_paste_shortcut.as_deref(),
+        Some("Ctrl+Shift+V")
+    );
+    assert_eq!(ctx.terminal.launcher_command.as_deref(), Some("claude"));
+    assert_eq!(
+        ctx.terminal.move_tab_left_shortcut.as_deref(),
+        Some("Ctrl+Left")
+    );
+    assert_eq!(
+        ctx.terminal.move_tab_right_shortcut.as_deref(),
+        Some("Ctrl+Right")
+    );
+}
+
+#[test]
+fn build_ctx_without_configuration_yml_returns_minimal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ctx = build_ctx(tmp.path(), String::new()).unwrap();
+    assert_eq!(ctx.base_dir, tmp.path());
+    assert!(ctx.workspace.is_none());
+    assert!(ctx.worktrees.is_none());
+    assert!(ctx.repo_structure.is_empty());
+    assert!(ctx.open_with.is_empty());
+    assert!(ctx.pdf_viewer.is_empty());
+    assert_eq!(ctx.terminal.shell, None);
+}
+
+#[test]
+fn build_ctx_rejects_invalid_yaml() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(configuration_path(tmp.path()), "not: [valid").unwrap();
+    let err = build_ctx(tmp.path(), String::new()).unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("yaml") || err.to_string().contains("parsing"),
+        "unexpected error: {err}"
+    );
+}


### PR DESCRIPTION
## Summary
- Collapse `config/{repositories,preferences}.yml` into a single `configuration.yml` at the conception tree root.
- Persist the conception path in `~/.config/condash/settings.yaml`; drop the hard-coded `~/src/vcoeur/conception` fallback.
- Swap the structured Configuration modal for a plain-text YAML editor of `configuration.yml`.

## Changes
- New `user_config` module: load/save `settings.yaml` atomically with `0600`, plus a pure `resolve_from` precedence helper.
- `resolve_conception_path`: `CONDASH_CONCEPTION_PATH` → `settings.yaml` → (GUI) native folder picker → error.
- `build_ctx` now reads `<conception>/configuration.yml` (flat schema — workspace paths + `repositories` + `open_with` + `pdf_viewer` + `terminal`), with new `TerminalPrefs` + `pdf_viewer` fields on `RenderCtx`.
- First-run folder picker via `rfd`: validate (dir exists + contains `configuration.yml` or `projects/`), re-prompt on invalid, persist on accept, exit on cancel.
- `GET /configuration` + `POST /configuration` routes: raw YAML read, validate-then-atomic-rename on save.
- Modal markup + handlers replaced with a single `<textarea>` bound to the raw file contents.
- Watcher drops the `config/*.yml` debouncer — edits flow through the modal's explicit save path.
- `CLAUDE.md` Config section rewritten; legacy `config/*.yml` split files kept on disk for `condash-python`.
- Tests: end-to-end `build_ctx` fixture, resolution-chain + validation-helper unit tests, `user_config` round-trip + permissions test.

## Impact
- Requires `<conception>/configuration.yml` to exist. Without it, the Code tab is empty and the modal textarea opens blank.
- Saves via the modal land in `configuration.yml` only; `config/repositories.yml` / `preferences.yml` do not update. `condash-python` will see stale data until the user hand-syncs — accepted drift hazard.
- `RenderCtx` is not hot-swapped on save; the modal tells users to reopen condash for changes to take effect.

## Watchpoints
- Native folder picker via `rfd` uses GTK on Linux (already pulled in by webkit2gtk). Verify on the target hosts — portal issues have surfaced on some distros.
- `settings.yaml` writes `0600`; on filesystems without POSIX perms the call silently no-ops.