### PR TITLE
Drop once_cell; use std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,6 @@ dependencies = [
  "http-body-util",
  "mime_guess",
  "notify",
- "once_cell",
  "portable-pty",
  "rand 0.8.6",
  "regex",
@@ -651,7 +650,6 @@ name = "condash-mutations"
 version = "0.1.0"
 dependencies = [
  "condash-parser",
- "once_cell",
  "regex",
  "serde",
  "tempfile",
@@ -662,7 +660,6 @@ name = "condash-parser"
 version = "0.1.0"
 dependencies = [
  "md-5",
- "once_cell",
  "regex",
  "serde",
  "serde_json",
@@ -677,7 +674,6 @@ dependencies = [
  "condash-parser",
  "condash-state",
  "minijinja",
- "once_cell",
  "pulldown-cmark",
  "regex",
  "serde",
@@ -691,7 +687,6 @@ version = "0.1.0"
 dependencies = [
  "condash-parser",
  "md-5",
- "once_cell",
  "regex",
  "serde",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/condash-mutations/Cargo.toml
+++ b/crates/condash-mutations/Cargo.toml
@@ -5,11 +5,10 @@ description = "README.md write-side mutations for condash."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.80"
 
 [dependencies]
 condash-parser = { path = "../condash-parser" }
-once_cell = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/condash-mutations/src/files.rs
+++ b/crates/condash-mutations/src/files.rs
@@ -12,10 +12,10 @@
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 use std::time::UNIX_EPOCH;
 
 use condash_parser::{Kind, Priority};
-use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
 
@@ -143,11 +143,12 @@ impl RenameResult {
     }
 }
 
-static VALID_NEW_STEM_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\w.-]+$").expect("VALID_NEW_STEM_RE compiles"));
+static VALID_NEW_STEM_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\w.-]+$").expect("VALID_NEW_STEM_RE compiles"));
 
-static VALID_NOTE_FILENAME_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\w.-]+\.[A-Za-z0-9]+$").expect("VALID_NOTE_FILENAME_RE compiles"));
+static VALID_NOTE_FILENAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[\w.-]+\.[A-Za-z0-9]+$").expect("VALID_NOTE_FILENAME_RE compiles")
+});
 
 /// Rename `full_path` — which must already have been validated as a file
 /// under `<item>/notes/` — to `<same_dir>/<new_stem><same_ext>`. Returns
