### PR TITLE
Move machine-local preferences into settings.yaml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.0.20"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -7,16 +7,24 @@ description: The two YAML files condash reads — one at the conception tree roo
 
 ## At a glance
 
-condash reads **two** YAML files. They live in different places and have different scopes:
+condash reads **two** YAML files. They split responsibilities by scope:
 
 | File | Location | Scope | Owns |
 |------|----------|-------|------|
-| `configuration.yml` | `<conception_path>/configuration.yml` | Per-tree, versioned in git | `workspace_path`, `worktrees_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal` |
-| `settings.yaml` | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` | Per-user, per-machine | `conception_path` |
+| `configuration.yml` | `<conception_path>/configuration.yml` | Per-tree, versioned in git | `workspace_path`, `worktrees_path`, `repositories` (incl. `run:` / `force_stop:`) |
+| `settings.yaml` | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` | Per-user, per-machine | `conception_path`, `terminal`, `pdf_viewer`, `open_with` |
 
-The first file is inside the conception tree you're rendering — commit it and every developer on the tree gets the same workspace layout, `open_with` commands, PDF viewer chain, and terminal shortcuts. The second file is on the machine condash runs on, and stores only the path to the tree: it tells condash *which* tree to render. Everything else is in the tree.
+The tree-level file is versioned: commit it and every teammate who pulls picks up the same workspace layout and repo wiring. The per-user file lives on the machine condash runs on — it tells condash which tree to render, and carries the preferences that naturally differ per machine (which shell, which PDF viewer, which IDE command to shell out to).
 
-That split keeps the tree portable (clone it on a new laptop and it already knows which repos to scan) while letting the local machine point at whichever tree lives where on disk.
+### Precedence on overlap
+
+For backwards compatibility, `configuration.yml` still accepts `terminal`, `pdf_viewer`, and `open_with` keys. When the same key appears in both files, **`settings.yaml` wins**, merged field by field:
+
+- `terminal.<field>` — each field set in `settings.yaml` replaces the tree's value; missing fields fall through.
+- `pdf_viewer` — a non-empty list in `settings.yaml` replaces the tree's; empty / missing falls through.
+- `open_with.<slot>` — merged per slot. A user `commands` list replaces the tree's commands; a user `label` replaces the tree's label. A slot only set in the tree survives.
+
+Concretely: move any machine-specific preference from `configuration.yml` into `settings.yaml` on each machine; leave tree-wide preferences in `configuration.yml` and every teammate gets them automatically.
 
 ## `configuration.yml` (per-tree, versioned)
 
@@ -159,15 +167,38 @@ Embedded-terminal preferences. All keys are optional; an empty string means "fal
 
 ## `settings.yaml` (per-user, per-machine)
 
-Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Not versioned — it holds the one thing that only makes sense locally: where the conception tree lives on this machine.
+Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Not versioned. Every key is optional — a fresh install starts with the file empty (or absent) and fills it on first launch.
 
 ```yaml
 conception_path: /home/you/src/vcoeur/conception
+
+terminal:
+  shell: /bin/zsh
+  shortcut: Ctrl+T
+  launcher_command: claude
+  screenshot_dir: /home/you/Pictures/Screenshots
+
+pdf_viewer:
+  - xdg-open {path}
+  - evince {path}
+
+open_with:
+  main_ide:
+    label: Open in main IDE
+    commands:
+      - idea {path}
+      - idea.sh {path}
+  secondary_ide:
+    commands:
+      - code {path}
 ```
 
 | Key | Meaning |
 |-----|---------|
 | `conception_path` | Absolute path to the conception tree condash should render. |
+| `terminal.*` | Same keys as the tree-level `terminal` block above; any field set here overrides the tree value. Missing fields fall through. |
+| `pdf_viewer` | Fallback chain for opening PDFs. Non-empty list here replaces the tree's chain; empty or missing falls through. |
+| `open_with.<slot>.label`, `.commands` | Merged per slot. The user's `commands` replaces the tree's; the user's `label` replaces the tree's. Tree-only slots survive untouched. |
 
 Resolution order for the conception path, checked in sequence:
 
