### PR TITLE
Scrub Python-port prose from Rust sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.0.18"
+version = "1.0.19"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/condash-mutations/Cargo.toml
+++ b/crates/condash-mutations/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "condash-mutations"
 version = "0.1.0"
-description = "README.md write-side mutations for condash. Rust port of mutations.py step helpers."
+description = "README.md write-side mutations for condash."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"

--- a/crates/condash-mutations/src/files.rs
+++ b/crates/condash-mutations/src/files.rs
@@ -72,11 +72,10 @@ impl WriteNoteResult {
     }
 }
 
-/// Atomically rewrite `full_path` with `content`. Refuses when the on-
-/// disk mtime doesn't match `expected_mtime` so a stale editor never
-/// silently overwrites out-of-band edits. When `expected_mtime` is
-/// `None`, skips the guard (matches Python's `if expected_mtime is not
-/// None`).
+/// Atomically rewrite `full_path` with `content`. Refuses when the
+/// on-disk mtime doesn't match `expected_mtime` so a stale editor
+/// never silently overwrites out-of-band edits. When `expected_mtime`
+/// is `None`, skips the guard.
 pub fn write_note(
     full_path: &Path,
     content: &str,
@@ -569,8 +568,8 @@ impl From<ItemKind> for Kind {
     }
 }
 
