### PR TITLE
Finish Python -> Rust port of condash card actions (v1.0.3)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,5 +6,14 @@
 #
 # Install once: `cargo install sccache` (or via a prebuilt binary).
 # Verify the cache is active with `sccache --show-stats` after a build.
+#
+# CI runners don't have sccache pre-installed. The release workflow
+# sets `CARGO_BUILD_RUSTC_WRAPPER=""` to override this file on CI —
+# Swatinem/rust-cache already caches cargo artifacts across runs, so
+# stacking sccache on top adds nothing. Local developers who don't
+# install sccache must apply the same override (e.g.
+# `export CARGO_BUILD_RUSTC_WRAPPER=""` or their own
+# `~/.cargo/config.toml`) — otherwise every rustc invocation fails
+# with "could not execute process sccache".
 [build]
 rustc-wrapper = "sccache"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,17 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      # `.cargo/config.toml` wraps rustc with `sccache` for fast local
+      # rebuilds across branch switches. CI runners don't have sccache
+      # installed, so without this override every rustc invocation
+      # fails with "could not execute process sccache" before any
+      # compilation happens. Swatinem/rust-cache below already caches
+      # cargo artifacts across CI runs, so stacking sccache on top
+      # would be redundant — we just unset the wrapper here.
+      - name: Disable sccache wrapper on CI
+        shell: bash
+        run: echo "CARGO_BUILD_RUSTC_WRAPPER=" >> "$GITHUB_ENV"
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -641,8 +641,12 @@ dependencies = [
  "condash-parser",
  "condash-state",
  "minijinja",
+ "once_cell",
+ "pulldown-cmark",
+ "regex",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -3181,6 +3185,24 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.11.1",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "quick-xml"

--- a/crates/condash-render/Cargo.toml
+++ b/crates/condash-render/Cargo.toml
@@ -14,6 +14,12 @@ minijinja = { version = "2", features = ["loader", "builtins"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
+regex = "1"
+once_cell = "1"
+
+[dev-dependencies]
+tempfile = "3"
 
 [[bin]]
 name = "render-diff"

--- a/crates/condash-render/src/bin/render_diff.rs
+++ b/crates/condash-render/src/bin/render_diff.rs
@@ -158,7 +158,13 @@ fn build_ctx_from_py(ctx_json: &Value, base: &Path) -> RenderCtx {
                         .and_then(|l| l.as_str())
                         .unwrap_or(k.as_str())
                         .to_string();
-                    (k.clone(), OpenWithSlot { label })
+                    (
+                        k.clone(),
+                        OpenWithSlot {
+                            label,
+                            commands: Vec::new(),
+                        },
+                    )
                 })
                 .collect()
         })
@@ -199,13 +205,18 @@ fn render_rust(
     }
 
     let git_groups = collect_git_repos(ctx);