@@ -176,11 +207,13 @@ Resolution order for the conception path, checked in sequence:
 3. A first-run GUI prompt (Tauri build only). The prompt writes the chosen path back into this file so the next launch picks it up automatically.
 4. Hard error — condash refuses to start.
 
-The file is created on demand: first-run writes it; the gear modal's **General** tab writes it; you can also create it by hand.
+The file is created on demand: the first-run folder picker writes it; you can also create it by hand.
 
 ## Editing from the dashboard
 
-Click the gear icon in the header. A modal opens with a plain-text YAML editor showing the contents of `configuration.yml`. Save is atomic (temp file → rename), so a crash during save never corrupts the file. Most changes take effect immediately; a few (see below) need a restart and the save dialog tells you which.
+Click the gear icon in the header. A modal opens with a plain-text YAML editor showing the contents of `configuration.yml` — the tree-level file. Save is atomic (temp file → rename), so a crash during save never corrupts the file. Most changes take effect immediately; a few (see below) need a restart and the save dialog tells you which.
+
+Editing `settings.yaml` is hand-edit only today — no UI surface. Use your editor of choice; condash re-reads it on the next launch.
 
 Saves preserve your comments because the modal writes the raw text you edited — it does not round-trip the file through a parser.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.0.20"
+version = "1.1.0"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -1,13 +1,20 @@
-//! Config loader — reads `<conception>/configuration.yml` into a
-//! [`RenderCtx`].
+//! Config loader — reads `<conception>/configuration.yml` and
+//! overlays the per-machine `settings.yaml` into a [`RenderCtx`].
 //!
-//! Flat YAML: the top level carries both the workspace layout
-//! (`workspace_path`, `worktrees_path`, `repositories`, `open_with`)
-//! and the user preferences (`pdf_viewer`, `terminal`). Replaces the
-//! old split between `config/repositories.yml` and
-//! `config/preferences.yml` — those split files are still written on
-//! disk for the retired Python build (`condash-python`) but condash no
-//! longer reads them.
+//! Two layers:
+//!
+//! - **Tree-level** `configuration.yml` owns the workspace contract
+//!   (`workspace_path`, `worktrees_path`, `repositories.*`, including
+//!   each repo's `run:` + `force_stop:`). Versioned in git.
+//! - **Per-user** `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`
+//!   owns machine-local preferences (`terminal.*`, `pdf_viewer`,
+//!   `open_with.*`). Not versioned. On overlap, settings.yaml wins —
+//!   see the design note at
+//!   `projects/2026-04/2026-04-23-condash-rust-audit/notes/09-settings-split-schema.md`.
+//!
+//! Tree-level `configuration.yml` keeps reading `terminal` /
+//! `pdf_viewer` / `open_with` so old trees continue to work; the docs
+//! recommend moving those keys to `settings.yaml`.
 
 use std::collections::HashMap;
 use std::fs;
@@ -16,6 +23,8 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use condash_state::{OpenWithSlot, RenderCtx, RepoEntry, RepoSection, TerminalPrefs};
 use serde::Deserialize;
