### PR TITLE
Sync tauri.conf.json version, refresh description, bump v1.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.0.3"
+version = "1.0.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "condash"
-version = "1.0.3"
-description = "Conception dashboard — Tauri port (Phase 0 scaffold)"
+version = "1.0.4"
+description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "0.20.1",
+  "version": "1.0.4",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"
@@ -23,7 +23,7 @@
       "icons/icon.ico"
     ],
     "category": "DeveloperTool",
-    "shortDescription": "Conception dashboard",
-    "longDescription": "Standalone desktop dashboard for markdown-based conception items. Tauri port (Phase 0)."
+    "shortDescription": "A dashboard for the Markdown you already write.",
+    "longDescription": "condash renders a live desktop view of a conception/ Markdown tree — projects, incidents, documents, knowledge. Checklists, priorities, notes, and code-row git status all map directly to files on disk, so hand edits and condash edits stay in sync."
   }
 }


### PR DESCRIPTION
## Summary

- The `v1.0.3` release uploaded artifacts named `condash-0.20.1_*` (e.g. `condash-0.20.1_amd64.AppImage`) because `src-tauri/tauri.conf.json` still carried the pre-swap Python-era `"version": "0.20.1"`. Tauri prefers the JSON version over `Cargo.toml` during bundling, so the Cargo bump did not reach the artifact names.
- Brings both files back in sync at `1.0.4` and refreshes the obsolete `"Tauri port (Phase 0 scaffold)"` description to something end-user-facing.

## Changes

- `src-tauri/tauri.conf.json`: `version` 0.20.1 → 1.0.4.
- `src-tauri/tauri.conf.json`: `shortDescription` + `longDescription` rewritten — they ship in the Linux `.desktop` entry and the Windows installer metadata, so the old Phase-0 wording was visible to installing users.
- `src-tauri/Cargo.toml`: `version` 1.0.3 → 1.0.4, `description` → "A dashboard for the Markdown you already write."
- `Cargo.lock`: regenerated for the new crate version.

## Impact

- Next `v*` tag push publishes artifacts with consistent filenames (`condash-1.0.4_*`) and a non-developer-facing description in install-dialog UI (SmartScreen, Open Anyway, `.desktop` launcher).
- The existing v1.0.3 GitHub release keeps its misnamed artifacts. Either rename manually on the release page, delete + re-publish with v1.0.4 as the first "clean" user-facing release, or leave it — up to you; the binaries themselves are fine, only the filenames were wrong.

## Watchpoints

- Tauri did not accept `"version": "../Cargo.toml"` as a pointer (`failed to read version JSON file: expected value at line 1 column 2`), so the two files must be bumped together going forward. Consider a pre-push hook or a `make bump-version VERSION=…` target in a follow-up if this drifts again.