### PR TITLE
Rewrite reference/config.md for the current Rust build

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,26 +1,26 @@
 ---
 title: Config files · condash reference
-description: The two tree-level YAML config files — one team-shared, one per-machine — and every key in each.
+description: The two YAML files condash reads — one at the conception tree root, one in your XDG config — and every key in each.
 ---
 
 # Config files
 
 ## At a glance
 
-condash reads **two** config files, both under `<conception_path>/config/`. Which file owns which key is not cosmetic — it's how per-team and per-machine boundaries are kept separate.
+condash reads **two** YAML files. They live in different places and have different scopes:
 
 | File | Location | Scope | Owns |
 |------|----------|-------|------|
-| `repositories.yml` | `<conception_path>/config/repositories.yml` | Per-tree, versioned in git | `workspace_path`, `worktrees_path`, `repositories`, `open_with` |
-| `preferences.yml` | `<conception_path>/config/preferences.yml` | Per-tree but **not** versioned — per-machine preferences for this tree | `pdf_viewer`, `terminal` |
+| `configuration.yml` | `<conception_path>/configuration.yml` | Per-tree, versioned in git | `workspace_path`, `worktrees_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal` |
+| `settings.yaml` | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` | Per-user, per-machine | `conception_path` |
 
-The two YAML files live *inside* the conception tree itself. On any given machine, they're merged at load time: `preferences.yml` overrides `repositories.yml` on overlapping keys. Moving a team-wide setting into `repositories.yml` automatically propagates to every developer who pulls the tree.
+The first file is inside the conception tree you're rendering — commit it and every developer on the tree gets the same workspace layout, `open_with` commands, PDF viewer chain, and terminal shortcuts. The second file is on the machine condash runs on, and stores only the path to the tree: it tells condash *which* tree to render. Everything else is in the tree.
 
-One thing that isn't a file: the conception path itself. That comes from the `CONDASH_CONCEPTION_PATH` environment variable (defaulting to `$HOME/src/vcoeur/conception`), because the tree doesn't know where it lives on disk. See [Environment variables](env.md).
+That split keeps the tree portable (clone it on a new laptop and it already knows which repos to scan) while letting the local machine point at whichever tree lives where on disk.
 
-## `repositories.yml` (per-tree, versioned)
+## `configuration.yml` (per-tree, versioned)
 
-Lives at `<conception_path>/config/repositories.yml`. Commit it — every developer who pulls the tree gets the same workspace layout and "open with" commands.
+Lives at `<conception_path>/configuration.yml`. Commit it. Every key is optional — a minimal valid file is an empty document `{}`, in which case condash uses defaults everywhere.
 
 ```yaml
 workspace_path: /home/you/src
@@ -29,7 +29,13 @@ worktrees_path: /home/you/src/worktrees
 repositories:
   primary:
     - condash
-    - { name: helio, submodules: [apps/web, apps/api] }
+    - name: helio
+      submodules:
+        - { name: apps/web, run: make dev }
+        - { name: apps/api, run: make dev }
+    - name: notes.vcoeur.com
+      run: make dev
+      force_stop: fuser -k 8200/tcp 5200/tcp
   secondary:
     - conception
 
@@ -49,29 +55,7 @@ open_with:
     commands:
       - ghostty --working-directory={path}
       - gnome-terminal --working-directory {path}
