### PR TITLE
condash hygiene sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,7 +644,6 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tower",
- "tower-http",
 ]
 
 [[package]]
@@ -1860,12 +1859,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -5008,24 +5001,14 @@ checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
- "http-body-util",
- "http-range-header",
- "httpdate",
  "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
- "tokio",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/condash-render/src/git_render.rs
+++ b/crates/condash-render/src/git_render.rs
@@ -14,26 +14,9 @@ use std::collections::HashMap;
 
 use condash_state::{Checkout, Family, Group, Member, RenderCtx};
 
+use crate::h;
 use crate::icons::Icons;
 use crate::templating::embed_attr;
-
-/// HTML-escape — mirror of Python's `html.escape(str(text), quote=True)`.
-/// Kept separate from the minijinja formatter so raw string builders
-/// (this module, `render_page`) can share it.
-fn h(text: &str) -> String {
-    let mut out = String::with_capacity(text.len());
-    for c in text.chars() {
-        match c {
-            '&' => out.push_str("&amp;"),
-            '<' => out.push_str("&lt;"),
-            '>' => out.push_str("&gt;"),
-            '"' => out.push_str("&quot;"),
-            '\'' => out.push_str("&#x27;"),
-            other => out.push(other),
-        }
-    }
-    out
-}
 
 /// Canonical runner-registry key. Mirrors `_runner_key` in Python.
 pub fn runner_key(repo_name: &str, sub_name: Option<&str>) -> String {

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -1,18 +1,21 @@
 //! HTML rendering for the conception dashboard.
 //!
-//! Rust port of `src/condash/render.py`. Pairs with `condash-parser`
-//! (item + knowledge data types) and `condash-state` (`RenderCtx`,
-//! cache). The Jinja2 templates under `crates/condash-render/templates/` are
-//! embedded verbatim via `include_str!` in [`templating`] and driven
-//! through `minijinja` — no runtime filesystem dependency, no template
-//! deviation from the Python build.
+//! Pairs with `condash-parser` (item + knowledge data types) and
+//! `condash-state` (`RenderCtx`, cache). The Jinja2 templates under
+//! `crates/condash-render/templates/` are embedded verbatim via
+//! `include_str!` in [`templating`] and driven through `minijinja` —
+//! no runtime filesystem dependency.
 //!
-//! Phase 2 slice 3 covers the cards, knowledge tree, history, and
-//! dashboard shell. Git-strip rendering is stubbed to an empty string
-//! here; slice 4 wires the real implementation alongside `git_scan`.
-//! Note rendering (`_render_note`, `_render_markdown`) is deferred —
-//! those paths depend on pandoc + wikilink resolution and land with
-//! the note routes in a later slice.
+//! Surface:
+//!
+//! - [`render_page`] — the full dashboard shell (cards, knowledge tree,
+//!   history, git strip).
+//! - [`render_card_fragment`] / [`render_knowledge_card_fragment`] /
+//!   [`render_knowledge_group_fragment`] — per-node fragments used by
+//!   the long-poll `/fragment` endpoint.
+//! - [`git_render`] — the git-strip (peer cards, runner buttons).
+//! - [`note_render`] — the `/note` read path (markdown → HTML via
+//!   pulldown-cmark, wikilink resolution, raw-payload accessor).
 
 pub mod git_render;
 pub mod icons;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ rand = "0.8"
 rust-embed = { version = "8", features = ["mime-guess"] }
 mime_guess = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros", "sync", "time"] }
-tower-http = { version = "0.6", features = ["fs"] }
 notify = "8"
 futures-util = { version = "0.3", default-features = false }
 tokio-stream = { version = "0.1", features = ["sync"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.0.16"
+version = "1.0.17"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/bin/condash_serve.rs
+++ b/src-tauri/src/bin/condash_serve.rs
@@ -71,13 +71,12 @@ async fn async_main() -> Result<()> {
     };
 
     // Honor CONDASH_PORT if set, else pick a free one like the Tauri
-    // host does.
-    let port = if let Some(p) = std::env::var("CONDASH_PORT").ok() {
-        let port: u16 = p.parse().context("CONDASH_PORT is not a u16")?;
-        condash_lib::server::start_on(state, port).await?
-    } else {
-        condash_lib::server::start(state).await?
+    // host does (port = 0).
+    let requested_port = match std::env::var("CONDASH_PORT").ok() {
+        Some(p) => p.parse::<u16>().context("CONDASH_PORT is not a u16")?,
+        None => 0,
     };
+    let port = condash_lib::server::start(state, requested_port).await?;
     eprintln!("condash-serve: listening on http://127.0.0.1:{port}/");
 
     // Block forever — the server task owns the listener.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -117,7 +117,7 @@ pub fn run() {
             });
 
             // Start axum + grab the port it picked.
-            let port = tauri::async_runtime::block_on(server::start(state.clone()))
+            let port = tauri::async_runtime::block_on(server::start(state.clone(), 0))
                 .map_err(|e| format!("start server: {e}"))?;
             eprintln!("condash: HTTP server listening on 127.0.0.1:{port}");
 

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -44,7 +44,7 @@ static VALID_ITEM_FILE_RE: Lazy<Regex> = Lazy::new(|| {
 
 /// Restricted to files directly under `<item>/notes/` — used by rename
 /// (only notes are user-renamable). `_VALID_ITEM_NOTES_FILE_RE`.
-static VALID_ITEM_NOTES_FILE_RE: Lazy<Regex> = Lazy::new(|| {
+pub(crate) static VALID_ITEM_NOTES_FILE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}notes/[\w./-]+$"))
         .expect("VALID_ITEM_NOTES_FILE_RE compiles")
 });
@@ -130,13 +130,6 @@ pub fn validate_note_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
         ],
         true,
     )
-}
-
-/// `true` iff `rel_path` looks like `<item>/notes/<filename>`. Used by
-/// `rename_note` to refuse renaming anything that isn't a user note
-/// (item READMEs, loose files alongside the README, …).
-pub fn is_item_notes_file(rel_path: &str) -> bool {
-    VALID_ITEM_NOTES_FILE_RE.is_match(rel_path)
 }
 
 /// Validate a project-item folder path (`projects/YYYY-MM/<slug>/`) under