@@ -363,7 +364,7 @@ pub fn create_notes_subdir(
 // store_uploads
 // ---------------------------------------------------------------------
 
-static VALID_UPLOAD_FILENAME_RE: Lazy<Regex> = Lazy::new(|| {
+static VALID_UPLOAD_FILENAME_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[\w. \-()]+\.[A-Za-z0-9]+$").expect("VALID_UPLOAD_FILENAME_RE compiles")
 });
 
@@ -610,8 +611,8 @@ impl CreateItemResult {
 const ENVIRONMENTS: &[&str] = &["PROD", "STAGING", "DEV"];
 const SEVERITIES: &[&str] = &["low", "medium", "high"];
 
-static VALID_SLUG_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-z0-9]+(?:-[a-z0-9]+)*$").expect("VALID_SLUG_RE compiles"));
+static VALID_SLUG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9]+(?:-[a-z0-9]+)*$").expect("VALID_SLUG_RE compiles"));
 
 fn render_apps(apps_raw: &str) -> String {
     apps_raw

--- a/crates/condash-mutations/src/steps.rs
+++ b/crates/condash-mutations/src/steps.rs
@@ -13,9 +13,9 @@
 use std::fs;
 use std::io;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use condash_parser::sections::CheckboxStatus;
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 use condash_parser::regexes::{CHECKBOX_RE, HEADING2_RE, HEADING3_RE, METADATA_RE, STATUS_RE};
@@ -29,27 +29,27 @@ pub const PRIORITIES: &[&str] = &["now", "soon", "later", "backlog", "review", "
 /// with `##`, at least one whitespace, then `Steps` (case-insensitive).
 /// No `\b` anchor on purpose — Python's `re.match` doesn't either, so
 /// a heading like `## Steps (draft)` still counts as the Steps section.
-static STEPS_HEADING_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^##\s+Steps").expect("STEPS_HEADING_RE compiles"));
+static STEPS_HEADING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^##\s+Steps").expect("STEPS_HEADING_RE compiles"));
 
 /// Sections that must appear *after* a freshly-created `## Steps` block.
 /// When the README has no Steps section, `_add_step` inserts one in front
 /// of the first Notes/Timeline/Chronologie heading it finds.
-static NOTES_OR_TIMELINE_RE: Lazy<Regex> = Lazy::new(|| {
+static NOTES_OR_TIMELINE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)^##\s+(?:Notes|Timeline|Chronologie)\b")
         .expect("NOTES_OR_TIMELINE_RE compiles")
 });
 
 /// Any `## …` / `### …` / deeper heading — used by `add_step`'s
 /// explicit-section path to find where the target section ends.
-static ANY_HEADING_LEVEL_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(#{2,})\s+(.+)$").expect("ANY_HEADING_LEVEL_RE compiles"));
+static ANY_HEADING_LEVEL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(#{2,})\s+(.+)$").expect("ANY_HEADING_LEVEL_RE compiles"));
 
 /// Same as [`ANY_HEADING_LEVEL_RE`] but groups only the `#` prefix —
 /// cheap enough to keep as a second regex; saves a capture allocation
 /// in `_add_step`'s per-line scan inside an existing Steps section.
-static ANY_HEADING_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(#{2,})\s+").expect("ANY_HEADING_RE compiles"));
+static ANY_HEADING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(#{2,})\s+").expect("ANY_HEADING_RE compiles"));
 
 /// The literal string checkbox patterns Python's `_toggle_checkbox` tests
 /// against. Kept as separate `&str`s (rather than a regex) because the

--- a/crates/condash-parser/Cargo.toml
+++ b/crates/condash-parser/Cargo.toml
@@ -5,11 +5,10 @@ description = "Parser for conception item READMEs and the knowledge tree."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.80"
 
 [dependencies]
 regex = "1"
-once_cell = "1"
 serde = { version = "1", features = ["derive"] }
 md-5 = "0.10"
 

--- a/crates/condash-parser/src/regexes.rs
+++ b/crates/condash-parser/src/regexes.rs
@@ -4,41 +4,43 @@
 //! sites feed them line-by-line, so the default `regex` crate
 //! behaviour (where `^` is start-of-string) is what we want.
 
-use once_cell::sync::Lazy;
+use std::sync::LazyLock;
+
 use regex::Regex;
 
 /// `**Key**: value` metadata line at the top of an item README.
-pub static METADATA_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^\*\*(.+?)\*\*\s*:\s*(.+)$").expect("METADATA_RE compiles"));
+pub static METADATA_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^\*\*(.+?)\*\*\s*:\s*(.+)$").expect("METADATA_RE compiles"));
 
 /// `- [x] text`, `- [ ] text`, `- [~] text`, `- [-] text` checklist entry.
 /// Capture groups: indent, status char, body.
-pub static CHECKBOX_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(\s*)-\s*\[([ xX~\-])\]\s+(.+)$").expect("CHECKBOX_RE compiles"));
+pub static CHECKBOX_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(\s*)-\s*\[([ xX~\-])\]\s+(.+)$").expect("CHECKBOX_RE compiles")
+});
 
 /// `## Heading`.
-pub static HEADING2_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^##\s+(.+)$").expect("HEADING2_RE compiles"));
+pub static HEADING2_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^##\s+(.+)$").expect("HEADING2_RE compiles"));
 
 /// `### Heading`.
-pub static HEADING3_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^###\s+(.+)$").expect("HEADING3_RE compiles"));
+pub static HEADING3_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^###\s+(.+)$").expect("HEADING3_RE compiles"));
 
 /// `**Status**: …` metadata line. Case-insensitive to match Python's
 /// `re.IGNORECASE` — used by callers that just need to test presence.
-pub static STATUS_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"(?i)^\*\*Status\*\*\s*:\s*.*$").expect("STATUS_RE compiles"));
+pub static STATUS_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?i)^\*\*Status\*\*\s*:\s*.*$").expect("STATUS_RE compiles"));
 
 /// `- [Label](path.pdf) — optional description` in the Deliverables section.
-pub static DELIVERABLE_RE: Lazy<Regex> = Lazy::new(|| {
+pub static DELIVERABLE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"-\s+\[([^\]]+)\]\(([^)]+\.pdf)\)(?:\s*[—–-]\s*(.+))?$")
         .expect("DELIVERABLE_RE compiles")
 });
 
 /// `YYYY-MM-DD-slug` folder slug grammar: lowercase ASCII + digits, single
 /// hyphens only.
