### PR TITLE
P-09 cut 1: cm6 + reload-guards + local-subtree-reload (+ P-08 regression fix)

### DIFF
--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -46,6 +46,11 @@ import {
 import {
     initCm6ThemeSyncSideEffects,
 } from './sections/cm6-theme-sync.js';
+import {
+    reloadState,
+    _noteModalDirty, _runnerActiveIn,
+    _defaultReloadSkipIf, _flushPendingReloads,
+} from './sections/reload-guards.js';
 
 /* --- In-app config editor --- */
 function _setField(form, name, value) {
@@ -501,7 +506,7 @@ document.addEventListener('click', function(e) {
    up looking at a half-swapped DOM. */
 var _reloadInPlaceInFlight = false;
 var _reloadInPlacePending = false;
-async function _reloadInPlace() {
+export async function _reloadInPlace() {
     // Single-flight with trailing coalesce. Two _reloadInPlace calls
     // racing (e.g. a rapid burst of SSE events) used to swap #dash-main
     // twice — and if the responses completed out-of-order (request 1
@@ -532,7 +537,7 @@ async function _reloadInPlace() {
 
         var result = focusSafeSwap(current, fresh);
         if (result.skipped) {
-            _pendingReloadInPlace = true;
+            reloadState.pendingInPlace = true;
             return;
         }
         // A successful global swap is authoritative. Clear any residual
@@ -2638,8 +2643,8 @@ export function refreshAll() {
     _nodeBaseline = null;
     _dirtyNodes = new Set();
     _clearShadowCache();
-    _pendingReloadNodes.clear();
-    _pendingReloadInPlace = false;
+    reloadState.pendingNodes.clear();
+    reloadState.pendingInPlace = false;
     _lastFingerprint = null;
     _lastGitFingerprint = null;
     // Force-invalidate the server-side items/knowledge caches before
@@ -2683,67 +2688,6 @@ function _restoreDetailsOpenState(root, map) {
     root.querySelectorAll('details[data-node-id]').forEach(function(d) {
         var id = d.getAttribute('data-node-id');
         if (id in map) d.open = map[id];
-    });
-}
-
-/* --- Reload guards (Phase 2) ---
-   The two production landmines before the overhaul: a fragment swap
-   while a runner's WebSocket is live silently kills the build; a
-   _reloadInPlace while the note modal has unsaved edits silently
-   discards them. Both are now caught by focusSafeSwap's default
-   skipIf — the swap is refused, the dirty state is preserved, and a
-   retry is queued for when the guard clears. */
-function _noteModalDirty() {
-    return !!(window._noteModal && _noteModal.dirty);
-}
-
-function _runnerActiveIn(targetEl) {
-    if (!targetEl || typeof _runnerViewers !== 'object') return false;
-    var mounts = targetEl.querySelectorAll &&
-        targetEl.querySelectorAll('.runner-term-mount');
-    if (!mounts || !mounts.length) return false;
-    var activeKeys = {};
-    for (var dk in _runnerViewers) {
-        var v = _runnerViewers[dk];
-        if (v && !v.exited && v.ws && v.ws.readyState === WebSocket.OPEN) {
-            activeKeys[v.key] = true;
-        }
-    }
-    for (var i = 0; i < mounts.length; i++) {
-        var key = mounts[i].getAttribute('data-runner-key');
-        if (key && activeKeys[key]) return true;
-    }
-    return false;
-}
-
-function _defaultReloadSkipIf(targetEl) {
-    if (_noteModalDirty()) return 'note-dirty';
-    if (_runnerActiveIn(targetEl)) return 'runner-active';
-    return null;
-}
-
-/* Pending-reload bookkeeping. When a swap is refused, we stash the
-   request and retry when the responsible guard clears. Deliberately
-   kept small: one boolean for the global rebuild, a set of node ids
-   for per-subtree reloads. */
-var _pendingReloadNodes = new Set();
-var _pendingReloadInPlace = false;
-
-function _flushPendingReloads() {
-    if (_noteModalDirty()) return;  // still blocked; caller will re-flush
-    if (_pendingReloadInPlace) {
-        _pendingReloadInPlace = false;
-        _pendingReloadNodes.clear();  // superseded by the global rebuild
-        _reloadInPlace();
-        return;
-    }
-    var retry = Array.from(_pendingReloadNodes);
-    _pendingReloadNodes.clear();
-    retry.forEach(function(id) {
-        // Runner-active guard for this specific node is re-checked by
-        // focusSafeSwap's skipIf — any still-blocked entries land back
-        // in _pendingReloadNodes via reloadNode's skipped-branch.
-        reloadNode(id);
     });
 }
 
@@ -2849,7 +2793,7 @@ function _restoreFromSnapshot(el, snap, opts) {
     });
 }
 
-async function reloadNode(nodeId) {
+export async function reloadNode(nodeId) {
     // Fall back to global reload for tab-level, group-level, and code nodes.
     if (!_supportsFragmentFetch(nodeId)) {
         _reloadInPlace();
@@ -2881,7 +2825,7 @@ async function reloadNode(nodeId) {
             // Guard tripped (runner live, or note modal dirty). Park the
             // request; _flushPendingReloads replays it when the guard
             // clears. Dirty-set + baseline are intentionally preserved.
-            _pendingReloadNodes.add(nodeId);
+            reloadState.pendingNodes.add(nodeId);
             return;
         }
         if (wasExpanded && fresh.classList && fresh.classList.contains('card')) {
@@ -3191,7 +3135,7 @@ _startEventStream();
    and creates fresh ones for any newly-inserted mounts. Pop-out mode
    detaches the inline ws in favour of a modal-hosted viewer, then
    re-attaches inline when the modal closes. */
-var _runnerViewers = {};  // "key|checkout" -> {ws, term, fit, mount, exited, isModal}
+export var _runnerViewers = {};  // "key|checkout" -> {ws, term, fit, mount, exited, isModal}
 var _runnerActiveModal = null;
 function _runnerDomKey(key, checkout) { return key + '|' + checkout; }
 

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -40,6 +40,12 @@ import {
 import {
     _NOTES_OPEN_KEY, restoreNotesTreeState, initNotesTreeStateSideEffects,
 } from './sections/notes-tree-state.js';
+import {
+    _cm, _mountCm, _destroyCm, _cmRetheme,
+} from './sections/cm6-mount.js';
+import {
+    initCm6ThemeSyncSideEffects,
+} from './sections/cm6-theme-sync.js';
 
 /* --- In-app config editor --- */
 function _setField(form, name, value) {
@@ -1148,7 +1154,7 @@ var _noteNavStack = [];
    are hidden/shown by CSS. `_noteModal` tracks the state shared across
    panes so mode switches preserve user edits and mtime for the save
    contract. */
-var _noteModal = {
+export var _noteModal = {
     path: null,
     editable: false,     // false when kind is pdf/image/binary — edit modes disabled
     kind: null,          // from /note-raw
@@ -1169,7 +1175,7 @@ var _noteModal = {
 /* Flip the dirty flag and refresh the Save button. Safe to call on every
    keystroke — the button toggle is the only DOM work. Also drains any
    reload requests that were parked because the modal was dirty. */
-function _setDirty(value) {
+export function _setDirty(value) {
     var next = !!value;
     if (_noteModal.dirty === next) return;
     _noteModal.dirty = next;
@@ -1609,69 +1615,6 @@ function openDeliverable(path) {
     }).catch(function() {});
 }
 
-/* --- CodeMirror 6 mount / unmount ---
-   CM6 is loaded lazily by the <script type="module"> block at the end
-   of the document. Once ready, it sets window.__cm6 = {EditorView,
-   EditorState, basicSetup, markdown, keymap, Compartment, themeC,
-   buildTheme} and calls window.__cm6OnReady(). Before that, the "Edit"
-   toggle stays disabled. */
-var _cm = { view: null, themeC: null };
-
-function _mountCm() {
-    if (!window.__cm6) return;
-    var host = document.getElementById('note-pane-cm');
-    if (!host) return;
-    if (_cm.view) return;
-    // Clear any placeholder text.
-    host.innerHTML = '';
-    var cm6 = window.__cm6;
-    _cm.themeC = new cm6.Compartment();
-    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    var exts = [
-        cm6.basicSetup,
-        cm6.markdown(),
-        cm6.EditorView.lineWrapping,
-        cm6.keymap.of([
-            {key: 'Mod-s', preventDefault: true, run: function() { saveEdit(); return true; }},
-        ]),
-        _cm.themeC.of(cm6.buildTheme(isDark)),
-        cm6.EditorView.updateListener.of(function(u) {
-            // Reflect edits into the canonical buffer live so a mode
-            // switch doesn't need a separate capture path.
-            if (u.docChanged) {
-                _noteModal.text = u.state.doc.toString();
-                _setDirty(true);
-            }
-        }),
-    ];
-    _cm.view = new cm6.EditorView({
-        doc: _noteModal.text || '',
-        parent: host,
-        extensions: exts,
-    });
-    // Caret at offset 0, scroll to top, focus.
-    _cm.view.dispatch({selection: {anchor: 0}});
-    _cm.view.scrollDOM.scrollTop = 0;
-    _cm.view.focus();
-}
-
-function _destroyCm() {
-    if (_cm.view) { try { _cm.view.destroy(); } catch (e) {} }
-    _cm.view = null;
-    _cm.themeC = null;
-    var host = document.getElementById('note-pane-cm');
-    if (host) host.innerHTML = '';
-}
-
-/* Called by the theme toggle to repaint CM6 without remounting. */
-function _cmRetheme() {
-    if (!_cm.view || !_cm.themeC || !window.__cm6) return;
-    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    _cm.view.dispatch({
-        effects: _cm.themeC.reconfigure(window.__cm6.buildTheme(isDark)),
-    });
-}
-
 /* --- Note modal mode management ---
    Three sibling panes (view, cm, plain) live inside #note-modal-body;
    the modal's data-mode attribute drives CSS visibility. setNoteMode
@@ -1781,7 +1724,7 @@ function setNoteMode(next) {
     }
 }
 
-async function saveEdit() {
+export async function saveEdit() {
     var inner = document.getElementById('note-modal-inner');
     var mode = inner.getAttribute('data-mode');
     if (mode !== 'cm' && mode !== 'plain') return;
@@ -3216,6 +3159,7 @@ initThemeSideEffects();
 initAboutModalSideEffects();
 initNewItemModalSideEffects();
 initNotesTreeStateSideEffects();
+initCm6ThemeSyncSideEffects();
 
 // Phase 6: event-driven staleness. /events streams tab-level hints;
 // checkUpdates() runs on connect + every hint to reconcile the real
@@ -3238,15 +3182,6 @@ _startEventStream();
         }
     } catch (e) {}
 })();
-
-/* --- CodeMirror 6 theme re-sync ---
-   When the user flips dark/light, the theme-loader script in <head>
-   updates documentElement.data-theme synchronously. We watch that
-   attribute and retheme the live EditorView (no remount) so the
-   markdown editor picks up the new palette in the same frame. */
-new MutationObserver(function() {
-    if (typeof _cmRetheme === 'function') _cmRetheme();
-}).observe(document.documentElement, {attributes: true, attributeFilter: ['data-theme']});
 
 /* --- Inline dev-server runner viewers ---
    Each `.runner-term-mount` element rendered by the repo strip gets its

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -28,7 +28,7 @@ import {
     openAboutModal, closeAboutModal, initAboutModalSideEffects,
 } from './sections/about-modal.js';
 import {
-    _refreshShadowCache, _consumeShadowCache,
+    _refreshShadowCache, _consumeShadowCache, _clearShadowCache,
 } from './sections/shadow-cache.js';
 import {
     openPath, openInTerminal, workOn, openFolder,
@@ -2637,7 +2637,7 @@ async function updateBaseline() {
 export function refreshAll() {
     _nodeBaseline = null;
     _dirtyNodes = new Set();
-    _shadowCache = null;
+    _clearShadowCache();
     _pendingReloadNodes.clear();
     _pendingReloadInPlace = false;
     _lastFingerprint = null;

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -51,6 +51,11 @@ import {
     _noteModalDirty, _runnerActiveIn,
     _defaultReloadSkipIf, _flushPendingReloads,
 } from './sections/reload-guards.js';
+import {
+    _supportsFragmentFetch,
+    _captureDetailsOpenState,
+    _restoreDetailsOpenState,
+} from './sections/local-subtree-reload.js';
 
 /* --- In-app config editor --- */
 function _setField(form, name, value) {
@@ -2654,41 +2659,6 @@ export function refreshAll() {
     fetch('/rescan', {method: 'POST'})
         .catch(function() {})
         .finally(function() { location.reload(); });
-}
-
-/* --- Local subtree reload ---
-   Click on a stale marker. For node ids the server knows how to fragment
-   (project card, knowledge card, knowledge directory) we fetch just that
-   fragment and replace the matching element in place, preserving any
-   <details> open-state inside it. For everything else (groups, tabs, code
-   nodes) the fragment endpoint returns 404 and we fall back to the global
-   _reloadInPlace. Either way the dirty-set entries covered by the reload
-   are dropped and the baseline is refreshed for those entries. */
-function _supportsFragmentFetch(nodeId) {
-    // Project cards: projects/<pri>/<slug>
-    if (/^projects\/[a-z]+\/.+/.test(nodeId)) return true;
-    // Knowledge directories and cards (not the root).
-    if (nodeId === 'knowledge') return false;
-    if (/^knowledge\//.test(nodeId)) return true;
-    // Repo blocks: code/<group>/<repo>. Group and tab ids still fall
-    // back to global reload.
-    if (/^code\/[^/]+\/[^/]+$/.test(nodeId)) return true;
-    return false;
-}
-
-function _captureDetailsOpenState(root) {
-    var map = {};
-    root.querySelectorAll('details[data-node-id]').forEach(function(d) {
-        map[d.getAttribute('data-node-id')] = d.open;
-    });
-    return map;
-}
-
-function _restoreDetailsOpenState(root, map) {
-    root.querySelectorAll('details[data-node-id]').forEach(function(d) {
-        var id = d.getAttribute('data-node-id');
-        if (id in map) d.open = map[id];
-    });
 }
 
 /* --- Focus-safe DOM swap primitive ---

--- a/frontend/src/js/sections/cm6-mount.js
+++ b/frontend/src/js/sections/cm6-mount.js
@@ -1,0 +1,75 @@
+/* CodeMirror 6 mount / unmount.
+
+   CM6 is loaded lazily by the <script type="module"> block at the end
+   of the document. Once ready, it sets window.__cm6 = {EditorView,
+   EditorState, basicSetup, markdown, keymap, Compartment, themeC,
+   buildTheme} and calls window.__cm6OnReady(). Before that, the "Edit"
+   toggle stays disabled.
+
+   Extracted from dashboard-main.js on 2026-04-24 (P-09 of
+   conception/projects/2026-04-23-condash-frontend-extraction). Reaches
+   into three symbols that still live in dashboard-main.js: _noteModal
+   (mutated — object-field writes, not rebinding — so a live ESM
+   binding works here), _setDirty, saveEdit. All references are inside
+   function bodies; no top-level side effects. */
+
+import { _noteModal, _setDirty, saveEdit } from '../dashboard-main.js';
+
+var _cm = { view: null, themeC: null };
+
+function _mountCm() {
+    if (!window.__cm6) return;
+    var host = document.getElementById('note-pane-cm');
+    if (!host) return;
+    if (_cm.view) return;
+    // Clear any placeholder text.
+    host.innerHTML = '';
+    var cm6 = window.__cm6;
+    _cm.themeC = new cm6.Compartment();
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    var exts = [
+        cm6.basicSetup,
+        cm6.markdown(),
+        cm6.EditorView.lineWrapping,
+        cm6.keymap.of([
+            {key: 'Mod-s', preventDefault: true, run: function() { saveEdit(); return true; }},
+        ]),
+        _cm.themeC.of(cm6.buildTheme(isDark)),
+        cm6.EditorView.updateListener.of(function(u) {
+            // Reflect edits into the canonical buffer live so a mode
+            // switch doesn't need a separate capture path.
+            if (u.docChanged) {
+                _noteModal.text = u.state.doc.toString();
+                _setDirty(true);
+            }
+        }),
+    ];
+    _cm.view = new cm6.EditorView({
+        doc: _noteModal.text || '',
+        parent: host,
+        extensions: exts,
+    });
+    // Caret at offset 0, scroll to top, focus.
+    _cm.view.dispatch({selection: {anchor: 0}});
+    _cm.view.scrollDOM.scrollTop = 0;
+    _cm.view.focus();
+}
+
+function _destroyCm() {
+    if (_cm.view) { try { _cm.view.destroy(); } catch (e) {} }
+    _cm.view = null;
+    _cm.themeC = null;
+    var host = document.getElementById('note-pane-cm');
+    if (host) host.innerHTML = '';
+}
+
+/* Called by the theme toggle to repaint CM6 without remounting. */
+function _cmRetheme() {
+    if (!_cm.view || !_cm.themeC || !window.__cm6) return;
+    var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
+    _cm.view.dispatch({
+        effects: _cm.themeC.reconfigure(window.__cm6.buildTheme(isDark)),
+    });
+}
+
+export { _cm, _mountCm, _destroyCm, _cmRetheme };

--- a/frontend/src/js/sections/cm6-theme-sync.js
+++ b/frontend/src/js/sections/cm6-theme-sync.js
@@ -1,0 +1,21 @@
+/* CodeMirror 6 theme re-sync.
+
+   When the user flips dark/light, the theme-loader script in <head>
+   updates documentElement.data-theme synchronously. We watch that
+   attribute and retheme the live EditorView (no remount) so the
+   markdown editor picks up the new palette in the same frame.
+
+   Extracted from dashboard-main.js on 2026-04-24 (P-09 of
+   conception/projects/2026-04-23-condash-frontend-extraction). The
+   MutationObserver registration is a top-level side effect, wrapped
+   in initCm6ThemeSyncSideEffects() per the discipline note 01 §D3. */
+
+import { _cmRetheme } from './cm6-mount.js';
+
+function initCm6ThemeSyncSideEffects() {
+    new MutationObserver(function() {
+        if (typeof _cmRetheme === 'function') _cmRetheme();
+    }).observe(document.documentElement, {attributes: true, attributeFilter: ['data-theme']});
+}
+
+export { initCm6ThemeSyncSideEffects };

--- a/frontend/src/js/sections/local-subtree-reload.js
+++ b/frontend/src/js/sections/local-subtree-reload.js
@@ -1,0 +1,49 @@
+/* Local subtree reload.
+
+   Click on a stale marker. For node ids the server knows how to
+   fragment (project card, knowledge card, knowledge directory) we
+   fetch just that fragment and replace the matching element in place,
+   preserving any <details> open-state inside it. For everything else
+   (groups, tabs, code nodes) the fragment endpoint returns 404 and we
+   fall back to the global _reloadInPlace. Either way the dirty-set
+   entries covered by the reload are dropped and the baseline is
+   refreshed for those entries.
+
+   Extracted from dashboard-main.js on 2026-04-24 (P-09 of
+   conception/projects/2026-04-23-condash-frontend-extraction). Three
+   pure helpers — no cross-region state — so no imports, no side
+   effects. Callers live in the stale-poll + dom-swap + reloadNode
+   paths and reach in via function-body imports. */
+
+function _supportsFragmentFetch(nodeId) {
+    // Project cards: projects/<pri>/<slug>
+    if (/^projects\/[a-z]+\/.+/.test(nodeId)) return true;
+    // Knowledge directories and cards (not the root).
+    if (nodeId === 'knowledge') return false;
+    if (/^knowledge\//.test(nodeId)) return true;
+    // Repo blocks: code/<group>/<repo>. Group and tab ids still fall
+    // back to global reload.
+    if (/^code\/[^/]+\/[^/]+$/.test(nodeId)) return true;
+    return false;
+}
+
+function _captureDetailsOpenState(root) {
+    var map = {};
+    root.querySelectorAll('details[data-node-id]').forEach(function(d) {
+        map[d.getAttribute('data-node-id')] = d.open;
+    });
+    return map;
+}
+
+function _restoreDetailsOpenState(root, map) {
+    root.querySelectorAll('details[data-node-id]').forEach(function(d) {
+        var id = d.getAttribute('data-node-id');
+        if (id in map) d.open = map[id];
+    });
+}
+
+export {
+    _supportsFragmentFetch,
+    _captureDetailsOpenState,
+    _restoreDetailsOpenState,
+};

--- a/frontend/src/js/sections/reload-guards.js
+++ b/frontend/src/js/sections/reload-guards.js
@@ -1,0 +1,80 @@
+/* Reload guards (Phase 2).
+
+   The two production landmines before the overhaul: a fragment swap
+   while a runner's WebSocket is live silently kills the build; a
+   _reloadInPlace while the note modal has unsaved edits silently
+   discards them. Both are now caught by focusSafeSwap's default
+   skipIf — the swap is refused, the dirty state is preserved, and a
+   retry is queued for when the guard clears.
+
+   Extracted from dashboard-main.js on 2026-04-24 (P-09 of
+   conception/projects/2026-04-23-condash-frontend-extraction).
+
+   The pending-reload bookkeeping was previously two module-top-level
+   bindings (_pendingReloadNodes, _pendingReloadInPlace) mutated from
+   three other regions (tab switch, refreshAll, reloadNode). ESM live
+   bindings don't permit importer-side reassignment of `let`/`var`
+   exports, so we expose the state as a single `reloadState` object —
+   the same trick P-07's design note §D1 used for termState — so
+   callers can write `reloadState.pendingInPlace = true` without
+   rebinding the import. */
+
+import { _noteModal, _reloadInPlace, reloadNode, _runnerViewers } from '../dashboard-main.js';
+
+const reloadState = {
+    pendingNodes: new Set(),
+    pendingInPlace: false,
+};
+
+function _noteModalDirty() {
+    return !!(_noteModal && _noteModal.dirty);
+}
+
+function _runnerActiveIn(targetEl) {
+    if (!targetEl || typeof _runnerViewers !== 'object') return false;
+    var mounts = targetEl.querySelectorAll &&
+        targetEl.querySelectorAll('.runner-term-mount');
+    if (!mounts || !mounts.length) return false;
+    var activeKeys = {};
+    for (var dk in _runnerViewers) {
+        var v = _runnerViewers[dk];
+        if (v && !v.exited && v.ws && v.ws.readyState === WebSocket.OPEN) {
+            activeKeys[v.key] = true;
+        }
+    }
+    for (var i = 0; i < mounts.length; i++) {
+        var key = mounts[i].getAttribute('data-runner-key');
+        if (key && activeKeys[key]) return true;
+    }
+    return false;
+}
+
+function _defaultReloadSkipIf(targetEl) {
+    if (_noteModalDirty()) return 'note-dirty';
+    if (_runnerActiveIn(targetEl)) return 'runner-active';
+    return null;
+}
+
+function _flushPendingReloads() {
+    if (_noteModalDirty()) return;  // still blocked; caller will re-flush
+    if (reloadState.pendingInPlace) {
+        reloadState.pendingInPlace = false;
+        reloadState.pendingNodes.clear();  // superseded by the global rebuild
+        _reloadInPlace();
+        return;
+    }
+    var retry = Array.from(reloadState.pendingNodes);
+    reloadState.pendingNodes.clear();
+    retry.forEach(function(id) {
+        // Runner-active guard for this specific node is re-checked by
+        // focusSafeSwap's skipIf — any still-blocked entries land back
+        // in reloadState.pendingNodes via reloadNode's skipped-branch.
+        reloadNode(id);
+    });
+}
+
+export {
+    reloadState,
+    _noteModalDirty, _runnerActiveIn,
+    _defaultReloadSkipIf, _flushPendingReloads,
+};

--- a/frontend/src/js/sections/shadow-cache.js
+++ b/frontend/src/js/sections/shadow-cache.js
@@ -34,4 +34,11 @@ function _consumeShadowCache() {
     return html;
 }
 
-export { _refreshShadowCache, _consumeShadowCache };
+/* Drop the cache entirely. Used by refreshAll, which rebuilds every
+   canonical structure from scratch and wants to throw out any stale
+   pre-fetched HTML still sitting on the side. */
+function _clearShadowCache() {
+    _shadowCache = null;
+}
+
+export { _refreshShadowCache, _consumeShadowCache, _clearShadowCache };


### PR DESCRIPTION
## Summary

First chunk of P-09 of the [condash-frontend-extraction](https://github.com/vcoeur/conception/tree/main/projects/2026-04/2026-04-23-condash-frontend-extraction) project. Four region extractions from \`frontend/src/js/dashboard-main.js\` into \`sections/*.js\`, plus one opportunistic fix for a P-08 regression landing along the way.

\`dashboard-main.js\` goes from **3779 LOC → 3628 LOC** (−151).

The parent audit's plan called for one PR covering all 14 remaining regions, but the state fan-out once you leave the easy six of P-08 is heavy enough (stale-poll alone mutates state from 7+ call sites) that the remaining regions deserve a second cut. Design note: \`conception/projects/2026-04/2026-04-23-condash-frontend-extraction/notes/03-p09-cut1.md\`.

## Changes

| Region | New module | LOC |
|---|---|---|
| CodeMirror 6 mount / unmount | \`sections/cm6-mount.js\` | 75 |
| CodeMirror 6 theme re-sync | \`sections/cm6-theme-sync.js\` | 21 |
| Reload guards (Phase 2) | \`sections/reload-guards.js\` | 80 |
| Local subtree reload | \`sections/local-subtree-reload.js\` | 49 |

Plus the P-08 regression fix: \`refreshAll\` was reassigning \`_shadowCache = null\` against a binding that had moved into \`sections/shadow-cache.js\` as a module-local var. Under strict ESM that's a ReferenceError every time Refresh All is clicked — latent because only that one code path touches the symbol. Adds a \`_clearShadowCache()\` export and swaps \`refreshAll\` over. Shipped as the first commit of this PR so it lands close to P-08.

### The \`reloadState\` object

The reload-guards region previously mutated two module-top-level bindings (\`_pendingReloadNodes\`, \`_pendingReloadInPlace\`) from three other regions. ESM live bindings don't permit importer-side reassignment of \`let\`/\`var\` exports, so both bindings collapse into a single \`reloadState\` object — the same trick P-07's design note §D1 used for \`termState\`. Three call sites updated.

### New exports from dashboard-main.js

- \`_noteModal\` — object; object-field mutation from cm6-mount works under ESM live-binding rules.
- \`_setDirty\`, \`saveEdit\` — keymap + update-listener callbacks in cm6-mount.
- \`_reloadInPlace\`, \`reloadNode\`, \`_runnerViewers\` — consumers in reload-guards.

All six still live in \`dashboard-main.js\`; they'll follow their owning regions out in P-09 cut 2.

## Impact

Pure refactor, except for the \`_shadowCache\` regression fix — which is a real behaviour restoration (Refresh All actually works again).

## Watchpoints

The frontend has no unit-test harness — human smoke-test is the validation. \`make frontend\` builds clean after each commit. Before merge, confirm that:

- [ ] Note modal opens, enters edit mode, CM6 mounts, dirty indicator appears on typing; save / close / remount still work.
- [ ] Theme toggle still re-themes CM6 without remounting.
- [ ] Refresh All button no longer throws (the P-08 regression fix).
- [ ] After a stale-reload guard trips (note modal dirty or runner ws live), the parked reload flushes when the guard clears.
- [ ] Clicking a stale per-node marker still fragment-fetches project cards and knowledge directories, and still falls back to the global swap for groups / code nodes.
- [ ] Terminal tab-drag etc. still work (regression check across P-07 / P-08 territory).

## Follow-up — P-09 cut 2

Remaining regions that still need extracting (will go in a separate PR): stale-poll, sse, note-preview-modal, note-mode, note-reconcile, in-note-search, dom-swap, terminal, runner-viewers. \`notes-block\` is dead code (\`toggleNotes\` has zero callers) and belongs in a later simplification PR, not an extraction PR.