-```
 
-| Key | Meaning |
-|-----|---------|
-| `workspace_path` | Directory condash scans for git repositories. Every direct subdirectory containing a `.git/` shows up in the **Code** tab. If unset, the tab is hidden. |
-| `worktrees_path` | Additional sandbox for the "open in IDE" buttons. Paths outside `workspace_path` and `worktrees_path` are rejected before the shell sees them. |
-| `repositories.primary` | List of bare directory names (not paths) matched against the scan. Shown in the `PRIMARY` card. |
-| `repositories.secondary` | Same as primary, shown in the `SECONDARY` card. Anything under `workspace_path` not named in either list lands in an `OTHERS` card. |
-| Entry with `submodules` | An inline map `{name: repo, submodules: [sub/one, sub/two]}` renders the repo as an expandable row with sub-rows for each listed subdirectory. Each submodule keeps its own dirty count and "open with" buttons. Useful for monorepos where different subtrees are edited independently. |
-| Entry with `run` | Either a top-level inline map `{name: repo, run: "<cmd>"}` or a sub-repo map `{name: apps/web, run: "<cmd>"}` wires an [inline dev-server runner](inline-runner.md) into that row. `run:` is independent of `submodules:` — a parent's `run:` is **not** inherited by its submodules. |
-| `open_with.<slot>` | Three vendor-neutral launcher slots (`main_ide`, `secondary_ide`, `terminal`). Each slot has a `label` (tooltip) and a `commands` fallback chain. |
-
-### `{path}` substitution
-
-Each `commands` entry is a single shell-style string. The literal `{path}` is replaced with the absolute path of the repo / worktree being opened. Commands are tried in order until one starts successfully — if `idea {path}` isn't on `$PATH`, the button falls through to `idea.sh {path}` automatically.
-
-Built-in defaults reproduce common IntelliJ / VS Code / terminal behaviour, so a `repositories.yml` with no `open_with` section still gives functional buttons. Override only the slots you want to customise.
-
-## `preferences.yml` (per-tree, **not** versioned)
-
-Lives at `<conception_path>/config/preferences.yml`. **Do not** commit this file — add it to the tree's `.gitignore`. It holds per-machine overrides for this tree, so different trees on the same machine can use different terminal shortcuts or PDF viewers, and different machines sharing the same tree can carry their own preferences.
-
-```yaml
 pdf_viewer:
   - xdg-open {path}
   - evince {path}