@@ -255,16 +248,12 @@ mod tests {
     }
 
     #[test]
-    fn is_item_notes_file_gates_rename_source() {
-        assert!(is_item_notes_file(
-            "projects/2026-04/2026-04-22-demo/notes/first.md"
-        ));
-        assert!(!is_item_notes_file(
-            "projects/2026-04/2026-04-22-demo/README.md"
-        ));
-        assert!(!is_item_notes_file(
-            "projects/2026-04/2026-04-22-demo/loose.md"
-        ));
+    fn valid_item_notes_file_re_gates_rename_source() {
+        assert!(
+            VALID_ITEM_NOTES_FILE_RE.is_match("projects/2026-04/2026-04-22-demo/notes/first.md")
+        );
+        assert!(!VALID_ITEM_NOTES_FILE_RE.is_match("projects/2026-04/2026-04-22-demo/README.md"));
+        assert!(!VALID_ITEM_NOTES_FILE_RE.is_match("projects/2026-04/2026-04-22-demo/loose.md"));
     }
 
     #[test]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -504,7 +504,7 @@ async fn post_note_rename(
     let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &p.path) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
-    if !crate::paths::is_item_notes_file(&p.path) {
+    if !crate::paths::VALID_ITEM_NOTES_FILE_RE.is_match(&p.path) {
         return error_json(
             StatusCode::BAD_REQUEST,
             "only files under <item>/notes/ can be renamed",

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1,12 +1,12 @@
-//! axum HTTP server — the Phase 2 read-only route surface.
+//! axum HTTP server — the dashboard's entire HTTP + WebSocket surface.
 //!
 //! The Tauri host owns the `RenderCtx` + `WorkspaceCache` and spawns
 //! this server on a free localhost port at startup. The main webview
-//! then navigates to `http://127.0.0.1:<port>/` so the dashboard's
-//! existing JS — which speaks plain HTTP fetches — stays unchanged
-//! between the Python and Rust builds.
+//! then navigates to `http://127.0.0.1:<port>/` so the dashboard's JS —
+//! which speaks plain HTTP fetches — has a fixed origin regardless of
+//! host.
 //!
-//! Routes mounted here:
+//! Read / static surface:
 //!
 //! - `GET /` — full dashboard page (cards + knowledge + git strip)
 //! - `GET /fragment?id=<node-id>` — per-card / per-family HTML
@@ -18,7 +18,7 @@
 //! - `GET /asset/<path>` — any file under the conception tree
 //!   (notes, deliverables, file-tree previews)
 //!
-//! Phase 3 slice 2 added the step-mutation surface:
+//! Step mutations (operate on a single README checkbox line):
 //!
 //! - `POST /toggle`         — flip one checkbox's state
 //! - `POST /add-step`       — insert a new `- [ ]` line
@@ -27,8 +27,10 @@
 //! - `POST /set-priority`   — update the `**Status**` metadata line
 //! - `POST /reorder-all`    — shuffle checkboxes within their section
 //!
-//! Phase 3 slice 3 added the file-level mutation surface:
+//! File-level mutations:
 //!
+//! - `GET  /note`           — read a note file's body + mtime
+//! - `GET  /note-raw`       — read a note file as `text/plain`
 //! - `POST /note`           — atomically overwrite a note file
 //! - `POST /note/rename`    — rename a file under `<item>/notes/`
 //! - `POST /note/create`    — create an empty note file
@@ -36,13 +38,15 @@
 //! - `POST /note/upload`    — multipart file uploads (≤ 50 MB each)
 //! - `POST /create-item`    — scaffold a new project/incident/document
 //!
-//! Phase 3 slice 4 added the SSE channel:
+//! Staleness + rescan:
 //!
-//! - `GET /events`          — server-sent events (fan-out from the
+//! - `GET  /events`         — server-sent events (fan-out from the
 //!   filesystem watcher in `events.rs`; `hello` frame on connect, then
 //!   per-tab staleness payloads, with a 30 s keep-alive `ping`)
+//! - `POST /rescan`         — rebuild `RenderCtx` from disk + clear
+//!   cached slices
 //!
-//! Phase 4 slice 1 added the embedded terminal WebSocket:
+//! Embedded terminal:
 //!
 //! - `GET /ws/term`         — upgrade to a WebSocket streaming PTY
 //!   bytes. `info` frame on connect, binary frames for output, text
@@ -52,20 +56,30 @@
 //!   instead of a shell; falls back to the login shell when that config
 //!   field is empty or malformed.
 //!
-//! Phase 4 slice 2 added the inline dev-server runner surface:
+//! Inline dev-server runners:
 //!
-//! - `POST /api/runner/start` — spawn a dev server for a configured
+//! - `POST /api/runner/start`      — spawn a dev server for a configured
 //!   repo key (template from `ctx.repo_run_templates`, sandbox-gated
 //!   path)
-//! - `POST /api/runner/stop`  — SIGTERM + reap the runner session and
-//!   clear its registry slot
-//! - `GET  /ws/runner/:key`   — attach a WebSocket viewer to an
+//! - `POST /api/runner/stop`       — SIGTERM + reap the runner session
+//!   and clear its registry slot
+//! - `POST /api/runner/force-stop` — nuclear-option shell escape for
+//!   the repo-level "free the port" button
+//! - `GET  /ws/runner/:key`        — attach a WebSocket viewer to an
 //!   existing runner's PTY; no-spawn on miss
 //!
-//! Routes *not* ported here (Phase 5+ territory): `/note-raw`
-//! (read-side convenience endpoint; the bulk-read `/note` write path
-//! already covers the primary editor flow) and the config-editing
-//! surface.
+//! Configuration + openers:
+//!
+//! - `GET  /configuration`   — raw `configuration.yml` for the modal
+//! - `POST /configuration`   — validate + atomically replace the file
+//! - `GET  /config`          — small JSON summary (conception_path,
+//!   terminal) used by the frontend for setup banners and shortcut
+//!   loading
+//! - `POST /open`, `/open-folder`, `/open-external`, `/open-doc` —
+//!   dispatch user-visible "Open with …" actions to detached external
+//!   processes; sandbox-gated
+//! - `GET  /recent-screenshot` — resolve the most recent screenshot
+//!   inside `terminal.screenshot_dir`, for the paste-into-note flow
 
 use std::collections::HashMap;
 use std::net::{SocketAddr, TcpListener};
@@ -109,10 +123,10 @@ pub struct AppState {
     pub cache: Arc<WorkspaceCache>,
     /// Source of the dashboard shell (`dashboard.html`),
     /// `favicon.{svg,ico}`, `dist/`, and `vendor/`. Production binaries
-    /// use [`assets::AssetSource::Embedded`]; dev runs can flip to
-    /// [`assets::AssetSource::Disk`] via the `CONDASH_ASSET_DIR` env
-    /// var. Phase 5 step 1 landed the embedded variant so the binary
-    /// is self-contained.
+    /// use [`assets::AssetSource::Embedded`] so the binary is
+    /// self-contained; dev runs can flip to [`assets::AssetSource::Disk`]
+    /// via the `CONDASH_ASSET_DIR` env var to reload bundles without a
+    /// rebuild.
     pub assets: crate::assets::AssetSource,
     /// Version string stamped into the dashboard shell at `{{VERSION}}`.
     pub version: Arc<String>,
@@ -176,23 +190,23 @@ pub fn build_router(state: AppState) -> Router {
         .route("/vendor/{*path}", get(vendor_asset))
         .route("/assets/dist/{*path}", get(dist_asset))
         .route("/asset/{*path}", get(conception_asset))
-        // Phase 3 slice 2 — step mutations.
+        // Step mutations (operate on a single README checkbox line).
         .route("/toggle", post(toggle))
         .route("/add-step", post(add_step_route))
         .route("/remove-step", post(remove_step_route))
         .route("/edit-step", post(edit_step_route))
         .route("/set-priority", post(set_priority_route))
         .route("/reorder-all", post(reorder_all_route))
-        // Phase 3 slice 4 — SSE events channel.
+        // SSE staleness channel.
         .route("/events", get(events_stream))
-        // Phase 4 slice 1 — embedded terminal WebSocket.
+        // Embedded terminal WebSocket.
         .route("/ws/term", get(term_ws))
-        // Phase 4 slice 2 — inline dev-server runners.
+        // Inline dev-server runners.
         .route("/api/runner/start", post(runner_start_route))
         .route("/api/runner/stop", post(runner_stop_route))
         .route("/api/runner/force-stop", post(runner_force_stop_route))
         .route("/ws/runner/{key}", get(runner_ws))
-        // Phase 3 slice 3 — file-level mutations.
+        // File-level mutations.
         .route("/note", get(get_note).post(post_note))
         .route("/note-raw", get(get_note_raw))
         .route("/note/rename", post(post_note_rename))
@@ -231,11 +245,10 @@ pub fn build_router(state: AppState) -> Router {
 }
 
 // ---------------------------------------------------------------------
-// Phase 3 slice 2: step-mutation handlers.
-// Shape matches `src/condash/routes/steps.py` — each handler validates
-// the README path with `paths::validate_readme_path`, delegates to the
-// matching helper in `condash-mutations`, and — on success — flushes
-// the items cache so the next `/check-updates` sees a fresh fingerprint.
+// Step-mutation handlers. Each handler validates the README path with
+// `paths::validate_readme_path`, delegates to the matching helper in
+// `condash-mutations`, and — on success — flushes the items cache so
+// the next `/check-updates` sees a fresh fingerprint.
 // ---------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -409,9 +422,9 @@ async fn reorder_all_route(
 }
 
 // ---------------------------------------------------------------------
-// Phase 3 slice 3: file-level mutation handlers.
-// Shape matches `src/condash/routes/notes.py` and
-// `src/condash/routes/items.py`.
+// File-level mutation handlers — note read/write, rename, create,
+// mkdir, multipart upload, and `/create-item` (new project/incident/
+// document scaffold).
 // ---------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
@@ -901,8 +914,7 @@ async fn fragment(
 }
 
 // ---------------------------------------------------------------------
-// Phase 4 slice 1: /ws/term embedded-terminal handler.
-// Mirrors `routes/terminals.py` + `pty.py::attach_ws`:
+// /ws/term — embedded-terminal handler.
 // - Query params: `session_id` (reattach), `cwd` (override working dir),
 //   `launcher` (=1 to spawn the configured launcher instead of a shell).
 // - Frames: `info` on attach, `session-expired` for stale reattach,
@@ -1102,10 +1114,11 @@ async fn handle_term_ws(mut socket: axum::extract::ws::WebSocket, state: AppStat
 }
 
 // ---------------------------------------------------------------------
-// Phase 4 slice 2: runner routes.
-// - `POST /api/runner/start` — spawn a dev server for a configured key
-// - `POST /api/runner/stop`  — SIGTERM + reap + clear
-// - `GET  /ws/runner/:key`   — attach a viewer to the live session
+// Runner routes — inline dev-server processes.
+// - `POST /api/runner/start`      — spawn a dev server for a configured key
+// - `POST /api/runner/stop`       — SIGTERM + reap + clear
+// - `POST /api/runner/force-stop` — repo-level nuclear stop (free a port)
+// - `GET  /ws/runner/:key`        — attach a viewer to the live session
 // ---------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -79,16 +79,15 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json, Router};
 use chrono::Datelike;
-use condash_mutations::write_note;
 use condash_mutations::{
     add_step, create_item, create_note, create_notes_subdir, edit_step, remove_step, rename_note,
-    reorder_all, set_priority, store_uploads, toggle_checkbox, CreateItemResult, CreateNoteResult,
-    CreateSubdirResult, NewItemSpec, RenameResult, WriteNoteResult,
+    reorder_all, set_priority, store_uploads, toggle_checkbox, write_note, CreateItemResult,
+    CreateNoteResult, CreateSubdirResult, NewItemSpec, RenameResult, WriteNoteResult,
 };
 use condash_parser::{
     compute_fingerprint, compute_knowledge_node_fingerprints, compute_project_node_fingerprints,
+    find_card, find_node,
 };
-use condash_parser::{find_card, find_node};
 use condash_render::git_render::render_git_repo_fragment;
 use condash_render::{
     render_card_fragment, render_knowledge_card_fragment, render_knowledge_group_fragment,
@@ -128,15 +127,10 @@ pub struct AppState {
     pub runner_registry: crate::runners::RunnerRegistry,
 }
 
-/// Start the axum server on a free localhost port and return the port
-/// so the caller can point the Tauri webview at it. The server runs
-/// forever on the current tokio runtime.
-pub async fn start(state: AppState) -> Result<u16> {
-    start_on(state, 0).await
-}
-
-/// Start the axum server on an explicit port (`0` means any free port).
-pub async fn start_on(state: AppState, port: u16) -> Result<u16> {
+/// Start the axum server on the given localhost port (`0` means any free
+/// port) and return the bound port so the caller can point the Tauri
+/// webview at it. The server runs forever on the current tokio runtime.
+pub async fn start(state: AppState, port: u16) -> Result<u16> {
     let std_listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], port)))
         .context("binding 127.0.0.1 for the dashboard HTTP server")?;
     std_listener.set_nonblocking(true)?;
@@ -434,10 +428,10 @@ async fn get_note(
     Query(q): Query<NotePathQuery>,
 ) -> impl IntoResponse {
     if q.path.is_empty() {
-        return error(StatusCode::BAD_REQUEST, "missing path");
+        return error_json(StatusCode::BAD_REQUEST, "missing path");
     }
     let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &q.path) else {
-        return error(StatusCode::FORBIDDEN, "invalid path");
+        return error_json(StatusCode::FORBIDDEN, "invalid path");
     };
     let html = condash_render::render_note(&q.path, &full, &state.ctx.base_dir);
     html_response(html)
@@ -776,10 +770,14 @@ async fn post_create_item(
     }
 }
 
+fn json_response<T: serde::Serialize>(body: &T) -> Response {
+    json_with_status(body, StatusCode::OK)
+}
+
 fn json_with_status<T: serde::Serialize>(body: &T, code: StatusCode) -> Response {
     let bytes = match serde_json::to_vec(body) {
         Ok(b) => b,
-        Err(e) => return error(StatusCode::INTERNAL_SERVER_ERROR, &format!("json: {e}")),
+        Err(e) => return error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("json: {e}")),
     };
     Response::builder()
         .status(code)
@@ -788,8 +786,9 @@ fn json_with_status<T: serde::Serialize>(body: &T, code: StatusCode) -> Response
         .unwrap()
 }
 
-/// JSON error response matching `routes/_common.error()` — a
-/// `{"error": <msg>}` body plus the given status code.
+/// JSON error response — a `{"error": <msg>}` body plus the given
+/// status code. Every failure path in this module funnels through here
+/// so the frontend parses one shape.
 fn error_json(code: StatusCode, msg: &str) -> Response {
     let body = serde_json::json!({"error": msg});
     let bytes = serde_json::to_vec(&body).unwrap_or_default();
@@ -846,14 +845,14 @@ async fn fragment(
 ) -> impl IntoResponse {
     let id = q.id;
     if id.is_empty() {
-        return error(StatusCode::BAD_REQUEST, "missing id");
+        return error_json(StatusCode::BAD_REQUEST, "missing id");
     }
 
     if let Some(rest) = id.strip_prefix("projects/") {
         // projects/<priority>/<slug> — look up the card by slug.
         let parts: Vec<&str> = rest.splitn(2, '/').collect();
         if parts.len() != 2 {
-            return error(StatusCode::NOT_FOUND, "not a card id");
+            return error_json(StatusCode::NOT_FOUND, "not a card id");
         }
         let slug = parts[1];
         let items = state.cache.get_items(&state.ctx);
@@ -862,25 +861,25 @@ async fn fragment(
                 return html_response(render_card_fragment(item));
             }
         }
-        return error(StatusCode::NOT_FOUND, "card not found");
+        return error_json(StatusCode::NOT_FOUND, "card not found");
     }
 
     if id == "knowledge" {
         // Root tab — fall back to global reload like Python.
-        return error(StatusCode::NOT_FOUND, "use global reload");
+        return error_json(StatusCode::NOT_FOUND, "use global reload");
     }
 
     if let Some(rest) = id.strip_prefix("code/") {
         if !rest.contains('/') {
             // A bare code group — only whole-repo nodes are fragmentable.
-            return error(StatusCode::NOT_FOUND, "use global reload");
+            return error_json(StatusCode::NOT_FOUND, "use global reload");
         }
         let groups = collect_git_repos(&state.ctx);
         let live_runners = live_runners_snapshot(&state);
         if let Some(html) = render_git_repo_fragment(&state.ctx, &groups, &id, &live_runners) {
             return html_response(html);
         }
-        return error(StatusCode::NOT_FOUND, "repo not found");
+        return error_json(StatusCode::NOT_FOUND, "repo not found");
     }
 
     if id.starts_with("knowledge/") {
@@ -890,15 +889,15 @@ async fn fragment(
             if let Some(card) = find_card(root, &id) {
                 return html_response(render_knowledge_card_fragment(card));
             }
-            return error(StatusCode::NOT_FOUND, "card not found");
+            return error_json(StatusCode::NOT_FOUND, "card not found");
         }
         if let Some(node) = find_node(root, &id) {
             return html_response(render_knowledge_group_fragment(node));
         }
-        return error(StatusCode::NOT_FOUND, "dir not found");
+        return error_json(StatusCode::NOT_FOUND, "dir not found");
     }
 
-    error(StatusCode::NOT_FOUND, "unsupported id")
+    error_json(StatusCode::NOT_FOUND, "unsupported id")
 }
 
 // ---------------------------------------------------------------------
@@ -1591,7 +1590,7 @@ fn serve_embedded(source: &crate::assets::AssetSource, rel_path: &str) -> Respon
                 .body(Body::from(bytes.into_owned()))
                 .unwrap()
         }
