### PR TITLE
Finish condash audit — data-action dispatch, dialog plugin swap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,181 +69,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ashpd"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f3f79755c74fd155000314eb349864caa787c6592eace6c6882dad873d9c39"
-dependencies = [
- "async-fs",
- "async-net",
- "enumflags2",
- "futures-channel",
- "futures-util",
- "rand 0.9.4",
- "raw-window-handle",
- "serde",
- "serde_repr",
- "url",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols",
- "zbus",
-]
-
-[[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-fs"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
-dependencies = [
- "async-lock",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-net"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
-dependencies = [
- "async-io",
- "blocking",
- "futures-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -392,19 +217,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -603,15 +415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "condash"
 version = "1.2.0"
 dependencies = [
@@ -630,7 +433,6 @@ dependencies = [
  "portable-pty",
  "rand 0.8.6",
  "regex",
- "rfd",
  "rust-embed",
  "serde",
  "serde_json",
@@ -639,6 +441,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-clipboard-manager",
+ "tauri-plugin-dialog",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -987,15 +790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dlib"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
-dependencies = [
- "libloading",
-]
-
-[[package]]
 name = "dlopen2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,33 +899,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,27 +930,6 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
-]
 
 [[package]]
 name = "fastrand"
@@ -1367,19 +1113,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1786,12 +1519,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2778,6 +2505,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2844,16 +2572,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "os_pipe"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,12 +2605,6 @@ dependencies = [
  "libc",
  "system-deps",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3134,17 +2846,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3188,26 +2889,6 @@ dependencies = [
  "flate2",
  "miniz_oxide",
 ]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "pollster"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "portable-pty"
@@ -3628,26 +3309,26 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.4"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
 dependencies = [
- "ashpd",
  "block2",
  "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
  "js-sys",
  "log",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
- "pollster",
  "raw-window-handle",
- "urlencoding",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3784,12 +3465,6 @@ dependencies = [
  "serde_derive_internals",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -4132,16 +3807,6 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
 
 [[package]]
 name = "simd-adler32"
@@ -4563,6 +4228,48 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa4150c95ae391946cc8b8f905ab14797427caba3a8a2f79628e956da91809"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e1ec28b79f3d0683f4507e1615c36292c0ea6716668770d4396b9b39871ed8"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
+ "url",
 ]
 
 [[package]]
@@ -5025,19 +4732,7 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -5115,17 +4810,6 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
-
-[[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset 0.9.1",
- "tempfile",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "unic-char-property"
@@ -5210,12 +4894,6 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
-
-[[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "urlpattern"
@@ -5445,7 +5123,6 @@ dependencies = [
  "cc",
  "downcast-rs",
  "rustix",
- "scoped-tls",
  "smallvec",
  "wayland-sys",
 ]
@@ -5504,8 +5181,6 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
 dependencies = [
- "dlib",
- "log",
  "pkg-config",
 ]
 
@@ -6056,9 +5731,6 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"
@@ -6312,67 +5984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-lite",
- "hex",
- "libc",
- "ordered-stream",
- "rustix",
- "serde",
- "serde_repr",
- "tracing",
- "uds_windows",
- "uuid",
- "windows-sys 0.61.2",
- "winnow 0.7.15",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
-dependencies = [
- "serde",
- "winnow 0.7.15",
- "zvariant",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6465,45 +6076,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
 dependencies = [
  "zune-core",
-]
-
-[[package]]
-name = "zvariant"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "url",
- "winnow 0.7.15",
- "zvariant_derive",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.117",
- "winnow 0.7.15",
 ]

--- a/crates/condash-render/templates/_macros.html.j2
+++ b/crates/condash-render/templates/_macros.html.j2
@@ -6,13 +6,13 @@
   <span class="drag-handle" onpointerdown="stepPointerDown(event)">⠿</span>
   <span class="status-dot status-{{ step.status }}"
     onmousedown="event.stopPropagation();event.preventDefault()"
-    onclick="var s=this.closest('.step');cycle({{ file_path | embed }},+s.dataset.line,s)">{{ dot }}</span>
+    data-action="cycle-step" data-file-path="{{ file_path }}">{{ dot }}</span>
   <span class="text"
     onmousedown="event.stopPropagation()"
-    onclick="event.stopPropagation();startEditText(this)">{{ step.text }}</span>
+    data-action="start-edit-text" data-stop="1">{{ step.text }}</span>
   <button class="remove-btn"
     onmousedown="event.stopPropagation();event.preventDefault()"
-    onclick="var s=this.closest('.step');removeStep({{ file_path | embed }},+s.dataset.line,this)">×</button>
+    data-action="remove-step" data-file-path="{{ file_path }}">×</button>
 </div>
 {% endmacro %}
 
@@ -22,7 +22,7 @@
 {% set total = items | length %}
 {% set all_done = total > 0 and done == total %}
 <div class="sec-group">
-  <div class="sec-heading{% if not all_done %} open{% endif %}" onclick="toggleSection(this)">
+  <div class="sec-heading{% if not all_done %} open{% endif %}" data-action="toggle-section">
     {{ heading }} <span class="sec-count">({{ done }}/{{ total }})</span>
   </div>
   <div class="sec-items" style="display:{% if all_done %}none{% else %}block{% endif %}">
@@ -30,7 +30,8 @@
     <div class="add-row">
       <input type="text" placeholder="Add task…"
         onkeydown="if(event.key==='Enter')addStep({{ file_path | embed }},{{ heading | embed }},this)">
-      <button onclick="addStep({{ file_path | embed }},{{ heading | embed }},this.previousElementSibling)">+</button>
+      <button data-action="add-step"
+        data-file-path="{{ file_path }}" data-heading="{{ heading }}">+</button>
     </div>
   </div>
 </div>
@@ -40,7 +41,8 @@
 {% macro file_entry(n) %}
 {% set label = n.name[:-3] if n.name[-3:] == '.md' else n.name %}
 <div class="note-item" data-kind="{{ n.kind | default('md') }}"
-  onclick="openNotePreview({{ n.path | embed }},'{{ n.name }}')">{{ label }}</div>
+  data-action="open-note-preview"
+  data-path="{{ n.path }}" data-title="{{ n.name }}">{{ label }}</div>
 {% endmacro %}
 
 
@@ -53,11 +55,14 @@
     <span class="notes-count">({{ group_ | subtree_count }})</span>
     {% if readme_rel %}
     <button class="notes-new-btn" title="New note in this folder"
-      onclick="event.stopPropagation();event.preventDefault();createNoteFor({{ readme_rel | embed }},{{ group_.rel_dir | embed }})">+</button>
+      data-action="create-note-for" data-stop="1" data-prevent="1"
+      data-readme-rel="{{ readme_rel }}" data-rel-dir="{{ group_.rel_dir }}">+</button>
     <button class="notes-upload-btn" title="Upload files into this folder"
-      onclick="event.stopPropagation();event.preventDefault();uploadToNotes({{ readme_rel | embed }},{{ group_.rel_dir | embed }})">↑</button>
+      data-action="upload-to-notes" data-stop="1" data-prevent="1"
+      data-readme-rel="{{ readme_rel }}" data-rel-dir="{{ group_.rel_dir }}">↑</button>
     <button class="notes-mkdir-btn" title="New subdirectory inside this folder"
-      onclick="event.stopPropagation();event.preventDefault();createNotesSubdir({{ readme_rel | embed }},{{ group_.rel_dir | embed }})">+ folder</button>
+      data-action="create-notes-subdir" data-stop="1" data-prevent="1"
+      data-readme-rel="{{ readme_rel }}" data-rel-dir="{{ group_.rel_dir }}">+ folder</button>
     {% endif %}
   </summary>
   <div class="notes-list">
@@ -75,7 +80,8 @@
     {% if readme_rel %}
     <button class="notes-mkdir-btn"
       title="New folder at the item root (sibling of notes/)"
-      onclick="event.stopPropagation();event.preventDefault();createNotesSubdir({{ readme_rel | embed }},'')">+ folder</button>
+      data-action="create-notes-subdir" data-stop="1" data-prevent="1"
+      data-readme-rel="{{ readme_rel }}" data-rel-dir="">+ folder</button>
     {% endif %}
   </div>
   <div class="notes-list">
@@ -88,7 +94,8 @@
 
 {% macro readme_link(item) %}
 <div class="readme-preview"
-  onclick="openNotePreview({{ item.path | embed }},{{ item.title | embed }})">≡ README</div>
+  data-action="open-note-preview"
+  data-path="{{ item.path }}" data-title="{{ item.title }}">≡ README</div>
 {% endmacro %}
 
 
@@ -99,7 +106,8 @@
   {% for d in deliverables %}
   <div class="dlv-item">
     <a class="dlv-link" href="#"
-      onclick="event.preventDefault();event.stopPropagation();openDeliverable({{ d.full_path | embed }});return false;"
+      data-action="open-deliverable" data-stop="1" data-prevent="1"
+      data-full-path="{{ d.full_path }}"
       {% if d.desc %}title="{{ d.desc }}"{% endif %}>⤓ {{ d.label }}</a>{% if d.desc %} <span class="dlv-desc">— {{ d.desc }}</span>{% endif %}
   </div>
   {% endfor %}
@@ -114,24 +122,26 @@
 <div class="card-actions">
   <button class="git-action-btn card-action-work-on"
     title="{{ work_title }}" aria-label="{{ work_title }}"
-    onclick="workOn(event,{{ item.slug | embed }})">{{ icons.work_on | safe }}</button>
+    data-action="work-on" data-slug="{{ item.slug }}">{{ icons.work_on | safe }}</button>
   <button class="git-action-btn card-action-folder"
     title="Open folder in file manager" aria-label="Open folder in file manager"
-    onclick="openFolder(event,{{ rel_dir | embed }})">{{ icons.folder | safe }}</button>
+    data-action="open-folder" data-rel-dir="{{ rel_dir }}">{{ icons.folder | safe }}</button>
 </div>
 {% endmacro %}
 
 
 {% macro index_badge(idx, top_level=false) %}
 <a class="knowledge-index-badge{% if top_level %} knowledge-index-top{% endif %}"
-  onclick="event.stopPropagation();openNotePreview({{ idx.path | embed }},{{ idx.title | embed }})"
+  data-action="open-note-preview" data-stop="1"
+  data-path="{{ idx.path }}" data-title="{{ idx.title }}"
   title="{{ idx.path }}">index</a>
 {% endmacro %}
 
 
 {% macro knowledge_card(e) %}
 <div class="knowledge-card" data-node-id="{{ e.path }}"
-  onclick="openNotePreview({{ e.path | embed }},{{ e.title | embed }})">
+  data-action="open-note-preview"
+  data-path="{{ e.path }}" data-title="{{ e.title }}">
   <div class="knowledge-title">{{ e.title }}</div>
   {% if e.desc %}<div class="knowledge-desc">{{ e.desc }}</div>{% endif %}
   <div class="knowledge-path">{{ e.path }}</div>

--- a/crates/condash-render/templates/card.html.j2
+++ b/crates/condash-render/templates/card.html.j2
@@ -5,7 +5,7 @@
 <div class="card collapsed" id="{{ item.slug }}"
   data-kind="{{ kind }}" data-priority="{{ pri }}" data-node-id="{{ node_id }}">
   <div class="card-header">
-    <div class="card-header-left" onclick="toggleCard(this.closest('.card'))">
+    <div class="card-header-left" data-action="toggle-card">
       <span class="kind-prefix kind-{{ kind }}">{{ kind }}</span>
       <span class="card-title">{{ item.title }}</span>
       {% if item.deliverables %}<span class="dlv-icon" title="Has deliverables">PDF</span>{% endif %}
@@ -24,12 +24,13 @@
         <span class="invalid-status-badge"
           title='Unknown Status "{{ item.invalid_status }}" in README — treated as backlog. Valid: now, soon, later, backlog, review, done.'>!? {{ item.invalid_status }}</span>
       {% endif %}
-      <span class="pri-wrap" onclick="event.stopPropagation();togglePriMenu(this)">
+      <span class="pri-wrap" data-action="toggle-pri-menu" data-stop="1">
         <span class="pri-current pri-{{ pri }}">{{ pri }}</span>
         <span class="pri-menu">
           {% for p in priorities %}
           <span class="pri-option pri-{{ p }}"
-            onclick="event.stopPropagation();pickPriority({{ item.path | embed }},'{{ p }}',this.closest('.pri-wrap'))">{{ p }}</span>
+            data-action="pick-priority" data-stop="1"
+            data-path="{{ item.path }}" data-priority="{{ p }}">{{ p }}</span>
           {% endfor %}
         </span>
       </span>
@@ -39,7 +40,7 @@
   </div>
   {% if next_step %}
   <div class="card-next-step"
-    onclick="toggleCard(this.closest('.card'))"
+    data-action="toggle-card"
     title="Next pending step">
     <span class="next-step-marker next-step-{{ next_step.status }}" aria-hidden="true"></span>
     <span class="next-step-text">{{ next_step.text }}</span>

--- a/crates/condash-render/templates/history.html.j2
+++ b/crates/condash-render/templates/history.html.j2
@@ -19,7 +19,8 @@
         {% for item in month['items'] %}
         <div class="knowledge-card history-card"
           data-priority="{{ item.priority }}" data-kind="{{ item.kind }}"
-          onclick="openNotePreview({{ item.path | embed }},{{ item.title | embed }})">
+          data-action="open-note-preview"
+          data-path="{{ item.path }}" data-title="{{ item.title }}">
           <div class="knowledge-title">{{ item.title }}</div>
           <div class="history-meta">
             <span class="pill pri-{{ item.priority }}">{{ item.priority }}</span>

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -44,44 +44,44 @@
 <div id="dash-main" class="app">
 <div class="topbar">
     <div class="tabs tabs-primary">
-        <div class="tab active" data-tab="projects" onclick="switchTab('projects')">Projects<span class="tab-count">({{COUNT_PROJECTS}})</span></div>
-        <div class="tab" data-tab="code" onclick="switchTab('code')">Code<span class="tab-count">({{COUNT_REPOS}})</span></div>
-        <div class="tab" data-tab="knowledge" onclick="switchTab('knowledge')">Knowledge<span class="tab-count">({{COUNT_KNOWLEDGE}})</span></div>
-        <div class="tab" data-tab="history" onclick="switchTab('history')">History<span class="tab-count">({{COUNT_HISTORY}})</span></div>
+        <div class="tab active" data-tab="projects" data-action="switch-tab" data-tab="projects">Projects<span class="tab-count">({{COUNT_PROJECTS}})</span></div>
+        <div class="tab" data-tab="code" data-action="switch-tab" data-tab="code">Code<span class="tab-count">({{COUNT_REPOS}})</span></div>
+        <div class="tab" data-tab="knowledge" data-action="switch-tab" data-tab="knowledge">Knowledge<span class="tab-count">({{COUNT_KNOWLEDGE}})</span></div>
+        <div class="tab" data-tab="history" data-action="switch-tab" data-tab="history">History<span class="tab-count">({{COUNT_HISTORY}})</span></div>
     </div>
     <div class="header-actions">
         <span id="reconnecting-pill" class="reconnecting-pill" hidden title="Lost connection to the dashboard backend — retrying…">Reconnecting…</span>
-        <button id="refresh-all-btn" class="theme-toggle" onclick="refreshAll()" title="Hard refresh — clear cached state and re-scan from disk" aria-label="Hard refresh">
+        <button id="refresh-all-btn" class="theme-toggle" data-action="refresh-all" title="Hard refresh — clear cached state and re-scan from disk" aria-label="Hard refresh">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <polyline points="23 4 23 10 17 10"/>
                 <polyline points="1 20 1 14 7 14"/>
                 <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/>
             </svg>
         </button>
-        <div class="theme-toggle" onclick="toggleTheme()" title="Switch theme">
+        <div class="theme-toggle" data-action="toggle-theme" title="Switch theme">
             <span class="icon" id="theme-icon">&#9790;</span>
             <span id="theme-label">Dark</span>
         </div>
-        <button id="term-btn" class="theme-toggle" onclick="toggleTerminal()" title="Toggle terminal" aria-label="Toggle terminal">
+        <button id="term-btn" class="theme-toggle" data-action="toggle-terminal" title="Toggle terminal" aria-label="Toggle terminal">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <polyline points="4 17 10 11 4 5"/>
                 <line x1="12" y1="19" x2="20" y2="19"/>
             </svg>
         </button>
-        <button id="new-item-btn" class="theme-toggle" onclick="openNewItemModal()" title="New item — scaffold a project, incident, or document" aria-label="New item">
+        <button id="new-item-btn" class="theme-toggle" data-action="open-new-item-modal" title="New item — scaffold a project, incident, or document" aria-label="New item">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <line x1="12" y1="5" x2="12" y2="19"/>
                 <line x1="5" y1="12" x2="19" y2="12"/>
             </svg>
         </button>
-        <button class="theme-toggle about-toggle" onclick="openAboutModal()" title="About condash" aria-label="About condash">
+        <button class="theme-toggle about-toggle" data-action="open-about-modal" title="About condash" aria-label="About condash">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="10"/>
                 <line x1="12" y1="16" x2="12" y2="12"/>
                 <line x1="12" y1="8" x2="12.01" y2="8"/>
             </svg>
         </button>
-        <button class="theme-toggle config-toggle" onclick="openConfigModal()" title="Edit configuration" aria-label="Edit configuration">
+        <button class="theme-toggle config-toggle" data-action="open-config-modal" title="Edit configuration" aria-label="Edit configuration">
             <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                 <circle cx="12" cy="12" r="3"/>
                 <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
@@ -91,13 +91,13 @@
 </div>
 <div id="setup-banner" class="setup-banner" style="display:none">
     <span><strong>Welcome to condash.</strong> Set <code>conception_path</code> to point at your conception tree (with a <code>projects/</code> directory) to get started.</span>
-    <button type="button" onclick="openConfigModal()">Configure</button>
+    <button type="button" data-action="open-config-modal">Configure</button>
 </div>
 <div id="projects-subtabs" class="tabs tabs-secondary">
-    <div class="tab active" data-subtab="current" onclick="switchSubtab('current')">Current<span class="tab-count">({{COUNT_CURRENT}})</span></div>
-    <div class="tab" data-subtab="next" onclick="switchSubtab('next')">Next<span class="tab-count">({{COUNT_NEXT}})</span></div>
-    <div class="tab" data-subtab="backlog" onclick="switchSubtab('backlog')">Backlog<span class="tab-count">({{COUNT_BACKLOG}})</span></div>
-    <div class="tab" data-subtab="done" onclick="switchSubtab('done')">Done<span class="tab-count">({{COUNT_DONE}})</span></div>
+    <div class="tab active" data-subtab="current" data-action="switch-subtab" data-subtab="current">Current<span class="tab-count">({{COUNT_CURRENT}})</span></div>
+    <div class="tab" data-subtab="next" data-action="switch-subtab" data-subtab="next">Next<span class="tab-count">({{COUNT_NEXT}})</span></div>
+    <div class="tab" data-subtab="backlog" data-action="switch-subtab" data-subtab="backlog">Backlog<span class="tab-count">({{COUNT_BACKLOG}})</span></div>
+    <div class="tab" data-subtab="done" data-action="switch-subtab" data-subtab="done">Done<span class="tab-count">({{COUNT_DONE}})</span></div>
 </div>
 <main id="main-scroll">
     <div id="projects-pane" data-node-id="projects">
@@ -125,13 +125,13 @@
     <div class="term-handle" onmousedown="termDragStart(event)" title="Drag to resize"></div>
     <div class="term-top-row">
         <div class="term-tabs term-tabs-left" id="term-tabs-left"></div>
-        <button class="term-new-tab" onclick="termNewTab('left')" title="New tab (left)" aria-label="New tab (left)">+</button>
-        <button class="term-new-tab" id="term-launcher-left" onclick="termNewLauncherTab('left')" hidden>λ</button>
+        <button class="term-new-tab" data-action="term-new-tab" data-side="left" title="New tab (left)" aria-label="New tab (left)">+</button>
+        <button class="term-new-tab" id="term-launcher-left" data-action="term-new-launcher-tab" data-side="left" hidden>λ</button>
         <span class="term-spacer"></span>
         <div class="term-tabs term-tabs-right" id="term-tabs-right"></div>
-        <button class="term-new-tab" onclick="termNewTab('right')" title="New tab (right)" aria-label="New tab (right)">+</button>
-        <button class="term-new-tab" id="term-launcher-right" onclick="termNewLauncherTab('right')" hidden>λ</button>
-        <button class="term-new-tab term-close" onclick="toggleTerminal()" title="Close terminal pane" aria-label="Close terminal pane">&times;</button>
+        <button class="term-new-tab" data-action="term-new-tab" data-side="right" title="New tab (right)" aria-label="New tab (right)">+</button>
+        <button class="term-new-tab" id="term-launcher-right" data-action="term-new-launcher-tab" data-side="right" hidden>λ</button>
+        <button class="term-new-tab term-close" data-action="toggle-terminal" title="Close terminal pane" aria-label="Close terminal pane">&times;</button>
     </div>
     <div class="term-body">
         <div class="term-side" data-side="left">
@@ -143,32 +143,32 @@
         </div>
     </div>
 </div>
-<div id="note-modal" class="note-modal-backdrop" onclick="if(event.target===this)closeNotePreview()">
+<div id="note-modal" class="note-modal-backdrop" data-action="close-on-backdrop" data-target="note-preview">
     <div class="note-modal" id="note-modal-inner" data-mode="view">
         <div class="note-modal-header">
-            <button class="note-modal-back" id="note-modal-back" onclick="noteNavBack()" aria-label="Back" title="Back to previous note" hidden>&#9664;</button>
+            <button class="note-modal-back" id="note-modal-back" data-action="note-nav-back" aria-label="Back" title="Back to previous note" hidden>&#9664;</button>
             <span class="note-modal-title" id="note-modal-title" ondblclick="startRenameNote()" title="Double-click to rename (notes/ files only)">Note</span>
             <div class="note-mode-toggle" id="note-mode-toggle" role="group" aria-label="Note mode">
-                <button class="note-mode-btn" data-mode="view" onclick="setNoteMode('view')" title="View (rendered)">View</button>
-                <button class="note-mode-btn" data-mode="cm" onclick="setNoteMode('cm')" title="Edit with syntax highlighting (Ctrl+E)">Edit</button>
-                <button class="note-mode-btn" data-mode="plain" onclick="setNoteMode('plain')" title="Plain textarea edit">Plain</button>
+                <button class="note-mode-btn" data-mode="view" data-action="set-note-mode" data-mode="view" title="View (rendered)">View</button>
+                <button class="note-mode-btn" data-mode="cm" data-action="set-note-mode" data-mode="cm" title="Edit with syntax highlighting (Ctrl+E)">Edit</button>
+                <button class="note-mode-btn" data-mode="plain" data-action="set-note-mode" data-mode="plain" title="Plain textarea edit">Plain</button>
             </div>
             <div class="note-modal-actions">
-                <button id="note-save-btn" class="note-action-btn note-action-primary" onclick="saveEdit()" style="display:none">Save</button>
-                <button class="note-modal-close" onclick="closeNotePreview()" aria-label="Close">&times;</button>
+                <button id="note-save-btn" class="note-action-btn note-action-primary" data-action="save-edit" style="display:none">Save</button>
+                <button class="note-modal-close" data-action="close-note-preview" aria-label="Close">&times;</button>
             </div>
         </div>
         <div class="note-modal-external-banner" id="note-modal-external-banner" hidden>
             <span>This note changed on disk.</span>
-            <button type="button" class="note-action-btn" onclick="_noteReconcileDismiss()">Keep my edits</button>
-            <button type="button" class="note-action-btn note-action-primary" onclick="_noteReconcileReload()">Reload from disk</button>
+            <button type="button" class="note-action-btn" data-action="note-reconcile-dismiss">Keep my edits</button>
+            <button type="button" class="note-action-btn note-action-primary" data-action="note-reconcile-reload">Reload from disk</button>
         </div>
         <div class="note-modal-search" id="note-search-bar" hidden>
             <input type="search" id="note-search-input" placeholder="Find in note…" autocomplete="off" oninput="noteSearchRun()">
             <span class="note-search-count" id="note-search-count"></span>
-            <button class="note-action-btn" onclick="noteSearchStep(-1)" title="Previous (Shift+Enter)" aria-label="Previous match">&uarr;</button>
-            <button class="note-action-btn" onclick="noteSearchStep(1)" title="Next (Enter)" aria-label="Next match">&darr;</button>
-            <button class="note-action-btn" onclick="noteSearchClose()" title="Close (Esc)" aria-label="Close search">&times;</button>
+            <button class="note-action-btn" data-action="note-search-step" data-delta="-1" title="Previous (Shift+Enter)" aria-label="Previous match">&uarr;</button>
+            <button class="note-action-btn" data-action="note-search-step" data-delta="1" title="Next (Enter)" aria-label="Next match">&darr;</button>
+            <button class="note-action-btn" data-action="note-search-close" title="Close (Esc)" aria-label="Close search">&times;</button>
         </div>
         <div class="note-modal-body" id="note-modal-body">
             <div class="note-pane note-pane-view" id="note-pane-view"></div>
@@ -180,11 +180,11 @@
         </div>
     </div>
 </div>
-<div id="about-modal" class="note-modal-backdrop" onclick="if(event.target===this)closeAboutModal()">
+<div id="about-modal" class="note-modal-backdrop" data-action="close-on-backdrop" data-target="about-modal">
     <div class="note-modal about-modal">
         <div class="note-modal-header">
             <span class="note-modal-title">About</span>
-            <button class="note-modal-close" onclick="closeAboutModal()" aria-label="Close">&times;</button>
+            <button class="note-modal-close" data-action="close-about-modal" aria-label="Close">&times;</button>
         </div>
         <div class="note-modal-body">
             <div class="about-header">
@@ -207,11 +207,11 @@
         </div>
     </div>
 </div>
-<div id="config-modal" class="note-modal-backdrop" onclick="if(event.target===this)closeConfigModal()">
+<div id="config-modal" class="note-modal-backdrop" data-action="close-on-backdrop" data-target="config-modal">
     <div class="note-modal config-modal config-modal-wide">
         <div class="note-modal-header">
             <span class="note-modal-title">Configuration</span>
-            <button class="note-modal-close" onclick="closeConfigModal()" aria-label="Close">&times;</button>
+            <button class="note-modal-close" data-action="close-config-modal" aria-label="Close">&times;</button>
         </div>
         <div class="note-modal-body">
             <form id="config-form" onsubmit="saveConfig(event)">
@@ -227,7 +227,7 @@
                 <div id="config-error" class="config-error" style="display:none"></div>
                 <div id="config-saved" class="config-saved" style="display:none;color:#2a7a2a;margin-top:8px"></div>
                 <div class="config-actions">
-                    <button type="button" onclick="closeConfigModal()">Cancel</button>
+                    <button type="button" data-action="close-config-modal">Cancel</button>
                     <button type="submit" class="config-save">Save</button>
                 </div>
             </form>
@@ -236,11 +236,11 @@
 </div>
 
 
-<div id="new-item-modal" class="note-modal-backdrop" onclick="if(event.target===this)closeNewItemModal()">
+<div id="new-item-modal" class="note-modal-backdrop" data-action="close-on-backdrop" data-target="new-item-modal">
     <div class="note-modal config-modal" style="max-width:560px">
         <div class="note-modal-header">
             <span class="note-modal-title">New item</span>
-            <button class="note-modal-close" onclick="closeNewItemModal()" aria-label="Close">&times;</button>
+            <button class="note-modal-close" data-action="close-new-item-modal" aria-label="Close">&times;</button>
         </div>
         <div class="note-modal-body">
             <form id="new-item-form" onsubmit="submitNewItem(event)">
@@ -303,7 +303,7 @@
                 </fieldset>
                 <div id="new-item-error" class="config-error" style="display:none"></div>
                 <div class="config-actions">
-                    <button type="button" onclick="closeNewItemModal()">Cancel</button>
+                    <button type="button" data-action="close-new-item-modal">Cancel</button>
                     <button type="submit" class="config-save">Create item</button>
                 </div>
             </form>

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -94,6 +94,9 @@ import {
 import {
     _setDirty,
 } from './sections/note-preview.js';
+import {
+    initActionDispatch, registerAction,
+} from './sections/action-dispatch.js';
 
 /* --- In-app config editor --- */
 function _setField(form, name, value) {
@@ -1475,6 +1478,56 @@ function startEditText(el) {
 // DOM-level side effects now that both modules have finished
 // evaluating — see the notes for P-07
 // (projects/2026-04-23-condash-frontend-extraction/notes/01-p07-tab-drag-split.md).
+/* Register all click actions rendered by the server as `data-action`
+   attrs. Keep this block in one place so the inventory is obvious — one
+   registerAction call per distinct action name, grouped by subsystem. */
+function registerDashboardActions() {
+    // Top-level navigation
+    registerAction('switch-tab',          (_e, _el, d) => switchTab(d.tab));
+    registerAction('switch-subtab',       (_e, _el, d) => switchSubtab(d.subtab));
+    registerAction('refresh-all',         () => refreshAll());
+    registerAction('toggle-theme',        () => toggleTheme());
+    registerAction('toggle-terminal',     () => toggleTerminal());
+
+    // Modals — open
+    registerAction('open-new-item-modal', () => openNewItemModal());
+    registerAction('open-about-modal',    () => openAboutModal());
+    registerAction('open-config-modal',   () => openConfigModal());
+
+    // Modals — close (explicit button, and backdrop-click variant)
+    registerAction('close-new-item-modal', () => closeNewItemModal());
+    registerAction('close-about-modal',    () => closeAboutModal());
+    registerAction('close-config-modal',   () => closeConfigModal());
+    registerAction('close-note-preview',   () => closeNotePreview());
+    registerAction('close-on-backdrop', (event, el) => {
+        if (event.target !== el) return;
+        const target = el.dataset.target;
+        if (target === 'note-preview') closeNotePreview();
+        else if (target === 'about-modal') closeAboutModal();
+        else if (target === 'config-modal') closeConfigModal();
+        else if (target === 'new-item-modal') closeNewItemModal();
+    });
+
+    // Terminal
+    registerAction('term-new-tab',          (_e, _el, d) => termNewTab(d.side));
+    registerAction('term-new-launcher-tab', (_e, _el, d) => termNewLauncherTab(d.side));
+
+    // Note preview / edit
+    registerAction('note-nav-back', () => noteNavBack());
+    registerAction('set-note-mode', (_e, _el, d) => setNoteMode(d.mode));
+    registerAction('save-edit',     () => saveEdit());
+
+    // Note reconcile modal
+    registerAction('note-reconcile-dismiss', () => _noteReconcileDismiss());
+    registerAction('note-reconcile-reload',  () => _noteReconcileReload());
+
+    // In-note search
+    registerAction('note-search-step', (_e, _el, d) => noteSearchStep(parseInt(d.delta, 10) || 0));
+    registerAction('note-search-close', () => noteSearchClose());
+}
+registerDashboardActions();
+initActionDispatch();
+
 initTabDragSideEffects();
 initThemeSideEffects();
 initAboutModalSideEffects();

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -1524,6 +1524,44 @@ function registerDashboardActions() {
     // In-note search
     registerAction('note-search-step', (_e, _el, d) => noteSearchStep(parseInt(d.delta, 10) || 0));
     registerAction('note-search-close', () => noteSearchClose());
+
+    // Card header / priority menu
+    registerAction('toggle-card',    (_e, el) => toggleCard(el.closest('.card')));
+    registerAction('toggle-pri-menu', (_e, el) => togglePriMenu(el));
+    registerAction('pick-priority',  (_e, el, d) =>
+        pickPriority(d.path, d.priority, el.closest('.pri-wrap')));
+
+    // Steps + section folding
+    registerAction('cycle-step',     (_e, el, d) => {
+        const step = el.closest('.step');
+        cycle(d.filePath, +step.dataset.line, step);
+    });
+    registerAction('start-edit-text', (_e, el) => startEditText(el));
+    registerAction('remove-step',     (_e, el, d) => {
+        const step = el.closest('.step');
+        removeStep(d.filePath, +step.dataset.line, el);
+    });
+    registerAction('toggle-section',  (_e, el) => toggleSection(el));
+    registerAction('add-step',        (_e, el, d) =>
+        addStep(d.filePath, d.heading, el.previousElementSibling));
+
+    // Note preview (cards, history, knowledge, readme link, index badges)
+    registerAction('open-note-preview', (_e, _el, d) => openNotePreview(d.path, d.title));
+
+    // Notes/files tree actions
+    registerAction('create-note-for', (_e, _el, d) =>
+        createNoteFor(d.readmeRel, d.relDir));
+    registerAction('upload-to-notes', (_e, _el, d) =>
+        uploadToNotes(d.readmeRel, d.relDir));
+    registerAction('create-notes-subdir', (_e, _el, d) =>
+        createNotesSubdir(d.readmeRel, d.relDir));
+
+    // Deliverables
+    registerAction('open-deliverable', (_e, _el, d) => openDeliverable(d.fullPath));
+
+    // Card actions (work-on, open-folder)
+    registerAction('work-on',     (event, _el, d) => workOn(event, d.slug));
+    registerAction('open-folder', (event, _el, d) => openFolder(event, d.relDir));
 }
 registerDashboardActions();
 initActionDispatch();
@@ -1561,40 +1599,20 @@ initSseSideEffects();
     } catch (e) {}
 })();
 
-// Re-export the externally-called surface so Jinja-rendered onclick
-// handlers, Python-rendered HTML, and the CM6 mount trailer (cm6-mount.js)
-// can find these functions on window — identical to the global visibility
-// the inline <script> block used to provide. Functions listed in the
-// original spec are all declared above. Additional entries
-// (openNotePreview, addStep, removeStep, cycle, pickPriority,
-// createNoteFor, createNotesSubdir, openFolder, openConfigModal,
-// openAboutModal, closeAboutModal, closeConfigModal, closeNewItemModal,
-// closeNotePreview, toggleTheme, toggleTerminal, termNewTab,
-// termNewLauncherTab, switchTab, switchSubtab, switchConfigTab,
-// refreshAll, setNoteMode, noteSearchStep, noteSearchClose, saveEdit,
-// noteNavBack, jumpToProject, _openHistoryHit, _noteReconcileDismiss,
-// _noteReconcileReload) were added after grepping src/condash/render.py,
-// src/condash/templates/*.j2, and the residual markup in dashboard.html
-// for onclick="<name>(" occurrences.
+// The post-data-action residual: a few inline handlers still reach the
+// global scope because they fire on non-click events (oninput, onkeydown,
+// ondblclick, onsubmit, onmousedown, onpointerdown). Every click-driven
+// attribute moved to `data-action` + `registerAction(…)` above. The CM6
+// init bridge (`cm6-init.js`) also reads `window._syncModeControls` when
+// the CodeMirror bundle finishes loading, since that file is a classic
+// (non-ESM) script.
 Object.assign(window, {
-    toggleCard, togglePriMenu, uploadToNotes, workOn, toggleSection,
-    openInTerminal, startEditText, stepPointerDown, openDeliverable,
-    startRenameNote, runnerStart, runnerStop, runnerSwitch,
-    runnerForceStop,
-    runnerToggleCollapse, runnerJump, runnerPopout,
-    runnerStopInline, gitToggleOpenPopover, gitClosePopovers,
-    updateProgress, _syncModeControls,
-    openNotePreview, addStep, removeStep, cycle, pickPriority,
-    createNoteFor, createNotesSubdir, openFolder,
-    openConfigModal, openNewItemModal, openAboutModal,
-    closeConfigModal, closeNewItemModal, closeAboutModal, closeNotePreview,
-    toggleTheme, toggleTerminal, termNewTab, termNewLauncherTab,
-    termDragStart, termSplitStart,
-    switchTab, switchSubtab, switchConfigTab, refreshAll, setNoteMode,
-    noteSearchStep, noteSearchClose, noteSearchRun, saveEdit, noteNavBack,
-    openPath,
-    filterHistory, filterKnowledge,
-    saveConfig, submitNewItem, _setDirty,
-    jumpToProject, _openHistoryHit,
-    _noteReconcileDismiss, _noteReconcileReload,
+    addStep,                                  // onkeydown in _macros.html.j2 (Add-step input)
+    startRenameNote,                          // ondblclick on the note-modal title
+    stepPointerDown,                          // onpointerdown on the step drag handle
+    termDragStart, termSplitStart,            // onmousedown on the terminal handles
+    filterHistory, filterKnowledge,           // oninput on the search inputs
+    noteSearchRun, _setDirty,                 // oninput on the note search bar + textarea
+    saveConfig,                               // onsubmit on the config form
+    _syncModeControls,                        // cm6-init.js reaches for this on load
 });

--- a/frontend/src/js/sections/action-dispatch.js
+++ b/frontend/src/js/sections/action-dispatch.js
@@ -1,0 +1,48 @@
+/* Delegated click dispatch for server-rendered markup.
+
+   Server-rendered HTML uses `data-action="<name>"` + optional `data-*`
+   attributes to declare clickable behaviour. A single document-level
+   click listener reads `target.closest('[data-action]')` and routes to
+   a registered handler. This removes the need to park every handler on
+   `window` for inline `onclick="..."` attributes to reach it — those
+   attrs are gone entirely as of this module.
+
+   Handler signature: `handler(event, el, dataset)` where `el` is the
+   element carrying `data-action` and `dataset` is `el.dataset` (read-
+   only copy of the data-* attrs). Return value is ignored.
+
+   Attribute modifiers on the click source:
+   - `data-stop="1"`  → call `event.stopPropagation()` before dispatch.
+   - `data-prevent="1"` → call `event.preventDefault()` before dispatch.
+
+   Registration is one-time and uses the exported `registerAction(name,
+   handler)`. Double-registration throws so a typo or collision surfaces
+   at boot rather than becoming a silent override. */
+
+const _actions = new Map();
+
+export function registerAction(name, handler) {
+    if (typeof name !== 'string' || !name) {
+        throw new Error('registerAction: name must be a non-empty string');
+    }
+    if (typeof handler !== 'function') {
+        throw new Error(`registerAction(${name}): handler must be a function`);
+    }
+    if (_actions.has(name)) {
+        throw new Error(`registerAction(${name}): already registered`);
+    }
+    _actions.set(name, handler);
+}
+
+export function initActionDispatch() {
+    document.addEventListener('click', function(event) {
+        const el = event.target.closest('[data-action]');
+        if (!el) return;
+        const name = el.dataset.action;
+        const handler = _actions.get(name);
+        if (!handler) return;
+        if (el.dataset.stop === '1') event.stopPropagation();
+        if (el.dataset.prevent === '1') event.preventDefault();
+        handler(event, el, el.dataset);
+    });
+}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.2.0"
+version = "1.3.0"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-dialog = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml_ng = "0.10"
@@ -37,7 +38,6 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 anyhow = "1"
 regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
-rfd = "0.15"
 shlex = "1"
 md-5 = "0.10"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -53,12 +53,15 @@ pub fn load_template_for_bin(source: &assets::AssetSource) -> anyhow::Result<Str
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_dialog::init())
         .setup(|app| {
             let conception_path = match resolve_conception_path() {
                 Ok(p) => p,
-                Err(unset) => prompt_for_conception_path(unset).ok_or_else(|| {
-                    "condash cancelled at the conception folder picker".to_string()
-                })?,
+                Err(unset) => {
+                    prompt_for_conception_path(app.handle(), unset).ok_or_else(|| {
+                        "condash cancelled at the conception folder picker".to_string()
+                    })?
+                }
             };
             let asset_source = assets::pick_from_env();
             let template =
@@ -223,8 +226,12 @@ pub fn resolve_from(
 /// On success, persists the choice to the on-disk settings file so the
 /// next launch skips the picker. Returns `None` when the user cancels
 /// (the caller should exit cleanly).
-fn prompt_for_conception_path(initial: ConceptionPathUnset) -> Option<PathBuf> {
-    // Title picks a friendlier form than the raw error.
+fn prompt_for_conception_path(
+    app: &tauri::AppHandle,
+    initial: ConceptionPathUnset,
+) -> Option<PathBuf> {
+    use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+
     let title = "Select your conception tree";
     let message = format!(
         "{}\n\nPick the root of your conception tree (the directory that \
@@ -234,9 +241,15 @@ fn prompt_for_conception_path(initial: ConceptionPathUnset) -> Option<PathBuf> {
     eprintln!("condash: {message}");
 
     loop {
-        let Some(picked) = rfd::FileDialog::new().set_title(title).pick_folder() else {
-            // User hit Cancel — bail to the caller.
+        let Some(picked) = app.dialog().file().set_title(title).blocking_pick_folder() else {
             return None;
+        };
+        let picked: PathBuf = match picked.into_path() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("condash: dialog returned non-path result ({e}) — giving up");
+                return None;
+            }
         };
 
         match validate_conception_candidate(&picked) {
@@ -246,9 +259,6 @@ fn prompt_for_conception_path(initial: ConceptionPathUnset) -> Option<PathBuf> {
                     ..Default::default()
                 };
                 if let Err(e) = user_config::save(&cfg) {
-                    // Don't fail the launch on a save failure — the
-                    // user still gets a working session with this path,
-                    // and they'll see the same picker on the next run.
                     eprintln!("condash: warning — could not persist settings.yaml: {e}");
                 } else if let Some(path) = user_config::settings_file_path() {
                     eprintln!("condash: saved conception path to {}", path.display());
@@ -256,12 +266,11 @@ fn prompt_for_conception_path(initial: ConceptionPathUnset) -> Option<PathBuf> {
                 return Some(picked);
             }
             Err(reason) => {
-                // Show a non-blocking error and loop back to the picker.
-                rfd::MessageDialog::new()
-                    .set_title("Not a conception tree")
-                    .set_description(&format!("{}\n\n{}", picked.display(), reason))
-                    .set_level(rfd::MessageLevel::Warning)
-                    .show();
+                app.dialog()
+                    .message(format!("{}\n\n{}", picked.display(), reason))
+                    .title("Not a conception tree")
+                    .kind(MessageDialogKind::Warning)
+                    .blocking_show();
             }
         }
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

- Finishes the three items deferred from PR #44 (v1.2.0 audit): replaces all inline `onclick=` with a `data-action` dispatcher, and swaps the ~400 KB `rfd` dependency for `tauri-plugin-dialog`. Splits the dispatcher work into three commits so the migration can be reviewed in layers.
- Eliminates the `Object.assign(window, {...})` re-export surface that caused the v1.1.3 regression (missed-import on `_syncModeControls`). The residual `window.*` exports now only carry the handful of non-click inline attributes (`oninput`, `onkeydown`, `onmousedown`, etc.) — a small, well-scoped surface.
- C-08 (split `dashboard-main.js`) is explicitly deferred to a future PR — see the README of the audit-followup project for the rationale.

## Changes

- **C-05a** — Add `frontend/src/js/sections/action-dispatch.js`: a single document-level click listener that reads `target.closest("[data-action]")` and dispatches to a named handler registered via `registerAction(name, fn)`. Supports `data-stop="1"` / `data-prevent="1"` modifiers for the common patterns. Wired into boot via `initActionDispatch()` in `dashboard-main.js`.
- **C-05a (dashboard.html)** — Migrate all ~35 inline `onclick=` sites in `frontend/dashboard.html` to `data-action` + `data-*` attributes. Backdrop-dismiss clicks use a single `data-action="close-on-backdrop" data-target="<modal>"` handler that checks `event.target === el`.
- **C-05c (templates)** — Migrate every `onclick=` in `crates/condash-render/templates/{card,history,_macros}.html.j2` to `data-action` + `data-*` attributes. Replaces the custom `embed`-filtered JS arg form with plain HTML-attr-escaped values (auto-escape already handles it). Slims the `Object.assign(window, { ... })` trailer from ~60 symbols to 9 (the non-click inline handlers that remain).
- **C-13** — Drop `rfd = "0.15"` from `src-tauri/Cargo.toml`; add `tauri-plugin-dialog = "2"`. Register the plugin in `Builder::default()`. Refactor `prompt_for_conception_path` to take `&tauri::AppHandle`, call `app.dialog().file().blocking_pick_folder()` + `app.dialog().message(...).blocking_show()` instead of the standalone `rfd` calls. Removes the ~400 KB of bundled GTK dialog code that `rfd` ships.
- Bump condash to v1.3.0.

## Impact

- The `window.*` surface that server-rendered HTML can reach is now explicitly a **9-name list** (`addStep`, `startRenameNote`, `stepPointerDown`, `termDragStart`, `termSplitStart`, `filterHistory`, `filterKnowledge`, `noteSearchRun`, `_setDirty`, `saveConfig`, `_syncModeControls`) — no new inline `onclick=` / `ondblclick=` / etc. should be added without either registering a `data-action` or extending that list explicitly.
- The native folder / message dialogs now come from Tauris plugin rather than `rfd`s in-process GTK. On Linux this means dialogs integrate with the same GTK stack the webview uses rather than spawning a second one.
- Binary size drops noticeably — `rfd` carried its own dialog implementation and several transitive GTK deps.

## Watchpoints

- **First-run picker on a fresh machine.** The folder picker is the one path in condash that is hard to reach without uninstalling and reinstalling, so verify once on a host without `~/.config/condash/settings.yaml` (or `CONDASH_CONCEPTION_PATH` unset). The failure mode to watch for: the dialog doesnt appear, or it appears but the returned path comes back as `None` / fails to parse.
- **Click-through smoke on every tab after deploy.** The data-action migration touches cards, knowledge, history, steps, deliverables, and every modal. A subtle regression — a forgotten site, a typo in a `data-action` name — would surface as "one specific button does nothing." Relevant paths: click into a project → toggle a step → cycle priority → open a note → edit and save → open terminal → switch between projects/code/knowledge/history → open config modal → open about modal.
- **Dispatcher collision detection.** `registerAction` throws on duplicate registration. If a future module starts registering an action that already exists, boot will crash loudly rather than silently override — watch for startup errors in the webview console after any follow-up touches `registerDashboardActions`.