-    let git_html = render_git_repos(ctx, &git_groups);
+    // The diff harness only compares rendered HTML shapes; runners are a
+    // per-process-state concern the harness doesn't model. Pass an
+    // empty live set so both builds render the "no session" branch.
+    let live_runners: std::collections::HashSet<String> = Default::default();
+    let git_html = render_git_repos(ctx, &git_groups, &live_runners);
     let mut git_fragments: HashMap<String, String> = HashMap::new();
     for group in &git_groups {
         let group_id = format!("code/{}", group.label);
         for family in &group.families {
             let node_id = format!("{group_id}/{}", family.name);
-            if let Some(html) = render_git_repo_fragment(ctx, &git_groups, &node_id) {
+            if let Some(html) = render_git_repo_fragment(ctx, &git_groups, &node_id, &live_runners)
+            {
                 git_fragments.insert(node_id, html);
             }
         }

--- a/crates/condash-render/src/bin/render_diff.rs
+++ b/crates/condash-render/src/bin/render_diff.rs
@@ -207,8 +207,8 @@ fn render_rust(
     let git_groups = collect_git_repos(ctx);
     // The diff harness only compares rendered HTML shapes; runners are a
     // per-process-state concern the harness doesn't model. Pass an
-    // empty live set so both builds render the "no session" branch.
-    let live_runners: std::collections::HashSet<String> = Default::default();
+    // empty live map so both builds render the "no session" branch.
+    let live_runners: condash_render::git_render::LiveRunners = Default::default();
     let git_html = render_git_repos(ctx, &git_groups, &live_runners);
     let mut git_fragments: HashMap<String, String> = HashMap::new();
     for group in &git_groups {

--- a/crates/condash-render/src/git_render.rs
+++ b/crates/condash-render/src/git_render.rs
@@ -1,18 +1,16 @@
 //! Git-strip rendering — Rust port of render.py's peer-card / branch-row
 //! / runner-button / open-with helpers.
 //!
-//! The public entry points take a `live_set` slice of runner keys that
-//! currently have an active PTY session. The set drives three visible
-//! bits of UI: the peer-card "live" tag, the `.runner-term-mount` div
-//! the frontend attaches xterm + WebSocket to, and the `.peer-row-live`
-//! modifier on the active row. The Rust server passes
-//! `state.runner_registry.keys()`; tests pass an empty set.
-//!
-//! The string-concat style mirrors Python's render.py one-for-one so
-//! the byte-for-byte diff tool can prove they agree on the live
-//! workspace.
+//! The public entry points take a [`LiveRunners`] map keyed by runner
+//! key. Each entry records the checkout that owns the session and the
+//! exit code (or `None` if still live). Three visible bits of UI lean
+//! on this: the peer-card "live" tag, the `.runner-term-mount` div the
+//! frontend attaches xterm + WebSocket to (only emitted on the row
+//! that owns the session), and the tri-state Start / Stop / Switch
+//! button on every row of the same runner. The Rust server builds the
+//! map from `state.runner_registry`; tests pass an empty map.
 
-use std::collections::HashSet;
+use std::collections::HashMap;
 
 use condash_state::{Checkout, Family, Group, Member, RenderCtx};
 
@@ -44,6 +42,24 @@ pub fn runner_key(repo_name: &str, sub_name: Option<&str>) -> String {
         Some(s) => format!("{repo_name}--{s}"),
     }
 }
+
+/// Snapshot of a runner session as far as the renderer is concerned.
+/// The server builds one of these per live-or-exited entry in the
+/// runner registry before rendering so the render crate stays pure.
+#[derive(Debug, Clone, Default)]
+pub struct RunnerLive {
+    /// `checkout_key` that started the session (`"main"` or a worktree
+    /// key). The mount + "live" row modifier only appear on this
+    /// checkout's row.
+    pub checkout_key: String,
+    /// `Some(code)` iff the session has exited; `None` while the PTY
+    /// is still running.
+    pub exit_code: Option<i32>,
+}
+
+/// Map of runner-key → session snapshot. Empty is the common case;
+/// populated as sessions start and drop as they are cleared.
+pub type LiveRunners = HashMap<String, RunnerLive>;
 
 fn runner_key_for_member(family: &Family, member: &Member) -> String {
     if member.is_subrepo {
@@ -117,16 +133,51 @@ fn icon_for(slot_key: &str) -> &'static str {
     }
 }
 
-/// Per-checkout Run / Stop / Switch pill. Phase 2 always takes the
-/// "no session" branch → green Start button.
-fn render_runner_button(key: &str, checkout_key: &str, checkout_path: &str) -> String {
+/// Per-checkout Run / Stop / Switch pill. The icon + onclick depend on
+/// whether a live session owns this runner key, and if so which
+/// checkout it is anchored to:
+///
+/// - no session (or session exited)     → green Start
+/// - session on this checkout           → red Stop
+/// - session on a different checkout    → amber Switch (confirm dialog)
+fn render_runner_button(
+    key: &str,
+    checkout_key: &str,
+    checkout_path: &str,
+    live: Option<&RunnerLive>,
+) -> String {
     let js_key = embed_attr(&key);
     let js_checkout = embed_attr(&checkout_key);
     let js_path = embed_attr(&checkout_path);
-    let title = "Start dev runner";
-    let cls = "git-action-runner-run";
-    let icon = Icons::runner_run;
-    let onclick = format!("runnerStart(event,{js_key},{js_checkout},{js_path})");
+    let (title, cls, icon, onclick) = match live {
+        None => (
+            "Start dev runner",
+            "git-action-runner-run",
+            Icons::runner_run,
+            format!("runnerStart(event,{js_key},{js_checkout},{js_path})"),
+        ),
+        Some(RunnerLive { exit_code, .. }) if exit_code.is_some() => (
+            "Start dev runner",
+            "git-action-runner-run",
+            Icons::runner_run,
+            format!("runnerStart(event,{js_key},{js_checkout},{js_path})"),
+        ),
+        Some(RunnerLive {
+            checkout_key: owner,
+            ..
+        }) if owner == checkout_key => (
+            "Stop dev runner",
+            "git-action-runner-stop",
+            Icons::runner_stop,
+            format!("runnerStop(event,{js_key})"),
+        ),
+        Some(_) => (
+            "Switch runner to this checkout",
+            "git-action-runner-switch",
+            Icons::runner_run,
+            format!("runnerSwitch(event,{js_key},{js_checkout},{js_path})"),
+        ),
+    };
     format!(
         "<button class=\"git-action-btn git-action-runner {cls}\" \
          title=\"{t}\" aria-label=\"{t}\" \
@@ -135,16 +186,53 @@ fn render_runner_button(key: &str, checkout_key: &str, checkout_path: &str) -> S
     )
 }
 
-/// Inline runner mount — emitted when the runner identified by `key` has
-/// a live session. The div carries the data attributes the frontend's
-/// `runnerReattachAll()` scans for; xterm + `/ws/runner/<key>`
-/// attachment happens entirely on the client side.
-fn render_runner_mount(key: &str, checkout_key: &str) -> String {
+/// Inline runner mount — returns the empty string unless the runner
+/// identified by `key` has a live-or-exited session anchored at
+/// `checkout_key`. Fresh mounts start collapsed; the user reveals the
+/// output by clicking the header. `data-exit-code` is set on exited
+/// sessions so the header styling flips to the muted variant.
+fn render_runner_mount(key: &str, checkout_key: &str, live: Option<&RunnerLive>) -> String {
+    let Some(session) = live else {
+        return String::new();
+    };
+    if session.checkout_key != checkout_key {
+        return String::new();
+    }
+    let exited_attr = match session.exit_code {
+        Some(code) => format!(" data-exit-code=\"{code}\""),
+        None => String::new(),
+    };
+    let label = format!("{key} @ {checkout_key}");
     format!(
-        "<div class=\"runner-term-mount\" data-runner-key=\"{k}\" \
-         data-runner-checkout=\"{c}\"></div>",
+        "<div class=\"runner-term-mount runner-collapsed\" \
+         data-runner-key=\"{k}\" data-runner-checkout=\"{c}\"{ex}>\
+         <div class=\"runner-term-header\" \
+         title=\"Click to collapse / expand (keeps process running)\" \
+         onclick=\"runnerToggleCollapse(this)\">\
+         <span class=\"runner-term-label\">{label_h}</span>\
+         <span class=\"runner-term-status\" aria-live=\"polite\"></span>\
+         <button class=\"runner-control runner-collapse\" \
+         aria-label=\"Collapse terminal\" tabindex=\"-1\" \
+         onclick=\"event.stopPropagation();runnerToggleCollapse(this)\">\
+         {collapse_icon}</button>\
+         <button class=\"runner-control runner-popout\" \
+         title=\"Pop out\" aria-label=\"Pop out\" \
+         onclick=\"event.stopPropagation();runnerPopout(this)\">\
+         {popout_icon}</button>\
+         <button class=\"runner-control runner-stop-inline\" \
+         title=\"Stop\" aria-label=\"Stop\" \
+         onclick=\"event.stopPropagation();runnerStopInline(this)\">\
+         {stop_icon}</button>\
+         </div>\
+         <div class=\"runner-term-host\"></div>\
+         </div>",
         k = h(key),
         c = h(checkout_key),
+        ex = exited_attr,
+        label_h = h(&label),
+        collapse_icon = Icons::runner_collapse,
+        popout_icon = Icons::runner_popout,
+        stop_icon = Icons::runner_stop,
     )
 }
 
@@ -201,7 +289,7 @@ fn render_branch_row_inner(
     checkout_key: &str,
     is_main: bool,
     node_id: &str,
-    live_set: &HashSet<String>,
+    live: &LiveRunners,
 ) -> String {
     // Branch label: subrepo's main row inherits the parent's branch.
     let branch_label = if !info_branch.is_empty() {
@@ -220,9 +308,12 @@ fn render_branch_row_inner(
     // Runner pill — only for configured members that aren't missing.
     let mut runner_pill = String::new();
     let member_key = runner_key_for_member(family, member);
-    let is_live = live_set.contains(&member_key);
+    let session = live.get(&member_key);
+    let is_live = session
+        .map(|s| s.exit_code.is_none() && s.checkout_key == checkout_key)
+        .unwrap_or(false);
     if !info_missing && ctx.repo_run_keys.contains(&member_key) {
-        runner_pill = render_runner_button(&member_key, checkout_key, info_path);
+        runner_pill = render_runner_button(&member_key, checkout_key, info_path, session);
     }
     let _ = info_changed;
     let _ = info_changed_files;
@@ -276,7 +367,7 @@ fn render_branch_row_main(
     family: &Family,
     member: &Member,
     node_id: &str,
-    live_set: &HashSet<String>,
+    live: &LiveRunners,
 ) -> String {
     let status_html = branch_status_cell_member(member);
     render_branch_row_inner(
@@ -293,7 +384,7 @@ fn render_branch_row_main(
         "main",
         true,
         node_id,
-        live_set,
+        live,
     )
 }
 
@@ -303,7 +394,7 @@ fn render_branch_row_worktree(
     member: &Member,
     wt: &Checkout,
     node_id: &str,
-    live_set: &HashSet<String>,
+    live: &LiveRunners,
 ) -> String {
     let status_html = branch_status_cell(wt);
     render_branch_row_inner(
@@ -320,7 +411,7 @@ fn render_branch_row_worktree(
         &wt.key,
         false,
         node_id,
-        live_set,
+        live,
     )
 }
 
@@ -331,7 +422,7 @@ fn render_peer_card(
     family: &Family,
     member: &Member,
     member_id: &str,
-    live_set: &HashSet<String>,
+    live: &LiveRunners,
 ) -> String {
     let is_subrepo = member.is_subrepo;
     let is_missing = member.missing;
@@ -359,8 +450,13 @@ fn render_peer_card(
         "<span class=\"peer-tag peer-tag-clean\">clean</span>".to_string()
     };
     let member_key = runner_key_for_member(family, member);
-    let live = !is_missing && live_set.contains(&member_key);
-    let head_tag = if live {
+    let session = live.get(&member_key);
+    let is_live = !is_missing && session.map(|s| s.exit_code.is_none()).unwrap_or(false);
+    // Emit the mount (exited or running) whenever a session is anchored
+    // here — so the "exited: N" state survives until the user clicks
+    // Stop. Matches Python's `_render_runner_mount` truth table.
+    let has_session_here = !is_missing && session.is_some();
+    let head_tag = if is_live {
         format!("{head_tag}<span class=\"peer-tag peer-tag-live\">live</span>")
     } else {
         head_tag
@@ -377,7 +473,7 @@ fn render_peer_card(
     if dirty_branches > 0 {
         card_cls.push_str(" peer-card-dirty");
     }
-    if live {
+    if is_live {
         card_cls.push_str(" peer-card-live");
     }
     if is_missing {
@@ -407,20 +503,24 @@ fn render_peer_card(
         family,
         member,
         &format!("{member_id}/b:main"),
-        live_set,
+        live,
     ));
     for wt in &member.worktrees {
         let wt_id = format!("{member_id}/wt:{}", wt.key);
         parts.push(render_branch_row_worktree(
-            ctx, family, member, wt, &wt_id, live_set,
+            ctx, family, member, wt, &wt_id, live,
         ));
     }
     parts.push("</div>".into()); // /peer-rows
 
-    // Inline runner terminal mount — only when the session is live.
-    if live {
-        let mount = render_runner_mount(&member_key, "main");
-        parts.push(format!("<div class=\"peer-term\">{mount}</div>"));
+    // Inline runner terminal mount — rendered on the row that owns the
+    // session (live or exited). Empty string when no session here.
+    if has_session_here {
+        let owner_checkout = session.map(|s| s.checkout_key.as_str()).unwrap_or("main");
+        let mount = render_runner_mount(&member_key, owner_checkout, session);
+        if !mount.is_empty() {
+            parts.push(format!("<div class=\"peer-term\">{mount}</div>"));
+        }
     }
 
     let foot_path = &member.path;
@@ -428,7 +528,7 @@ fn render_peer_card(
         "<span class=\"peer-foot-path\">{p}</span>",
         p = h(foot_path)
     );
-    if live {
+    if is_live {
         foot.push_str(&format!(
             "<button type=\"button\" class=\"peer-jump\" \
              title=\"Jump to live terminal\" aria-label=\"Jump to live terminal\" \
@@ -447,7 +547,7 @@ fn render_flat_group(
     ctx: &RenderCtx,
     family: &Family,
     group_id: &str,
-    live_set: &HashSet<String>,
+    live: &LiveRunners,
 ) -> String {
     let family_id = format!("{group_id}/{}", family.name);
     let is_compound = family.members.len() > 1;
@@ -469,7 +569,7 @@ fn render_flat_group(
     }
     for member in &family.members {
         let member_id = format!("{family_id}/m:{}", member.name);
-        parts.push(render_peer_card(ctx, family, member, &member_id, live_set));
+        parts.push(render_peer_card(ctx, family, member, &member_id, live));
     }
     parts.push("</div>".into());
     parts.join("\n")
@@ -481,7 +581,7 @@ pub fn render_git_repo_fragment(
     ctx: &RenderCtx,
     groups: &[Group],
     node_id: &str,
-    live_set: &HashSet<String>,
+    live: &LiveRunners,
 ) -> Option<String> {
     let rest = node_id.strip_prefix("code/")?;
     let (group_label, family_name) = rest.split_once('/')?;
@@ -495,7 +595,7 @@ pub fn render_git_repo_fragment(
                     ctx,
                     family,
                     &format!("code/{group_label}"),
-                    live_set,
+                    live,
                 ));
             }
         }
@@ -505,7 +605,7 @@ pub fn render_git_repo_fragment(
 
 /// Render the full Code tab given the list of discovered groups.
 /// Port of `_render_git_repos`.
-pub fn render_git_repos(ctx: &RenderCtx, groups: &[Group], live_set: &HashSet<String>) -> String {
+pub fn render_git_repos(ctx: &RenderCtx, groups: &[Group], live: &LiveRunners) -> String {
     if groups.is_empty() {
         return String::new();
     }
@@ -520,7 +620,7 @@ pub fn render_git_repos(ctx: &RenderCtx, groups: &[Group], live_set: &HashSet<St
             label = h(&group.label),
         ));
         for family in &group.families {
-            parts.push(render_flat_group(ctx, family, &group_id, live_set));
+            parts.push(render_flat_group(ctx, family, &group_id, live));
         }
         parts.push("</div></section>".into());
     }

--- a/crates/condash-render/src/git_render.rs
+++ b/crates/condash-render/src/git_render.rs
@@ -1,17 +1,18 @@
 //! Git-strip rendering — Rust port of render.py's peer-card / branch-row
 //! / runner-button / open-with helpers.
 //!
-//! Phase 2 scope: the readers. Runner sessions don't exist yet in the
-//! Rust build (Phase 4 territory), so `_render_runner_button` always
-//! takes the "no session" branch (green "Start" button) and
-//! `_render_runner_mount` returns an empty string. The fingerprint
-//! layer already emits `|run:off` for configured rows — the rendered
-//! HTML here matches what Python emits when `runners.registry()` is
-//! empty, which is the Phase 2 invariant on both sides.
+//! The public entry points take a `live_set` slice of runner keys that
+//! currently have an active PTY session. The set drives three visible
+//! bits of UI: the peer-card "live" tag, the `.runner-term-mount` div
+//! the frontend attaches xterm + WebSocket to, and the `.peer-row-live`
+//! modifier on the active row. The Rust server passes
+//! `state.runner_registry.keys()`; tests pass an empty set.
 //!
 //! The string-concat style mirrors Python's render.py one-for-one so
 //! the byte-for-byte diff tool can prove they agree on the live
 //! workspace.
+
+use std::collections::HashSet;
 
 use condash_state::{Checkout, Family, Group, Member, RenderCtx};
 
@@ -134,11 +135,17 @@ fn render_runner_button(key: &str, checkout_key: &str, checkout_path: &str) -> S
     )
 }
 
-/// Inline runner mount — in Phase 2 we have no live sessions, so this
-/// always returns the empty string (matches Python's `if session is
-/// None: return ""` branch).
-fn render_runner_mount(_key: &str, _checkout_key: &str) -> String {
-    String::new()
+/// Inline runner mount — emitted when the runner identified by `key` has
+/// a live session. The div carries the data attributes the frontend's
+/// `runnerReattachAll()` scans for; xterm + `/ws/runner/<key>`
+/// attachment happens entirely on the client side.
+fn render_runner_mount(key: &str, checkout_key: &str) -> String {
+    format!(
+        "<div class=\"runner-term-mount\" data-runner-key=\"{k}\" \
+         data-runner-checkout=\"{c}\"></div>",
+        k = h(key),
+        c = h(checkout_key),
+    )
 }
 
 fn branch_status_cell(info: &Checkout) -> String {
@@ -194,6 +201,7 @@ fn render_branch_row_inner(
     checkout_key: &str,
     is_main: bool,
     node_id: &str,
+    live_set: &HashSet<String>,
 ) -> String {
     // Branch label: subrepo's main row inherits the parent's branch.
     let branch_label = if !info_branch.is_empty() {
@@ -212,12 +220,9 @@ fn render_branch_row_inner(
     // Runner pill — only for configured members that aren't missing.
     let mut runner_pill = String::new();
     let member_key = runner_key_for_member(family, member);
-    let mut is_live = false; // Phase 2: no live sessions.
+    let is_live = live_set.contains(&member_key);
     if !info_missing && ctx.repo_run_keys.contains(&member_key) {
         runner_pill = render_runner_button(&member_key, checkout_key, info_path);
-        // Python here re-checks runners_mod.get(); Phase 2 has no
-        // sessions so is_live stays false.
-        let _ = &mut is_live;
     }
     let _ = info_changed;
     let _ = info_changed_files;
@@ -271,6 +276,7 @@ fn render_branch_row_main(
     family: &Family,
     member: &Member,
     node_id: &str,
+    live_set: &HashSet<String>,
 ) -> String {
     let status_html = branch_status_cell_member(member);
     render_branch_row_inner(
@@ -287,6 +293,7 @@ fn render_branch_row_main(
         "main",
         true,
         node_id,
+        live_set,
     )
 }
 
@@ -296,6 +303,7 @@ fn render_branch_row_worktree(
     member: &Member,
     wt: &Checkout,
     node_id: &str,
+    live_set: &HashSet<String>,
 ) -> String {
     let status_html = branch_status_cell(wt);
     render_branch_row_inner(
@@ -312,12 +320,19 @@ fn render_branch_row_worktree(
         &wt.key,
         false,
         node_id,
+        live_set,
     )
 }
 
 /// One peer card (parent or promoted subrepo). Port of
 /// `_render_peer_card`.
-fn render_peer_card(ctx: &RenderCtx, family: &Family, member: &Member, member_id: &str) -> String {
+fn render_peer_card(
+    ctx: &RenderCtx,
+    family: &Family,
+    member: &Member,
+    member_id: &str,
+    live_set: &HashSet<String>,
+) -> String {
     let is_subrepo = member.is_subrepo;
     let is_missing = member.missing;
 
@@ -343,8 +358,8 @@ fn render_peer_card(ctx: &RenderCtx, family: &Family, member: &Member, member_id
     } else {
         "<span class=\"peer-tag peer-tag-clean\">clean</span>".to_string()
     };
-    // Phase 2: no live runner sessions, so never append the "live" tag.
-    let live = false;
+    let member_key = runner_key_for_member(family, member);
+    let live = !is_missing && live_set.contains(&member_key);
     let head_tag = if live {
         format!("{head_tag}<span class=\"peer-tag peer-tag-live\">live</span>")
     } else {
@@ -392,21 +407,20 @@ fn render_peer_card(ctx: &RenderCtx, family: &Family, member: &Member, member_id
         family,
         member,
         &format!("{member_id}/b:main"),
+        live_set,
     ));
     for wt in &member.worktrees {
         let wt_id = format!("{member_id}/wt:{}", wt.key);
-        parts.push(render_branch_row_worktree(ctx, family, member, wt, &wt_id));
+        parts.push(render_branch_row_worktree(
+            ctx, family, member, wt, &wt_id, live_set,
+        ));
     }
     parts.push("</div>".into()); // /peer-rows
 
-    // Inline runner terminal mount — only present when a live session
-    // is running. Phase 2: never.
+    // Inline runner terminal mount — only when the session is live.
     if live {
-        let member_key = runner_key_for_member(family, member);
         let mount = render_runner_mount(&member_key, "main");
-        if !mount.is_empty() {
-            parts.push(format!("<div class=\"peer-term\">{mount}</div>"));
-        }
+        parts.push(format!("<div class=\"peer-term\">{mount}</div>"));
     }
 
     let foot_path = &member.path;
@@ -429,7 +443,12 @@ fn render_peer_card(ctx: &RenderCtx, family: &Family, member: &Member, member_id
 }
 
 /// One family → bucket-grid wrapper. Port of `_render_flat_group`.
-fn render_flat_group(ctx: &RenderCtx, family: &Family, group_id: &str) -> String {
+fn render_flat_group(
+    ctx: &RenderCtx,
+    family: &Family,
+    group_id: &str,
+    live_set: &HashSet<String>,
+) -> String {
     let family_id = format!("{group_id}/{}", family.name);
     let is_compound = family.members.len() > 1;
     let cls = if is_compound {
@@ -450,7 +469,7 @@ fn render_flat_group(ctx: &RenderCtx, family: &Family, group_id: &str) -> String
     }
     for member in &family.members {
         let member_id = format!("{family_id}/m:{}", member.name);
-        parts.push(render_peer_card(ctx, family, member, &member_id));
+        parts.push(render_peer_card(ctx, family, member, &member_id, live_set));
     }
     parts.push("</div>".into());
     parts.join("\n")
@@ -462,6 +481,7 @@ pub fn render_git_repo_fragment(
     ctx: &RenderCtx,
     groups: &[Group],
     node_id: &str,
+    live_set: &HashSet<String>,
 ) -> Option<String> {
     let rest = node_id.strip_prefix("code/")?;
     let (group_label, family_name) = rest.split_once('/')?;
@@ -475,6 +495,7 @@ pub fn render_git_repo_fragment(
                     ctx,
                     family,
                     &format!("code/{group_label}"),
+                    live_set,
                 ));
             }
         }
@@ -484,7 +505,7 @@ pub fn render_git_repo_fragment(
 
 /// Render the full Code tab given the list of discovered groups.
 /// Port of `_render_git_repos`.
-pub fn render_git_repos(ctx: &RenderCtx, groups: &[Group]) -> String {
+pub fn render_git_repos(ctx: &RenderCtx, groups: &[Group], live_set: &HashSet<String>) -> String {
     if groups.is_empty() {
         return String::new();
     }
@@ -499,7 +520,7 @@ pub fn render_git_repos(ctx: &RenderCtx, groups: &[Group]) -> String {
             label = h(&group.label),
         ));
         for family in &group.families {
-            parts.push(render_flat_group(ctx, family, &group_id));
+            parts.push(render_flat_group(ctx, family, &group_id, live_set));
         }
         parts.push("</div></section>".into());
     }

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -16,7 +16,10 @@
 
 pub mod git_render;
 pub mod icons;
+pub mod note_render;
 pub mod templating;
+
+pub use note_render::{raw_payload as note_raw_payload, render_note};
 
 use condash_parser::{knowledge_title_and_desc, Item, KnowledgeCard, KnowledgeNode};
 use condash_state::{collect_git_repos, RenderCtx};
@@ -203,6 +206,7 @@ pub fn render_page(
     items: &[Item],
     knowledge: Option<&KnowledgeNode>,
     version: &str,
+    live_runners: &std::collections::HashSet<String>,
 ) -> String {
     // Sort: by (pri_order, slug[:10]), then within each priority reverse
     // by slug[:10]. Matches Python's two-pass sort exactly.
@@ -267,7 +271,7 @@ pub fn render_page(
     }
 
     let git_groups = collect_git_repos(ctx);
-    let git_html = git_render::render_git_repos(ctx, &git_groups);
+    let git_html = git_render::render_git_repos(ctx, &git_groups, live_runners);
     let count_repos: usize = git_groups.iter().map(|g| g.families.len()).sum();
 
     let knowledge_html = render_knowledge(knowledge);
@@ -401,7 +405,8 @@ mod tests {
             template: "<html>{{CARDS}} | count={{COUNT_PROJECTS}} | v={{VERSION}}</html>".into(),
             ..Default::default()
         };
-        let out = render_page(&ctx, &[], None, "0.99.0");
+        let live: std::collections::HashSet<String> = Default::default();
+        let out = render_page(&ctx, &[], None, "0.99.0", &live);
         assert!(out.contains("count=0"));
         assert!(out.contains("v=0.99.0"));
     }

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -206,7 +206,7 @@ pub fn render_page(
     items: &[Item],
     knowledge: Option<&KnowledgeNode>,
     version: &str,
-    live_runners: &std::collections::HashSet<String>,
+    live_runners: &git_render::LiveRunners,
 ) -> String {
     // Sort: by (pri_order, slug[:10]), then within each priority reverse
     // by slug[:10]. Matches Python's two-pass sort exactly.
@@ -405,7 +405,7 @@ mod tests {
             template: "<html>{{CARDS}} | count={{COUNT_PROJECTS}} | v={{VERSION}}</html>".into(),
             ..Default::default()
         };
-        let live: std::collections::HashSet<String> = Default::default();
+        let live: git_render::LiveRunners = Default::default();
         let out = render_page(&ctx, &[], None, "0.99.0", &live);
         assert!(out.contains("count=0"));
         assert!(out.contains("v=0.99.0"));

--- a/crates/condash-render/src/note_render.rs
+++ b/crates/condash-render/src/note_render.rs
@@ -1,0 +1,253 @@
+//! Note preview HTML — driven by `GET /note`. Dispatches on
+//! [`condash_parser::note_kind`] and emits the markup the dashboard's
+//! view pane mounts into (`_mountPdfsIn`, `_renderMermaidIn`,
+//! `_wireNoteLinks` in `frontend/src/js/dashboard-main.js`).
+//!
+//! The markdown path uses `pulldown-cmark` for the core conversion and
+//! post-processes `[[wikilink]]` / `[[target|label]]` patterns into the
+//! `<a class="wikilink">` and `<a class="wikilink-missing">` shapes the
+//! frontend's click handler already understands. Resolution is a simple
+//! existence check against `base_dir` — conception/projects use
+//! path-style links anyway, so deep wikilink parity with the old
+//! Kasten-style resolver is out of scope for the note-modal port.
+
+use std::path::Path;
+
+use once_cell::sync::Lazy;
+use pulldown_cmark::{html as md_html, Options, Parser};
+use regex::Regex;
+
+use crate::h;
+
+/// `[[target]]` or `[[target|label]]`. Target may contain `/`, `.`, `-`,
+/// `_`; label is anything non-`]`.
+static WIKILINK_RE: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]").expect("wikilink regex compiles"));
+
+/// Render a note for the view pane. `rel_path` is relative to the
+/// conception tree; `full_path` is the resolved absolute path (already
+/// sandbox-validated by the caller).
+pub fn render_note(rel_path: &str, full_path: &Path, base_dir: &Path) -> String {
+    let kind = condash_parser::note_kind(full_path);
+    match kind {
+        "md" => render_markdown(rel_path, full_path, base_dir),
+        "pdf" => render_pdf_host(rel_path, full_path),
+        "image" => render_image(rel_path, full_path),
+        "text" => render_text(full_path),
+        _ => format!(
+            "<p class=\"note-error\">Binary file — use the Plain tab to view or download.</p>"
+        ),
+    }
+}
+
+fn render_markdown(rel_path: &str, full_path: &Path, base_dir: &Path) -> String {
+    let raw = std::fs::read_to_string(full_path).unwrap_or_default();
+    let note_dir = rel_path.rsplit_once('/').map(|(d, _)| d).unwrap_or("");
+    let with_wikilinks = rewrite_wikilinks(&raw, note_dir, base_dir);
+
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+    opts.insert(Options::ENABLE_TASKLISTS);
+    opts.insert(Options::ENABLE_FOOTNOTES);
+    opts.insert(Options::ENABLE_HEADING_ATTRIBUTES);
+    let parser = Parser::new_ext(&with_wikilinks, opts);
+    let mut html = String::new();
+    md_html::push_html(&mut html, parser);
+    format!("<div class=\"note-md\">{html}</div>")
+}
+
+/// Rewrite `[[target]]` / `[[target|label]]` into anchors the frontend
+/// recognises. Existence is checked against `base_dir` when the target
+/// looks path-like; otherwise the wikilink is left as unresolved.
+fn rewrite_wikilinks(src: &str, note_dir: &str, base_dir: &Path) -> String {
+    WIKILINK_RE
+        .replace_all(src, |caps: &regex::Captures| {
+            let target = caps.get(1).map(|m| m.as_str().trim()).unwrap_or("");
+            let label = caps
+                .get(2)
+                .map(|m| m.as_str().trim())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(target);
+            if target.is_empty() {
+                return format!(
+                    "<a class=\"wikilink-missing\" title=\"Empty wikilink\">{}</a>",
+                    h(label)
+                );
+            }
+            let resolved = resolve_wikilink(target, note_dir, base_dir);
+            match resolved {
+                Some(rel) => format!(
+                    "<a class=\"wikilink\" href=\"{}\">{}</a>",
+                    h(&rel),
+                    h(label)
+                ),
+                None => format!(
+                    "<a class=\"wikilink-missing\" title=\"Unresolved wikilink: {}\">{}</a>",
+                    h(target),
+                    h(label)
+                ),
+            }
+        })
+        .into_owned()
+}
+
+fn resolve_wikilink(target: &str, note_dir: &str, base_dir: &Path) -> Option<String> {
+    // Treat `target` as a conception-tree-relative path if it contains `/`
+    // or ends in `.md`; otherwise resolve relative to the note's directory.
+    let candidates: Vec<String> = if target.contains('/') {
+        vec![target.to_string(), format!("{target}.md")]
+    } else if note_dir.is_empty() {
+        vec![target.to_string(), format!("{target}.md")]
+    } else {
+        vec![
+            format!("{note_dir}/{target}"),
+            format!("{note_dir}/{target}.md"),
+            target.to_string(),
+            format!("{target}.md"),
+        ]
+    };
+    for cand in candidates {
+        let full = base_dir.join(&cand);
+        if full.is_file() {
+            return Some(cand);
+        }
+    }
+    None
+}
+
+fn render_pdf_host(rel_path: &str, full_path: &Path) -> String {
+    let filename = full_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| rel_path.to_string());
+    format!(
+        "<div class=\"note-pdf-host\" data-pdf-src=\"/asset/{src}\" data-pdf-filename=\"{name}\"></div>",
+        src = h(rel_path),
+        name = h(&filename),
+    )
+}
+
+fn render_image(rel_path: &str, full_path: &Path) -> String {
+    let alt = full_path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| rel_path.to_string());
+    format!(
+        "<div class=\"note-image\"><img src=\"/asset/{src}\" alt=\"{alt}\" loading=\"lazy\"></div>",
+        src = h(rel_path),
+        alt = h(&alt),
+    )
+}
+
+fn render_text(full_path: &Path) -> String {
+    match std::fs::read_to_string(full_path) {
+        Ok(body) => format!("<pre class=\"note-text\">{}</pre>", h(&body)),
+        Err(_) => "<p class=\"note-error\">Failed to read file.</p>".into(),
+    }
+}
+
+/// File metadata payload returned by `GET /note-raw`. `mtime` is the
+/// modified-time as epoch seconds; `kind` is the same string the view
+/// renderer dispatches on.
+pub fn raw_payload(full_path: &Path) -> Option<serde_json::Value> {
+    let kind = condash_parser::note_kind(full_path);
+    let content = match kind {
+        "md" | "text" => std::fs::read_to_string(full_path).ok()?,
+        _ => return None,
+    };
+    let mtime = full_path
+        .metadata()
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+    Some(serde_json::json!({
+        "content": content,
+        "kind": kind,
+        "mtime": mtime,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write(path: &Path, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn markdown_renders_headings_and_links() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let note = base.join("projects/2026-04/foo/notes/a.md");
+        write(&note, "# Title\n\nSee [link](../README.md).\n");
+        let html = render_note("projects/2026-04/foo/notes/a.md", &note, base);
+        assert!(html.contains("<h1"));
+        assert!(html.contains("Title"));
+        assert!(html.contains("href=\"../README.md\""));
+    }
+
+    #[test]
+    fn wikilinks_resolve_against_base() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let note = base.join("projects/2026-04/foo/README.md");
+        write(&note, "body\n");
+        let target = base.join("knowledge/conventions.md");
+        write(&target, "k\n");
+        let src = "See [[knowledge/conventions.md|conv]] and [[missing/thing]].";
+        let out = rewrite_wikilinks(src, "projects/2026-04/foo", base);
+        assert!(out.contains("class=\"wikilink\""));
+        assert!(out.contains("href=\"knowledge/conventions.md\""));
+        assert!(out.contains("class=\"wikilink-missing\""));
+    }
+
+    #[test]
+    fn pdf_host_emits_expected_attrs() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let pdf = base.join("projects/2026-04/foo/notes/report.pdf");
+        write(&pdf, "%PDF-1.4\n");
+        let html = render_note("projects/2026-04/foo/notes/report.pdf", &pdf, base);
+        assert!(html.contains("class=\"note-pdf-host\""));
+        assert!(html.contains("data-pdf-src=\"/asset/projects/2026-04/foo/notes/report.pdf\""));
+        assert!(html.contains("data-pdf-filename=\"report.pdf\""));
+    }
+
+    #[test]
+    fn image_emits_asset_url() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let img = base.join("k/photo.png");
+        write(&img, "PNG");
+        let html = render_note("k/photo.png", &img, base);
+        assert!(html.contains("<img"));
+        assert!(html.contains("src=\"/asset/k/photo.png\""));
+    }
+
+    #[test]
+    fn raw_payload_roundtrips_md() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let note = base.join("note.md");
+        write(&note, "# hi\n");
+        let v = raw_payload(&note).expect("payload");
+        assert_eq!(v["kind"], "md");
+        assert_eq!(v["content"], "# hi\n");
+        assert!(v["mtime"].as_f64().unwrap() > 0.0);
+    }
+
+    #[test]
+    fn raw_payload_none_for_binary() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let pdf = base.join("note.pdf");
+        write(&pdf, "%PDF");
+        assert!(raw_payload(&pdf).is_none());
+    }
+}

--- a/crates/condash-state/src/ctx.rs
+++ b/crates/condash-state/src/ctx.rs
@@ -28,12 +28,14 @@ pub struct RepoEntry {
 }
 
 /// One "Open with …" slot config entry. Mirrors Python's
-/// `OpenWithSlot` — only the user-visible `label` is needed for
-/// rendering; the `commands` list is used by the mutations / openers
-/// layer (Phase 3+) and lives elsewhere.
+/// `OpenWithSlot`: the user-visible `label` drives rendering, and the
+/// `commands` fallback chain is tried in order by the openers layer.
+/// Each command is a shell template with `{path}` substitution — the
+/// first that exits 0 wins.
 #[derive(Debug, Clone, Default)]
 pub struct OpenWithSlot {
     pub label: String,
+    pub commands: Vec<String>,
 }
 
 /// Embedded-terminal preferences. Carries the Python

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -3044,7 +3044,13 @@ function refreshAll() {
     _pendingReloadInPlace = false;
     _lastFingerprint = null;
     _lastGitFingerprint = null;
-    location.reload();
+    // Force-invalidate the server-side items/knowledge caches before
+    // reloading so the next GET / re-walks the tree from disk. Best
+    // effort: reload unconditionally even if the POST errors, since
+    // `location.reload()` is also the user-requested action.
+    fetch('/rescan', {method: 'POST'})
+        .catch(function() {})
+        .finally(function() { location.reload(); });
 }
 
 /* --- Local subtree reload ---
@@ -4985,8 +4991,12 @@ Object.assign(window, {
     openConfigModal, openNewItemModal, openAboutModal,
     closeConfigModal, closeNewItemModal, closeAboutModal, closeNotePreview,
     toggleTheme, toggleTerminal, termNewTab, termNewLauncherTab,
+    termDragStart, termSplitStart,
     switchTab, switchSubtab, switchConfigTab, refreshAll, setNoteMode,
-    noteSearchStep, noteSearchClose, saveEdit, noteNavBack,
+    noteSearchStep, noteSearchClose, noteSearchRun, saveEdit, noteNavBack,
+    openPath,
+    filterHistory, filterKnowledge,
+    saveConfig, submitNewItem, _setDirty,
     jumpToProject, _openHistoryHit,
     _noteReconcileDismiss, _noteReconcileReload,
 });

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.0.2"
+version = "1.0.3"
 description = "Conception dashboard — Tauri port (Phase 0 scaffold)"
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -121,7 +121,8 @@ enum SubmoduleYaml {
 struct OpenWithSlotYaml {
     #[serde(default)]
     label: Option<String>,
-    // commands: skipped for Phase 2 — consumed by the mutations layer.
+    #[serde(default)]
+    commands: Vec<String>,
 }
 
 /// Path to the merged configuration file inside a conception tree.
@@ -220,7 +221,13 @@ pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> 
             .into_iter()
             .map(|(key, slot)| {
                 let label = slot.label.unwrap_or_else(|| key.clone());
-                (key, OpenWithSlot { label })
+                (
+                    key,
+                    OpenWithSlot {
+                        label,
+                        commands: slot.commands,
+                    },
+                )
             })
             .collect();
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use tauri::Manager;
 pub mod assets;
 pub mod config;
 pub mod events;
+pub mod openers;
 pub mod paths;
 pub mod pty;
 pub mod runners;

--- a/src-tauri/src/openers.rs
+++ b/src-tauri/src/openers.rs
@@ -1,0 +1,127 @@
+//! External-launcher helpers — one place to spawn IDE / file-manager /
+//! PDF-viewer / browser processes, detached from the condash lifetime.
+//!
+//! Port of `src/condash/openers.py` (Python build). Shape: take a
+//! shell-template fallback chain, substitute `{path}` (or `{url}`),
+//! spawn each in order until one exits 0 within a short window.
+//! Spawning is detached via `/bin/sh -c` with all standard streams
+//! redirected to `/dev/null`, so condash doesn't hold the child's
+//! output buffers and the process outlives the window.
+
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Default fallbacks for `POST /open-folder` when no `open_with.folder`
+/// slot is configured. Tried in order; first that exits 0 wins.
+pub const FOLDER_FALLBACKS: &[&str] = &[
+    "xdg-open {path}",
+    "gio open {path}",
+    "nautilus {path}",
+    "dolphin {path}",
+    "thunar {path}",
+];
+
+/// Default fallbacks for `POST /open-doc` when no `pdf_viewer` chain is
+/// configured. Tried in order.
+pub const DOC_FALLBACKS: &[&str] = &[
+    "xdg-open {path}",
+    "gio open {path}",
+    "evince {path}",
+    "okular {path}",
+    "zathura {path}",
+];
+
+/// Default fallbacks for `POST /open-external` URLs.
+pub const URL_FALLBACKS: &[&str] = &["xdg-open {url}", "gio open {url}"];
+
+/// How long to wait on each candidate before moving on to the next.
+/// Long enough for a cold Electron launcher to fork its child, short
+/// enough that a no-op wrong-chain iteration doesn't hang the UI.
+const ATTEMPT_GRACE: Duration = Duration::from_millis(600);
+
+/// Substitute `{path}` in `template` with `value`. Also supports the
+/// `{url}` alias so the URL fallbacks and the path fallbacks share the
+/// same substitutor.
+pub fn substitute(template: &str, key: &str, value: &str) -> String {
+    template
+        .replace(&format!("{{{key}}}"), value)
+        .replace("{path}", value)
+}
+
+/// Try each template in order with `{path}` / `{url}` replaced by
+/// `value`. Returns the template that won, or `None` if the whole chain
+/// fell through. Spawns detached — the child owns its own session so
+/// closing condash doesn't take the IDE down.
+pub fn try_chain(templates: &[String], key: &str, value: &str) -> Option<String> {
+    for tpl in templates {
+        let filled = substitute(tpl, key, value);
+        if filled.trim().is_empty() {
+            continue;
+        }
+        match Command::new("sh")
+            .arg("-c")
+            .arg(&filled)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+        {
+            Ok(mut child) => {
+                let deadline = Instant::now() + ATTEMPT_GRACE;
+                loop {
+                    match child.try_wait() {
+                        Ok(Some(status)) => {
+                            if status.success() {
+                                return Some(tpl.clone());
+                            }
+                            break;
+                        }
+                        Ok(None) => {
+                            if Instant::now() >= deadline {
+                                // Still running past the grace window —
+                                // assume the GUI launcher forked and
+                                // treat as success. `xdg-open` exits
+                                // quickly; `idea` forks and lingers.
+                                return Some(tpl.clone());
+                            }
+                            std::thread::sleep(Duration::from_millis(20));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
+/// Convenience wrapper — same as [`try_chain`] but accepts `&[&str]`.
+pub fn try_chain_static(templates: &[&str], key: &str, value: &str) -> Option<String> {
+    let owned: Vec<String> = templates.iter().map(|s| s.to_string()).collect();
+    try_chain(&owned, key, value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn substitute_replaces_both_path_and_url_aliases() {
+        assert_eq!(substitute("xdg-open {path}", "url", "x"), "xdg-open x");
+        assert_eq!(substitute("xdg-open {url}", "url", "x"), "xdg-open x");
+    }
+
+    #[test]
+    fn try_chain_returns_first_successful() {
+        let chain = vec!["false".into(), "true".into(), "true".into()];
+        let won = try_chain(&chain, "path", "/tmp").expect("one succeeds");
+        assert_eq!(won, "true");
+    }
+
+    #[test]
+    fn try_chain_returns_none_when_all_fail() {
+        let chain = vec!["/nonexistent-binary-xyz --arg".into(), "false".into()];
+        assert!(try_chain(&chain, "path", "/tmp").is_none());
+    }
+}

--- a/src-tauri/src/runners.rs
+++ b/src-tauri/src/runners.rs
@@ -89,6 +89,20 @@ impl RunnerRegistry {
             .collect()
     }
 
+    /// Snapshot of every registry entry — the caller iterates to build
+    /// whatever aggregate it needs (e.g. the renderer's `LiveRunners`
+    /// map) without holding the mutex across the build. Both live and
+    /// exited sessions are returned; filter on `exit_code_now()` if
+    /// you only want the running ones.
+    pub fn snapshot(&self) -> Vec<Arc<RunnerSession>> {
+        self.inner
+            .lock()
+            .expect("runners mutex")
+            .values()
+            .cloned()
+            .collect()
+    }
+
     pub fn len(&self) -> usize {
         self.inner.lock().expect("runners mutex").len()
     }

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -800,8 +800,7 @@ fn error_json(code: StatusCode, msg: &str) -> Response {
 async fn index(State(state): State<AppState>) -> impl IntoResponse {
     let items = state.cache.get_items(&state.ctx);
     let knowledge = state.cache.get_knowledge(&state.ctx);
-    let live_runners: std::collections::HashSet<String> =
-        state.runner_registry.keys().into_iter().collect();
+    let live_runners = live_runners_snapshot(&state);
     let html = render_page(
         &state.ctx,
         &items,
@@ -810,6 +809,26 @@ async fn index(State(state): State<AppState>) -> impl IntoResponse {
         &live_runners,
     );
     html_response(html)
+}
+
+/// Build the renderer's `LiveRunners` map from the current runner
+/// registry. One entry per session (live or exited); the renderer
+/// decides whether to paint the mount as running or "exited: N".
+fn live_runners_snapshot(state: &AppState) -> condash_render::git_render::LiveRunners {
+    state
+        .runner_registry
+        .snapshot()
+        .into_iter()
+        .map(|session| {
+            (
+                session.key.clone(),
+                condash_render::git_render::RunnerLive {
+                    checkout_key: session.checkout_key.clone(),
+                    exit_code: session.exit_code_now(),
+                },
+            )
+        })
+        .collect()
 }
 
 #[derive(Debug, Deserialize)]
@@ -854,8 +873,7 @@ async fn fragment(
             return error(StatusCode::NOT_FOUND, "use global reload");
         }
         let groups = collect_git_repos(&state.ctx);
-        let live_runners: std::collections::HashSet<String> =
-            state.runner_registry.keys().into_iter().collect();
+        let live_runners = live_runners_snapshot(&state);
         if let Some(html) = render_git_repo_fragment(&state.ctx, &groups, &id, &live_runners) {
             return html_response(html);
         }

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -151,6 +151,25 @@ pub async fn start_on(state: AppState, port: u16) -> Result<u16> {
     Ok(port)
 }
 
+/// Middleware — log any non-2xx response at warn-level with method +
+/// path + status. Written to stderr so it lands in the Tauri host's
+/// stdout capture and in `condash-serve`'s console. Keeps silent 404s
+/// from hiding unported routes; a future regression shows up as a
+/// one-liner after the first click.
+async fn log_non_2xx(
+    req: axum::extract::Request,
+    next: axum::middleware::Next,
+) -> axum::response::Response {
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let response = next.run(req).await;
+    let status = response.status();
+    if status.is_client_error() || status.is_server_error() {
+        eprintln!("[condash] {method} {path} -> {}", status.as_u16());
+    }
+    response
+}
+
 pub fn build_router(state: AppState) -> Router {
     Router::new()
         .route("/", get(index))
@@ -178,18 +197,39 @@ pub fn build_router(state: AppState) -> Router {
         .route("/api/runner/stop", post(runner_stop_route))
         .route("/ws/runner/{key}", get(runner_ws))
         // Phase 3 slice 3 — file-level mutations.
-        .route("/note", post(post_note))
+        .route("/note", get(get_note).post(post_note))
+        .route("/note-raw", get(get_note_raw))
         .route("/note/rename", post(post_note_rename))
         .route("/note/create", post(post_note_create))
         .route("/note/mkdir", post(post_note_mkdir))
         .route("/note/upload", post(post_note_upload))
         .route("/create-item", post(post_create_item))
+        // `/api/items` is the legacy path the bundled frontend still
+        // calls for the New Item modal. Kept as an alias so the modal
+        // works without a frontend rebuild; semantically identical.
+        .route("/api/items", post(post_create_item))
         // Configuration modal — plain-text YAML editor of
         // <conception>/configuration.yml.
         .route(
             "/configuration",
             get(get_configuration).post(post_configuration),
         )
+        // Legacy config summary — used by the frontend for setup-banner
+        // detection and terminal shortcut loading. Returns a small JSON
+        // dict with `conception_path` + `terminal` fields only.
+        .route("/config", get(get_config_summary))
+        // Open-path surface — these four dispatch the user-visible
+        // "Open with", "Open folder", "Open external", "Open doc"
+        // actions into detached external processes.
+        .route("/open", post(post_open))
+        .route("/open-folder", post(post_open_folder))
+        .route("/open-external", post(post_open_external))
+        .route("/open-doc", post(post_open_doc))
+        // Hard-refresh hook — rebuild RenderCtx from disk + invalidate
+        // cached slices. `refreshAll` in the frontend hits this before
+        // `location.reload()`.
+        .route("/rescan", post(post_rescan))
+        .layer(axum::middleware::from_fn(log_non_2xx))
         .with_state(state)
 }
 
@@ -376,6 +416,48 @@ async fn reorder_all_route(
 // Shape matches `src/condash/routes/notes.py` and
 // `src/condash/routes/items.py`.
 // ---------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct NotePathQuery {
+    #[serde(default)]
+    path: String,
+}
+
+/// `GET /note?path=…` — rendered HTML for the modal view pane. Dispatches
+/// on `note_kind` and returns preformatted text, `<img>`, a PDF host
+/// placeholder the frontend mounts PDF.js into, or the markdown render.
+async fn get_note(
+    State(state): State<AppState>,
+    Query(q): Query<NotePathQuery>,
+) -> impl IntoResponse {
+    if q.path.is_empty() {
+        return error(StatusCode::BAD_REQUEST, "missing path");
+    }
+    let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &q.path) else {
+        return error(StatusCode::FORBIDDEN, "invalid path");
+    };
+    let html = condash_render::render_note(&q.path, &full, &state.ctx.base_dir);
+    html_response(html)
+}
+
+/// `GET /note-raw?path=…` — JSON `{content, kind, mtime}` for the edit
+/// pane. Binary kinds (pdf/image) return 415 so the frontend silently
+/// leaves the edit modes disabled (it catches the non-ok response).
+async fn get_note_raw(
+    State(state): State<AppState>,
+    Query(q): Query<NotePathQuery>,
+) -> impl IntoResponse {
+    if q.path.is_empty() {
+        return error_json(StatusCode::BAD_REQUEST, "missing path");
+    }
+    let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &q.path) else {
+        return error_json(StatusCode::FORBIDDEN, "invalid path");
+    };
+    match condash_render::note_raw_payload(&full) {
+        Some(body) => json_response(&body),
+        None => error_json(StatusCode::UNSUPPORTED_MEDIA_TYPE, "not editable"),
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct NoteWritePayload {
@@ -718,11 +800,14 @@ fn error_json(code: StatusCode, msg: &str) -> Response {
 async fn index(State(state): State<AppState>) -> impl IntoResponse {
     let items = state.cache.get_items(&state.ctx);
     let knowledge = state.cache.get_knowledge(&state.ctx);
+    let live_runners: std::collections::HashSet<String> =
+        state.runner_registry.keys().into_iter().collect();
     let html = render_page(
         &state.ctx,
         &items,
         knowledge.as_ref().as_ref(),
         &state.version,
+        &live_runners,
     );
     html_response(html)
 }
@@ -769,7 +854,9 @@ async fn fragment(
             return error(StatusCode::NOT_FOUND, "use global reload");
         }
         let groups = collect_git_repos(&state.ctx);
-        if let Some(html) = render_git_repo_fragment(&state.ctx, &groups, &id) {
+        let live_runners: std::collections::HashSet<String> =
+            state.runner_registry.keys().into_iter().collect();
+        if let Some(html) = render_git_repo_fragment(&state.ctx, &groups, &id, &live_runners) {
             return html_response(html);
         }
         return error(StatusCode::NOT_FOUND, "repo not found");
@@ -1496,12 +1583,196 @@ async fn post_configuration(State(state): State<AppState>, body: String) -> Resp
         return error(StatusCode::BAD_REQUEST, &format!("{e}"));
     }
     match crate::config::write_configuration(&state.ctx.base_dir, &body) {
-        Ok(_path) => (
-            StatusCode::OK,
-            [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
-            "saved. Close and reopen condash for changes to take effect.\n",
-        )
-            .into_response(),
+        Ok(_path) => {
+            // Invalidate caches so the next `/` hit re-walks the tree.
+            // The RenderCtx itself still only rebuilds on restart or
+            // /rescan — the modal's success message tells the user as
+            // much.
+            state.cache.invalidate_items();
+            state.cache.invalidate_knowledge();
+            (
+                StatusCode::OK,
+                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+                "saved. Close and reopen condash for changes to take effect.\n",
+            )
+                .into_response()
+        }
         Err(e) => error(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e}")),
     }
+}
+
+// ---------------------------------------------------------------------
+// Legacy `/config` summary endpoint — kept for the bundled frontend's
+// setup-banner detection and terminal-shortcut loader. Returns only the
+// fields those two callers actually use. For full-config editing the
+// frontend uses `/configuration`.
+// ---------------------------------------------------------------------
+
+async fn get_config_summary(State(state): State<AppState>) -> Response {
+    let conception_path = state.ctx.base_dir.to_string_lossy().into_owned();
+    let term = &state.ctx.terminal;
+    let body = serde_json::json!({
+        "conception_path": conception_path,
+        "terminal": {
+            "shell": term.shell.clone().unwrap_or_default(),
+            "shortcut": term.shortcut.clone().unwrap_or_default(),
+            "screenshot_dir": term.screenshot_dir.clone().unwrap_or_default(),
+            "screenshot_paste_shortcut": term.screenshot_paste_shortcut.clone().unwrap_or_default(),
+            "launcher_command": term.launcher_command.clone().unwrap_or_default(),
+            "move_tab_left_shortcut": term.move_tab_left_shortcut.clone().unwrap_or_default(),
+            "move_tab_right_shortcut": term.move_tab_right_shortcut.clone().unwrap_or_default(),
+        }
+    });
+    json_response(&body)
+}
+
+// ---------------------------------------------------------------------
+// External-opener routes — `POST /open`, `/open-folder`, `/open-external`,
+// `/open-doc`. Each one validates the incoming path (URL for
+// /open-external) and dispatches to the openers module, which spawns a
+// detached `sh -c "<template with {path} filled in>"` and walks the
+// configured fallback chain. Returns 200 on first success, 502 when the
+// entire chain falls through, 400/403 on validation failures.
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct OpenPayload {
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    tool: String,
+}
+
+async fn post_open(State(state): State<AppState>, Json(p): Json<OpenPayload>) -> impl IntoResponse {
+    if p.path.trim().is_empty() || p.tool.trim().is_empty() {
+        return error_json(StatusCode::BAD_REQUEST, "path and tool required");
+    }
+    let Some(validated) = validate_open_path(&state.ctx, &p.path) else {
+        return error_json(StatusCode::FORBIDDEN, "path out of sandbox");
+    };
+    let Some(slot) = state.ctx.open_with.get(&p.tool) else {
+        return error_json(StatusCode::NOT_FOUND, &format!("unknown tool: {}", p.tool));
+    };
+    if slot.commands.is_empty() {
+        return error_json(
+            StatusCode::FAILED_DEPENDENCY,
+            &format!("no commands configured for {}", p.tool),
+        );
+    }
+    let value = validated.to_string_lossy().into_owned();
+    match crate::openers::try_chain(&slot.commands, "path", &value) {
+        Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
+        None => error_json(StatusCode::BAD_GATEWAY, "all commands failed"),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct PathOnlyPayload {
+    #[serde(default)]
+    path: String,
+}
+
+async fn post_open_folder(
+    State(state): State<AppState>,
+    Json(p): Json<PathOnlyPayload>,
+) -> impl IntoResponse {
+    if p.path.trim().is_empty() {
+        return error_json(StatusCode::BAD_REQUEST, "path required");
+    }
+    let Some(validated) = validate_open_path(&state.ctx, &p.path) else {
+        return error_json(StatusCode::FORBIDDEN, "path out of sandbox");
+    };
+    let value = validated.to_string_lossy().into_owned();
+    match crate::openers::try_chain_static(crate::openers::FOLDER_FALLBACKS, "path", &value) {
+        Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
+        None => error_json(StatusCode::BAD_GATEWAY, "no folder opener succeeded"),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ExternalPayload {
+    #[serde(default)]
+    url: String,
+}
+
+async fn post_open_external(Json(p): Json<ExternalPayload>) -> impl IntoResponse {
+    let url = p.url.trim();
+    if url.is_empty() {
+        return error_json(StatusCode::BAD_REQUEST, "url required");
+    }
+    // Only hand verified URL schemes to `xdg-open` — never bare paths
+    // or `javascript:` / `data:` tricks the webview might let through.
+    let allowed = url.starts_with("http://")
+        || url.starts_with("https://")
+        || url.starts_with("mailto:")
+        || url.starts_with("file://");
+    if !allowed {
+        return error_json(StatusCode::BAD_REQUEST, "unsupported url scheme");
+    }
+    match crate::openers::try_chain_static(crate::openers::URL_FALLBACKS, "url", url) {
+        Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
+        None => error_json(StatusCode::BAD_GATEWAY, "no url opener succeeded"),
+    }
+}
+
+async fn post_open_doc(
+    State(state): State<AppState>,
+    Json(p): Json<PathOnlyPayload>,
+) -> impl IntoResponse {
+    if p.path.trim().is_empty() {
+        return error_json(StatusCode::BAD_REQUEST, "path required");
+    }
+    // /open-doc may land on an absolute path (from a note link) or a
+    // conception-tree-relative path (from a card button). Try to
+    // resolve it either way inside the sandbox. The note-link path is
+    // already sandbox-safe (the note path itself was validated to open
+    // the modal), so we first try the raw value and fall back to
+    // base_dir-rooted resolution.
+    let full = match validate_open_path(&state.ctx, &p.path) {
+        Some(v) => v,
+        None => {
+            let rel = state.ctx.base_dir.join(&p.path);
+            match std::fs::canonicalize(&rel).ok().and_then(|c| {
+                let base = std::fs::canonicalize(&state.ctx.base_dir).ok()?;
+                if c.starts_with(&base) {
+                    Some(c)
+                } else {
+                    None
+                }
+            }) {
+                Some(v) => v,
+                None => return error_json(StatusCode::FORBIDDEN, "path out of sandbox"),
+            }
+        }
+    };
+    let value = full.to_string_lossy().into_owned();
+    // Prefer the user's configured pdf_viewer chain; fall back to the
+    // xdg-open / gio open chain.
+    let chain: Vec<String> = if state.ctx.pdf_viewer.is_empty() {
+        crate::openers::DOC_FALLBACKS
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    } else {
+        state.ctx.pdf_viewer.clone()
+    };
+    match crate::openers::try_chain(&chain, "path", &value) {
+        Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
+        None => error_json(StatusCode::BAD_GATEWAY, "no doc opener succeeded"),
+    }
+}
+
+// ---------------------------------------------------------------------
+// Hard-refresh — invalidate cached slices. The RenderCtx itself still
+// rebuilds only when the user actively edits configuration.yml through
+// the modal; this endpoint exists so the top-bar refresh button forces
+// a fresh filesystem walk through the WorkspaceCache on the next
+// request, picking up out-of-band edits (git pull, external renames,
+// direct YAML hand-edits after close+reopen).
+// ---------------------------------------------------------------------
+
+async fn post_rescan(State(state): State<AppState>) -> impl IntoResponse {
+    state.cache.invalidate_items();
+    state.cache.invalidate_knowledge();
+    json_response(&serde_json::json!({"ok": true}))
 }


### PR DESCRIPTION
## Summary

- The Rust/Tauri port of condash left five user-facing interactions broken after the 2026-04-22 repo swap (Open note, Run dev server, Open with, terminal resize/splitter, Hard refresh). This PR closes the port and bumps to v1.0.3 — patch, because every change is a fix or observability hook.
- A separate commit unblocks the Windows bundle job on CI, which was failing before any Rust compilation because hosted runners do not have sccache installed.

## Changes

- Frontend: extend the `Object.assign(window, { … })` tail of `dashboard-main.js` with `openPath`, `termDragStart`, `termSplitStart`, `saveConfig`, `submitNewItem`, `filterHistory`, `filterKnowledge`, `noteSearchRun`, `_setDirty`. The bundle is built as an esbuild IIFE (`--format=iife --global-name=Condash`), so any inline `onclick` / `onmousedown` / `onsubmit` referencing a symbol not in this list throws `ReferenceError` at runtime.
- Server: register `GET /note` and `GET /note-raw` (missing since the port). The view pane is driven by a new `condash-render::note_render` module that dispatches on `note_kind` — `pulldown-cmark` for markdown with wikilink rewrite, a `.note-pdf-host` placeholder the frontend mounts PDF.js into, `<img>` for images, `<pre>` for text. The edit pane gets `{content, kind, mtime}` JSON.
- Server: register `POST /open`, `/open-folder`, `/open-external`, `/open-doc`. A new `src-tauri/src/openers.rs` spawns `sh -c "<template>"` detached and walks a fallback chain. `/open-external` accepts only `http(s)` / `mailto` / `file` schemes. All four path-based routes revalidate through `validate_open_path` against `ctx.workspace` / `ctx.worktrees`.
- Server: `POST /rescan` invalidates the items + knowledge cache slices; the frontend `refreshAll` awaits it before `location.reload()`. `GET /config` returns a small summary JSON for the two legacy frontend callers (setup-banner + terminal shortcuts). `/api/items` is aliased to `/create-item` so the New Item modal works without a frontend rewrite.
- Server: an axum middleware layer writes `METHOD PATH -> STATUS` to stderr for any 4xx/5xx response, so the next unported route is not silent.
- State: `OpenWithSlot` gains `commands: Vec<String>`; `OpenWithSlotYaml` now parses the `commands` list from `configuration.yml`, so the YAML `open_with.*.commands` fallback chain actually reaches the opener module.
- Render: `render_runner_mount` now emits a real `<div class="runner-term-mount" data-runner-key data-runner-checkout>` when the key is live, and `is_live` is computed from a live-set threaded through `render_git_repos` / `render_git_repo_fragment` / `render_page`. The server passes `state.runner_registry.keys()` so the Code tab reflects runner state after start/stop.
- CI (separate commit): `CARGO_BUILD_RUSTC_WRAPPER` is unset on hosted runners. `Swatinem/rust-cache` already caches cargo artifacts across CI runs, so stacking sccache on top buys nothing and was breaking every rustc invocation on Windows with `could not execute process sccache`.
- Bump `src-tauri/Cargo.toml` to `1.0.3`.

## Impact

- Opening a note modal now succeeds for `.md`, `.pdf`, image and text kinds.
- Clicking "Run dev server" on a Code row spawns the PTY as before **and** surfaces output inline; the peer card flips to a `live` state.
- "Open with → Open in main IDE / secondary IDE / terminal" actually launches the configured command.
- Terminal pane vertical drag handle and the left/right splitter both respond to mouse drag.
- The top-bar hard refresh button forces a disk rescan before `location.reload()` — out-of-band edits (git pull, hand-edits to `configuration.yml`) surface without restart.
- The Windows bundle step in the release workflow no longer fails before compilation.

## Watchpoints

- The local signal is a dev-profile `cargo test --workspace` (all 24-ish suites green). CI runs a release Tauri bundle for all three OSes via `tauri-action`; the authoritative signal is that run succeeding, not the local check.
- Markdown rendering uses `pulldown-cmark`; wikilinks resolve via a small regex + existence check rather than the Python resolver. Parity with the old pandoc output is intentional-approximate — watch for broken wikilinks on notes that relied on Kasten-style resolution.
- `/open-external` safelists only `http(s)` / `mailto:` / `file:` URL schemes. If a note link contains something else (`ssh://`, `magnet:`) the route 400s; confirm in practice that no real note depends on those.
- The 404 stderr log is best-effort — in Tauri release bundles that stream goes to the OS-specific console (launch-from-terminal on Linux, Console.app on macOS, nowhere visible on Windows). Works for dev debugging, less useful post-ship.