### PR TITLE
Type ItemReadme.priority + .kind as enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/condash-mutations/src/files.rs
+++ b/crates/condash-mutations/src/files.rs
@@ -19,8 +19,6 @@ use condash_parser::{Kind, Priority};
 use regex::Regex;
 use serde::Serialize;
 
-use crate::steps::PRIORITIES;
-
 // ---------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------
@@ -779,9 +777,9 @@ pub fn create_item(
         }
     };
     if Priority::from_lowercase(&status_raw).is_none() {
-        let joined = PRIORITIES
+        let joined = Priority::ALL
             .iter()
-            .map(|p| format!("'{p}'"))
+            .map(|p| format!("'{}'", p.as_str()))
             .collect::<Vec<_>>()
             .join(", ");
         return Ok(CreateItemResult::Err {

--- a/crates/condash-mutations/src/lib.rs
+++ b/crates/condash-mutations/src/lib.rs
@@ -27,6 +27,4 @@ pub use files::{
     CreateItemResult, CreateNoteResult, CreateSubdirResult, ItemKind, NewItemSpec, RenameResult,
     StoreUploadsResult, UploadRejection, WriteNoteResult,
 };
-pub use steps::{
-    add_step, edit_step, remove_step, reorder_all, set_priority, toggle_checkbox, PRIORITIES,
-};
+pub use steps::{add_step, edit_step, remove_step, reorder_all, set_priority, toggle_checkbox};

--- a/crates/condash-mutations/src/steps.rs
+++ b/crates/condash-mutations/src/steps.rs
@@ -15,14 +15,10 @@ use std::io;
 use std::path::Path;
 use std::sync::LazyLock;
 
-use condash_parser::sections::CheckboxStatus;
-use regex::Regex;
-
 use condash_parser::regexes::{CHECKBOX_RE, HEADING2_RE, HEADING3_RE, METADATA_RE, STATUS_RE};
-
-/// Priority values accepted by [`set_priority`]. Order mirrors Python's
-/// `PRIORITIES` tuple in `parser.py`.
-pub const PRIORITIES: &[&str] = &["now", "soon", "later", "backlog", "review", "done"];
+use condash_parser::sections::CheckboxStatus;
+use condash_parser::Priority;
+use regex::Regex;
 
 /// `## Steps` — matches exactly what Python's
 /// `re.match(r"^##\s+Steps", line, re.IGNORECASE)` matches: line starts
@@ -61,19 +57,18 @@ const DONE_MARK_BIG_X: &str = "- [X]";
 const PROGRESS_MARK: &str = "- [~]";
 const ABANDONED_MARK: &str = "- [-]";
 
-/// Rewrite the `**Status**: …` metadata line, or insert a new one below
-/// the existing metadata block. Returns `Ok(false)` if `priority` is not
-/// in [`PRIORITIES`]; Python's `_set_priority` returns `False` in the
-/// same case.
+/// Rewrite the `**Status**: …` metadata line, or insert a new one
+/// below the existing metadata block. Returns `Ok(false)` when
+/// `priority` is not a known [`Priority`] value.
 ///
 /// The `**Status** : value` (space before colon) vs `**Status**: value`
-/// choice mirrors the surrounding metadata style — Python looks at the
-/// first metadata line's spacing when inserting a new status line, so
-/// the port does the same.
+/// choice mirrors the surrounding metadata style — the first metadata
+/// line's spacing decides how new ones are inserted.
 pub fn set_priority(path: &Path, priority: &str) -> io::Result<bool> {
-    if !PRIORITIES.iter().any(|p| *p == priority) {
+    let Some(priority) = Priority::from_lowercase(priority) else {
         return Ok(false);
-    }
+    };
+    let priority = priority.as_str();
 
     let text = fs::read_to_string(path)?;
     let mut lines: Vec<String> = text.split('\n').map(|s| s.to_string()).collect();

--- a/crates/condash-parser/src/collect.rs
+++ b/crates/condash-parser/src/collect.rs
@@ -131,7 +131,7 @@ mod tests {
 
         let item_out = parse_readme(base, &item.join("README.md"), None).unwrap();
         assert_eq!(item_out.readme.slug, "2026-04-22-foo");
-        assert_eq!(item_out.readme.priority, "now");
+        assert_eq!(item_out.readme.priority, crate::Priority::Now);
         assert_eq!(
             item_out.readme.path,
             "projects/2026-04/2026-04-22-foo/README.md"

--- a/crates/condash-parser/src/fingerprint.rs
+++ b/crates/condash-parser/src/fingerprint.rs
@@ -137,8 +137,8 @@ fn item_fingerprint_tuple(readme: &ItemReadme, files: &ItemTree) -> PyValue {
     PyValue::Tuple(vec![
         PyValue::Str(readme.slug.clone()),
         PyValue::Str(readme.title.clone()),
-        PyValue::Str(readme.priority.clone()),
-        PyValue::Str(readme.kind.clone()),
+        PyValue::Str(readme.priority.as_str().to_string()),
+        PyValue::Str(readme.kind.as_str().to_string()),
         apps_tuple(&readme.apps),
         PyValue::Str(readme.summary.clone()),
         sections_tuple(readme),
@@ -155,7 +155,7 @@ fn card_content_data(readme: &ItemReadme, files: &ItemTree) -> PyValue {
     PyValue::Tuple(vec![
         PyValue::Str(readme.slug.clone()),
         PyValue::Str(readme.title.clone()),
-        PyValue::Str(readme.kind.clone()),
+        PyValue::Str(readme.kind.as_str().to_string()),
         apps_tuple(&readme.apps),
         PyValue::Str(readme.summary.clone()),
         sections_tuple(readme),
@@ -235,7 +235,11 @@ pub fn compute_project_node_fingerprints(items: &[Item]) -> HashMap<String, Stri
 
     // Per-card hashes.
     for item in items {
-        let id = format!("projects/{}/{}", item.readme.priority, item.readme.slug);
+        let id = format!(
+            "projects/{}/{}",
+            item.readme.priority.as_str(),
+            item.readme.slug
+        );
         out.insert(id, hash(&card_content_data(&item.readme, &item.files)));
     }
 
@@ -264,7 +268,12 @@ pub fn compute_project_node_fingerprints(items: &[Item]) -> HashMap<String, Stri
     // Whole-tab membership hash.
     let mut tab_pairs: Vec<(String, String)> = items
         .iter()
-        .map(|i| (i.readme.priority.clone(), i.readme.slug.clone()))
+        .map(|i| {
+            (
+                i.readme.priority.as_str().to_string(),
+                i.readme.slug.clone(),
+            )
+        })
         .collect();
     tab_pairs.sort();
     let tab_tuple = PyValue::Tuple(
@@ -440,7 +449,7 @@ mod tests {
                 slug: "foo".into(),
                 title: "Foo".into(),
                 date: "".into(),
-                priority: "now".into(),
+                priority: crate::Priority::Now,
                 invalid_status: None,
                 apps: vec![],
                 severity: None,
@@ -458,7 +467,7 @@ mod tests {
                 done: 1,
                 total: 1,
                 path: "x".into(),
-                kind: "project".into(),
+                kind: crate::Kind::Project,
             },
             files: ItemTree::default(),
         };

--- a/crates/condash-parser/src/lib.rs
+++ b/crates/condash-parser/src/lib.rs
@@ -108,4 +108,12 @@ impl Kind {
             _ => None,
         }
     }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Kind::Project => "project",
+            Kind::Incident => "incident",
+            Kind::Document => "document",
+        }
+    }
 }

--- a/crates/condash-parser/src/readme.rs
+++ b/crates/condash-parser/src/readme.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use crate::deliverables::{parse_deliverables, Deliverable};
 use crate::regexes::{HEADING2_RE, HEADING3_RE, METADATA_RE};
 use crate::sections::{parse_sections, Section};
-use crate::Priority;
+use crate::{Kind, Priority};
 
 /// Maximum summary length in *codepoints* (count user-visible glyphs,
 /// not bytes). When exceeded, the summary is truncated to
@@ -30,7 +30,7 @@ pub struct ItemReadme {
     pub slug: String,
     pub title: String,
     pub date: String,
-    pub priority: String,
+    pub priority: Priority,
     pub invalid_status: Option<String>,
     pub apps: Vec<String>,
     pub severity: Option<String>,
@@ -40,7 +40,7 @@ pub struct ItemReadme {
     pub done: usize,
     pub total: usize,
     pub path: String,
-    pub kind: String,
+    pub kind: Kind,
 }
 
 /// Parse one item's README content into an [`ItemReadme`].
@@ -221,34 +221,37 @@ fn extract_summary(lines: &[&str], first_section_idx: Option<usize>) -> String {
     }
 }
 
-/// Coerce a raw `**Status**:` value into a known priority. Returns
-/// `(priority, invalid_status)` where `invalid_status` holds the original
-/// raw string (case preserved) when the value wasn't in [`Priority::ALL`].
-fn resolve_status(raw: Option<&str>) -> (String, Option<String>) {
+/// Coerce a raw `**Status**:` value into a known [`Priority`]. Returns
+/// `(priority, invalid_status)` where `invalid_status` holds the
+/// original raw string (case preserved) when the value wasn't a known
+/// priority; an empty or unknown value defaults the priority to
+/// `Backlog`.
+fn resolve_status(raw: Option<&str>) -> (Priority, Option<String>) {
     let raw = raw.map(|s| s.trim()).unwrap_or("");
     if raw.is_empty() {
-        return ("backlog".to_string(), None);
+        return (Priority::Backlog, None);
     }
-    let lowered = raw.to_lowercase();
-    if Priority::from_lowercase(&lowered).is_some() {
-        (lowered, None)
-    } else {
-        ("backlog".to_string(), Some(raw.to_string()))
+    match Priority::from_lowercase(&raw.to_lowercase()) {
+        Some(p) => (p, None),
+        None => (Priority::Backlog, Some(raw.to_string())),
     }
 }
 
 /// Resolve item kind from `**Kind**:` header, then the caller-provided
-/// fallback, then the hardcoded `"project"` default. Python equivalent:
-/// `meta.get("kind", "").lower() or kind or "project"`.
-fn resolve_kind(from_meta: Option<&str>, fallback: Option<&str>) -> String {
-    let from_meta = from_meta.map(|s| s.to_lowercase()).unwrap_or_default();
-    if !from_meta.is_empty() {
-        from_meta
-    } else if let Some(k) = fallback {
-        k.to_string()
-    } else {
-        "project".to_string()
+/// fallback, then the hardcoded `Project` default. Unknown strings in
+/// either the header or the fallback fall through to the next layer.
+fn resolve_kind(from_meta: Option<&str>, fallback: Option<&str>) -> Kind {
+    if let Some(raw) = from_meta {
+        if let Some(k) = Kind::from_lowercase(&raw.to_lowercase()) {
+            return k;
+        }
     }
+    if let Some(raw) = fallback {
+        if let Some(k) = Kind::from_lowercase(&raw.to_lowercase()) {
+            return k;
+        }
+    }
+    Kind::Project
 }
 
 #[cfg(test)]
@@ -309,8 +312,8 @@ Evaluate whether to port condash, and if so execute that port.
         let r = parse(md);
         assert_eq!(r.title, "Port condash to Rust + Tauri");
         assert_eq!(r.date, "2026-04-21");
-        assert_eq!(r.kind, "project");
-        assert_eq!(r.priority, "now");
+        assert_eq!(r.kind, Kind::Project);
+        assert_eq!(r.priority, Priority::Now);
         assert_eq!(r.invalid_status, None);
         assert_eq!(r.apps, vec!["condash"]);
         assert_eq!(r.severity, None);
@@ -334,21 +337,21 @@ Evaluate whether to port condash, and if so execute that port.
     #[test]
     fn missing_status_defaults_to_backlog() {
         let r = parse("# T\n\n## Goal\n\nbody\n");
-        assert_eq!(r.priority, "backlog");
+        assert_eq!(r.priority, Priority::Backlog);
         assert_eq!(r.invalid_status, None);
     }
 
     #[test]
     fn unknown_status_records_invalid_preserving_case() {
         let r = parse("# T\n\n**Status**: InProgress\n\n## Goal\n\nbody\n");
-        assert_eq!(r.priority, "backlog");
+        assert_eq!(r.priority, Priority::Backlog);
         assert_eq!(r.invalid_status, Some("InProgress".to_string()));
     }
 
     #[test]
     fn valid_status_is_lowercased() {
         let r = parse("# T\n\n**Status**: NOW\n\n## Goal\n\nbody\n");
-        assert_eq!(r.priority, "now");
+        assert_eq!(r.priority, Priority::Now);
         assert_eq!(r.invalid_status, None);
     }
 
@@ -400,7 +403,7 @@ Evaluate whether to port condash, and if so execute that port.
             Some("project"),
         )
         .unwrap();
-        assert_eq!(got.kind, "incident");
+        assert_eq!(got.kind, Kind::Incident);
     }
 
     #[test]
@@ -413,13 +416,13 @@ Evaluate whether to port condash, and if so execute that port.
             Some("document"),
         )
         .unwrap();
-        assert_eq!(got.kind, "document");
+        assert_eq!(got.kind, Kind::Document);
     }
 
     #[test]
     fn kind_defaults_to_project_without_fallback() {
         let r = parse("# T\n\n## G\n\nbody\n");
-        assert_eq!(r.kind, "project");
+        assert_eq!(r.kind, Kind::Project);
     }
 
     #[test]

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -48,22 +48,18 @@ pub fn h(text: &str) -> String {
     out
 }
 
-/// Priority ordering — maps the lowercase priority string to a sort
-/// key. Unknown / missing priorities sort as 9 ("after everything").
-fn pri_order(priority: &str) -> i32 {
-    match priority {
-        "now" => 0,
-        "soon" => 1,
-        "later" => 2,
-        "backlog" => 3,
-        "review" => 4,
-        "done" => 5,
-        _ => 9,
-    }
+/// Priorities in user-visible column order, rendered as lowercase
+/// strings for the template layer.
+pub fn priorities() -> [&'static str; 6] {
+    [
+        condash_parser::Priority::Now.as_str(),
+        condash_parser::Priority::Soon.as_str(),
+        condash_parser::Priority::Later.as_str(),
+        condash_parser::Priority::Backlog.as_str(),
+        condash_parser::Priority::Review.as_str(),
+        condash_parser::Priority::Done.as_str(),
+    ]
 }
-
-/// Priorities in user-visible order, shared with Python.
-pub const PRIORITIES: &[&str] = &["now", "soon", "later", "backlog", "review", "done"];
 
 /// First pending step across all sections, or `None`. Mirrors
 /// `_next_step` — "pending" = `open` or `progress`; `abandoned` isn't
@@ -96,7 +92,7 @@ pub fn render_card(item: &Item) -> String {
     let total = total_files(&item.files);
     let ctx = context! {
         item => Value::from_serialize(item),
-        priorities => Value::from_serialize(PRIORITIES),
+        priorities => Value::from_serialize(priorities()),
         next_step => next_step(item).unwrap_or(Value::from(())),
         files_tree => Value::from_serialize(&item.files),
         files_total => total,
@@ -212,13 +208,12 @@ pub fn render_page(
     version: &str,
     live_runners: &git_render::LiveRunners,
 ) -> String {
-    // Sort: by (pri_order, slug[:10]), then within each priority reverse
-    // by slug[:10]. Matches Python's two-pass sort exactly.
+    // Sort: by priority (Now < Soon < … < Done — the enum's derived
+    // Ord uses variant declaration order), then within each priority
+    // reverse by slug[:10].
     let mut sorted: Vec<&Item> = items.iter().collect();
     sorted.sort_by(|a, b| {
-        let pa = pri_order(&a.readme.priority);
-        let pb = pri_order(&b.readme.priority);
-        pa.cmp(&pb).then_with(|| {
+        a.readme.priority.cmp(&b.readme.priority).then_with(|| {
             a.readme.slug[..a.readme.slug.len().min(10)]
                 .cmp(&b.readme.slug[..b.readme.slug.len().min(10)])
         })
@@ -227,9 +222,9 @@ pub fn render_page(
     let mut ordered: Vec<&Item> = Vec::with_capacity(sorted.len());
     let mut i = 0usize;
     while i < sorted.len() {
-        let pri = &sorted[i].readme.priority;
+        let pri = sorted[i].readme.priority;
         let mut j = i;
-        while j < sorted.len() && &sorted[j].readme.priority == pri {
+        while j < sorted.len() && sorted[j].readme.priority == pri {
             j += 1;
         }
         let mut group: Vec<&Item> = sorted[i..j].to_vec();
@@ -265,12 +260,12 @@ pub fn render_page(
 
     let (mut cur, mut next, mut bl, mut dn) = (0usize, 0usize, 0usize, 0usize);
     for it in &all_items {
-        match it.readme.priority.as_str() {
-            "now" | "review" => cur += 1,
-            "soon" | "later" => next += 1,
-            "backlog" => bl += 1,
-            "done" => dn += 1,
-            _ => {}
+        use condash_parser::Priority::*;
+        match it.readme.priority {
+            Now | Review => cur += 1,
+            Soon | Later => next += 1,
+            Backlog => bl += 1,
+            Done => dn += 1,
         }
     }
 
@@ -322,16 +317,16 @@ mod tests {
     use super::*;
     use condash_parser::{
         sections::{CheckboxStatus, Section, SectionItem},
-        Deliverable, ItemReadme, ItemTree,
+        Deliverable, ItemReadme, ItemTree, Kind, Priority,
     };
 
-    fn simple_item(slug: &str, priority: &str) -> Item {
+    fn simple_item(slug: &str, priority: Priority) -> Item {
         Item {
             readme: ItemReadme {
                 slug: slug.into(),
                 title: format!("Title {slug}"),
                 date: "2026-04-22".into(),
-                priority: priority.into(),
+                priority,
                 invalid_status: None,
                 apps: vec!["condash".into()],
                 severity: None,
@@ -354,7 +349,7 @@ mod tests {
                 done: 0,
                 total: 1,
                 path: format!("projects/2026-04/{slug}/README.md"),
-                kind: "project".into(),
+                kind: Kind::Project,
             },
             files: ItemTree::default(),
         }
@@ -367,7 +362,7 @@ mod tests {
 
     #[test]
     fn render_card_produces_card_div() {
-        let item = simple_item("2026-04-22-foo", "now");
+        let item = simple_item("2026-04-22-foo", Priority::Now);
         let html = render_card(&item);
         eprintln!("=== HTML BEGIN ===\n{html}\n=== HTML END ===");
         assert!(html.contains("class=\"card collapsed\""));
@@ -377,7 +372,7 @@ mod tests {
 
     #[test]
     fn render_card_fragment_matches_render_card() {
-        let item = simple_item("slug", "soon");
+        let item = simple_item("slug", Priority::Soon);
         assert_eq!(render_card_fragment(&item), render_card(&item));
     }
 

--- a/crates/condash-state/src/search.rs
+++ b/crates/condash-state/src/search.rs
@@ -35,13 +35,13 @@ fn source_weight(src: &str) -> i64 {
     }
 }
 
-fn status_to_subtab(status: &str) -> &'static str {
+fn status_to_subtab(status: condash_parser::Priority) -> &'static str {
+    use condash_parser::Priority::*;
     match status {
-        "now" | "review" => "current",
-        "soon" | "later" => "next",
-        "backlog" => "backlog",
-        "done" => "done",
-        _ => "current",
+        Now | Review => "current",
+        Soon | Later => "next",
+        Backlog => "backlog",
+        Done => "done",
     }
 }
 
@@ -296,13 +296,13 @@ pub fn search_items(ctx: &RenderCtx, items: &[Item], query: &str) -> Vec<SearchR
             continue;
         }
 
-        let status = &item.readme.priority;
+        let status = item.readme.priority;
         let header_text = format!(
             "{} {} {} {} {}",
             item.readme.title,
             item.readme.slug,
-            item.readme.kind,
-            status,
+            item.readme.kind.as_str(),
+            status.as_str(),
             item.readme.apps.join(" "),
         );
         let header_lower = header_text.to_lowercase();
@@ -462,8 +462,8 @@ pub fn search_items(ctx: &RenderCtx, items: &[Item], query: &str) -> Vec<SearchR
             SearchResult {
                 slug: item.readme.slug.clone(),
                 title: item.readme.title.clone(),
-                kind: item.readme.kind.clone(),
-                status: status.clone(),
+                kind: item.readme.kind.as_str().into(),
+                status: status.as_str().into(),
                 subtab: status_to_subtab(status).into(),
                 path: item.readme.path.clone(),
                 month,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.1.0"
+version = "1.1.1"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

- \`ItemReadme\` now carries \`priority: Priority\` and \`kind: Kind\` instead of untyped strings. Downstream callers get exhaustive match coverage and no longer hand-compare against \`\"now\"\` / \`\"done\"\` at every use site.
- Drops the parallel \`PRIORITIES: &[&str]\` constants in \`condash-mutations\` and \`condash-render\` — \`Priority::ALL\` is the one canonical list.
- Closes F-23 + F-24 from the 2026-04-23 condash audit.

## Changes

- \`readme.rs\`: field types changed. \`resolve_status\` now returns \`(Priority, Option<String>)\`; unknown values still fall back to \`Backlog\` and the raw string is kept in \`invalid_status\`. \`resolve_kind\` returns \`Kind\` (unknown metadata / fallback falls through to \`Project\`).
- \`fingerprint.rs\`: read priority / kind through \`.as_str()\` so the cross-build fingerprint bytes are unchanged.
- \`condash-render\`: deleted the private \`pri_order\` sort-key helper and the \`PRIORITIES\` constant. Card sort now uses \`Priority\`'s derived \`Ord\` (variant declaration order matches the column order). The card template still receives a \`priorities\` array of lowercase strings via a new \`priorities()\` helper enumerating \`Priority::ALL\`.
- \`condash-mutations\`: \`steps.rs::set_priority\` calls \`Priority::from_lowercase\` directly. \`files.rs::create_item\` builds the validation error's \"must be one of [...]\" message from \`Priority::ALL\`. The public \`PRIORITIES\` export is removed.
- \`condash-state::search\`: \`status_to_subtab\` takes \`Priority\`; \`SearchResult.kind\` / \`.status\` are still lowercase strings via \`.as_str()\` so \`/search-history\` wire format is identical.
- \`Kind\` gained \`as_str()\` for symmetry with \`Priority\`.
- Bump \`src-tauri/Cargo.toml\` + \`tauri.conf.json\` from 1.0.20 to 1.0.21.

## Impact

- JSON wire format unchanged — \`#[serde(rename_all = \"lowercase\")]\` on both enums keeps \`\"priority\": \"now\"\` / \`\"kind\": \"project\"\` in every serialised response. Fingerprints are byte-identical.
- \`cargo build --workspace\` + \`cargo test --workspace\` green; no user-visible behaviour change.