### PR TITLE
Sweep stale config-split copy across docs + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,20 @@ make build                 # produce the signed installer under src-tauri/target
 For running the HTTP surface headless (useful for Playwright, curl, or hacking the server without the GUI deps):
 
 ```bash
-make serve                 # runs condash-serve against $HOME/src/vcoeur/conception
+make serve                 # runs condash-serve against the tree configured in settings.yaml
 CONDASH_CONCEPTION_PATH=/other/tree make serve
 ```
 
 ## First launch
 
-`condash` reads `CONDASH_CONCEPTION_PATH` to find your tree (default: `$HOME/src/vcoeur/conception`). On first launch, click the gear icon in the dashboard header and set the path in the **General** tab of the Configuration modal. The change takes effect on the next window launch.
+On first launch with no tree configured, `condash` opens a folder picker and writes your choice to `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Subsequent launches reuse the saved path. Override with the `CONDASH_CONCEPTION_PATH` env var for one-shot runs.
 
-All other configuration — the workspace of code repos, the "open in IDE" launchers, per-machine preferences — lives in two YAML files **inside the conception tree**:
+Configuration lives in two YAML files:
 
-- `<conception_path>/config/repositories.yml` — versioned with the tree, describes the workspace shape and "open with" commands.
-- `<conception_path>/config/preferences.yml` — local machine overrides (PDF viewer, terminal shortcut).
+- `<conception_path>/configuration.yml` — tree-level, versioned with the tree. Owns `workspace_path`, `worktrees_path`, `repositories` (with optional `run:` / `force_stop:`).
+- `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` — per-user, per-machine. Owns `conception_path`, `terminal`, `pdf_viewer`, `open_with`.
 
-Full schema: [Config files reference](https://condash.vcoeur.com/reference/config/).
+On overlap, `settings.yaml` wins field by field. Full schema: [Config files reference](https://condash.vcoeur.com/reference/config/).
 
 ## What it does
 

--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -74,20 +74,20 @@ See [`crates/condash-parser/src/fingerprint.rs`](https://github.com/vcoeur/conda
 
 Hashes are MD5 truncated to 16 hex chars. MD5 is fine here — this is an equality check, not a security primitive, and the 64-bit output is plenty to avoid collisions on trees of a few thousand items.
 
-## Config: env var plus tree-level YAML
+## Config: tree-level YAML plus per-user YAML
 
-condash reads configuration from two places:
+condash reads configuration from two YAML files at distinct scopes:
 
-- **The `CONDASH_CONCEPTION_PATH` environment variable.** Tells condash which tree to render. Defaults to `$HOME/src/vcoeur/conception`. That's the only piece of configuration that has to live outside the tree, because the tree itself doesn't know where it lives on disk.
-- **Two YAML files inside the tree**, under `<conception_path>/config/`:
-  - `repositories.yml` — workspace layout, repo grouping, `open_with` command chains. Team-shared; commit it.
-  - `preferences.yml` — per-machine scoping for this tree (PDF viewer chain, terminal shortcuts). Gitignored.
+- **`<conception_path>/configuration.yml`** — versioned inside the tree. Owns the workspace contract: `workspace_path`, `worktrees_path`, `repositories` (with optional `run:` / `force_stop:` per repo). Team-shared.
+- **`${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`** — per-user, outside the tree. Owns `conception_path` (which tree to render) plus the three blocks that naturally differ per machine: `terminal`, `pdf_viewer`, `open_with`.
 
-Splitting between the two YAML files is a *what does this describe* question, not a *how do you edit it* question. `repositories.yml` describes the team's shape — workspace layout, repo structure, "open with IntelliJ" chains — and should be identical for every teammate. `preferences.yml` describes one developer's preferences on one tree on one machine; committing it would force the team onto your terminal shortcut.
+`CONDASH_CONCEPTION_PATH` remains as an override for `conception_path` — useful for scratch runs and CI fixtures.
+
+Splitting across the two files is a *what scope does this belong to* question. `configuration.yml` describes the team's shape; it should be identical for every teammate. `settings.yaml` describes one developer's preferences on one machine; committing it would force the team onto your terminal shortcut.
 
 ### Example
 
-`<conception>/config/repositories.yml`, committed:
+`<conception>/configuration.yml`, committed:
 
 ```yaml
 workspace_path: /home/alice/src
@@ -100,24 +100,29 @@ repositories:
   secondary:
     - conception
     - condash
-open_with:
-  main_ide: { label: "Open in IntelliJ",   commands: ["idea {path}"] }
-  terminal: { label: "Open in Ghostty",    commands: ["ghostty --working-directory={path}"] }
 ```
 
-`<conception>/config/preferences.yml`, **not** committed (gitignored):
+`${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`, per-user, not in any tree:
 
 ```yaml
+conception_path: /home/alice/src/vcoeur/conception
 terminal:
   shortcut: "Ctrl+Shift+`"
   screenshot_paste_shortcut: "Ctrl+Alt+V"
+open_with:
+  main_ide:
+    label: "Open in IntelliJ"
+    commands: ["idea {path}"]
+  terminal:
+    label: "Open in Ghostty"
+    commands: ["ghostty --working-directory={path}"]
 ```
 
-The result: teammates who clone the tree get the same `workspace_path` shape and `open_with` chains; my keyboard shortcut override stays local.
+The result: teammates who clone the tree get the same `workspace_path` shape and `repositories`; my keyboard shortcut override and IDE launcher paths stay local.
 
-### On machine-local configuration
+### Precedence
 
-An earlier design had a third file — a per-machine TOML — for settings that don't belong in either YAML (ports, PDF viewer, the native-window toggle). The current build gets by without it: the conception path comes from the environment, everything tree-scoped lives in the two YAMLs, and the few remaining per-machine toggles are either compile-time defaults or reachable via env vars. A future release may bring the TOML back for users who want a persistent machine-local override surface that isn't a shell rc file; for now there is no such file and the loader doesn't look for one.
+On overlap, `settings.yaml` wins, merged field by field. See the [config reference](../reference/config.md) for the exact rules.
 
 See [multi-machine setup](../guides/multi-machine.md) for how to structure a two-machine workflow.
 

--- a/docs/guides/configure-conception-path.md
+++ b/docs/guides/configure-conception-path.md
@@ -9,14 +9,9 @@ description: Point condash at the directory it should render — persistently, f
 
 The conception path is the only piece of configuration condash needs before it can start. Everything else has a sensible default.
 
-## Option 1 — from the gear modal
+## Option 1 — first-launch folder picker
 
-Click the gear icon in the dashboard header. The **General** tab shows the current conception path in an editable field:
-
-![Gear modal — General tab](../assets/screenshots/gear-modal-light.png#only-light)
-![Gear modal — General tab](../assets/screenshots/gear-modal-dark.png#only-dark)
-
-Typing a new path and clicking **Save** reloads the dashboard against the new tree. No restart needed.
+On first launch with no tree configured, condash opens a native folder picker. Pick the directory containing your `projects/` + (optional) `configuration.yml` and condash writes the choice to `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Subsequent launches reuse the saved path automatically.
 
 This is the right setup for your main tree — the path you work in every day.
 
@@ -32,17 +27,33 @@ To make it persistent, export it from your shell's rc file:
 
 ```bash
 # ~/.bashrc, ~/.zshrc, etc.
-export CONDASH_CONCEPTION_PATH="$HOME/src/vcoeur/conception"
+export CONDASH_CONCEPTION_PATH="$HOME/conception"
 ```
 
 Useful for:
 
-- Trying a fresh tree layout without disturbing your working config.
+- Trying a fresh tree layout without disturbing your saved path.
 - Running two condash instances side-by-side (pin each with a different `CONDASH_PORT` on `condash-serve`) to compare trees.
 - Scripts and demos where you want an explicit path in the recipe.
 
-!!! note "Default path"
-    If `CONDASH_CONCEPTION_PATH` is unset, condash falls back to `$HOME/src/vcoeur/conception`. Works out of the box if you keep your tree at that location; otherwise, set the variable.
+## Option 3 — edit `settings.yaml` by hand
+
+Change the saved path without re-launching the picker by editing `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` directly:
+
+```yaml
+conception_path: /home/you/another-tree
+```
+
+Delete the file to force the folder picker on the next launch.
+
+## Resolution order
+
+On startup condash checks, in order:
+
+1. `CONDASH_CONCEPTION_PATH` environment variable (wins when set).
+2. `conception_path` in `settings.yaml`.
+3. First-launch folder picker (Tauri build only). Writes the choice back to `settings.yaml`.
+4. Hard error — condash refuses to start.
 
 ## When to use a scratch tree
 
@@ -63,6 +74,4 @@ The Projects tab will be empty but the dashboard will render. Add README files u
 
 ## Multiple machines pointed at the same tree
 
-If you sync the conception tree between machines via git, each machine needs its own `CONDASH_CONCEPTION_PATH` — the absolute path typically differs (different users, different mount points).
-
-The tree itself carries the team-shared config (`config/repositories.yml`) and each machine's local tweaks (`config/preferences.yml`). See [Multi-machine setup](multi-machine.md) for the full split.
+If you sync the conception tree between machines via git, each machine keeps its own `conception_path` in `settings.yaml` — the absolute path typically differs (different users, different mount points). The tree itself carries the team-shared config in `configuration.yml`; per-machine preferences live in each machine's `settings.yaml`. See [Multi-machine setup](multi-machine.md) for the full split.

--- a/docs/guides/deliverables.md
+++ b/docs/guides/deliverables.md
@@ -68,7 +68,7 @@ Refresh the dashboard; the PDF badge lights up and the viewer picks up the file.
 
 ## Overriding the viewer
 
-If you'd rather open PDFs in your OS-native viewer (Evince, Okular, Preview, Sumatra, …), configure the `pdf_viewer` fallback chain in `preferences.yml`:
+If you'd rather open PDFs in your OS-native viewer (Evince, Okular, Preview, Sumatra, …), configure the `pdf_viewer` fallback chain in `settings.yaml`:
 
 ```yaml
 pdf_viewer:

--- a/docs/guides/multi-machine.md
+++ b/docs/guides/multi-machine.md
@@ -1,25 +1,25 @@
 ---
 title: Multi-machine setup · condash guide
-description: Sync a conception tree between machines via git. What goes in version control, what stays local, how to split configs.
+description: Sync a conception tree between machines via git. What goes in version control, what stays per-machine, and how condash layers the two.
 ---
 
 # Multi-machine setup
 
 **When to read this.** You work across two (or more) machines — a desktop and a laptop, your work box and a personal box — and you want the same tree on each, with per-machine tweaks that don't fight each other.
 
-condash was designed for this split from day one. The tree-versioned YAML layout, plus a single per-machine environment variable, is the whole answer.
+condash was designed for this split from day one. One versioned YAML file at the tree root, one per-machine YAML file in your XDG config directory. The two layer at launch with clear precedence.
 
 ## The two config files
 
 | File | Lives in | Committed? | Per-machine or per-tree? |
 |---|---|---|---|
-| `repositories.yml` | `<conception_path>/config/` | **Yes** | Per-tree (shared) |
-| `preferences.yml` | `<conception_path>/config/` | **No** | Per-tree, per-machine |
+| `configuration.yml` | `<conception_path>/configuration.yml` | **Yes** | Per-tree (shared) |
+| `settings.yaml` | `${XDG_CONFIG_HOME:-~/.config}/condash/` | **No** — outside the tree | Per-user, per-machine |
 
-- **`repositories.yml`** — lives inside the tree. **Commit this.** It's the team-shared config: workspace layout, repo grouping, open-with command chains. When a teammate pulls, their repo strip matches yours.
-- **`preferences.yml`** — lives inside the tree, beside `repositories.yml`. **Don't commit it.** Per-machine overrides scoped to this tree. Useful when machine A has Ghostty and machine B has gnome-terminal, or when you want a different terminal shortcut on each host.
+- **`configuration.yml`** — inside the tree. **Commit this.** It's the team-shared config: workspace layout, repo grouping, optional `run:` / `force_stop:` commands. When a teammate pulls, their repo strip matches yours.
+- **`settings.yaml`** — outside the tree, in your XDG config. **Not versioned.** Holds `conception_path` (which tree to render) plus the three blocks that naturally differ per machine: `terminal.*`, `pdf_viewer`, `open_with.*`.
 
-The one thing that isn't a file is the conception path itself — that's `CONDASH_CONCEPTION_PATH`, set per-machine in your shell's rc file (or left unset to fall through to the `$HOME/src/vcoeur/conception` default).
+The two layer at launch: `configuration.yml` loads first, then `settings.yaml` overrides matching keys field by field. See [Precedence on overlap](#precedence-on-overlap) below for the exact rules.
 
 ## Installing condash on each machine
 
@@ -30,14 +30,14 @@ Each machine needs its own condash build. Two options:
 
 The two machines don't need to run the same condash version — the HTTP API, README format, and config files are stable across minor versions.
 
-## Syncing via git
+## Syncing the tree via git
 
 Treat the conception tree as a plain git repository:
 
 ```bash
 cd ~/conception
 git init
-git add projects/ knowledge/ config/repositories.yml
+git add projects/ knowledge/ configuration.yml
 git commit -m "Initial conception tree"
 git remote add origin git@github.com:you/conception.git
 git push -u origin main
@@ -49,24 +49,25 @@ On the other machine:
 git clone git@github.com:you/conception.git ~/conception
 ```
 
-Then set `CONDASH_CONCEPTION_PATH` on each machine to point at the local clone. Paths typically differ (different usernames, different home directories), which is exactly why this lives in a per-machine env var rather than the tree.
+Then tell condash on the second machine where the tree lives — either set the env var per shell session, or let the first-launch folder picker write it to `settings.yaml`:
 
 ```bash
 # ~/.bashrc or ~/.zshrc on each machine
 export CONDASH_CONCEPTION_PATH="$HOME/conception"
 ```
 
+Paths typically differ per machine (different usernames, different home directories), which is exactly why `conception_path` is per-machine rather than part of the versioned tree.
+
 ## `.gitignore` for the tree
 
 Drop this into the tree's `.gitignore`:
 
 ```
-config/preferences.yml
 *.local.md
 .DS_Store
 ```
 
-The first line is the important one — it's the only file inside `config/` that should never be versioned.
+`settings.yaml` does not need to appear here — it lives outside the tree (in `${XDG_CONFIG_HOME:-~/.config}/condash/`), so git inside the conception tree cannot see it.
 
 If you use the `/conception` skill suite or have `.claude/` subdirectories, add them too:
 
@@ -80,9 +81,10 @@ Negate only the directories you intentionally share. Default is to hide everythi
 
 ## Per-machine terminal tweaks
 
-Example: your desktop has `ghostty`, your laptop has only `gnome-terminal`. The shared `repositories.yml` wires a fallback chain that works on both:
+Example: your desktop has `ghostty`, your laptop has only `gnome-terminal`. Wire the fallback in the **tree**'s `configuration.yml` so both machines see the same chain:
 
 ```yaml
+# configuration.yml
 open_with:
   terminal:
     commands:
@@ -90,41 +92,50 @@ open_with:
       - gnome-terminal --working-directory {path}
 ```
 
-No per-machine edit needed — the first command that resolves wins.
+The first command that resolves on each machine wins — no per-machine edit needed.
 
-But if you want a different **terminal toggle shortcut** on each machine (say `` Ctrl+` `` on one and `Ctrl+T` on the other because the laptop's keyboard intercepts the backtick), put the override in `preferences.yml` on each machine:
+But if you want a different **terminal toggle shortcut** on each machine (say `` Ctrl+` `` on one and `Ctrl+T` on the other because the laptop's keyboard intercepts the backtick), put the override in each machine's `settings.yaml`:
 
 ```yaml
-# preferences.yml on the laptop
+# ~/.config/condash/settings.yaml on the laptop
+conception_path: /home/you/conception
 terminal:
   shortcut: Ctrl+T
 ```
 
-Leave `preferences.yml` absent on the desktop and condash falls back to its defaults.
+Leave that key absent on the desktop and condash falls back to whatever `configuration.yml` declares (or the built-in default if the tree doesn't set it either).
 
 The same pattern works for `screenshot_dir` (different directories per OS), `launcher_command` (different Claude Code install paths), and the `pdf_viewer` chain.
 
-## Merge order
+## Precedence on overlap
 
-When condash boots, the effective config is the result of layering in this order, top to bottom wins:
+When condash boots, each key is resolved in this order — the first layer that sets it wins:
 
-1. Built-in defaults.
-2. `<conception_path>/config/repositories.yml`.
-3. `<conception_path>/config/preferences.yml`.
+1. **`settings.yaml`** (`${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`) — per-machine.
+2. **`configuration.yml`** (`<conception_path>/configuration.yml`) — tree-level.
+3. Built-in defaults compiled into the binary.
 
-A key set in `preferences.yml` overrides everything else. A key set only in `repositories.yml` survives because nothing below overrode it. `CONDASH_CONCEPTION_PATH` is orthogonal — it only decides which tree those two files belong to.
+Merging is **per field**:
+
+- `terminal.<field>`: each field set in `settings.yaml` replaces the tree's value; missing fields fall through.
+- `pdf_viewer`: a non-empty list in `settings.yaml` replaces the tree's; empty or missing falls through.
+- `open_with.<slot>`: merged per slot. A user `commands` replaces the tree's commands; a user `label` replaces the tree's label. A slot only set in the tree survives.
+
+`CONDASH_CONCEPTION_PATH` is orthogonal — it only decides which tree the tree-level file belongs to; it does not affect merging between the two files.
 
 Full details in the [config reference](../reference/config.md).
 
-## Handling conflicts in the shared `repositories.yml`
+## Handling conflicts in `configuration.yml`
 
-Because `repositories.yml` is versioned, any team-wide layout change is a git commit. If two teammates edit it simultaneously, resolve conflicts the usual way — the file is YAML, conflicts are readable, and no binary format gets in the way.
+Because `configuration.yml` is versioned, any team-wide layout change is a git commit. If two teammates edit it simultaneously, resolve conflicts the usual way — the file is plain YAML, conflicts are readable, and no binary format gets in the way.
 
-One rule of thumb: **keep `workspace_path` and `worktrees_path` at the top of the file**, even though they're per-user. Different teammates will have different absolute paths, which means this file is technically per-user even though it's committed — each teammate edits their two path lines post-clone.
+Typical flow when you need to tweak a machine-local value:
 
-The cleaner approach: leave those two keys out of `repositories.yml` and put them in `preferences.yml` instead. Yes, this breaks the "repositories.yml is shared, preferences.yml is local" rule slightly — but it avoids a merge conflict on every pull. Pick whichever trade-off bothers you less.
+1. **Tempted to edit `configuration.yml`?** Stop — if the change only makes sense for your machine, put it in `settings.yaml` instead. No conflict with teammates.
+2. **Change is team-wide?** Edit `configuration.yml`, commit, push. Teammates get it on the next pull.
 
 ## Next
 
 - [Configure the conception path](configure-conception-path.md) — the basic `CONDASH_CONCEPTION_PATH` setup, per-machine.
-- [Repositories and open-with buttons](repositories-and-open-with.md) — the full `repositories.yml` schema.
+- [Repositories and open-with buttons](repositories-and-open-with.md) — the full `repositories` schema inside `configuration.yml`.
+- [Config reference](../reference/config.md) — every key in both files.

--- a/docs/guides/repositories-and-open-with.md
+++ b/docs/guides/repositories-and-open-with.md
@@ -7,7 +7,7 @@ description: Point condash at your workspace, group repos into primary / seconda
 
 **When to read this.** The **Code** tab shows the wrong repos, or the wrong repos are in the primary card, or the "open in IDE" button launches the wrong thing (or nothing).
 
-Everything on this page lives in `<conception_path>/config/repositories.yml`. This file is versioned with the tree — changes propagate to every teammate who pulls. Per-machine overrides go in `preferences.yml` (see [Multi-machine setup](multi-machine.md)).
+Everything on this page lives in `<conception_path>/configuration.yml`. This file is versioned with the tree — changes propagate to every teammate who pulls. Per-machine overrides go in `settings.yaml` (see [Multi-machine setup](multi-machine.md)).
 
 ## Workspace and worktrees paths
 
@@ -61,7 +61,7 @@ The `submodules` entry is an inline map (`{name: …, submodules: […]}`), not 
 
 ## The three `open_with` slots
 
-Each repo row has three icon buttons: **main IDE**, **secondary IDE**, **terminal**. Wire them in `repositories.yml`:
+Each repo row has three icon buttons: **main IDE**, **secondary IDE**, **terminal**. Wire them in `configuration.yml`:
 
 ```yaml
 open_with:
@@ -89,18 +89,13 @@ The fallback chain is the key feature: on machine A where `idea` resolves, you g
 
 Commands are parsed with `shlex`, so quoting works the way you'd expect: `"/Applications/JetBrains Toolbox/idea.app" {path}` is a single argv[0] + `{path}`.
 
-Built-in defaults for the three slots reproduce the previous IntelliJ / VS Code / terminal behaviour, so a `repositories.yml` without any `open_with` section still gives functional buttons. Override only the slots you want to customise.
+Built-in defaults for the three slots reproduce the previous IntelliJ / VS Code / terminal behaviour, so a `configuration.yml` without any `open_with` section still gives functional buttons. Override only the slots you want to customise.
 
 ## Editing via the gear modal
 
-Click the gear icon in the header, switch to the **Repositories** tab:
+Click the gear icon in the header to open a plain-text YAML editor backed by `configuration.yml`. Save is atomic (temp file → rename) and changes to `open_with` / `pdf_viewer` / `terminal` reload the dashboard live; `workspace_path`, `worktrees_path`, and the `repositories` list need a restart (the save dialog tells you which).
 
-![Gear modal — Repositories tab](../assets/screenshots/gear-modal-repositories-light.png#only-light)
-![Gear modal — Repositories tab](../assets/screenshots/gear-modal-repositories-dark.png#only-dark)
-
-Form fields for `workspace_path`, `worktrees_path`, and the primary / secondary lists. Saves write `repositories.yml` atomically and reload the dashboard live. Add new repos to the primary list by dragging them up from the OTHERS card on the dashboard itself.
-
-`open_with` is not currently exposed in the modal — edit `repositories.yml` directly for launcher changes.
+Prefer overriding IDE launcher paths per machine? Put the override in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` instead — `settings.yaml` wins on overlap. See [Multi-machine setup](multi-machine.md).
 
 ## Starting a dev server from the row
 

--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -14,7 +14,7 @@ The embedded terminal is a real PTY over a WebSocket. `bash` (or your configured
 Two ways:
 
 - Click the `>_` icon in the dashboard header.
-- Press the configured toggle shortcut. Default is `` Ctrl+` ``; change it under `terminal.shortcut` in `preferences.yml`.
+- Press the configured toggle shortcut. Default is `` Ctrl+` ``; change it under `terminal.shortcut` in `settings.yaml`.
 
 ![Terminal pane open beneath the dashboard](../assets/screenshots/terminal-light.png#only-light)
 ![Terminal pane open beneath the dashboard](../assets/screenshots/terminal-dark.png#only-dark)
@@ -62,7 +62,7 @@ Clipboard-based paste (`Ctrl+V`) also works for regular text, and uses the OS cl
 
 ## Configuration surface
 
-Everything lives under `terminal:` in `<conception_path>/config/preferences.yml`:
+Everything lives under `terminal:` in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`:
 
 ```yaml
 terminal:
@@ -77,14 +77,9 @@ terminal:
 
 See the [config reference](../reference/config.md) for the full key table with defaults.
 
-## Editing shortcuts via the gear modal
+## Editing shortcuts
 
-The gear modal's **Preferences** tab has form fields for every `[terminal]` key:
-
-![Gear modal — Preferences tab with terminal settings](../assets/screenshots/gear-modal-preferences-light.png#only-light)
-![Gear modal — Preferences tab with terminal settings](../assets/screenshots/gear-modal-preferences-dark.png#only-dark)
-
-Saves go to `preferences.yml`. The shortcut field shows a live "press the combination" capture when you click into it — less error-prone than hand-typing `KeyboardEvent.key` names.
+Edit `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` directly — `settings.yaml` is hand-edited today; the gear modal only edits the tree-level `configuration.yml`. Changes land on the next launch. To test a new shortcut quickly, set it, relaunch, and press the combination.
 
 ## Platform note
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -5,7 +5,7 @@ description: The two condash binaries and how to configure them.
 
 # CLI
 
-condash ships two binaries. Neither takes subcommands or flags — everything that used to live behind a flag is now either an environment variable or a tab in the in-app gear modal.
+condash ships two binaries. Neither takes subcommands or flags — everything that used to live behind a flag is now either an environment variable or a line in `settings.yaml` / `configuration.yml`.
 
 ## At a glance
 
@@ -34,7 +34,7 @@ A developer-oriented binary that runs the same HTTP server without opening a win
 condash-serve
 ```
 
-Prints the bound URL (e.g. `http://127.0.0.1:11111`) and keeps running until you `Ctrl+C`. Open the URL in your normal browser.
+Prints the bound URL (e.g. `http://127.0.0.1:43217`) and keeps running until you `Ctrl+C`. Open the URL in your normal browser. Without `CONDASH_PORT`, the OS assigns any free port — the URL varies across launches.
 
 Reasons to use `condash-serve`:
 
@@ -44,19 +44,20 @@ Reasons to use `condash-serve`:
 
 ## Configuration
 
-Neither binary reads flags. The two places configuration lives:
+Neither binary reads flags. Configuration lives in three layers (see [Config files](config.md) for the full schema):
 
 1. **Environment variables** — three of them, all prefixed `CONDASH_`:
 
    | Variable | Meaning |
    |---|---|
-   | `CONDASH_CONCEPTION_PATH` | Absolute path to the conception tree to render. Defaults to `$HOME/src/vcoeur/conception`. |
+   | `CONDASH_CONCEPTION_PATH` | Absolute path to the conception tree to render. Overrides `conception_path` in `settings.yaml`. |
    | `CONDASH_ASSET_DIR` | Override the embedded dashboard bundle with a live directory on disk. Dev-only. |
-   | `CONDASH_PORT` | Pin the listen port of `condash-serve`. Defaults to a free port in `11111–12111`. |
+   | `CONDASH_PORT` | Pin the listen port of `condash-serve`. Unset → any free port. |
 
    See [Environment variables](env.md) for the full list.
 
-2. **The gear modal in the dashboard.** Click the gear icon in the top right of the window. Three tabs — **General**, **Repositories**, **Preferences** — cover the tree-level YAML config (`<conception_path>/config/repositories.yml`, `<conception_path>/config/preferences.yml`). Saves are atomic and reload live.
+2. **`settings.yaml`** at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` — per-user, per-machine. Holds `conception_path` plus the three blocks that naturally differ per machine: `terminal`, `pdf_viewer`, `open_with`.
+3. **`configuration.yml`** at `<conception_path>/configuration.yml` — per-tree, versioned in git. Holds `workspace_path`, `worktrees_path`, `repositories` (incl. `run:` / `force_stop:`). Edit it by hand or through the gear icon in the dashboard header (plain-text YAML editor).
 
 ## What's not in the CLI
 

--- a/docs/reference/conception-convention.md
+++ b/docs/reference/conception-convention.md
@@ -28,8 +28,7 @@ conception/
 │           └── README.md
 ├── knowledge/                                ← optional, explorer tab
 │   └── …
-└── config/                                   ← repositories.yml + preferences.yml
-    └── repositories.yml
+└── configuration.yml                         ← tree-level config
 ```
 
 Rules, enforced or conventional:

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -9,26 +9,22 @@ description: The short list of environment variables condash reads.
 
 | Name | Purpose | Default | Accepted values |
 |---|---|---|---|
-| `CONDASH_CONCEPTION_PATH` | Path to the conception tree condash renders | `$HOME/src/vcoeur/conception` | Any absolute path to a directory containing `projects/` |
+| `CONDASH_CONCEPTION_PATH` | Path to the conception tree condash renders | unset — falls through to `settings.yaml`, then to the first-launch folder picker | Any absolute path to a directory containing `projects/` |
 | `CONDASH_ASSET_DIR` | Override the embedded dashboard bundle with a live directory on disk | unset (use the `rust-embed` bundle compiled into the binary) | Path to a directory with the same layout as `frontend/` |
-| `CONDASH_PORT` | Pin the listen port of `condash-serve` | pick a free port in `11111–12111` | `1024–65535` |
+| `CONDASH_PORT` | Pin the listen port of `condash-serve` | unset — OS assigns any free port | `1024–65535` |
 | `SHELL` | Fallback for `terminal.shell` | `/bin/bash` | Absolute path to an interactive shell |
 
 ## `CONDASH_CONCEPTION_PATH`
 
-The only variable condash absolutely needs. If unset, the loader falls back to `$HOME/src/vcoeur/conception` — works out of the box when you keep your tree at that location, otherwise set this explicitly in your shell's rc file.
+Optional pointer at the tree to render. condash's resolution order is: env var → `settings.yaml` → first-launch folder picker → hard error. In normal use, the first-launch picker writes the chosen path into `settings.yaml`, so this env var is only useful for overrides.
 
-```bash
-export CONDASH_CONCEPTION_PATH="$HOME/src/vcoeur/conception"
-```
-
-One-shot overrides for a single run:
+One-shot override for a single run:
 
 ```bash
 CONDASH_CONCEPTION_PATH=/tmp/scratch-tree condash
 ```
 
-Or set the path via the gear modal's **General** tab — the modal stores it in the tree's `preferences.yml` (not the environment) so it survives shell sessions.
+Or persist a different path by editing `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` directly — `conception_path: /home/you/other-tree`.
 
 ## `CONDASH_ASSET_DIR`
 
@@ -43,7 +39,7 @@ See [`src-tauri/src/assets.rs`](https://github.com/vcoeur/condash/blob/main/src-
 
 ## `CONDASH_PORT`
 
-Read by `condash-serve` only (the Tauri `condash` binary always picks a free port automatically — the window doesn't care what port the embedded server uses).
+Read by `condash-serve` only (the Tauri `condash` binary always picks a free port automatically — the window doesn't care what port the embedded server uses). When unset, `condash-serve` asks the OS for any free port; read it from the `condash-serve: listening on …` stderr line.
 
 ```bash
 CONDASH_PORT=11500 condash-serve
@@ -53,11 +49,11 @@ Useful for Playwright fixtures that need a stable URL, and for running two `cond
 
 ## `SHELL`
 
-Standard POSIX shell variable. Used as the fallback command when `terminal.shell` is not configured in `preferences.yml`. The embedded terminal spawns a PTY running this shell.
+Standard POSIX shell variable. Used as the fallback command when `terminal.shell` is not configured in `configuration.yml` or `settings.yaml`. The embedded terminal spawns a PTY running this shell.
 
 ## Not read from the environment
 
 - `CONCEPTION_PATH` — despite the [management skill](skill.md) reading it, condash itself looks for `CONDASH_CONCEPTION_PATH`, not `CONCEPTION_PATH`.
 - `PORT` — only the namespaced `CONDASH_PORT` is honoured, to avoid clashing with other tools on the same host.
 - `NO_COLOR`, `CLICOLOR`, `FORCE_COLOR` — unused. The dashboard's colour scheme is driven by the theme toggle.
-- `VISUAL`, `EDITOR` — condash doesn't spawn an editor itself. Edit `preferences.yml` with whichever editor you like; the gear modal writes it for you otherwise.
+- `VISUAL`, `EDITOR` — condash doesn't spawn an editor itself. Edit `configuration.yml` or `settings.yaml` with whichever editor you like; the gear modal edits the tree-level file for you otherwise.

--- a/docs/reference/inline-runner.md
+++ b/docs/reference/inline-runner.md
@@ -43,7 +43,7 @@ Rules:
 - **Inheritance is off.** A parent's `run:` doesn't cascade to its submodules; a submodule without its own `run:` has no Run button. This is deliberate — a repo's top-level dev command is almost never what a subdir wants.
 - `run` lives on the inline-map form. If you still have a bare-string repo entry, promote it to `{ name: …, run: "…" }` when you add a runner.
 
-The gear modal's **Repositories** tab doesn't expose `run:` yet; edit `repositories.yml` directly for now.
+The gear modal's YAML editor lets you tweak `run:` directly in `configuration.yml` — no special UI.
 
 ## The Run button lifecycle
 

--- a/docs/reference/mutations.md
+++ b/docs/reference/mutations.md
@@ -11,7 +11,7 @@ The dashboard's **write surface is small**. It touches three places only:
 
 1. An item's `README.md` (step + status edits).
 2. Files under an item's root, mostly the `notes/` subdirectory (create, rename, upload, overwrite).
-3. The two tree-level YAML files — `<conception_path>/config/repositories.yml` and `<conception_path>/config/preferences.yml`.
+3. The tree-level `<conception_path>/configuration.yml`.
 
 It does **not** touch `.git/`, does not move or rename item directories, does not run shell commands other than the user-configured `open_with.*` / `pdf_viewer` / `terminal.launcher_command` chains.
 
@@ -90,13 +90,15 @@ See [`crates/condash-mutations/src/lib.rs`](https://github.com/vcoeur/condash/bl
 
 ## Config edits
 
-Two YAML files under `<conception_path>/config/` can be written from the gear modal.
+The tree-level `<conception_path>/configuration.yml` can be written from the gear modal.
 
 | Action | HTTP | Trigger | Effect |
 |---|---|---|---|
-| Save config | `POST /config` | Gear modal "Save" | Writes `repositories.yml` and / or `preferences.yml`. All writes are atomic (`.tmp` + rename) and preserve comments outside the managed blocks. |
+| Save config | `POST /configuration` | Gear modal "Save" | Atomically replaces `configuration.yml` with the raw YAML from the textarea. Parse errors return 400 before anything lands on disk. |
 
-A handful of fields (listen port, webview-host toggle) require a restart — the response surfaces those in `restart_required` so the dashboard can warn the user. Every other field reloads live by rebuilding `RenderCtx`.
+`settings.yaml` is not written by any route — edit it by hand; condash reads it on the next launch.
+
+Most changes reload live by rebuilding `RenderCtx`. Structural changes (`workspace_path`, `worktrees_path`, `repositories` list) need a restart — the save dialog surfaces which.
 
 See [Config files](config.md) for the full key schema and which file owns which key.
 

--- a/docs/reference/shortcuts.md
+++ b/docs/reference/shortcuts.md
@@ -41,7 +41,7 @@ Inside the CodeMirror edit pane:
 
 ## Embedded terminal — pane-level
 
-These live at the dashboard level and can fire from outside the terminal pane (e.g. toggle it open from anywhere). Configurable via the `terminal:` block in `preferences.yml`. Shortcut strings follow the `KeyboardEvent.key` convention — modifiers are `Ctrl`, `Shift`, `Alt`, `Meta`.
+These live at the dashboard level and can fire from outside the terminal pane (e.g. toggle it open from anywhere). Configurable via the `terminal:` block in `settings.yaml` (preferred, per-machine) or `configuration.yml` (tree default). Shortcut strings follow the `KeyboardEvent.key` convention — modifiers are `Ctrl`, `Shift`, `Alt`, `Meta`.
 
 | Default | Action | Config key |
 |---|---|---|
@@ -96,4 +96,4 @@ This keeps `` Ctrl+` `` from firing while you're typing in the history-tab searc
 
 ## Reloading shortcut changes
 
-`terminal:` shortcut changes saved via the gear modal take effect **live** — the page re-reads `/config` on save and rebuilds the parsed shortcut specs. No restart needed. Changes made by hand-editing `preferences.yml` require a page refresh.
+`terminal:` shortcut changes saved via the gear modal take effect **live** — the page re-reads `/config` on save and rebuilds the parsed shortcut specs. No restart needed. Changes made by hand-editing `configuration.yml` or `settings.yaml` require a page refresh.

--- a/docs/tutorials/daily-loop.md
+++ b/docs/tutorials/daily-loop.md
@@ -39,7 +39,7 @@ Switch to the **Code** tab. Three helio repos render as rows: `helio`, `helio-we
 
 Each repo has four icon buttons: README preview, code browser, embedded terminal, and "open in main IDE". Click the IDE icon on `helio` — your main editor launches in that directory.
 
-The launcher command chain lives in `config/repositories.yml`, under `open_with.main_ide.commands`. The dashboard tries each command until one succeeds. See [Repositories and open-with buttons](../guides/repositories-and-open-with.md) for how to wire your own editor in.
+The launcher command chain lives in `configuration.yml`, under `open_with.main_ide.commands`. The dashboard tries each command until one succeeds. See [Repositories and open-with buttons](../guides/repositories-and-open-with.md) for how to wire your own editor in.
 
 ## 3. Run the repro in the embedded terminal
 
@@ -60,7 +60,7 @@ You get a `thread 'main' panicked at 'attempt to subtract with overflow'` — co
 
 The terminal has two useful quality-of-life features:
 
-- **Screenshot paste** — press `Ctrl+Shift+V` anywhere in the dashboard and condash inserts the absolute path of the newest file in your configured screenshot directory into the active terminal prompt. Useful for "take a screenshot of the crash → paste the path into an `ls -la` or a `cat`". Configurable under the gear modal's Preferences tab.
+- **Screenshot paste** — press `Ctrl+Shift+V` anywhere in the dashboard and condash inserts the absolute path of the newest file in your configured screenshot directory into the active terminal prompt. Useful for "take a screenshot of the crash → paste the path into an `ls -la` or a `cat`". Configure `terminal.screenshot_dir` in `settings.yaml` (see [Config reference](../reference/config.md)).
 - **Multiple tabs** — click the `+` in the terminal pane header to open a second tab; each tab keeps its own bash session and scrollback even when you toggle the pane closed.
 
 See [Use the embedded terminal](../guides/terminal.md) for the full feature set.

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -49,9 +49,7 @@ Inspect what you got:
 ```
 ~/conception-demo/
 ├── README.md
-├── config/
-│   ├── preferences.yml
-│   └── repositories.yml
+├── configuration.yml
 ├── projects/
 │   ├── 2026-03/         # items created last month (2 done)
 │   └── 2026-04/         # 7 items created this month (3 now, 1 review, 1 soon, 1 later, 1 backlog)
@@ -65,15 +63,15 @@ Everything is plain Markdown. Open `projects/2026-04/2026-04-02-fuzzy-search-v2/
 
 ## 3. Point condash at the tree
 
-condash reads the conception tree location from the `CONDASH_CONCEPTION_PATH` environment variable. Default is `$HOME/src/vcoeur/conception`.
+On first launch with no tree configured, condash opens a native folder picker and writes your choice to `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Pick `~/conception-demo` the first time and the next launches reuse it automatically.
 
-The quickest way to try the demo tree for a single run is:
+For a one-shot run without touching the saved path, set the env var:
 
 ```bash
 CONDASH_CONCEPTION_PATH=~/conception-demo condash
 ```
 
-To make it persistent, export the variable from your shell's rc file (`~/.bashrc`, `~/.zshrc`, or the equivalent). Or, once the window is open, click the gear icon in the dashboard header and set the path in the **General** tab — that writes it to `~/conception-demo/config/preferences.yml` for next time.
+To make a different tree the default, either re-launch with the picker (delete `settings.yaml` first) or edit `conception_path` in `settings.yaml` by hand.
 
 ## 4. Launch
 
@@ -96,11 +94,11 @@ Take two minutes to click through:
 - **Next** — the soon bucket. One project (`json-export`).
 - **Backlog** — one project, parked.
 - **Done** — two archived items from the previous month.
-- **Code** — three repos: condash scanned `workspace_path: /tmp/conception-demo-workspace` from `config/repositories.yml` and found one `.git/` per entry. (If the Code tab shows 0, the workspace path on your machine doesn't exist yet — we'll set that up properly in [Your first project](first-project.md).)
+- **Code** — three repos: condash scanned `workspace_path: /tmp/conception-demo-workspace` from `configuration.yml` and found one `.git/` per entry. (If the Code tab shows 0, the workspace path on your machine doesn't exist yet — we'll set that up properly in [Your first project](first-project.md).)
 - **Knowledge** — the `knowledge/` tree rendered as an explorer: `conventions.md` at the root, `Internal` and `Topics` folders with index files.
 - **History** — full-text search across every item + note. Type `fuzzy` to see ranked matches.
 
-Click the gear icon in the top right to see the **Configuration** modal with three tabs — General / Repositories / Preferences. The General tab holds the conception path and a few per-machine defaults; the other two map directly to `conception-demo/config/repositories.yml` and `conception-demo/config/preferences.yml` (tree-versioned). You'll use this modal in the next tutorial.
+Click the gear icon in the top right to see the **Configuration** modal — a plain-text YAML editor backed by `conception-demo/configuration.yml`. Save is atomic (temp file → rename). Per-machine preferences (`terminal`, `pdf_viewer`, `open_with`) live separately in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` and are hand-edited. You'll use this modal in the next tutorial.
 
 ## 6. Close the window
 
@@ -109,9 +107,9 @@ Closing the native window exits condash. Relaunch with `condash` whenever you wa
 ## What you just learned
 
 - Installing condash is either a one-click installer from GitHub Releases or three `make` targets from source.
-- `CONDASH_CONCEPTION_PATH` plus the gear modal is the whole setup flow. The path is the only thing you must set.
+- The first-launch folder picker plus `CONDASH_CONCEPTION_PATH` is the whole setup flow. The path is the only thing you must set.
 - The dashboard renders the files as-is on every page load. There's no database, no watcher, no cache.
-- The tree carries two YAML config files in `config/` — one team-shared (`repositories.yml`), one per-machine (`preferences.yml`). We'll dig into that split in [Configure the conception path](../guides/configure-conception-path.md).
+- The tree carries two YAML config files in `config/` — one team-shared (`configuration.yml`), one per-machine (`settings.yaml`). We'll dig into that split in [Configure the conception path](../guides/configure-conception-path.md).
 
 ## Next
 


### PR DESCRIPTION
## Summary

- After P-D1 and P-S1 landed, the docs still read as if condash shipped with \`config/repositories.yml\` + \`config/preferences.yml\` + a three-tab gear modal. This PR walks every page and replaces the stale narrative with the current \`configuration.yml\` (tree) + \`settings.yaml\` (XDG) split.
- Closes the remaining docs findings from the 2026-04-23 audit (D-10 through D-20, D-28 through D-45 across files).

## Changes

- \`docs/guides/multi-machine.md\` — full rewrite around the new two-file split, precedence rule, updated .gitignore recipe.
- \`docs/guides/configure-conception-path.md\` — folder-picker-first onboarding; \`settings.yaml\` hand-edit path; explicit resolution order.
- \`docs/guides/repositories-and-open-with.md\` — plain YAML editor; per-machine IDE overrides go in \`settings.yaml\`.
- \`docs/guides/terminal.md\` — terminal shortcut config under \`settings.yaml\`; drop the three-tab modal screenshot block.
- \`docs/guides/deliverables.md\` — pdf_viewer chain lives in \`settings.yaml\`.
- \`docs/tutorials/first-run.md\` — demo tree no longer has \`config/\`; first-launch picker replaces the General-tab narrative.
- \`docs/tutorials/daily-loop.md\` — screenshot-paste config points at \`settings.yaml\`.
- \`docs/reference/env.md\` — drop the bogus \`\$HOME/src/vcoeur/conception\` default; drop the invented \`11111–12111\` port range.
- \`docs/reference/cli.md\` — three-layer config description; no three-tab modal.
- \`docs/reference/mutations.md\` — write surface is \`POST /configuration\`; \`settings.yaml\` is hand-edited.
- \`docs/reference/shortcuts.md\` — settings.yaml as the preferred override layer.
- \`docs/reference/conception-convention.md\` — tree layout sample shows \`configuration.yml\` at root.
- \`docs/reference/inline-runner.md\` — gear modal is a YAML editor.
- \`docs/explanation/internals.md\` — Config section rewritten around the new split.
- \`README.md\` — first-launch + config files section.

## Impact

- \`mkdocs build --strict\` green — no broken links, no deferred references.
- Purely documentation: no code changes, no API shape changes. The only remaining mentions of \`repositories.yml\` / \`preferences.yml\` live in the audit notes inside the \`conception\` repo, which is out of scope.