@@ -86,53 +70,132 @@ terminal:
   move_tab_right_shortcut: Ctrl+Right
 ```
 
-### Top-level keys
+Paths may use `~` (expanded to `$HOME`) or absolute paths. The in-app gear modal is a plain-text YAML editor and writes the file verbatim on save, so your hand-edited comments round-trip.
+
+### Workspace keys
 
 | Key | Meaning |
 |-----|---------|
-| `pdf_viewer` | Bare list of shell-style commands, tried in order. `{path}` is replaced with the absolute path of the PDF. Unset or empty → falls back to the OS default. |
+| `workspace_path` | Directory condash scans for git repositories. Every direct subdirectory containing a `.git/` shows up in the **Code** tab. If unset, the tab is hidden. |
+| `worktrees_path` | Additional sandbox for the "open in IDE" buttons. Paths outside `workspace_path` and `worktrees_path` are rejected before the shell sees them. |
+
+### `repositories`
+
+Two buckets, `primary` and `secondary`, each a list of repo entries. Entries may take one of four shapes:
+
+```yaml
+repositories:
+  primary:
+    - condash                               # bare name
+    - { name: helio }                       # same thing, inline map
+    - name: helio
+      submodules: [apps/web, apps/api]      # expandable row with sub-rows
+    - name: notes.vcoeur.com
+      run: make dev                         # inline dev-server runner
+      force_stop: fuser -k 8200/tcp         # nuclear-stop helper
+```
+
+| Shape | Effect |
+|---|---|
+| Bare name | Directory name (not a path) matched against the scan of `workspace_path`. |
+| `{name: repo}` | Same as bare — the inline-map form coexists because a repo may want sibling keys. |
+| `{name: repo, submodules: [sub/a, sub/b]}` | Renders the repo as an expandable row. Each listed submodule gets its own dirty count and "open with" buttons. Useful for monorepos where subtrees are edited independently. |
+| `{name: repo, run: "<cmd>"}` | Wires an [inline dev-server runner](inline-runner.md) into that row. `run:` is independent of `submodules:` — a parent's `run:` is **not** inherited by its submodules; add `run:` per submodule if they each have their own dev server. |
+| `{name: repo, run: "<cmd>", force_stop: "<cmd>"}` | Same as above plus a repo-level **force-stop** button. The button runs `force_stop` as a shell command, without going through condash's own process tracking — use it to free a port held by a server condash didn't start (stale process from a previous run, a server launched from another terminal, etc.). Typical values: `fuser -k 8300/tcp`, `pkill -f 'manage.py runserver'`, `lsof -ti :8300 \| xargs -r kill -9`. Same shell trust level as `run:` — you're running these commands on your own machine, so a malicious tree is a malicious shell. |
+
+Anything under `workspace_path` not named in either bucket lands in a third `OTHERS` card.
+
+### `open_with`
+
+Three vendor-neutral launcher slots used by the "Open with …" buttons on every repo row and note file:
+
+| Slot | Typical use |
+|------|-------------|
+| `main_ide` | Full IDE — IntelliJ IDEA, PyCharm, RustRover, WebStorm. |
+| `secondary_ide` | Lighter editor — VS Code, VSCodium, Zed. |
+| `terminal` | Spawn a terminal already `cd`-ed into the target. |
+
+Each slot takes a `label` (tooltip text) and a `commands` list.
+
+```yaml
+open_with:
+  main_ide:
+    label: Open in main IDE
+    commands:
+      - idea {path}
+      - idea.sh {path}
+      - intellij-idea-ultimate {path}
+```
+
+Commands are tried in order until one starts successfully. `{path}` is substituted with the absolute path of the repo, worktree, or directory being opened. If no command in the chain is on `$PATH`, the button reports failure via a toast.
+
+Built-in defaults reproduce common IntelliJ / VS Code / terminal behaviour, so a `configuration.yml` with no `open_with` section still gives functional buttons. Override only the slots you want to customise.
+
+### `pdf_viewer`
+
+Bare list of shell-style commands for opening PDFs from deliverable links. `{path}` is replaced with the absolute path of the PDF. Tried in order.
+
+```yaml
+pdf_viewer:
+  - xdg-open {path}
+  - evince {path}
+```
+
+Empty list or missing key → falls back to the OS default (`xdg-open` on Linux, `open` on macOS).
 
 ### `terminal`
+
+Embedded-terminal preferences. All keys are optional; an empty string means "fall back to the built-in default".
 
 | Key | Default | Meaning |
 |-----|---------|---------|
 | `shell` | `$SHELL` → `/bin/bash` | Absolute path to an interactive shell. |
 | `shortcut` | `` Ctrl+` `` | Toggle the terminal pane. Modifiers: `Ctrl`, `Shift`, `Alt`, `Meta`. Key names follow the HTML `KeyboardEvent.key` convention. |
 | `screenshot_dir` | `~/Pictures/Screenshots` on Linux, `~/Desktop` on macOS | Directory scanned for "most recent screenshot" by the paste shortcut. |
-| `screenshot_paste_shortcut` | `Ctrl+Shift+V` | Inserts the absolute path of the newest image in `screenshot_dir` into the active terminal. No `Enter` — user confirms. |
+| `screenshot_paste_shortcut` | `Ctrl+Shift+V` | Inserts the absolute path of the newest image in `screenshot_dir` into the active terminal. No `Enter` — you confirm. |
 | `launcher_command` | `claude` | Shell-style command spawned by the secondary `+` button in each terminal side. Empty hides the button. |
 | `move_tab_left_shortcut` | `Ctrl+Left` | Move the active tab to the left pane. |
 | `move_tab_right_shortcut` | `Ctrl+Right` | Move the active tab to the right pane. |
 
-## Merge order
+## `settings.yaml` (per-user, per-machine)
 
-At load time:
+Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Not versioned — it holds the one thing that only makes sense locally: where the conception tree lives on this machine.
 