-pub static VALID_SLUG_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[a-z0-9]+(?:-[a-z0-9]+)*$").expect("VALID_SLUG_RE compiles"));
+pub static VALID_SLUG_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[a-z0-9]+(?:-[a-z0-9]+)*$").expect("VALID_SLUG_RE compiles"));
 
 #[cfg(test)]
 mod tests {

--- a/crates/condash-render/Cargo.toml
+++ b/crates/condash-render/Cargo.toml
@@ -5,7 +5,7 @@ description = "HTML rendering for the conception dashboard."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.80"
 
 [dependencies]
 condash-parser = { path = "../condash-parser" }
@@ -16,7 +16,6 @@ serde_json = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 regex = "1"
-once_cell = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/condash-render/src/note_render.rs
+++ b/crates/condash-render/src/note_render.rs
@@ -12,8 +12,8 @@
 //! Kasten-style resolver is out of scope for the note-modal port.
 
 use std::path::Path;
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use pulldown_cmark::{html as md_html, Options, Parser};
 use regex::Regex;
 
@@ -21,8 +21,9 @@ use crate::h;
 
 /// `[[target]]` or `[[target|label]]`. Target may contain `/`, `.`, `-`,
 /// `_`; label is anything non-`]`.
-static WIKILINK_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]").expect("wikilink regex compiles"));
+static WIKILINK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]").expect("wikilink regex compiles")
+});
 
 /// Render a note for the view pane. `rel_path` is relative to the
 /// conception tree; `full_path` is the resolved absolute path (already

--- a/crates/condash-state/Cargo.toml
+++ b/crates/condash-state/Cargo.toml
@@ -5,12 +5,11 @@ description = "Runtime context + workspace cache for condash."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.80"
 
 [dependencies]
 condash-parser = { path = "../condash-parser" }
 md-5 = "0.10"
-once_cell = "1"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/condash-state/src/search.rs
+++ b/crates/condash-state/src/search.rs
@@ -98,10 +98,11 @@ fn html_escape(s: &str) -> String {
     out
 }
 
-/// Python's `re.sub(r"\s+", " ", text).strip()`.
+/// Collapse any run of whitespace to a single space and strip both
+/// ends. Uses `regex` so Unicode whitespace (non-breaking space, CJK
+/// ideographic space, …) is handled the same as ASCII.
 fn collapse_whitespace(text: &str) -> String {
-    // Using regex to match Python's unicode-aware `\s+` precisely.
-    static WS_RE: once_cell::sync::OnceCell<Regex> = once_cell::sync::OnceCell::new();
+    static WS_RE: std::sync::OnceLock<Regex> = std::sync::OnceLock::new();
     let re = WS_RE.get_or_init(|| Regex::new(r"\s+").unwrap());
     re.replace_all(text, " ").trim().to_string()
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,7 +5,7 @@ description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.77"
+rust-version = "1.80"
 default-run = "condash"
 
 [lib]
@@ -35,7 +35,6 @@ notify = "8"
 futures-util = { version = "0.3", default-features = false }
 tokio-stream = { version = "0.1", features = ["sync"] }
 anyhow = "1"
-once_cell = "1"
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 rfd = "0.15"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.0.19"
+version = "1.0.20"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -11,65 +11,66 @@
 //! 4. Optionally require the resolved entry be a file on disk.
 
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
-use once_cell::sync::Lazy;
 use regex::Regex;
 
 /// Common item-path prefix — `projects/YYYY-MM/YYYY-MM-DD-<slug>/`.
 const VALID_ITEM_PREFIX: &str = r"^projects/\d{4}-\d{2}/\d{4}-\d{2}-\d{2}-[\w.-]+/";
 
 /// `projects/YYYY-MM/YYYY-MM-DD-<slug>/README.md`.
-static VALID_README_RE: Lazy<Regex> = Lazy::new(|| {
+static VALID_README_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!("{VALID_ITEM_PREFIX}README\\.md$")).expect("VALID_README_RE compiles")
 });
 
 /// `<item>/<anything>.md`.
-static VALID_NOTE_RE: Lazy<Regex> = Lazy::new(|| {
+static VALID_NOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}[\w./-]+\.md$")).expect("VALID_NOTE_RE compiles")
 });
 
 /// `knowledge/<file>.md`. Matches `knowledge/` at any depth.
-static VALID_KNOWLEDGE_NOTE_RE: Lazy<Regex> = Lazy::new(|| {
+static VALID_KNOWLEDGE_NOTE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^knowledge/(?:[\w.-]+/)*[\w.-]+\.md$").expect("VALID_KNOWLEDGE_NOTE_RE compiles")
 });
 
 /// Any file at any depth inside an item directory.