-/// Input spec for `create_item`. Mirrors the keyword-arguments shape of
-/// the Python helper.
+/// Input spec for `create_item` — the fields the `/create-item` and
+/// `/api/items` routes collect from the new-item modal.
 #[derive(Debug, Default, Clone)]
 pub struct NewItemSpec {
     pub title: String,
@@ -583,9 +582,8 @@ pub struct NewItemSpec {
     pub languages: String,
 }
 
-/// `{ok, rel_path, slug, folder_name, priority, month}` or
-/// `{ok: false, reason}`. Serialised shape matches Python byte-for-byte
-/// so the existing frontend doesn't need to change.
+/// `{ok, rel_path, slug, folder_name, priority, month}` on success
+/// or `{ok: false, reason}` on a validation failure.
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum CreateItemResult {

--- a/crates/condash-mutations/src/lib.rs
+++ b/crates/condash-mutations/src/lib.rs
@@ -1,21 +1,23 @@
-//! README.md write-side mutations — Rust port of `src/condash/mutations.py`.
+//! README.md write-side mutations.
 //!
-//! Phase 3 slice 1 covered the six step-mutation helpers behind the
-//! `/toggle`, `/add-step`, `/remove-step`, `/edit-step`, `/set-priority`,
-//! and `/reorder-all` routes ([`steps`]).
+//! Two surfaces:
 //!
-//! Phase 3 slice 3 adds the file-level write helpers ([`files`]) behind
-//! `/note`, `/note/rename`, `/note/create`, `/note/mkdir`, `/note/upload`,
-//! and `/create-item`.
+//! - [`steps`] — the six step-mutation helpers behind `/toggle`,
+//!   `/add-step`, `/remove-step`, `/edit-step`, `/set-priority`, and
+//!   `/reorder-all`.
+//! - [`files`] — file-level write helpers behind `/note`,
+//!   `/note/rename`, `/note/create`, `/note/mkdir`, `/note/upload`,
+//!   and `/create-item`.
 //!
-//! Every helper reads the target file(s) as UTF-8 (or raw bytes for
-//! uploads), mutates in place, and writes back — byte-identical to the
-//! Python port, including the trailing-newline convention Python's
-//! `str.split("\n")` + `"\n".join(...)` round-trips.
+//! Every helper reads the target file as UTF-8 (or raw bytes for
+//! uploads), mutates in place, and writes back — preserving the
+//! trailing-newline convention that `str::split('\n').collect::<_>()
+//! .join('\n')` round-trips.
 //!
-//! The helpers are pure with respect to [`RenderCtx`][condash_state::RenderCtx]
-//! — path validation is the caller's job (see `src-tauri/src/paths.rs`)
-//! and these functions take already-resolved absolute paths.
+//! The helpers are pure with respect to
+//! [`RenderCtx`][condash_state::RenderCtx] — path validation is the
+//! caller's job (see `src-tauri/src/paths.rs`) and these functions
+//! take already-resolved absolute paths.
 
 pub mod files;
 pub mod steps;

--- a/crates/condash-parser/Cargo.toml
+++ b/crates/condash-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "condash-parser"
 version = "0.1.0"
-description = "Parser for conception item READMEs and the knowledge tree. Rust port of condash/src/condash/parser.py."
+description = "Parser for conception item READMEs and the knowledge tree."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"

--- a/crates/condash-parser/src/collect.rs
+++ b/crates/condash-parser/src/collect.rs
@@ -1,7 +1,5 @@
-//! Disk-reading wrappers around `parse_readme_content` + `list_item_tree`.
-//!
-//! Rust port of `parse_readme` (the disk-reading entry point) and
-//! `collect_items` in `src/condash/parser.py`.
+//! Disk-reading wrappers around `parse_readme_content` and
+//! `list_item_tree` — glue the pure parse step to the filesystem.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -11,9 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::readme::{parse_readme_content, ItemReadme};
 use crate::tree::{list_item_tree, ItemTree};
 
-/// A parsed README combined with its files-tree. Mirrors the Python
-/// `parse_readme` return value — the same dict, just with a typed
-/// `files` field instead of an untyped one.
+/// A parsed README combined with its files-tree.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Item {
     #[serde(flatten)]
@@ -21,9 +17,9 @@ pub struct Item {
     pub files: ItemTree,
 }
 
-/// Read one README off disk and assemble the `Item`. Returns `None` on
-/// read / UTF-8 failures — matching Python which logs a warning and
-/// skips the item in that case.
+/// Read one README off disk and assemble the `Item`. Returns `None`
+/// on read / UTF-8 failures — the collector silently skips unreadable
+/// items so one malformed README doesn't fail the whole `/` render.
 pub fn parse_readme(
     base_dir: &Path,
     readme_path: &Path,
@@ -45,9 +41,8 @@ pub fn parse_readme(
 }
 
 /// Find and parse every item README under `<base_dir>/projects/`.
-///
-/// Mirrors Python's `collect_items`: walks the `*/*/README.md` glob in
-/// sorted order, skips items that fail to parse, returns the rest.
+/// Walks the `*/*/README.md` glob in sorted order so the output is
+/// deterministic; items that fail to parse are skipped silently.
 pub fn collect_items(base_dir: &Path) -> Vec<Item> {
     let projects = base_dir.join("projects");
     if !projects.is_dir() {
@@ -63,8 +58,8 @@ pub fn collect_items(base_dir: &Path) -> Vec<Item> {
         .collect()
 }
 
-/// Walk `projects/*/*/README.md` — exactly two levels of subdirectory,
-/// matching the Python `base.glob("*/*/README.md")` shape.
+/// Walk `projects/*/*/README.md` — exactly two levels of subdirectory
+/// (month then slug), matching the on-disk layout.
 fn collect_readmes(projects: &Path) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = Vec::new();
     let Ok(months) = fs::read_dir(projects) else {

--- a/crates/condash-parser/src/deliverables.rs
+++ b/crates/condash-parser/src/deliverables.rs
@@ -12,14 +12,12 @@ use crate::regexes::{DELIVERABLE_RE, HEADING2_RE};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Deliverable {
     pub label: String,
-    /// PDF path relative to the item directory (same as Python's `path`).
+    /// PDF path relative to the item directory.
     pub path: String,
     pub desc: String,
-    /// `<item_dir>/<path>`. Absent on the raw `parse_deliverables` output;
-    /// `parse_readme_content` fills it once it knows the item directory.
-    /// Serialised as `"full_path"` matching the Python dict key; skipped
-    /// when absent so standalone `parse_deliverables` callers see the same
-    /// three-field shape as before.
+    /// `<item_dir>/<path>` — filled in by `parse_readme_content` once
+    /// it knows the item directory. Skipped when absent so standalone
+    /// `parse_deliverables` callers see the same three-field shape.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub full_path: Option<String>,
 }

--- a/crates/condash-parser/src/knowledge.rs
+++ b/crates/condash-parser/src/knowledge.rs
@@ -1,11 +1,8 @@
-//! Knowledge-tree walker shared by the knowledge and code explorer tabs.
-//!
-//! Rust port of `_knowledge_title_and_desc`, `collect_knowledge`,
-//! `collect_tree`, `_tree_node`, `find_knowledge_node`, and
-//! `find_knowledge_card` in `src/condash/parser.py`. The returned node
-//! shape matches Python's `{name, label, rel_dir, index, body, children,
-//! count}` so downstream consumers (render, fingerprints) can hand the
-//! JSON back and forth byte-identically.
+//! Knowledge-tree walker shared by the knowledge and code explorer
+//! tabs. Builds a recursive `{name, label, rel_dir, index, body,
+//! children, count}` node shape from the on-disk `knowledge/` tree;
+//! the render layer and fingerprint hasher both consume this shape
+//! directly.
 
 use std::fs;
 use std::path::Path;
@@ -229,7 +226,6 @@ pub fn find_node<'a>(tree: Option<&'a KnowledgeNode>, rel_dir: &str) -> Option<&
 }
 
 /// Return the card entry (index or body) at file `path` or `None`.
-/// Mirrors `find_knowledge_card`.
 pub fn find_card<'a>(tree: Option<&'a KnowledgeNode>, path: &str) -> Option<&'a KnowledgeCard> {
     let tree = tree?;
     if let Some(idx) = tree.index.as_ref() {
@@ -291,7 +287,7 @@ mod tests {
         let td = tempfile::tempdir().unwrap();
         let p = td.path().join("x.md");
         write(&p, "# T\n\nEllipsis ok...\n");
-        // rstrip('.') strips every trailing dot — matches Python.
+        // Every trailing dot is stripped — `"foo."` and `"foo…"` collapse.
         let (_t, d) = knowledge_title_and_desc(&p);
         assert_eq!(d, "Ellipsis ok");
     }
@@ -302,8 +298,8 @@ mod tests {
         let p = td.path().join("x.md");
         // `---` lines and `#` lines are skipped; the first other non-blank
         // line wins. YAML-frontmatter keys between fences leak through on
-        // purpose — condash's parser is intentionally cheap, matching
-        // Python's parse behavior.
+        // purpose — the parser is intentionally cheap and doesn't model
+        // frontmatter structurally.
         write(&p, "# Title\n\n## A subheading\n\nActual body line.\n");
         let (t, d) = knowledge_title_and_desc(&p);
         assert_eq!(t, "Title");
@@ -316,7 +312,6 @@ mod tests {
         let p = td.path().join("x.md");
         write(&p, "---\nmeta: here\n---\n# Title\n\nActual body.\n");
         // `---` lines skipped, `meta: here` is a plain line → taken as desc.
-        // This mirrors the Python parser one-for-one.
         let (_t, d) = knowledge_title_and_desc(&p);
         assert_eq!(d, "meta: here");
     }

--- a/crates/condash-parser/src/lib.rs
+++ b/crates/condash-parser/src/lib.rs
@@ -1,16 +1,17 @@
-//! Rust port of condash's markdown parser (`src/condash/parser.py`).
+//! Parser for conception item READMEs and the knowledge tree.
 //!
-//! Layered by side-effect:
-//!   - Pure string-level primitives: `regexes`, `sections`, `deliverables`,
-//!     `readme` (`parse_readme_content`), `note_kind`.
-//!   - Filesystem-walking: `tree` (`list_item_tree`), `knowledge`
-//!     (`collect_knowledge` + tree walker), `collect` (`parse_readme` +
-//!     `collect_items`).
+//! Layered by side-effect so unit tests can exercise the pure core
+//! without touching the disk:
 //!
-//! Fingerprint helpers (`_compute_fingerprint`, `compute_*_node_fingerprints`)
-//! land alongside the `/check-updates` route port, not here — they depend
-//! on matching Python's `repr()` output for cross-build stability, which
-//! is easier to settle once the cache + route layer is in place.
+//!   - Pure string-level primitives: [`regexes`], [`sections`],
+//!     [`deliverables`], [`readme`] (`parse_readme_content`),
+//!     [`note_kind`].
+//!   - Filesystem-walking: [`tree`] (`list_item_tree`), [`knowledge`]
+//!     (`collect_knowledge` + tree walker), [`collect`]
+//!     (`parse_readme` + `collect_items`).
+//!   - [`fingerprint`] — cross-build-stable hashing for
+//!     `/check-updates`; see the module docs for the `repr()`-style
+//!     normalisation it performs.
 
 pub mod collect;
 pub mod deliverables;
@@ -37,9 +38,9 @@ pub use readme::{parse_readme_content, ItemReadme};
 pub use sections::{parse_sections, CheckboxStatus, Section, SectionItem};
 pub use tree::{flatten_tree_paths, list_item_tree, FileEntry, GroupEntry, ItemTree};
 
-/// Ordered priority / status enum. The order of variants mirrors Python's
-/// `PRIORITIES` tuple — call sites that sort by `as usize` get the same
-/// total order the Python dashboard uses.
+/// Ordered priority / status enum. Variant order is load-bearing:
+/// sort-by-`as usize` yields the dashboard's canonical column order
+/// (now → soon → later → backlog → review → done).
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
 )]
@@ -63,9 +64,9 @@ impl Priority {
         Priority::Done,
     ];
 
-    /// Match Python's lowercase string parsing; returns `None` for unknown
-    /// values (parse_readme coerces those to `Backlog` and records the raw
-    /// input in `invalid_status`).
+    /// Parse a lowercase string; returns `None` for unknown values.
+    /// `parse_readme_content` coerces unknowns to `Backlog` and
+    /// records the raw input in the item's `invalid_status` field.
     pub fn from_lowercase(value: &str) -> Option<Priority> {
         match value {
             "now" => Some(Priority::Now),

--- a/crates/condash-parser/src/note_kind.rs
+++ b/crates/condash-parser/src/note_kind.rs
@@ -1,8 +1,8 @@
 //! File-extension classifier — drives the preview dispatcher.
 //!
-//! Rust port of `_note_kind` in `src/condash/parser.py`. The extension
-//! lists mirror the Python `_IMAGE_EXTS` / `_PDF_EXTS` / `_TEXT_EXTS`
-//! sets one-for-one; anything else classifies as `binary`.
+//! A note file is routed to one of four preview paths — markdown,
+//! image, pdf, text — based on its extension. Anything outside the
+//! lists below classifies as `binary` and is not previewable.
 
 use std::path::Path;
 

--- a/crates/condash-parser/src/readme.rs
+++ b/crates/condash-parser/src/readme.rs
@@ -1,17 +1,10 @@
-//! `parse_readme` body, ported as a pure function.
+//! `parse_readme_content` — the pure parsing step.
 //!
-//! Python's `parse_readme(ctx, path, kind)` does three things that this
-//! Rust port splits apart:
-//!
-//! 1. Reads the file off disk and computes `slug` / `path` / `item_dir`
-//!    from `path.parent.relative_to(ctx.base_dir)`. Filesystem + config.
-//! 2. Parses the file content into an item dict. Pure.
-//! 3. Calls `_list_item_tree(ctx, path.parent)` for the `files` field.
-//!    Filesystem.
-//!
-//! This module only handles (2). The Phase 2 route layer wraps it with
-//! the filesystem reads and the files-tree walk. Keeping the parse pure
-//! is what makes the Python↔Rust diff test tractable.
+//! This module takes the README body as a string and produces an
+//! [`ItemReadme`]. The filesystem reads (loading the file, walking the
+//! item directory for the `files` field) live one layer up in
+//! [`crate::collect`], which makes this function trivial to exercise
+//! from unit tests without touching the disk.
 
 use std::collections::HashMap;
 
@@ -22,15 +15,16 @@ use crate::regexes::{HEADING2_RE, HEADING3_RE, METADATA_RE};
 use crate::sections::{parse_sections, Section};
 use crate::Priority;
 
-/// Maximum summary length in *codepoints* (matches Python's `len(str)`).
-/// When exceeded, the summary is truncated to `SUMMARY_MAX - 3` codepoints
-/// and `...` is appended, so the final string is exactly `SUMMARY_MAX`.
+/// Maximum summary length in *codepoints* (count user-visible glyphs,
+/// not bytes). When exceeded, the summary is truncated to
+/// `SUMMARY_MAX - 3` codepoints and `...` is appended, so the final
+/// string is exactly `SUMMARY_MAX`.
 const SUMMARY_MAX: usize = 300;
 const SUMMARY_HEAD: usize = 297;
 
-/// Parsed item README. Field order + names mirror the Python dict so that
-/// `serde_json::to_value` equals the Python output key-by-key (modulo the
-/// `files` key, which the filesystem wrapper fills in later).
+/// Parsed item README. The `files` field is filled in by the collector
+/// one layer up — it lives on this struct for ergonomic template
+/// rendering but isn't populated by the pure parse step.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ItemReadme {
     pub slug: String,
@@ -51,16 +45,13 @@ pub struct ItemReadme {
 
 /// Parse one item's README content into an [`ItemReadme`].
 ///
-/// `content` is the raw UTF-8 text of the file. `slug` is the item folder
-/// name (`path.parent.name` in Python). `rel_path` is the README path
-/// relative to `ctx.base_dir`. `item_dir` is the item folder relative to
-/// `ctx.base_dir` — i.e. `rel_path` with the trailing `/README.md` lopped.
-/// `fallback_kind` matches Python's optional `kind` argument: used when
-/// the README has no `**Kind**:` header.
+/// `content` is the raw UTF-8 text of the file. `slug` is the item
+/// folder name. `rel_path` is the README path relative to
+/// `ctx.base_dir`; `item_dir` is the same minus the trailing
+/// `/README.md`. `fallback_kind` is used only when the README has no
+/// `**Kind**:` header.
 ///
-/// Returns `None` only when `content` itself is empty (matching Python's
-/// `if not lines: return None` — Python never actually hits that since
-/// `"".split("\n") == [""]`, but we keep parity).
+/// Returns `None` when `content` is empty.
 pub fn parse_readme_content(
     content: &str,
     slug: &str,

--- a/crates/condash-parser/src/regexes.rs
+++ b/crates/condash-parser/src/regexes.rs
@@ -1,10 +1,8 @@
-//! Regex primitives, 1:1 with `parser.py`'s module-level constants.
+//! Regex primitives shared across parse steps.
 //!
-//! None of the Python regexes use lookaround or backrefs, so the Rust
-//! `regex` crate ports them directly. All patterns are single-line and
-//! anchored with `^`/`$` — the call sites feed them line-by-line, so the
-//! default crate behaviour (where `^` is start-of-string) matches Python's
-//! `re.match` semantics exactly.
+//! All patterns are single-line and anchored with `^`/`$` — the call
+//! sites feed them line-by-line, so the default `regex` crate
+//! behaviour (where `^` is start-of-string) is what we want.
 
 use once_cell::sync::Lazy;
 use regex::Regex;

--- a/crates/condash-parser/src/sections.rs
+++ b/crates/condash-parser/src/sections.rs
@@ -32,7 +32,8 @@ impl CheckboxStatus {
         }
     }
 
-    /// Mirror `status in ("done", "abandoned")` from the Python parser.
+    /// Both `done` and `abandoned` count as "this step is finished"
+    /// for the progress-bar math — the difference is only visual.
     pub fn is_done(self) -> bool {
         matches!(self, CheckboxStatus::Done | CheckboxStatus::Abandoned)
     }

--- a/crates/condash-parser/src/tree.rs
+++ b/crates/condash-parser/src/tree.rs
@@ -1,8 +1,7 @@
 //! Item files-tree — `files` field on a parsed item README.
 //!
-//! Rust port of `_list_item_tree` + `_flatten_tree_paths` in
-//! `src/condash/parser.py`. Filesystem-walking, unlike the rest of the
-//! crate, so tests exercise it against `tempfile`-built fixtures.
+//! Filesystem-walking, unlike the rest of the crate, so tests
+//! exercise this module against `tempfile`-built fixtures.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -11,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::note_kind::note_kind;
 
-/// One leaf file inside an item's tree. Mirrors the Python dict shape:
-/// `{name, path, kind}` where `path` is relative to `ctx.base_dir`.
+/// One leaf file inside an item's tree. `path` is relative to
+/// `ctx.base_dir`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FileEntry {
     pub name: String,
@@ -20,7 +19,7 @@ pub struct FileEntry {
     pub kind: String,
 }
 
-/// One subdirectory group. Mirrors `{rel_dir, label, files, groups}`.
+/// One subdirectory group — `{rel_dir, label, files, groups}`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GroupEntry {
     pub rel_dir: String,

--- a/crates/condash-render/Cargo.toml
+++ b/crates/condash-render/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "condash-render"
 version = "0.1.0"
-description = "HTML rendering for the conception dashboard. Rust port of condash/render.py + templates/."
+description = "HTML rendering for the conception dashboard."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"

--- a/crates/condash-render/src/git_render.rs
+++ b/crates/condash-render/src/git_render.rs
@@ -1,5 +1,5 @@
-//! Git-strip rendering — Rust port of render.py's peer-card / branch-row
-//! / runner-button / open-with helpers.
+//! Git-strip rendering — peer cards, branch rows, runner buttons,
+//! open-with launcher buttons.
 //!
 //! The public entry points take a [`LiveRunners`] map keyed by runner
 //! key. Each entry records the checkout that owns the session and the
@@ -18,7 +18,8 @@ use crate::h;
 use crate::icons::Icons;
 use crate::templating::embed_attr;
 
-/// Canonical runner-registry key. Mirrors `_runner_key` in Python.
+/// Canonical runner-registry key. Sub-repos use `<repo>--<sub>` to
+/// keep each submodule's runner session distinct from the parent's.
 pub fn runner_key(repo_name: &str, sub_name: Option<&str>) -> String {
     match sub_name {
         None => repo_name.to_string(),

--- a/crates/condash-render/src/icons.rs
+++ b/crates/condash-render/src/icons.rs
@@ -1,14 +1,11 @@
-//! Static SVG icon strings — Rust port of `render.py::_ICON_SVGS`.
+//! Static SVG icon strings.
 //!
 //! Every icon appears as a raw `<svg>…</svg>` string so the template
-//! engine can emit it with `{{ icons.foo | safe }}`. Kept in a single
-//! module to mirror Python's dict; the enum is constructed once per
-//! render and serialised into the minijinja `Value` tree.
+//! engine can emit it with `{{ icons.foo | safe }}`. The struct is
+//! constructed once per render and serialised into the minijinja
+//! `Value` tree.
 
 /// Named SVG icons referenced by the dashboard templates.
-///
-/// Field names mirror the Python dict keys so the templates — which
-/// live alongside the wheel — can be reused unchanged.
 pub struct Icons;
 
 macro_rules! def_icons {

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -29,9 +29,10 @@ use condash_state::{collect_git_repos, RenderCtx};
 use minijinja::context;
 use minijinja::value::Value;
 
-/// HTML-escape a string — mirror of Python's `html.escape(str(text))`.
-/// minijinja's autoescape covers most cases, but direct string
-/// interpolation (e.g. into substitution placeholders) still needs it.
+/// HTML-escape a string for insertion into page body or attribute
+/// text. minijinja's autoescape covers most template contexts, but
+/// direct string interpolation (e.g. into substitution placeholders)
+/// still needs this.
 pub fn h(text: &str) -> String {
     let mut out = String::with_capacity(text.len());
     for c in text.chars() {
@@ -47,8 +48,8 @@ pub fn h(text: &str) -> String {
     out
 }
 
-/// Priority ordering — matches Python's `PRI_ORDER` dict lookup where
-/// missing priorities sort as 9 ("after everything").
+/// Priority ordering — maps the lowercase priority string to a sort
+/// key. Unknown / missing priorities sort as 9 ("after everything").
 fn pri_order(priority: &str) -> i32 {
     match priority {
         "now" => 0,
@@ -198,12 +199,12 @@ pub fn render_history(ctx: &RenderCtx, items: &[Item]) -> String {
     templating::render("history.html.j2", tctx)
 }
 
-/// Public entry point for `/`. Port of `render_page`.
+/// Public entry point for `/` — the full dashboard HTML.
 ///
 /// `items` is typically `cache.get_items(ctx)`; `knowledge` is
-/// `cache.get_knowledge(ctx)`. `version` is rendered verbatim into the
-/// `{{VERSION}}` placeholder — the Tauri host passes its own version
-/// string (or propagates the Python wheel version in dual-build mode).
+/// `cache.get_knowledge(ctx)`. `version` is rendered verbatim into
+/// the `{{VERSION}}` placeholder — the Tauri host passes its own
+/// version string from `env!("CARGO_PKG_VERSION")`.
 pub fn render_page(
     ctx: &RenderCtx,
     items: &[Item],

--- a/crates/condash-render/src/templating.rs
+++ b/crates/condash-render/src/templating.rs
@@ -1,9 +1,8 @@
-//! `minijinja` environment + custom filters — Rust port of
-//! `condash/templating.py`.
+//! `minijinja` environment + custom filters.
 //!
-//! The Jinja2 templates from `crates/condash-render/templates/` are embedded via
-//! `include_str!` so they ship inside the binary. Two custom filters
-//! match the Python env:
+//! The Jinja2 templates under `crates/condash-render/templates/` are
+//! embedded via `include_str!` so they ship inside the binary. Two
+//! custom filters are registered:
 //!
 //! - `embed`: JSON-encode then swap `'`→`\'` and `"`→`'` so the result
 //!   is safe to drop into an HTML attribute. Returns a safe string
@@ -45,15 +44,16 @@ pub fn embed_attr<T: serde::Serialize>(value: &T) -> String {
 
 fn embed_json_string(json: &str) -> String {
     let ascii = ensure_ascii(json);
-    // `json.dumps(x).replace("'", "\\'").replace('"', "'")` — the
-    // replacements are applied in order: escape single quotes first,
-    // then swap the outer double quotes for singles.
+    // Escape single quotes first, then swap the outer double quotes
+    // for singles — in that order, so the final string is safe to
+    // drop inside a single-quoted HTML attribute.
     ascii.replace('\'', "\\'").replace('"', "'")
 }
 
 /// Replace every non-ASCII codepoint with `\uXXXX` (or a UTF-16
-/// surrogate pair for > U+FFFF). Mirrors Python's
-/// `json.dumps(..., ensure_ascii=True)`.
+/// surrogate pair for > U+FFFF). The `embed` filter emits JSON
+/// literals inside HTML attributes; keeping them ASCII avoids having
+/// to reason about the enclosing page's encoding.
 fn ensure_ascii(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -112,9 +112,7 @@ fn markupsafe_formatter(out: &mut Output, state: &State, value: &Value) -> Resul
 }
 
 fn dirname_filter(path: String) -> String {
-    // Parent-path filter: everything before the last `/`. Mirrors the
-    // Python filter of the same name in templating.py. Both engines
-    // consume the same macro so both register this.
+    // Parent-path filter: everything before the last `/`.
     match path.rfind('/') {
         Some(i) => path[..i].to_string(),
         None => String::new(),
@@ -122,7 +120,7 @@ fn dirname_filter(path: String) -> String {
 }
 
 fn subtree_count_filter(group: Value) -> Result<i64, Error> {
-    // Python: len(group.get("files") or []) + sum(subtree_count(g) for g in group.get("groups") or [])
+    // Recursive file count: own files + sum of children's counts.
     let files_len = match group.get_attr("files") {
         Ok(files) if !files.is_undefined() && !files.is_none() => match files.len() {
             Some(n) => n as i64,
@@ -145,16 +143,15 @@ fn subtree_count_filter(group: Value) -> Result<i64, Error> {
 
 static ENV: OnceLock<Environment<'static>> = OnceLock::new();
 
-/// Return the process-wide minijinja environment, built on first access.
-///
-/// Mirrors Python's `@lru_cache(maxsize=1) env()` pattern.
+/// Return the process-wide minijinja environment, built on first
+/// access and cached for the rest of the process's lifetime.
 pub fn env() -> &'static Environment<'static> {
     ENV.get_or_init(build_env)
 }
 
 fn build_env() -> Environment<'static> {
     let mut env = Environment::new();
-    // Autoescape for .html/.j2 — matches Python's select_autoescape.
+    // Autoescape for .html/.j2 — JS/CSS/etc. templates stay raw.
     env.set_auto_escape_callback(|name| {
         if name.ends_with(".html") || name.ends_with(".j2") || name.ends_with(".htm") {
             AutoEscape::Html
@@ -163,26 +160,18 @@ fn build_env() -> Environment<'static> {
         }
     });
 
-    // Whitespace control — Python's env sets both trim_blocks and
-    // lstrip_blocks. minijinja 2.19+ exposes the same knobs. Without
-    // them the two engines diverge on every template that leads with
-    // `{% import %}` (or any tag on its own line), producing stray
-    // `\n` or `  ` prefixes Python's build doesn't emit.
+    // trim_blocks + lstrip_blocks: without them every template that
+    // leads with `{% import %}` (or any tag on its own line) emits a
+    // stray `\n` or `  ` prefix into the rendered HTML.
     env.set_trim_blocks(true);
     env.set_lstrip_blocks(true);
 
-    // Custom formatter: markupsafe-compatible HTML escape. minijinja's
-    // default escape encodes `/` as `&#x2f;`, which Python Jinja2 (via
-    // markupsafe) doesn't do — so the two engines diverge on every
-    // attribute that carries a path. This formatter matches Python's
-    // exact output: escape only `& < > " '`, render `"` as `&#34;` and
-    // `'` as `&#39;` (markupsafe's canonical forms).
+    // Custom formatter: markupsafe-style HTML escape. minijinja's
+    // default escape encodes `/` as `&#x2f;`, which breaks every
+    // attribute carrying a path (e.g. `href="/foo/bar"`). The
+    // formatter below escapes only `& < > " '`, rendering `"` as
+    // `&#34;` and `'` as `&#39;`.
     env.set_formatter(markupsafe_formatter);
-
-    // trim_blocks / lstrip_blocks — match Python's env configuration.
-    // minijinja's `keep_trailing_newline` is the inverse of Jinja's
-    // default; Python Jinja trims the newline after a block. minijinja
-    // default also trims, so no flip needed here.
 
     env.add_template("_macros.html.j2", MACROS_TEMPLATE)
         .unwrap();

--- a/crates/condash-state/Cargo.toml
+++ b/crates/condash-state/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "condash-state"
 version = "0.1.0"
-description = "Runtime context + workspace cache for condash. Rust port of context.py + cache.py."
+description = "Runtime context + workspace cache for condash."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"

--- a/crates/condash-state/src/cache.rs
+++ b/crates/condash-state/src/cache.rs
@@ -1,4 +1,4 @@
-//! Filesystem-walk memoization — Rust port of `cache.py::WorkspaceCache`.
+//! Filesystem-walk memoization.
 //!
 //! Without a cache every request re-walks the conception tree: `/`,
 //! `/check-updates`, `/fragment`, and `/search-history` all call
@@ -7,14 +7,12 @@
 //!
 //! [`WorkspaceCache`] memoizes the two hot paths behind an `RwLock` so
 //! reads from Tauri route handlers are cheap and stay safe alongside
-//! invalidations driven by the filesystem watcher. The watcher coarsely
-//! routes tab events (`projects` / `knowledge`) to [`invalidate_items`]
-//! and [`invalidate_knowledge`] — matching Python's coarse-by-design
-//! invalidation scheme.
-//!
-//! The wikilink cache from Python lives separately in Phase 3 with the
-//! render layer; putting it here would force a dependency on a crate
-//! that doesn't exist yet.
+//! invalidations driven by the filesystem watcher. The watcher
+//! coarsely routes tab events (`projects` / `knowledge`) to
+//! [`invalidate_items`] and [`invalidate_knowledge`] — invalidating a
+//! whole tab on any event inside it keeps the invalidation logic tiny
+//! and a single cold rebuild is fast enough (<50 ms on a ~200-item
+//! tree) that sub-key invalidation isn't worth the book-keeping.
 //!
 //! [`invalidate_items`]: WorkspaceCache::invalidate_items
 //! [`invalidate_knowledge`]: WorkspaceCache::invalidate_knowledge

--- a/crates/condash-state/src/ctx.rs
+++ b/crates/condash-state/src/ctx.rs
@@ -1,19 +1,13 @@
-//! Immutable runtime context — Rust port of `context.py::RenderCtx`.
-//!
-//! The Python module carries a dataclass with `base_dir`, `workspace`,
-//! `worktrees`, `repo_structure`, `open_with`, `pdf_viewer`, `repo_run`,
-//! and `template`. Phase 2 only needs the read-only subset: `base_dir`
-//! for the parser, `template` for the dashboard shell. The config-heavy
-//! fields (`open_with`, `pdf_viewer`, `repo_run`, `repo_structure`) are
-//! stubbed as empty collections and will grow as mutations + openers +
-//! runners land in Phases 3–4.
+//! Immutable runtime context — the read-only data every rendering and
+//! mutation helper needs. Built once per effective config and swapped
+//! into the shared app state whenever the config modal posts a new
+//! body.
 
 use std::collections::HashMap;
 use std::path::PathBuf;
 
 /// One section of the repository explorer tab: a label (e.g. `"Primary"`)
-/// with a list of `(repo_name, submodules)` pairs. Matches Python's
-/// `list[tuple[str, list[tuple[str, list[str]]]]]` verbatim in shape.
+/// with an ordered list of repo entries.
 #[derive(Debug, Clone, Default)]
 pub struct RepoSection {
     pub label: String,
@@ -27,22 +21,20 @@ pub struct RepoEntry {
     pub submodules: Vec<String>,
 }
 
-/// One "Open with …" slot config entry. Mirrors Python's
-/// `OpenWithSlot`: the user-visible `label` drives rendering, and the
-/// `commands` fallback chain is tried in order by the openers layer.
-/// Each command is a shell template with `{path}` substitution — the
-/// first that exits 0 wins.
+/// One "Open with …" slot config entry. The user-visible `label`
+/// drives rendering, and the `commands` fallback chain is tried in
+/// order by the openers layer. Each command is a shell template with
+/// `{path}` substitution — the first that exits 0 wins.
 #[derive(Debug, Clone, Default)]
 pub struct OpenWithSlot {
     pub label: String,
     pub commands: Vec<String>,
 }
 
-/// Embedded-terminal preferences. Carries the Python
-/// `TerminalConfig` fields verbatim, all optional so the YAML
-/// round-trip via the plain-text config modal preserves whatever
-/// the user wrote. The renderer applies built-in defaults when a
-/// field is `None`.
+/// Embedded-terminal preferences. All fields optional so the YAML
+/// round-trip via the plain-text config modal preserves whatever the
+/// user wrote; the renderer applies built-in defaults when a field is
+/// `None`.
 #[derive(Debug, Clone, Default)]
 pub struct TerminalPrefs {
     pub shell: Option<String>,

--- a/crates/condash-state/src/lib.rs
+++ b/crates/condash-state/src/lib.rs
@@ -1,15 +1,15 @@
 //! Runtime context + workspace cache for condash.
 //!
-//! Rust port of `src/condash/context.py` + `src/condash/cache.py`.
-//! Split into two modules that mirror their Python counterparts:
-//!
-//! - [`ctx`] — immutable runtime context built from a config. Threaded
-//!   through every helper that needs config (base_dir, workspace, repo
-//!   structure, etc). Module-globals in Python live here instead.
+//! - [`ctx`] — immutable runtime context built from a config.
+//!   Threaded through every helper that needs config (base_dir,
+//!   workspace, repo structure, …).
 //! - [`cache`] — memoize the hot read paths (`collect_items`,
 //!   `collect_knowledge`) behind an `RwLock` so reads from route
-//!   handlers are safe alongside invalidations driven by the filesystem
-//!   watcher.
+//!   handlers are safe alongside invalidations driven by the
+//!   filesystem watcher.
+//! - [`git`] — per-repo HEAD / branch / dirty-count queries, shelled
+//!   out to `git` rather than via `libgit2`.
+//! - [`search`] — the history-tab search backend.
 
 pub mod cache;
 pub mod ctx;

--- a/crates/condash-state/src/search.rs
+++ b/crates/condash-state/src/search.rs
@@ -1,11 +1,9 @@
-//! History-tab search backend — Rust port of `src/condash/search.py`.
+//! History-tab search backend.
 //!
 //! Broadens the Projects-tab string filter: matches README bodies,
 //! note + text-file content, and filenames. Returns per-project hits
-//! with HTML-escaped snippets and `<mark>` wrapping, scored with the
-//! same weights the Python build uses. Output structure matches
-//! Python's dict one-for-one so `search-diff` can equality-check the
-//! JSON.
+//! with HTML-escaped snippets and `<mark>` wrapping, scored by source
+//! (title > header > body > filename) and recency.
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -26,7 +24,8 @@ const MAX_CONTENT_BYTES: u64 = 512 * 1024;
 
 const SNIPPET_RADIUS: usize = 60;
 
-/// Source-weight table. Matches Python's `_SOURCE_WEIGHTS`.
+/// Source-weight table — a title hit outranks a body hit so the
+/// ranking feels intuitive for "where did I write this?" queries.
 fn source_weight(src: &str) -> i64 {
     match src {
         "title" => 4,
@@ -111,17 +110,14 @@ fn build_snippet(text: &str, tokens: &[String], radius: usize) -> String {
     if text.is_empty() || tokens.is_empty() {
         return String::new();
     }
-    // All index math is done in char-space (not bytes) so the output
-    // matches Python's `str.find` / slicing exactly — Python 3 strings
-    // are arrays of code points, whereas Rust's `str::find` returns a
-    // byte offset. For ASCII text the two agree; for French content
-    // with accents or em-dashes they don't.
+    // All index math is done in char-space (not bytes). Rust's
+    // `str::find` returns a byte offset, which is fine for ASCII but
+    // slices mid-codepoint on French content with accents or em-dashes.
     let text_chars: Vec<char> = text.chars().collect();
     let hay_chars: Vec<char> = text.to_lowercase().chars().collect();
     // `to_lowercase()` can in theory change char count (rare Unicode
     // edge cases like `İ` → `i̇`). For the conception corpus this
-    // doesn't happen, and Python's `str.lower()` has the same quirk —
-    // falling out of parity there is a non-issue.
+    // doesn't happen, so we don't re-align the indices after lowercasing.
 
     let mut best: Option<(usize, usize)> = None;
     for tok in tokens {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.0.18"
+version = "1.0.19"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,25 +1,19 @@
-//! Filesystem-driven staleness push — Rust port of `src/condash/events.py`.
+//! Filesystem-driven staleness push.
 //!
 //! The watcher emits coarse per-tab events (`projects` / `knowledge` /
 //! `code`) whenever a watched path changes. The SSE handler in
-//! `server.rs` subscribes to the bus and streams events to the browser;
-//! the frontend treats every event as a hint to re-poll `/check-updates`.
+//! `server.rs` subscribes to the bus and streams events to the
+//! browser; the frontend treats every event as a hint to re-poll
+//! `/check-updates`.
 //!
-//! The merged `configuration.yml` is intentionally *not* watched —
-//! edits come from the in-app YAML editor which explicitly triggers a
+//! `configuration.yml` itself is intentionally *not* watched — edits
+//! come from the in-app YAML editor which explicitly triggers a
 //! `RenderCtx` rebuild on Save. Out-of-band edits (hand-edit from a
 //! different tool) require the user to reopen the modal or restart.
 //!
-//! Two differences from the Python original:
-//!
-//! 1. The fan-out uses a `tokio::sync::broadcast` channel instead of a
-//!    hand-rolled subscriber list + per-subscriber `asyncio.Queue`. The
-//!    broadcast channel gives us lagging-subscriber semantics for free
-//!    (the client re-polls on lag, which is the same fall-back the
-//!    reconciler already provides).
-//! 2. Config hot-reload is the config modal's responsibility — it
-//!    rebuilds the `RenderCtx` in-band after a successful save and the
-//!    event bus stays out of that path.
+//! Fan-out uses a `tokio::sync::broadcast` channel, which gives us
+//! lagging-subscriber semantics for free: the client re-polls on lag,
+//! which is the same fall-back the reconciler already provides.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -31,11 +25,10 @@ use serde::Serialize;
 use tokio::sync::broadcast;
 
 /// Drop duplicate events per tab within this window — a single editor
-/// save often produces swap-file + metadata-touch events too. Matches
-/// Python's `_DEBOUNCE_SECONDS`.
+/// save often produces swap-file + metadata-touch events too.
 pub const DEBOUNCE: Duration = Duration::from_millis(750);
 
-/// Payload emitted by the watcher. Wire format matches Python —
+/// Payload emitted by the watcher. Wire format is
 /// `{"tab": <tab>, "ts": <seconds>, "file": <leaf>?}`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct EventPayload {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,10 +1,8 @@
-//! Tauri host entry point. Phase 2 slice 5 wires axum in under the
-//! webview: we start an HTTP server on a free localhost port, warm the
-//! workspace cache, and navigate the main window to `http://127.0.0.1:<port>/`.
-//!
-//! The dashboard JS and templates are unchanged from the Python build —
-//! they all speak plain HTTP fetches, so pointing the webview at our
-//! axum server is the only integration delta.
+//! Tauri host entry point. Wires axum in under the webview: we start
+//! an HTTP server on a free localhost port, warm the workspace cache,
+//! and navigate the main window to `http://127.0.0.1:<port>/`. The
+//! dashboard JS and templates speak plain HTTP fetches, so pointing
+//! the webview at the local axum server is the only integration delta.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;

--- a/src-tauri/src/openers.rs
+++ b/src-tauri/src/openers.rs
@@ -1,12 +1,11 @@
 //! External-launcher helpers — one place to spawn IDE / file-manager /
 //! PDF-viewer / browser processes, detached from the condash lifetime.
 //!
-//! Port of `src/condash/openers.py` (Python build). Shape: take a
-//! shell-template fallback chain, substitute `{path}` (or `{url}`),
-//! spawn each in order until one exits 0 within a short window.
-//! Spawning is detached via `/bin/sh -c` with all standard streams
-//! redirected to `/dev/null`, so condash doesn't hold the child's
-//! output buffers and the process outlives the window.
+//! Take a shell-template fallback chain, substitute `{path}` (or
+//! `{url}`), and spawn each in order until one exits 0 within a short
+//! window. Spawning is detached via `/bin/sh -c` with all standard
+//! streams redirected to `/dev/null`, so condash doesn't hold the
+//! child's output buffers and the process outlives the window.
 
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -1,11 +1,8 @@
-//! Path validation for user-supplied paths. Mirrors the subset of
-//! `src/condash/paths.py` that the write-side routes need — the
-//! `_safe_resolve` helper plus the regex-gated validators
-//! (`_validate_path`, `validate_note_path`, …) and small helpers the
-//! mutation handlers depend on (`_resolve_under_item`,
-//! `_VALID_NOTE_FILENAME_RE`, …).
+//! Path validation for user-supplied paths used by the write-side
+//! routes: a `safe_resolve` helper plus regex-gated validators for
+//! READMEs, notes, item dirs, and filenames.
 //!
-//! Every validator follows the same shape Python does:
+//! Every validator follows the same four-step shape:
 //!
 //! 1. Reject empty / NUL / literal `..` outright.
 //! 2. Gate with one or more regexes.
@@ -21,60 +18,57 @@ use regex::Regex;
 /// Common item-path prefix — `projects/YYYY-MM/YYYY-MM-DD-<slug>/`.
 const VALID_ITEM_PREFIX: &str = r"^projects/\d{4}-\d{2}/\d{4}-\d{2}-\d{2}-[\w.-]+/";
 
-/// `projects/YYYY-MM/YYYY-MM-DD-<slug>/README.md` — `_VALID_PATH_RE`.
+/// `projects/YYYY-MM/YYYY-MM-DD-<slug>/README.md`.
 static VALID_README_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!("{VALID_ITEM_PREFIX}README\\.md$")).expect("VALID_README_RE compiles")
 });
 
-/// `<item>/<anything>.md` — `_VALID_NOTE_RE` in `paths.py`.
+/// `<item>/<anything>.md`.
 static VALID_NOTE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}[\w./-]+\.md$")).expect("VALID_NOTE_RE compiles")
 });
 
-/// `knowledge/<file>.md` — `_VALID_KNOWLEDGE_NOTE_RE`. Matches `knowledge/`
-/// at any depth.
+/// `knowledge/<file>.md`. Matches `knowledge/` at any depth.
 static VALID_KNOWLEDGE_NOTE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^knowledge/(?:[\w.-]+/)*[\w.-]+\.md$").expect("VALID_KNOWLEDGE_NOTE_RE compiles")
 });
 
-/// Any file at any depth inside an item directory — `_VALID_ITEM_FILE_RE`.
+/// Any file at any depth inside an item directory.
 static VALID_ITEM_FILE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}[\w./-]+$")).expect("VALID_ITEM_FILE_RE compiles")
 });
 
 /// Restricted to files directly under `<item>/notes/` — used by rename
-/// (only notes are user-renamable). `_VALID_ITEM_NOTES_FILE_RE`.
+/// (only notes are user-renamable).
 pub(crate) static VALID_ITEM_NOTES_FILE_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}notes/[\w./-]+$"))
         .expect("VALID_ITEM_NOTES_FILE_RE compiles")
 });
 
-/// Item directory itself — `projects/YYYY-MM/YYYY-MM-DD-<slug>/`, with or
-/// without the trailing slash. Mirrors `_VALID_ITEM_DIR_RE` from `paths.py`.
+/// Item directory itself — `projects/YYYY-MM/YYYY-MM-DD-<slug>/`, with
+/// or without the trailing slash.
 static VALID_ITEM_DIR_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^projects/\d{4}-\d{2}/\d{4}-\d{2}-\d{2}-[\w.-]+/?$")
         .expect("VALID_ITEM_DIR_RE compiles")
 });
 
-/// `<name>.<ext>` — `_VALID_NOTE_FILENAME_RE`. Used to validate the target
-/// of create_note / rename_note.
+/// `<name>.<ext>` — validates the target filename of create_note /
+/// rename_note.
 pub static VALID_NOTE_FILENAME_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[\w.-]+\.[A-Za-z0-9]+$").expect("VALID_NOTE_FILENAME_RE compiles"));
 
-/// Simple bare-filename regex allowed for rename new-stem. Matches what
-/// `mutations.py` inlines as `re.match(r"^[\w.-]+$", new_stem)`.
+/// Bare filename allowed for the rename target's new stem.
 pub static VALID_NEW_STEM_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[\w.-]+$").expect("VALID_NEW_STEM_RE compiles"));
 
-/// Subdirectory path (possibly nested) — `_VALID_SUBDIR_RE`. Used by
-/// `resolve_under_item` to reject anything that doesn't look like a
-/// sequence of `[\w.-]+` segments.
+/// Subdirectory path (possibly nested). Used by `resolve_under_item`
+/// to reject anything that doesn't look like a sequence of `[\w.-]+`
+/// segments.
 pub static VALID_SUBDIR_RE: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[\w.-]+(/[\w.-]+)*$").expect("VALID_SUBDIR_RE compiles"));
 
-/// Upload filename regex — `_VALID_UPLOAD_FILENAME_RE`. More permissive
-/// than the note regex to accept typical Camera/PDF exports (spaces,
-/// parentheses).
+/// Upload filename regex — more permissive than the note regex to
+/// accept typical Camera/PDF exports (spaces, parentheses).
 pub static VALID_UPLOAD_FILENAME_RE: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^[\w. \-()]+\.[A-Za-z0-9]+$").expect("VALID_UPLOAD_FILENAME_RE compiles")
 });
@@ -109,16 +103,15 @@ pub fn safe_resolve(
 }
 
 /// Validate a README path (`projects/YYYY-MM/<slug>/README.md`). The
-/// README must resolve to an existing file under `base_dir`. Mirrors
-/// `paths._validate_path` (plus the step-mutation handlers' implicit
-/// require_file=true, since they immediately read the file).
+/// README must resolve to an existing file under `base_dir`. Every
+/// step-mutation handler reads the file immediately after, so
+/// `require_file=true` is hardcoded.
 pub fn validate_readme_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
     safe_resolve(base_dir, rel_path, &[&VALID_README_RE], true)
 }
 
 /// Validate a note-like path — item-tree file, `<item>/notes/*.md`, or
-/// `knowledge/**/*.md`. Mirrors `paths.validate_note_path`. The target
-/// must resolve to an existing file.
+/// `knowledge/**/*.md`. The target must resolve to an existing file.
 pub fn validate_note_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
     safe_resolve(
         base_dir,
@@ -133,9 +126,9 @@ pub fn validate_note_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
 }
 
 /// Validate a project-item folder path (`projects/YYYY-MM/<slug>/`) under
-/// `base_dir`. Mirrors `paths._validate_item_dir`. Used by `/open-folder`
-/// so the "open folder in file manager" card button resolves against the
-/// conception tree (not the workspace/worktrees sandbox).
+/// `base_dir`. Used by `/open-folder` so the "open folder in file
+/// manager" card button resolves against the conception tree (not the
+/// workspace/worktrees sandbox).
 pub fn validate_item_dir(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
     let full = safe_resolve(base_dir, rel_path, &[&VALID_ITEM_DIR_RE], false)?;
     if !full.is_dir() {
@@ -144,10 +137,9 @@ pub fn validate_item_dir(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
     Some(full)
 }
 
-/// Resolve `subdir` (relative to `item_dir`) and verify the result stays
-/// inside the item directory. Empty `subdir` resolves to `item_dir`
-/// itself. Returns `None` on traversal / regex failure. Mirrors
-/// `mutations._resolve_under_item`.
+/// Resolve `subdir` (relative to `item_dir`) and verify the result
+/// stays inside the item directory. Empty `subdir` resolves to
+/// `item_dir` itself. Returns `None` on traversal / regex failure.
 pub fn resolve_under_item(item_dir: &Path, subdir: &str) -> Option<PathBuf> {
     let trimmed = subdir.trim().trim_matches('/');
     if trimmed.is_empty() {
@@ -160,8 +152,7 @@ pub fn resolve_under_item(item_dir: &Path, subdir: &str) -> Option<PathBuf> {
         return None;
     }
     let target = item_dir.join(trimmed);
-    // Python uses `.resolve().relative_to(item_dir.resolve())`. We match
-    // that via `canonicalize` when the target exists, and a literal
+    // Use `canonicalize` when the target exists, and a literal
     // prefix check when it does not (the target may legitimately not
     // exist yet in the create_note / mkdir flows — the regex + `..`
     // reject above is enough to keep us safely inside).

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -1,5 +1,4 @@
-//! PTY session lifecycle for the embedded terminal — Rust port of
-//! `src/condash/pty.py`.
+//! PTY session lifecycle for the embedded terminal.
 //!
 //! A PTY's lifetime is decoupled from any single WebSocket: a tab refresh
 //! should detach the viewer without killing the shell. Each session lives
@@ -100,7 +99,7 @@ impl PtySession {
         w.flush()
     }
 
-    /// Resize the PTY. Clamps to `>=2` rows/cols (matches Python).
+    /// Resize the PTY. Clamps to `>=2` rows/cols: many TUIs crash on 0/1.
     pub fn resize(&self, cols: u16, rows: u16) {
         let cols = cols.max(2);
         let rows = rows.max(2);

--- a/src-tauri/src/runners.rs
+++ b/src-tauri/src/runners.rs
@@ -1,6 +1,6 @@
-//! Inline dev-server runner registry — Rust port of `runners.py`.
+//! Inline dev-server runner registry.
 //!
-//! Each repo (or sub-repo) with a `run:` template in `repositories.yml`
+//! Each repo (or sub-repo) with a `run:` template in `configuration.yml`
 //! gets a keyed slot here. `/api/runner/start` spawns a PTY under
 //! [`PtyRegistry`][crate::pty::PtyRegistry] and stashes it in the
 //! registry; `/api/runner/stop` SIGTERMs + SIGKILLs with a grace window.
@@ -214,7 +214,7 @@ pub async fn stop(
     // manually so the UI isn't left showing "running" on a dead
     // process.
     if session.exit_code_now().is_none() {
-        *session.exit_code.lock().expect("exit mutex") = Some(-15); // matches Python's -SIGTERM convention
+        *session.exit_code.lock().expect("exit mutex") = Some(-15); // -SIGTERM convention: negate the signal number the runner was killed with
         *session.stamp.lock().expect("stamp mutex") = next_stamp();
     }
     let _ = runners.remove(key);

--- a/src-tauri/src/server.rs
+++ b/src-tauri/src/server.rs
@@ -664,8 +664,8 @@ async fn post_note_upload(
                 }
             }
             _ => {
-                // Silently drop unknown fields — matches Python which
-                // only picks `item_readme`, `subdir`, `file` keys.
+                // Silently drop unknown fields — the route contract
+                // is `item_readme`, `subdir`, `file`; extras are ignored.
                 let _ = field.bytes().await;
             }
         }
@@ -1468,8 +1468,9 @@ async fn handle_runner_ws(mut socket: axum::extract::ws::WebSocket, state: AppSt
 }
 
 /// Validate a filesystem path as an in-sandbox directory under
-/// `ctx.workspace` or `ctx.worktrees`. Rust port of
-/// `paths._validate_open_path` from `paths.py`.
+/// `ctx.workspace` or `ctx.worktrees`. Used by the opener routes so
+/// the shell-command-dispatching helpers only see paths the user
+/// legitimately asked condash to manage.
 fn validate_open_path(ctx: &condash_state::RenderCtx, path: &str) -> Option<std::path::PathBuf> {
     if path.is_empty() || path.contains('\0') {
         return None;
@@ -1895,18 +1896,17 @@ async fn post_open_doc(
 // `/recent-screenshot` — data source for the Ctrl+Shift+V screenshot-paste
 // shortcut. Returns the absolute path of the newest image in the
 // configured `terminal.screenshot_dir` (falls back to an XDG-aware
-// default). Shape mirrors the Python route so the existing frontend
-// consumer (`pasteRecentScreenshot` in dashboard-main.js) works unchanged:
-// `{path: <abs>, dir: <abs>}` on success, `{path: null, dir: <abs>,
-// reason: <message>}` when the directory is missing, unreadable, or empty.
+// default). Response shape:
+//   `{path: <abs>, dir: <abs>}` on success, or
+//   `{path: null, dir: <abs>, reason: <message>}` when the directory
+//   is missing, unreadable, or empty.
 // ---------------------------------------------------------------------
 
 const SCREENSHOT_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp"];
 
 /// Best-guess default location for OS screenshots. Honours
-/// `$XDG_PICTURES_DIR` (standard XDG user-dirs key); otherwise falls back
-/// to `~/Pictures/Screenshots` on Linux and `~/Desktop` on macOS. Mirrors
-/// `config.default_screenshot_dir` from the Python build.
+/// `$XDG_PICTURES_DIR` (standard XDG user-dirs key); otherwise falls
+/// back to `~/Pictures/Screenshots` on Linux and `~/Desktop` on macOS.
 fn default_screenshot_dir() -> std::path::PathBuf {
     if let Ok(xdg) = std::env::var("XDG_PICTURES_DIR") {
         if !xdg.is_empty() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

- The crate headers and module docs were written while the Rust and Python builds dogfooded in parallel. Most started with 'Rust port of X.py' and litered inline doc comments with 'matches Python…' claims. With condash-python retired, those read as if this build is still catching up to something.
- Rewrite the prose around what the module actually does. Where a comment explained *why* an unusual choice was made (codepoint math in search, ASCII-escaping JSON for HTML attributes, -SIGTERM convention, debounce window), restate the why without the Python reference.
- Closes F-09 from the 2026-04-23 condash audit.

## Changes

- **Crate descriptions** in four \`Cargo.toml\` files (parser, state, render, mutations) drop the 'Rust port of …' suffix.
- **Module headers** across the four \`condash-*\` crates and \`src-tauri/src/\` rewritten to lead with the module's responsibility, not its Python lineage. Files touched: \`crates/condash-parser/src/{lib,readme,collect,knowledge,note_kind,tree,regexes,sections,deliverables}.rs\`, \`crates/condash-state/src/{lib,ctx,cache,search}.rs\`, \`crates/condash-render/src/{lib,templating,icons,git_render}.rs\`, \`crates/condash-mutations/src/{lib,files}.rs\`, \`src-tauri/src/{lib,events,paths,runners,pty,openers,server}.rs\`.
- **Inline comments** that were pure 'matches Python' noise are dropped. Comments that conveyed load-bearing why are rephrased to state the why directly.
- Bump \`src-tauri/Cargo.toml\` + \`tauri.conf.json\` from 1.0.18 to 1.0.19.

## What stayed (on purpose)

- \`crates/condash-parser/src/fingerprint.rs\` — Python \`repr()\` parity is a hard cross-build stability constraint for \`/check-updates\` hashes. The Python references there are load-bearing.
- \`crates/condash-state/src/git.rs\` — the rationale for shelling out to \`git\` instead of using \`libgit2\` is a current decision, still useful.
- \`src-tauri/src/config.rs\` — the paragraph about \`config/*.yml\` files still existing on disk for the retired Python build is a valid historical note (explains why the repo carries those files); kept as-is.

## Impact

- No behaviour change. \`cargo build --workspace\` and \`cargo test --workspace\` are green.
- No user-visible doc change. Only \`//\` / \`///\` comments moved.