-1. Start with defaults compiled into the binary.
-2. Merge `<conception_path>/config/repositories.yml` on top.
-3. Merge `<conception_path>/config/preferences.yml` on top (overrides `repositories.yml` on overlapping keys — `pdf_viewer`, `terminal`).
+```yaml
+conception_path: /home/you/src/vcoeur/conception
+```
 
-Result: team-shared repo/IDE settings from the versioned YAML, plus per-tree per-machine tweaks from the untracked YAML.
+| Key | Meaning |
+|-----|---------|
+| `conception_path` | Absolute path to the conception tree condash should render. |
+
+Resolution order for the conception path, checked in sequence:
+
+1. The `CONDASH_CONCEPTION_PATH` environment variable (see [env reference](env.md)).
+2. `conception_path` in this file.
+3. A first-run GUI prompt (Tauri build only). The prompt writes the chosen path back into this file so the next launch picks it up automatically.
+4. Hard error — condash refuses to start.
+
+The file is created on demand: first-run writes it; the gear modal's **General** tab writes it; you can also create it by hand.
 
 ## Editing from the dashboard
 
-Click the gear icon in the header. A modal opens with three tabs:
+Click the gear icon in the header. A modal opens with a plain-text YAML editor showing the contents of `configuration.yml`. Save is atomic (temp file → rename), so a crash during save never corrupts the file. Most changes take effect immediately; a few (see below) need a restart and the save dialog tells you which.
 