-static VALID_ITEM_FILE_RE: Lazy<Regex> = Lazy::new(|| {
+static VALID_ITEM_FILE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}[\w./-]+$")).expect("VALID_ITEM_FILE_RE compiles")
 });
 
 /// Restricted to files directly under `<item>/notes/` — used by rename
 /// (only notes are user-renamable).
-pub(crate) static VALID_ITEM_NOTES_FILE_RE: Lazy<Regex> = Lazy::new(|| {
+pub(crate) static VALID_ITEM_NOTES_FILE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(&format!(r"{VALID_ITEM_PREFIX}notes/[\w./-]+$"))
         .expect("VALID_ITEM_NOTES_FILE_RE compiles")
 });
 
 /// Item directory itself — `projects/YYYY-MM/YYYY-MM-DD-<slug>/`, with
 /// or without the trailing slash.
-static VALID_ITEM_DIR_RE: Lazy<Regex> = Lazy::new(|| {
+static VALID_ITEM_DIR_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^projects/\d{4}-\d{2}/\d{4}-\d{2}-\d{2}-[\w.-]+/?$")
         .expect("VALID_ITEM_DIR_RE compiles")
 });
 
 /// `<name>.<ext>` — validates the target filename of create_note /
 /// rename_note.
-pub static VALID_NOTE_FILENAME_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\w.-]+\.[A-Za-z0-9]+$").expect("VALID_NOTE_FILENAME_RE compiles"));
+pub static VALID_NOTE_FILENAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[\w.-]+\.[A-Za-z0-9]+$").expect("VALID_NOTE_FILENAME_RE compiles")
+});
 
 /// Bare filename allowed for the rename target's new stem.
-pub static VALID_NEW_STEM_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\w.-]+$").expect("VALID_NEW_STEM_RE compiles"));
+pub static VALID_NEW_STEM_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\w.-]+$").expect("VALID_NEW_STEM_RE compiles"));
 
 /// Subdirectory path (possibly nested). Used by `resolve_under_item`
 /// to reject anything that doesn't look like a sequence of `[\w.-]+`
 /// segments.
-pub static VALID_SUBDIR_RE: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^[\w.-]+(/[\w.-]+)*$").expect("VALID_SUBDIR_RE compiles"));
+pub static VALID_SUBDIR_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\w.-]+(/[\w.-]+)*$").expect("VALID_SUBDIR_RE compiles"));
 
 /// Upload filename regex — more permissive than the note regex to
 /// accept typical Camera/PDF exports (spaces, parentheses).
-pub static VALID_UPLOAD_FILENAME_RE: Lazy<Regex> = Lazy::new(|| {
+pub static VALID_UPLOAD_FILENAME_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[\w. \-()]+\.[A-Za-z0-9]+$").expect("VALID_UPLOAD_FILENAME_RE compiles")
 });
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

- \`std::sync::LazyLock\` stabilised in Rust 1.80 and is a drop-in replacement for \`once_cell::sync::Lazy\`. With it, the \`once_cell\` dependency is pure overhead across every crate in the workspace.
- Bump the pinned \`rust-version\` from 1.77 to 1.80 workspace-wide so the floor reflects what the code actually uses.
- Closes F-08 from the 2026-04-23 condash audit.

## Changes

- \`once_cell = "1"\` removed from five Cargo.toml files (\`src-tauri\`, \`condash-parser\`, \`condash-state\`, \`condash-render\`, \`condash-mutations\`).
- \`rust-version = "1.77"\` → \`"1.80"\` in the same five files.
- Source migrations in six files:
  - \`crates/condash-parser/src/regexes.rs\` — 7 statics.
  - \`src-tauri/src/paths.rs\` — 9 statics.
  - \`crates/condash-render/src/note_render.rs\` — 1 static.
  - \`crates/condash-mutations/src/steps.rs\` — 4 statics.
  - \`crates/condash-mutations/src/files.rs\` — 4 statics.
  - \`crates/condash-state/src/search.rs\` — 1 OnceCell → \`std::sync::OnceLock\`.
- Bump \`src-tauri/Cargo.toml\` + \`tauri.conf.json\` from 1.0.19 to 1.0.20.

## Impact

- Rust floor rises to 1.80. The release workflow already uses \`dtolnay/rust-toolchain@stable\` (latest stable), so no CI change is needed; anyone building locally from an older toolchain must run \`rustup update\`.
- No runtime behaviour change. \`cargo build --workspace\` and \`cargo test --workspace\` green.
- One less transitive dependency (\`once_cell\`) resolved by the workspace, slightly faster cold builds.