-        None => error(StatusCode::NOT_FOUND, "no such asset"),
+        None => error_json(StatusCode::NOT_FOUND, "no such asset"),
     }
 }
 
@@ -1604,27 +1603,27 @@ async fn conception_asset(
 
 fn serve_under(base: &std::path::Path, rel: &str, mime_override: Option<&str>) -> Response {
     if rel.is_empty() || rel.contains('\0') {
-        return error(StatusCode::FORBIDDEN, "bad path");
+        return error_json(StatusCode::FORBIDDEN, "bad path");
     }
     for part in rel.split('/') {
         if part.is_empty() || part == ".." {
-            return error(StatusCode::FORBIDDEN, "path traversal");
+            return error_json(StatusCode::FORBIDDEN, "path traversal");
         }
     }
     let full = base.join(rel);
     let canonical = match std::fs::canonicalize(&full) {
         Ok(c) => c,
-        Err(_) => return error(StatusCode::NOT_FOUND, "no such file"),
+        Err(_) => return error_json(StatusCode::NOT_FOUND, "no such file"),
     };
     let base_canonical = match std::fs::canonicalize(base) {
         Ok(c) => c,
-        Err(_) => return error(StatusCode::NOT_FOUND, "base missing"),
+        Err(_) => return error_json(StatusCode::NOT_FOUND, "base missing"),
     };
     if !canonical.starts_with(&base_canonical) {
-        return error(StatusCode::FORBIDDEN, "outside base");
+        return error_json(StatusCode::FORBIDDEN, "outside base");
     }
     if !canonical.is_file() {
-        return error(StatusCode::NOT_FOUND, "not a file");
+        return error_json(StatusCode::NOT_FOUND, "not a file");
     }
     serve_fixed(
         &canonical,
@@ -1640,7 +1639,7 @@ fn serve_fixed(path: &std::path::Path, mime: &str) -> Response {
             .header(header::CACHE_CONTROL, "public, max-age=86400")
             .body(Body::from(bytes))
             .unwrap(),
-        Err(_) => error(StatusCode::NOT_FOUND, "read failed"),
+        Err(_) => error_json(StatusCode::NOT_FOUND, "read failed"),
     }
 }
 
@@ -1671,27 +1670,6 @@ fn html_response(body: String) -> Response {
     r
 }
 
-fn json_response<T: serde::Serialize>(body: &T) -> Response {
-    let bytes = match serde_json::to_vec(body) {
-        Ok(b) => b,
-        Err(e) => return error(StatusCode::INTERNAL_SERVER_ERROR, &format!("json: {e}")),
-    };
-    let mut r = Response::new(Body::from(bytes));
-    r.headers_mut().insert(
-        header::CONTENT_TYPE,
-        HeaderValue::from_static("application/json"),
-    );
-    r
-}
-
-fn error(code: StatusCode, msg: &str) -> Response {
-    Response::builder()
-        .status(code)
-        .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
-        .body(Body::from(format!("{code} — {msg}\n")))
-        .unwrap()
-}
-
 // ---------------------------------------------------------------------
 // Configuration modal (GET/POST /configuration) — plain-text YAML editor
 // backed by <conception>/configuration.yml.
@@ -1707,7 +1685,7 @@ async fn get_configuration(State(state): State<AppState>) -> Response {
     let body = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(e) => return error(StatusCode::INTERNAL_SERVER_ERROR, &format!("read: {e}")),
+        Err(e) => return error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("read: {e}")),
     };
     let mut r = Response::new(Body::from(body));
     r.headers_mut().insert(
@@ -1722,7 +1700,7 @@ async fn get_configuration(State(state): State<AppState>) -> Response {
 
 async fn post_configuration(State(state): State<AppState>, body: String) -> Response {
     if let Err(e) = crate::config::validate_configuration_yaml(&body) {
-        return error(StatusCode::BAD_REQUEST, &format!("{e}"));
+        return error_json(StatusCode::BAD_REQUEST, &format!("{e}"));
     }
     match crate::config::write_configuration(&state.ctx.base_dir, &body) {
         Ok(_path) => {
@@ -1739,7 +1717,7 @@ async fn post_configuration(State(state): State<AppState>, body: String) -> Resp
             )
                 .into_response()
         }
-        Err(e) => error(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e}")),
+        Err(e) => error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e}")),
     }
 }
 

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -1625,10 +1625,17 @@ fn serve_under(base: &std::path::Path, rel: &str, mime_override: Option<&str>) -
     if !canonical.is_file() {
         return error_json(StatusCode::NOT_FOUND, "not a file");
     }
-    serve_fixed(
-        &canonical,
-        mime_override.unwrap_or_else(|| guess_mime(&canonical)),
-    )
+    let guessed;
+    let mime = match mime_override {
+        Some(m) => m,
+        None => {
+            guessed = mime_guess::from_path(&canonical)
+                .first_or_octet_stream()
+                .to_string();
+            guessed.as_str()
+        }
+    };
+    serve_fixed(&canonical, mime)
 }
 
 fn serve_fixed(path: &std::path::Path, mime: &str) -> Response {
@@ -1640,24 +1647,6 @@ fn serve_fixed(path: &std::path::Path, mime: &str) -> Response {
             .body(Body::from(bytes))
             .unwrap(),
         Err(_) => error_json(StatusCode::NOT_FOUND, "read failed"),
-    }
-}
-
-fn guess_mime(path: &std::path::Path) -> &'static str {
-    match path.extension().and_then(|e| e.to_str()) {
-        Some("mjs") | Some("js") => "text/javascript",
-        Some("css") => "text/css",
-        Some("json") => "application/json",
-        Some("wasm") => "application/wasm",
-        Some("svg") => "image/svg+xml",
-        Some("png") => "image/png",
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("gif") => "image/gif",
-        Some("webp") => "image/webp",
-        Some("pdf") => "application/pdf",
-        Some("html") => "text/html; charset=utf-8",
-        Some("md") | Some("txt") => "text/plain; charset=utf-8",
-        _ => "application/octet-stream",
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"

--- a/src-tauri/tests/runner_routes.rs
+++ b/src-tauri/tests/runner_routes.rs
@@ -206,7 +206,9 @@ async fn stop_noop_on_unknown_key() {
 #[tokio::test]
 async fn ws_runner_sends_session_missing_frame_for_unknown_key() {
     let h = harness_with(vec![]);
-    let port = server::start(h.state.clone()).await.expect("start server");
+    let port = server::start(h.state.clone(), 0)
+        .await
+        .expect("start server");
     let url = format!("ws://127.0.0.1:{port}/ws/runner/unknown");
     let (mut stream, _resp) = tokio_tungstenite::connect_async(&url)
         .await
@@ -238,7 +240,9 @@ async fn ws_runner_sends_info_frame_for_live_session() {
     .await;
     assert_eq!(start_status, StatusCode::OK);
 
-    let port = server::start(h.state.clone()).await.expect("start server");
+    let port = server::start(h.state.clone(), 0)
+        .await
+        .expect("start server");
     let url = format!("ws://127.0.0.1:{port}/ws/runner/demo");
     let (mut stream, _resp) = tokio_tungstenite::connect_async(&url)
         .await

--- a/src-tauri/tests/term_ws.rs
+++ b/src-tauri/tests/term_ws.rs
@@ -35,7 +35,7 @@ async fn start_server() -> (u16, TempDir) {
         pty_registry: PtyRegistry::new(),
         runner_registry: condash_lib::runners::RunnerRegistry::new(),
     };
-    let port = server::start(state).await.expect("start server");
+    let port = server::start(state, 0).await.expect("start server");
     (port, tmp)
 }
 


### PR DESCRIPTION
## Summary

- Sweep across the Rust workspace and `src-tauri/src/server.rs` to close seven hygiene findings from the 2026-04-23 condash audit.
- Seven self-contained commits, each tagged with the finding it closes, and a final version bump to v1.0.17.
- Behaviour-preserving: no new features, no removed features, no route/contract changes. The only user-observable shift is that every `error(...)` response is now `application/json` instead of `text/plain`.

## Changes

- **F-01**: delete the private `h()` duplicate in `crates/condash-render/src/git_render.rs`; import the crate-public one instead.
- **F-02, F-14**: collapse `json_response` + `json_with_status` into one implementation and drop the `text/plain` `error()` helper; every failure path now goes through `error_json` → `{ "error": msg }`.
- **F-05**: merge the two adjacent `use condash_mutations::…` statements into one bracketed list (same for `condash_parser`).
- **F-13**: drop the `start` → `start_on` alias; callers (Tauri host, `condash-serve`, tests) pass the port directly (`0` = any free port).
- **F-07**: remove the `tower-http` dependency — it was listed with the `fs` feature but never imported; static serving is hand-rolled via `AssetSource::load`.
- **F-21**: inline `paths::is_item_notes_file` at its only call site; expose `VALID_ITEM_NOTES_FILE_RE` as `pub(crate)` and match directly.
- **F-22**: replace the hand-rolled `guess_mime` with `mime_guess::from_path(...).first_or_octet_stream()` (crate was already a dependency via `rust-embed`).
- **F-10, F-11**: scrub stale `Phase N slice M` markers and the "routes *not* ported here" / "slice 4 wires …" claims (those routes shipped long ago); reorganise the `server.rs` and `condash-render/src/lib.rs` doc headers by surface area. Kept the Python references in `fingerprint.rs` + `git.rs` where the rationale still applies.
- Bump `src-tauri/Cargo.toml` + `tauri.conf.json` from 1.0.16 to 1.0.17.

## Impact

- `error()` path now returns `application/json` with a `{ "error": msg }` body instead of `text/plain "{code} — {msg}\n"`. The frontend already parses JSON for every other error path; no frontend code branches on `Content-Type`.
- `.md` files served via `/asset/<path>` now carry the mime `mime_guess` assigns (usually `text/markdown`) rather than the previous `text/plain; charset=utf-8`. Other extensions resolve identically.