-![Gear modal General tab](../assets/screenshots/gear-modal-light.png#only-light)
-![Gear modal General tab](../assets/screenshots/gear-modal-dark.png#only-dark)
+Saves preserve your comments because the modal writes the raw text you edited — it does not round-trip the file through a parser.
 
-- **General** → the conception path (written to `preferences.yml`) plus a few per-machine defaults.
-- **Repositories** → writes `workspace_path`, `worktrees_path`, `repositories`, `open_with` to `repositories.yml`.
-- **Preferences** → writes `pdf_viewer`, `terminal` to `preferences.yml`.
+Changes that **do** need a restart:
 
-![Gear modal Repositories tab](../assets/screenshots/gear-modal-repositories-light.png#only-light)
-![Gear modal Repositories tab](../assets/screenshots/gear-modal-repositories-dark.png#only-dark)
+- `workspace_path` or `worktrees_path` change — the filesystem scanner is built once at launch.
+- `repositories` list change — the per-repo fingerprint graph is built once at launch.
 
-![Gear modal Preferences tab](../assets/screenshots/gear-modal-preferences-light.png#only-light)
-![Gear modal Preferences tab](../assets/screenshots/gear-modal-preferences-dark.png#only-dark)
+Changes that reload live without a restart:
 
-Saves are atomic and preserve comments you've added outside the managed blocks. Most changes reload live; a port or webview-host change requires a restart and the modal tells you so.
+- Everything under `open_with`, `pdf_viewer`, `terminal`.
+- `run:` / `force_stop:` on an existing repo entry.
 
-## Machine-local TOML
+## See also
 
-An earlier build also carried a per-machine TOML file (`~/.config/condash/config.toml`) for settings that didn't fit either YAML. That file is no longer read — the conception path lives in the `CONDASH_CONCEPTION_PATH` environment variable instead, and the remaining per-machine knobs are all in `preferences.yml`. A future release may reintroduce a machine-local override surface; for now there is none.
+- [Environment variables](env.md) — `CONDASH_CONCEPTION_PATH`, `CONDASH_ASSET_DIR`, `CONDASH_PORT`.
+- [Inline dev-server runner](inline-runner.md) — the `run:` field in `configuration.yml`.
+- [Terminal shortcuts](shortcuts.md) — what each `terminal.*` shortcut does in the UI.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,7 +8,7 @@ description: Exhaustive lookup for every command, config key, README field, muta
 Short pages, one per surface. Look things up here; learn them in the [Tutorials](../tutorials/index.md) and [Guides](../guides/index.md).
 
 - **[CLI](cli.md)** — the two binaries (`condash`, `condash-serve`) and their env vars.
-- **[Config files](config.md)** — `repositories.yml` (team-shared) + `preferences.yml` (per-machine), both under `<conception_path>/config/`.
+- **[Config files](config.md)** — `configuration.yml` at the conception tree root (team-shared) + `settings.yaml` in your XDG config (per-user, holds only `conception_path`).
 - **[README format](readme-format.md)** — header fields, kind-specific additions, field rules.
 - **[Status, steps, deliverables](conception-convention.md)** — the content-level syntax for step markers, deliverable links, and status transitions.
 - **[Mutation model](mutations.md)** — the exhaustive list of every action the dashboard takes on your files.

--- a/docs/reference/inline-runner.md
+++ b/docs/reference/inline-runner.md
@@ -17,7 +17,7 @@ For one-off commands (a test run, a manual repro), keep using the embedded termi
 
 ## Configuring a runner
 
-The runner is opt-in per repo and per sub-repo. Declare it in [`config/repositories.yml`](config.md#repositoriesyml-per-tree-versioned) with the `run:` field:
+The runner is opt-in per repo and per sub-repo. Declare it in [`configuration.yml`](config.md#repositories) with the `run:` field:
 
 ```yaml
 repositories:
@@ -101,4 +101,4 @@ Runner state is folded into the repo-strip fingerprint, so `/check-updates` (the
 
 - [Repositories and open-with buttons](../guides/repositories-and-open-with.md) — the related but distinct "launcher slots" that open external IDEs rather than PTY-owned processes.
 - [Use the embedded terminal](../guides/terminal.md) — the sibling surface for ad-hoc commands.
-- [Config files — `repositories.yml`](config.md#repositoriesyml-per-tree-versioned) — the broader schema the `run:` field sits inside.
+- [Config files — `repositories`](config.md#repositories) — the broader schema the `run:` field sits inside.


### PR DESCRIPTION
## Summary

- The \`docs/reference/config.md\` page still described the pre-2026-04-22 two-file split (\`config/repositories.yml\` + \`config/preferences.yml\`). The Rust build has read a unified \`configuration.yml\` at the tree root since v1.0.8; the split files are kept only for the retired Python build.
- Rewrite the page around the schema condash actually reads today: \`<conception>/configuration.yml\` for everything workspace + preferences, and \`\${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml\` for the single per-user key (\`conception_path\`).
- Keeps the deeper multi-machine.md / mutations.md / shortcuts.md sweep out of scope — that lands as a separate follow-up (P-D2). This PR only touches the config reference page plus the two callers whose old \`#repositoriesyml-per-tree-versioned\` anchor would otherwise break \`mkdocs build --strict\`.

## Changes

- \`docs/reference/config.md\` — full rewrite. At-a-glance table, \`configuration.yml\` section (workspace_path, worktrees_path, repositories with shape table, open_with, pdf_viewer, terminal with the full key table), \`settings.yaml\` section with the four-step \`conception_path\` resolution order, editing-from-the-dashboard section reflecting the current single-textarea gear modal, and a See-also block.
- \`docs/reference/inline-runner.md\` — update two links from \`config.md#repositoriesyml-per-tree-versioned\` to \`config.md#repositories\` to match the new anchor. Wording adjusted from \`config/repositories.yml\` to \`configuration.yml\`.
- \`docs/reference/index.md\` — one-line description under the Config files link now reflects the actual two-file layout.

## Impact

- \`mkdocs build --strict\` stays green. Broader stale-reference sweep (multi-machine.md, guides/\*, mutations.md, shortcuts.md still mentioning \`repositories.yml\` / \`preferences.yml\`) is explicitly deferred to the follow-up docs PR so this one is easy to review on its own.