+
+use crate::user_config::{self, UserConfig};
 
 #[derive(Debug, Deserialize, Default)]
 struct ConfigurationYaml {
@@ -170,11 +179,27 @@ pub fn write_configuration(conception_path: &Path, body: &str) -> Result<PathBuf
 
 /// Build a [`RenderCtx`] for the conception tree at `conception_path`.
 ///
-/// Reads `<conception>/configuration.yml` when present; falls back to
-/// a minimal ctx when absent (no workspace, no git strip, no
-/// preferences). `template` is the dashboard shell HTML — loaded once
-/// by the caller so render helpers don't re-read the asset per request.
+/// Reads `<conception>/configuration.yml` when present, then overlays
+/// `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` via
+/// [`user_config::load`]. Falls back to a minimal ctx when both
+/// sources are absent. `template` is the dashboard shell HTML —
+/// loaded once by the caller so render helpers don't re-read the
+/// asset per request.
 pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> {
+    let user = user_config::load().unwrap_or_else(|e| {
+        eprintln!("condash: ignoring invalid settings.yaml: {e}");
+        None
+    });
+    build_ctx_with_user(conception_path, template, user.as_ref())
+}
+
+/// Testable form of [`build_ctx`] — caller provides the parsed
+/// [`UserConfig`] (or `None` to skip the settings.yaml overlay).
+pub fn build_ctx_with_user(
+    conception_path: &Path,
+    template: String,
+    user: Option<&UserConfig>,
+) -> Result<RenderCtx> {
     let yaml_path = configuration_path(conception_path);
     let mut ctx = RenderCtx {
         base_dir: conception_path.to_path_buf(),
@@ -182,15 +207,14 @@ pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> 
         ..Default::default()
     };
 
-    if !yaml_path.is_file() {
-        // No configuration.yml yet — return a minimal ctx; the dashboard
-        // renders without the Code tab populated.
-        return Ok(ctx);
-    }
-    let raw = fs::read_to_string(&yaml_path)
-        .with_context(|| format!("reading {}", yaml_path.display()))?;
-    let parsed: ConfigurationYaml = serde_yaml_ng::from_str(&raw)
-        .with_context(|| format!("parsing YAML at {}", yaml_path.display()))?;
+    let parsed: ConfigurationYaml = if yaml_path.is_file() {
+        let raw = fs::read_to_string(&yaml_path)
+            .with_context(|| format!("reading {}", yaml_path.display()))?;
+        serde_yaml_ng::from_str(&raw)
+            .with_context(|| format!("parsing YAML at {}", yaml_path.display()))?
+    } else {
+        ConfigurationYaml::default()
+    };
 
     ctx.workspace = parsed.workspace_path.as_deref().map(expand_tilde);
     ctx.worktrees = parsed.worktrees_path.as_deref().map(expand_tilde);
@@ -228,28 +252,103 @@ pub fn build_ctx(conception_path: &Path, template: String) -> Result<RenderCtx> 
     ctx.repo_run_templates = repo_run_templates;
     ctx.repo_force_stop_templates = repo_force_stop_templates;
 
+    // Start from the tree-level preferences, then overlay settings.yaml
+    // on a per-field basis so a partial user override only replaces the
+    // keys it actually sets.
     if let Some(open_with) = parsed.open_with {
         ctx.open_with = open_with
             .into_iter()
-            .map(|(key, slot)| {
-                let label = slot.label.unwrap_or_else(|| key.clone());
-                (
-                    key,
-                    OpenWithSlot {
-                        label,
-                        commands: slot.commands,
-                    },
-                )
-            })
+            .map(|(key, slot)| (key.clone(), open_with_slot_from(key, slot)))
             .collect();
     }
-
     ctx.pdf_viewer = parsed.pdf_viewer;
     if let Some(term) = parsed.terminal {
         ctx.terminal = term.into_prefs();
     }
 
+    if let Some(user) = user {
+        overlay_user_config(&mut ctx, user);
+    }
+
     Ok(ctx)
+}
+
+fn open_with_slot_from(key: String, slot: OpenWithSlotYaml) -> OpenWithSlot {
+    OpenWithSlot {
+        label: slot.label.unwrap_or(key),
+        commands: slot.commands,
+    }
+}
+
+/// Merge `user`'s per-machine overrides into `ctx`. Rules:
+///
+/// - `user.terminal`: each `Some(...)` field replaces the tree's
+///   value; `None` falls through.
+/// - `user.pdf_viewer`: non-empty list replaces the tree's; empty or
+///   absent falls through.
+/// - `user.open_with`: merged per slot. A user slot with commands
+///   replaces the tree's commands; a user slot that only sets `label`
+///   replaces only the label. A tree-only slot survives untouched.
+fn overlay_user_config(ctx: &mut RenderCtx, user: &UserConfig) {
+    if let Some(term) = user.terminal.as_ref() {
+        if let Some(v) = term.shell.clone().filter(|s| !s.is_empty()) {
+            ctx.terminal.shell = Some(v);
+        }
+        if let Some(v) = term.shortcut.clone().filter(|s| !s.is_empty()) {
+            ctx.terminal.shortcut = Some(v);
+        }
+        if let Some(v) = term.screenshot_dir.clone().filter(|s| !s.is_empty()) {
+            ctx.terminal.screenshot_dir = Some(v);
+        }
+        if let Some(v) = term
+            .screenshot_paste_shortcut
+            .clone()
+            .filter(|s| !s.is_empty())
+        {
+            ctx.terminal.screenshot_paste_shortcut = Some(v);
+        }
+        if let Some(v) = term.launcher_command.clone().filter(|s| !s.is_empty()) {
+            ctx.terminal.launcher_command = Some(v);
+        }
+        if let Some(v) = term
+            .move_tab_left_shortcut
+            .clone()
+            .filter(|s| !s.is_empty())
+        {
+            ctx.terminal.move_tab_left_shortcut = Some(v);
+        }
+        if let Some(v) = term
+            .move_tab_right_shortcut
+            .clone()
+            .filter(|s| !s.is_empty())
+        {
+            ctx.terminal.move_tab_right_shortcut = Some(v);
+        }
+    }
+
+    if let Some(list) = user.pdf_viewer.as_ref() {
+        if !list.is_empty() {
+            ctx.pdf_viewer = list.clone();
+        }
+    }
+
+    if let Some(slots) = user.open_with.as_ref() {
+        for (key, user_slot) in slots {
+            let entry = ctx
+                .open_with
+                .entry(key.clone())
+                .or_insert_with(|| OpenWithSlot {
+                    label: key.clone(),
+                    commands: Vec::new(),
+                });
+            if let Some(label) = user_slot.label.clone().filter(|s| !s.is_empty()) {
+                entry.label = label;
+            }
+            if !user_slot.commands.is_empty() {
+                entry.commands = user_slot.commands.clone();
+            }
+        }
+    }
 }
 
 fn entries_from(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -243,6 +243,7 @@ fn prompt_for_conception_path(initial: ConceptionPathUnset) -> Option<PathBuf> {
             Ok(()) => {
                 let cfg = user_config::UserConfig {
                     conception_path: Some(picked.clone()),
+                    ..Default::default()
                 };
                 if let Err(e) = user_config::save(&cfg) {
                     // Don't fail the launch on a save failure — the
@@ -329,6 +330,7 @@ mod resolve_tests {
             Some(PathBuf::from("/from-env")),
             Some(UserConfig {
                 conception_path: Some(PathBuf::from("/from-file")),
+                ..Default::default()
             }),
             None,
         )
@@ -342,6 +344,7 @@ mod resolve_tests {
             Some(PathBuf::from("")),
             Some(UserConfig {
                 conception_path: Some(PathBuf::from("/from-file")),
+                ..Default::default()
             }),
             None,
         )
@@ -355,6 +358,7 @@ mod resolve_tests {
             None,
             Some(UserConfig {
                 conception_path: Some(PathBuf::from("/from-file")),
+                ..Default::default()
             }),
             None,
         )
@@ -377,6 +381,7 @@ mod resolve_tests {
             None,
             Some(UserConfig {
                 conception_path: None,
+                ..Default::default()
             }),
             None,
         )

--- a/src-tauri/src/user_config.rs
+++ b/src-tauri/src/user_config.rs
@@ -1,18 +1,36 @@
-//! Per-user persistent settings — the file condash writes after the
-//! first-run prompt so the next launch doesn't need the env var or a
-//! fresh GUI dialog.
+//! Per-user persistent settings — the per-machine companion to the
+//! tree-level `configuration.yml`.
 //!
-//! Stored at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` as a
-//! flat YAML document with a single key:
+//! Stored at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`.
+//! Schema:
 //!
 //! ```yaml
 //! conception_path: /home/alice/src/vcoeur/conception
+//! terminal:
+//!   shortcut: Ctrl+T
+//!   launcher_command: claude
+//! pdf_viewer:
+//!   - xdg-open {path}
+//!   - evince {path}
+//! open_with:
+//!   main_ide:
+//!     label: Open in main IDE
+//!     commands: [idea {path}]
 //! ```
+//!
+//! Every field is optional. `conception_path` tells condash *which*
+//! tree to render; the other three carry per-machine overrides for
+//! keys that also live in the tree's `configuration.yml`. See the
+//! design note in
+//! `projects/2026-04/2026-04-23-condash-rust-audit/notes/09-settings-split-schema.md`
+//! for rationale and the precedence rule (settings.yaml wins on
+//! overlap, field by field).
 //!
 //! Read order of precedence when resolving the conception tree lives in
 //! [`crate::resolve_conception_path`]: env var → this file → first-run
 //! prompt (Tauri only) → hard error.
 
+use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
@@ -21,11 +39,56 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct UserConfig {
-    /// Absolute path to the conception tree. Optional in the struct so a
-    /// future settings.yaml with other keys can still deserialize when
-    /// this one is missing — callers decide whether absence is fatal.
+    /// Absolute path to the conception tree. Optional so callers can
+    /// decide whether absence is fatal (first-run picker vs hard error).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub conception_path: Option<PathBuf>,
+
+    /// Per-machine overrides for `terminal.*` fields in the tree's
+    /// `configuration.yml`. Missing keys fall through to the tree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub terminal: Option<TerminalYaml>,
+
+    /// Per-machine PDF-viewer fallback chain. When present and
+    /// non-empty, replaces the tree's `pdf_viewer`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pdf_viewer: Option<Vec<String>>,
+
+    /// Per-machine "Open with …" slot overrides. Merged per-slot with
+    /// the tree's `open_with`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub open_with: Option<HashMap<String, OpenWithSlotYaml>>,
+}
+
+/// One `terminal:` block — fields mirror the tree's `configuration.yml`
+/// shape. Missing / empty strings mean "fall through to the tree / to
+/// the built-in default".
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct TerminalYaml {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shell: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shortcut: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub screenshot_dir: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub screenshot_paste_shortcut: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub launcher_command: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub move_tab_left_shortcut: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub move_tab_right_shortcut: Option<String>,
+}
+
+/// One `open_with.<slot>:` entry. Either field may be absent; a
+/// missing `label` falls through to the tree's value.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpenWithSlotYaml {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub commands: Vec<String>,
 }
 
 /// Resolve the on-disk settings file path. Returns `None` when neither
@@ -117,6 +180,7 @@ mod tests {
         let path = tmp.path().join("nested").join("settings.yaml");
         let cfg = UserConfig {
             conception_path: Some(PathBuf::from("/tmp/conception")),
+            ..Default::default()
         };
         save_to(&path, &cfg).unwrap();
         let loaded = load_from(&path).unwrap().unwrap();

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.0.20",
+  "version": "1.1.0",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"

--- a/src-tauri/tests/configuration_yml.rs
+++ b/src-tauri/tests/configuration_yml.rs
@@ -8,7 +8,8 @@
 use std::fs;
 use std::path::PathBuf;
 
-use condash_lib::config::{build_ctx, configuration_path};
+use condash_lib::config::{build_ctx, build_ctx_with_user, configuration_path};
+use condash_lib::user_config::{OpenWithSlotYaml, TerminalYaml, UserConfig};
 
 const FIXTURE: &str = r#"
 workspace_path: /tmp/vcoeur
@@ -170,4 +171,126 @@ fn build_ctx_rejects_invalid_yaml() {
         err.to_string().to_lowercase().contains("yaml") || err.to_string().contains("parsing"),
         "unexpected error: {err}"
     );
+}
+
+#[test]
+fn settings_yaml_terminal_overrides_configuration_yml() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(configuration_path(tmp.path()), FIXTURE).unwrap();
+
+    let user = UserConfig {
+        terminal: Some(TerminalYaml {
+            shortcut: Some("Ctrl+Alt+T".into()),
+            launcher_command: Some("zellij".into()),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let ctx = build_ctx_with_user(tmp.path(), String::new(), Some(&user)).unwrap();
+
+    // Fields set in settings.yaml win.
+    assert_eq!(ctx.terminal.shortcut.as_deref(), Some("Ctrl+Alt+T"));
+    assert_eq!(ctx.terminal.launcher_command.as_deref(), Some("zellij"));
+    // Fields not set in settings.yaml fall through to configuration.yml.
+    assert_eq!(ctx.terminal.shell.as_deref(), Some("/bin/zsh"));
+    assert_eq!(
+        ctx.terminal.move_tab_left_shortcut.as_deref(),
+        Some("Ctrl+Left")
+    );
+}
+
+#[test]
+fn settings_yaml_pdf_viewer_replaces_tree_chain() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(configuration_path(tmp.path()), FIXTURE).unwrap();
+
+    let user = UserConfig {
+        pdf_viewer: Some(vec!["xdg-open {path}".into()]),
+        ..Default::default()
+    };
+    let ctx = build_ctx_with_user(tmp.path(), String::new(), Some(&user)).unwrap();
+    assert_eq!(ctx.pdf_viewer, vec!["xdg-open {path}".to_string()]);
+}
+
+#[test]
+fn settings_yaml_empty_pdf_viewer_falls_through() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(configuration_path(tmp.path()), FIXTURE).unwrap();
+
+    let user = UserConfig {
+        pdf_viewer: Some(vec![]),
+        ..Default::default()
+    };
+    let ctx = build_ctx_with_user(tmp.path(), String::new(), Some(&user)).unwrap();
+    assert_eq!(
+        ctx.pdf_viewer,
+        vec!["evince {path}".to_string(), "okular {path}".to_string()]
+    );
+}
+
+#[test]
+fn settings_yaml_open_with_merges_per_slot() {
+    let tmp = tempfile::tempdir().unwrap();
+    fs::write(configuration_path(tmp.path()), FIXTURE).unwrap();
+
+    let mut slots = std::collections::HashMap::new();
+    // Existing slot — replace the commands, keep the tree's label.
+    slots.insert(
+        "main_ide".to_string(),
+        OpenWithSlotYaml {
+            label: None,
+            commands: vec!["rust-rover {path}".into()],
+        },
+    );
+    // New slot absent from the tree — gets added with its own label.
+    slots.insert(
+        "terminal".to_string(),
+        OpenWithSlotYaml {
+            label: Some("Open terminal here".into()),
+            commands: vec!["ghostty --working-directory={path}".into()],
+        },
+    );
+    let user = UserConfig {
+        open_with: Some(slots),
+        ..Default::default()
+    };
+    let ctx = build_ctx_with_user(tmp.path(), String::new(), Some(&user)).unwrap();
+
+    let main = ctx.open_with.get("main_ide").expect("main_ide present");
+    assert_eq!(main.label, "Open in main IDE"); // tree's label survives
+    assert_eq!(main.commands, vec!["rust-rover {path}".to_string()]);
+
+    // Untouched tree slot stays intact.
+    let sec = ctx
+        .open_with
+        .get("secondary_ide")
+        .expect("secondary_ide present");
+    assert_eq!(sec.label, "Open in VS Code");
+
+    let term = ctx.open_with.get("terminal").expect("terminal added");
+    assert_eq!(term.label, "Open terminal here");
+    assert_eq!(
+        term.commands,
+        vec!["ghostty --working-directory={path}".to_string()]
+    );
+}
+
+#[test]
+fn settings_yaml_only_still_populates_ctx() {
+    // No configuration.yml on disk — settings.yaml provides the
+    // preferences; workspace / repositories stay empty.
+    let tmp = tempfile::tempdir().unwrap();
+    let user = UserConfig {
+        terminal: Some(TerminalYaml {
+            shortcut: Some("Ctrl+`".into()),
+            ..Default::default()
+        }),
+        pdf_viewer: Some(vec!["xdg-open {path}".into()]),
+        ..Default::default()
+    };
+    let ctx = build_ctx_with_user(tmp.path(), String::new(), Some(&user)).unwrap();
+    assert_eq!(ctx.terminal.shortcut.as_deref(), Some("Ctrl+`"));
+    assert_eq!(ctx.pdf_viewer, vec!["xdg-open {path}".to_string()]);
+    assert!(ctx.workspace.is_none());
+    assert!(ctx.repo_structure.is_empty());
 }


### PR DESCRIPTION
## Summary

- \`configuration.yml\` at the conception-tree root used to hold everything — workspace paths, repositories, and the three blocks that naturally differ per machine (\`terminal\`, \`pdf_viewer\`, \`open_with\`). Teammates sharing a tree hit merge conflicts on every shortcut or IDE-launcher tweak.
- Move those three blocks into \`\${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml\`. Trees stay versioned and portable; machine-local preferences stop churning the tree.
- Backward-compatible: \`configuration.yml\` still accepts the three blocks, now as fall-throughs. On overlap, \`settings.yaml\` wins field by field.

## Changes

- \`src-tauri/src/user_config.rs\`: \`UserConfig\` gains \`Option<TerminalYaml>\`, \`Option<Vec<String>>\` (pdf_viewer), \`Option<HashMap<String, OpenWithSlotYaml>>\`. \`TerminalYaml\` + \`OpenWithSlotYaml\` move to this module as public types so the loader and tests can share them.
- \`src-tauri/src/config.rs\`: \`build_ctx\` loads \`settings.yaml\` via \`user_config::load()\` and forwards to \`build_ctx_with_user\`, which applies a per-field overlay:
  - \`terminal.<field>\`: a \`Some(non-empty)\` user value replaces the tree's; missing / empty falls through.
  - \`pdf_viewer\`: a non-empty user list replaces the tree's; empty / missing falls through.
  - \`open_with.<slot>\`: merged per slot — user \`commands\` replaces tree \`commands\`; user \`label\` replaces tree \`label\`; tree-only slots survive.
- \`src-tauri/tests/configuration_yml.rs\`: five new tests covering each overlap rule plus a settings-yaml-only baseline.
- \`docs/reference/config.md\`: at-a-glance table reflects the new ownership; new 'Precedence on overlap' section; \`settings.yaml\` section expanded with the full key surface.
- Minor bump to \`v1.1.0\` (new user-visible schema surface).

## Impact

- **No migration required.** Existing trees keep working — \`terminal\` / \`pdf_viewer\` / \`open_with\` in \`configuration.yml\` continue to populate the same \`RenderCtx\` fields. Tree maintainers move keys into \`settings.yaml\` at their own pace.
- Design note with the rationale + non-goals: \`projects/2026-04/2026-04-23-condash-rust-audit/notes/09-settings-split-schema.md\` in the conception repo, committed one step ahead of this PR.

## Watchpoints

- The gear modal only edits \`configuration.yml\` today; hand-editing \`settings.yaml\` is the only surface for the new keys. A follow-up PR can add a modal tab if needed.
- \`settings.yaml\` parse failures log a warning and fall through to "no overlay" rather than failing the launch.