### PR TITLE
Add tracing, per-item cache, lazy mermaid (v1.4.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -447,6 +447,8 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tower",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -494,6 +496,7 @@ dependencies = [
  "regex",
  "serde",
  "tempfile",
+ "tracing",
 ]
 
 [[package]]
@@ -2158,6 +2161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2407,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3787,6 +3808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4456,6 +4486,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4732,7 +4771,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4742,6 +4793,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "thread_local",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]

--- a/crates/condash-state/Cargo.toml
+++ b/crates/condash-state/Cargo.toml
@@ -12,6 +12,7 @@ condash-parser = { path = "../condash-parser" }
 md-5 = "0.10"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/condash-state/src/cache.rs
+++ b/crates/condash-state/src/cache.rs
@@ -7,19 +7,23 @@
 //!
 //! [`WorkspaceCache`] memoizes the two hot paths behind an `RwLock` so
 //! reads from Tauri route handlers are cheap and stay safe alongside
-//! invalidations driven by the filesystem watcher. The watcher
-//! coarsely routes tab events (`projects` / `knowledge`) to
-//! [`invalidate_items`] and [`invalidate_knowledge`] — invalidating a
-//! whole tab on any event inside it keeps the invalidation logic tiny
-//! and a single cold rebuild is fast enough (<50 ms on a ~200-item
-//! tree) that sub-key invalidation isn't worth the book-keeping.
+//! invalidations driven by the filesystem watcher.
 //!
-//! [`invalidate_items`]: WorkspaceCache::invalidate_items
-//! [`invalidate_knowledge`]: WorkspaceCache::invalidate_knowledge
+//! The items side is keyed by README path: a mutation that touches one
+//! item (step toggle, note save) calls [`invalidate_item_at`] to drop
+//! just that entry, so the next read re-parses one README instead of
+//! the whole tree. The watcher-driven path ([`on_event`]) stays
+//! coarse — a `Tab::Projects` event from the filesystem watcher doesn't
+//! carry a specific path, so it flushes the whole map.
+//!
+//! [`invalidate_item_at`]: WorkspaceCache::invalidate_item_at
+//! [`on_event`]: WorkspaceCache::on_event
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
-use condash_parser::{collect_items, collect_knowledge, Item, KnowledgeNode};
+use condash_parser::{collect_knowledge, parse_readme, Item, KnowledgeNode};
 
 use crate::RenderCtx;
 
@@ -34,10 +38,16 @@ pub enum Tab {
 
 #[derive(Default)]
 struct CacheInner {
-    items: Option<Arc<Vec<Item>>>,
+    /// Parsed items keyed by absolute README path. `None` means we've
+    /// never walked `projects/` — distinguishes "cold" from "walked but
+    /// empty".
+    items: Option<HashMap<PathBuf, Item>>,
+    /// Memoized ordered view of `items`. Built lazily on the first
+    /// `get_items` after any invalidation; invalidators clear it so the
+    /// next read rebuilds it.
+    items_snapshot: Option<Arc<Vec<Item>>>,
     /// Separate `loaded` flag so `None` legitimately means "no
-    /// knowledge/ directory on disk" (vs. "not yet warmed"). Matches
-    /// Python's `_knowledge_loaded` sentinel.
+    /// knowledge/ directory on disk" (vs. "not yet warmed").
     knowledge: Option<Arc<Option<KnowledgeNode>>>,
 }
 
@@ -62,15 +72,35 @@ impl WorkspaceCache {
     /// `get_items` call will rebuild a fresh one from a new read.
     #[tracing::instrument(skip_all, fields(base_dir = %ctx.base_dir.display()))]
     pub fn get_items(&self, ctx: &RenderCtx) -> Arc<Vec<Item>> {
-        if let Some(items) = self.inner.read().unwrap().items.clone() {
-            return items;
+        if let Some(snap) = self.inner.read().unwrap().items_snapshot.clone() {
+            return snap;
         }
-        let fresh = Arc::new(collect_items(&ctx.base_dir));
+        // Walk the tree and rebuild missing entries. Cheap when nothing
+        // is missing (snapshot was just cleared, map still populated);
+        // pays the full parser cost only on cold start or after a
+        // coarse invalidation.
+        let readmes = collect_readmes(&ctx.base_dir);
         let mut w = self.inner.write().unwrap();
-        // Another writer may have populated the slot between our read
-        // miss and this write — honor whatever's there so two readers
-        // that race end up with the same `Arc`.
-        w.items.get_or_insert_with(|| fresh.clone()).clone()
+        let map = w.items.get_or_insert_with(HashMap::new);
+        // Prune entries whose README is no longer on disk (handles
+        // deletions between invalidations).
+        let on_disk: std::collections::HashSet<&PathBuf> = readmes.iter().collect();
+        map.retain(|k, _| on_disk.contains(k));
+
+        let mut items: Vec<Item> = Vec::with_capacity(readmes.len());
+        for path in &readmes {
+            if let Some(cached) = map.get(path) {
+                items.push(cached.clone());
+                continue;
+            }
+            if let Some(item) = parse_readme(&ctx.base_dir, path, None) {
+                map.insert(path.clone(), item.clone());
+                items.push(item);
+            }
+        }
+        let snap = Arc::new(items);
+        w.items_snapshot = Some(snap.clone());
+        snap
     }
 
     /// Return the memoized knowledge tree, warming on first access.
@@ -86,11 +116,30 @@ impl WorkspaceCache {
         w.knowledge.get_or_insert_with(|| fresh.clone()).clone()
     }
 
-    /// Flush the items slice — next `get_items` re-walks `projects/`.
-    /// Python also flushes its wikilink cache here; we do the same once
-    /// wikilinks move into this crate.
+    /// Flush every cached item — next `get_items` re-parses every
+    /// README. Used by full-rescan endpoints and by the watcher when
+    /// the event carries no specific path.
     pub fn invalidate_items(&self) {
-        self.inner.write().unwrap().items = None;
+        let mut w = self.inner.write().unwrap();
+        w.items = None;
+        w.items_snapshot = None;
+    }
+
+    /// Drop the single item whose folder contains `path` and clear the
+    /// snapshot. Pass the absolute path to any file under the item —
+    /// the README itself (`.../README.md`), a note
+    /// (`.../notes/x.md`), etc. Falls back to a full invalidation when
+    /// no item-dir is found above `path`, which is the safe default.
+    pub fn invalidate_item_at(&self, path: &Path) {
+        let Some(readme) = readme_for(path) else {
+            self.invalidate_items();
+            return;
+        };
+        let mut w = self.inner.write().unwrap();
+        if let Some(map) = w.items.as_mut() {
+            map.remove(&readme);
+        }
+        w.items_snapshot = None;
     }
 
     /// Flush the knowledge tree slice.
@@ -103,11 +152,14 @@ impl WorkspaceCache {
     pub fn invalidate_all(&self) {
         let mut w = self.inner.write().unwrap();
         w.items = None;
+        w.items_snapshot = None;
         w.knowledge = None;
     }
 
     /// Route a filesystem-watcher tab event to the right invalidator.
-    /// Matches Python's `on_event` sync subscriber.
+    /// The watcher only publishes a coarse tab id, so this stays coarse
+    /// too — per-item invalidation is reserved for code paths that
+    /// know exactly which item just changed.
     pub fn on_event(&self, tab: Tab) {
         match tab {
             Tab::Projects => self.invalidate_items(),
@@ -116,12 +168,67 @@ impl WorkspaceCache {
     }
 }
 
+/// Walk `<base>/projects/*/*/README.md` into a sorted `Vec<PathBuf>`.
+/// Matches the two-level layout the parser itself walks.
+fn collect_readmes(base_dir: &Path) -> Vec<PathBuf> {
+    let projects = base_dir.join("projects");
+    let Ok(months) = std::fs::read_dir(&projects) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = Vec::new();
+    for month in months.flatten() {
+        let month_path = month.path();
+        if !month_path.is_dir() {
+            continue;
+        }
+        let Ok(items) = std::fs::read_dir(&month_path) else {
+            continue;
+        };
+        for item in items.flatten() {
+            let item_path = item.path();
+            if !item_path.is_dir() {
+                continue;
+            }
+            let readme = item_path.join("README.md");
+            if readme.is_file() {
+                out.push(readme);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Walk `path` upwards looking for an ancestor that holds a `README.md`
+/// whose grandparent is a `projects/<month>/` directory. Returns the
+/// README path when found — the cache keys items by this path.
+fn readme_for(path: &Path) -> Option<PathBuf> {
+    for ancestor in path.ancestors() {
+        let dir = if ancestor.file_name().and_then(|n| n.to_str()) == Some("README.md") {
+            ancestor.parent()?
+        } else {
+            ancestor
+        };
+        let readme = dir.join("README.md");
+        if !readme.is_file() {
+            continue;
+        }
+        let Some(month) = dir.parent() else { continue };
+        let Some(projects) = month.parent() else {
+            continue;
+        };
+        if projects.file_name().and_then(|n| n.to_str()) == Some("projects") {
+            return Some(readme);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs::{self, File};
     use std::io::Write;
-    use std::path::Path;
 
     fn write(p: &Path, contents: &str) {
         if let Some(parent) = p.parent() {
@@ -269,5 +376,63 @@ mod tests {
         cache.invalidate_all();
         assert!(!Arc::ptr_eq(&cache.get_items(&ctx), &items_a));
         assert!(!Arc::ptr_eq(&cache.get_knowledge(&ctx), &knowledge_a));
+    }
+
+    #[test]
+    fn invalidate_item_at_drops_only_one_entry() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let foo = base.join("projects/2026-04/2026-04-22-foo/README.md");
+        let bar = base.join("projects/2026-04/2026-04-22-bar/README.md");
+        write(&foo, SIMPLE_README);
+        write(&bar, SIMPLE_README);
+        let ctx = RenderCtx::with_base_dir(base);
+        let cache = WorkspaceCache::new();
+
+        // Warm the cache so both items are parsed and memoized.
+        assert_eq!(cache.get_items(&ctx).len(), 2);
+        let snap_a = cache.get_items(&ctx);
+
+        cache.invalidate_item_at(&foo);
+        let snap_b = cache.get_items(&ctx);
+        // Snapshot rebuilt…
+        assert!(!Arc::ptr_eq(&snap_a, &snap_b));
+        // …and `bar`'s map entry must have been preserved across the
+        // surgical invalidation (otherwise we've regressed to coarse).
+        let guard = cache.inner.read().unwrap();
+        let map = guard.items.as_ref().unwrap();
+        assert!(map.contains_key(&bar));
+        assert!(map.contains_key(&foo)); // re-parsed by the rebuild
+    }
+
+    #[test]
+    fn invalidate_item_at_accepts_a_note_path() {
+        let td = tempfile::tempdir().unwrap();
+        let base = td.path();
+        let readme = base.join("projects/2026-04/2026-04-22-foo/README.md");
+        let note = base.join("projects/2026-04/2026-04-22-foo/notes/a.md");
+        write(&readme, SIMPLE_README);
+        write(&note, "body\n");
+        let ctx = RenderCtx::with_base_dir(base);
+        let cache = WorkspaceCache::new();
+
+        assert_eq!(cache.get_items(&ctx).len(), 1);
+        cache.invalidate_item_at(&note);
+        // Map should have dropped the one entry; next read re-parses it.
+        let snap_b = cache.get_items(&ctx);
+        assert_eq!(snap_b.len(), 1);
+    }
+
+    #[test]
+    fn invalidate_item_at_outside_projects_falls_back_to_full_flush() {
+        let td = tempfile::tempdir().unwrap();
+        seed(td.path());
+        let ctx = RenderCtx::with_base_dir(td.path());
+        let cache = WorkspaceCache::new();
+
+        let snap_a = cache.get_items(&ctx);
+        cache.invalidate_item_at(&td.path().join("some-random-file.txt"));
+        let snap_b = cache.get_items(&ctx);
+        assert!(!Arc::ptr_eq(&snap_a, &snap_b));
     }
 }

--- a/crates/condash-state/src/cache.rs
+++ b/crates/condash-state/src/cache.rs
@@ -60,6 +60,7 @@ impl WorkspaceCache {
     /// Return the memoized parsed-item list, warming on first access.
     /// The returned `Arc` stays valid across invalidations — the next
     /// `get_items` call will rebuild a fresh one from a new read.
+    #[tracing::instrument(skip_all, fields(base_dir = %ctx.base_dir.display()))]
     pub fn get_items(&self, ctx: &RenderCtx) -> Arc<Vec<Item>> {
         if let Some(items) = self.inner.read().unwrap().items.clone() {
             return items;

--- a/crates/condash-state/src/git/scan.rs
+++ b/crates/condash-state/src/git/scan.rs
@@ -410,6 +410,7 @@ fn subrepo_member(parent: &ScannedRepo, sub_name: &str) -> Member {
 /// Find git repos under `ctx.workspace` and group them per the
 /// configured repo structure. Returns `[]` when `workspace` is unset.
 /// Port of `_collect_git_repos`.
+#[tracing::instrument(skip_all, fields(workspace = ?ctx.workspace.as_deref()))]
 pub fn collect_git_repos(ctx: &RenderCtx) -> Vec<Group> {
     let Some(workspace) = ctx.workspace.as_deref() else {
         return Vec::new();

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -20,7 +20,7 @@
     }
 })();
 </script>
-<script src="/vendor/mermaid/mermaid.min.js" defer></script>
+<!-- Mermaid is lazy-loaded on first use by frontend/src/js/sections/note-preview.js:_renderMermaidIn; saves ~3 MB on cold start for users who never view a mermaid-bearing note. -->
 <link rel="stylesheet" href="/vendor/xterm/css/xterm.min.css">
 <script src="/vendor/xterm/lib/xterm.min.js" defer></script>
 <script src="/vendor/xterm/lib/xterm-addon-fit.min.js" defer></script>

--- a/frontend/src/js/sections/note-preview.js
+++ b/frontend/src/js/sections/note-preview.js
@@ -17,8 +17,25 @@ import { _syncSaveButton, _captureActiveBuffer, _syncModeControls, _setNoteModeA
 import { noteSearchClose } from './in-note-search.js';
 import { reconcileState, _noteShowExternalBanner } from './note-reconcile.js';
 
+/* Lazy-load the vendored mermaid bundle on first render. The UMD script
+   weighs ~3 MB; loading it eagerly from dashboard.html made every cold
+   start pay for a feature only used by notes that embed diagrams. The
+   promise is memoized so subsequent notes reuse the same <script>. */
+var _mermaidLoader = null;
+function _loadMermaid() {
+    if (window.mermaid) return Promise.resolve(window.mermaid);
+    if (_mermaidLoader) return _mermaidLoader;
+    _mermaidLoader = new Promise(function(resolve, reject) {
+        var s = document.createElement('script');
+        s.src = '/vendor/mermaid/mermaid.min.js';
+        s.onload = function() { resolve(window.mermaid); };
+        s.onerror = function() { _mermaidLoader = null; reject(new Error('mermaid failed to load')); };
+        document.head.appendChild(s);
+    });
+    return _mermaidLoader;
+}
+
 function _renderMermaidIn(container) {
-    if (!window.mermaid) return;
     var blocks = container.querySelectorAll('pre.mermaid, pre > code.language-mermaid');
     if (!blocks.length) return;
     var nodes = [];
@@ -33,14 +50,16 @@ function _renderMermaidIn(container) {
         nodes.push(div);
     });
     var isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-    try {
-        window.mermaid.initialize({
-            startOnLoad: false,
-            theme: isDark ? 'dark' : 'default',
-            securityLevel: 'strict',
-        });
-        window.mermaid.run({ nodes: nodes }).catch(function() {});
-    } catch (e) {}
+    _loadMermaid().then(function(mermaid) {
+        try {
+            mermaid.initialize({
+                startOnLoad: false,
+                theme: isDark ? 'dark' : 'default',
+                securityLevel: 'strict',
+            });
+            mermaid.run({ nodes: nodes }).catch(function() {});
+        } catch (e) {}
+    }).catch(function() {});
 }
 
 /* Mount the vendored PDF.js viewer on every .note-pdf-host inside the

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.3.1"
+version = "1.4.0"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,8 @@ regex = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 shlex = "1"
 md-5 = "0.10"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }
 
 condash-parser = { path = "../crates/condash-parser" }
 condash-state = { path = "../crates/condash-state" }

--- a/src-tauri/src/bin/condash_serve.rs
+++ b/src-tauri/src/bin/condash_serve.rs
@@ -33,6 +33,7 @@ fn main() -> Result<()> {
 }
 
 async fn async_main() -> Result<()> {
+    condash_lib::init_tracing();
     // Headless binary: env var → ~/.config/condash/settings.yaml →
     // hard error. No folder picker, no hard-coded default.
     let conception_path = resolve_conception_path().map_err(|e| anyhow::anyhow!("{e}"))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,6 +31,28 @@ pub use config::build_ctx as build_ctx_for_bin;
 /// Playwright fixtures that want a stable path.
 pub const CONCEPTION_ENV: &str = "CONDASH_CONCEPTION_PATH";
 
+/// Environment variable controlling tracing output. Accepts the usual
+/// [`tracing-subscriber`] `EnvFilter` grammar, e.g.
+/// `CONDASH_LOG=condash=debug` or `CONDASH_LOG=condash_state=trace`.
+/// When unset, no subscriber is installed and `#[instrument]` spans are
+/// zero-cost.
+pub const LOG_ENV: &str = "CONDASH_LOG";
+
+/// Install the tracing subscriber iff `CONDASH_LOG` is set. Idempotent
+/// via `try_init` — a second call (e.g. in tests) is a silent no-op.
+pub fn init_tracing() {
+    use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+    let Ok(filter) = std::env::var(LOG_ENV) else {
+        return;
+    };
+    let env_filter = EnvFilter::try_new(&filter).unwrap_or_else(|_| EnvFilter::new("condash=info"));
+    let _ = tracing_subscriber::registry()
+        .with(env_filter)
+        .with(fmt::layer().with_target(true).with_writer(std::io::stderr))
+        .try_init();
+}
+
 /// Load the dashboard HTML template from the configured asset source.
 /// Fails loudly when it's missing — the dashboard is unusable without
 /// it, and the embedded variant ships it unconditionally, so a failure
@@ -50,7 +72,9 @@ pub fn load_template_for_bin(source: &assets::AssetSource) -> anyhow::Result<Str
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
+#[tracing::instrument]
 pub fn run() {
+    init_tracing();
     tauri::Builder::default()
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_dialog::init())

--- a/src-tauri/src/server/notes.rs
+++ b/src-tauri/src/server/notes.rs
@@ -78,7 +78,7 @@ pub(super) async fn post_note(
     }
     match write_note(&full, &p.content, p.expected_mtime) {
         Ok(WriteNoteResult::Ok { mtime, .. }) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({"ok": true, "mtime": mtime}))
         }
         Ok(WriteNoteResult::Err { reason, mtime, .. }) => {
@@ -113,7 +113,7 @@ pub(super) async fn post_note_rename(
     }
     match rename_note(&full, &p.new_stem, &state.ctx.base_dir) {
         Ok(RenameResult::Ok { path, mtime, .. }) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({"ok": true, "path": path, "mtime": mtime}))
         }
         Ok(RenameResult::Err { reason, .. }) => error_json(StatusCode::BAD_REQUEST, &reason),
@@ -151,7 +151,7 @@ pub(super) async fn post_note_create(
         subdir_was_supplied,
     ) {
         Ok(CreateNoteResult::Ok { path, mtime, .. }) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&readme);
             json_response(&serde_json::json!({"ok": true, "path": path, "mtime": mtime}))
         }
         Ok(CreateNoteResult::Err { reason, .. }) => error_json(StatusCode::BAD_REQUEST, &reason),
@@ -196,7 +196,7 @@ pub(super) async fn post_note_mkdir(
             subdir_key,
             ..
         }) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&readme);
             json_response(&serde_json::json!({
                 "ok": true,
                 "rel_dir": rel_dir,
@@ -297,7 +297,7 @@ pub(super) async fn post_note_upload(
                     .unwrap_or_else(|| "upload failed".into());
                 return error_json(StatusCode::BAD_REQUEST, &reason);
             }
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&readme);
             json_response(&serde_json::json!({
                 "ok": true,
                 "stored": res.stored,

--- a/src-tauri/src/server/shell.rs
+++ b/src-tauri/src/server/shell.rs
@@ -89,6 +89,7 @@ pub(super) struct FragmentQuery {
     id: String,
 }
 
+#[tracing::instrument(skip_all, fields(id = %q.id))]
 pub(super) async fn fragment(
     State(state): State<AppState>,
     headers: HeaderMap,

--- a/src-tauri/src/server/steps.rs
+++ b/src-tauri/src/server/steps.rs
@@ -32,7 +32,7 @@ pub(super) async fn toggle(
     }
     match toggle_checkbox(&full, p.line as usize) {
         Ok(Some(status)) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({
                 "ok": true,
                 "status": status,
@@ -66,7 +66,7 @@ pub(super) async fn add_step_route(
     let section = p.section.as_deref();
     match add_step(&full, text, section) {
         Ok(line) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({"ok": true, "line": line}))
         }
         Err(e) => error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("add-step: {e}")),
@@ -91,7 +91,7 @@ pub(super) async fn remove_step_route(
     }
     match remove_step(&full, p.line as usize) {
         Ok(true) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({"ok": true}))
         }
         Ok(false) => error_json(StatusCode::BAD_REQUEST, "cannot remove"),
@@ -123,7 +123,7 @@ pub(super) async fn edit_step_route(
     }
     match edit_step(&full, p.line as usize, text) {
         Ok(true) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({"ok": true}))
         }
         Ok(false) => error_json(StatusCode::BAD_REQUEST, "cannot edit"),
@@ -146,7 +146,7 @@ pub(super) async fn set_priority_route(
     };
     match set_priority(&full, &p.priority) {
         Ok(true) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({
                 "ok": true,
                 "priority": p.priority,
@@ -179,7 +179,7 @@ pub(super) async fn reorder_all_route(
     let order: Vec<usize> = p.order.iter().map(|&n| n as usize).collect();
     match reorder_all(&full, &order) {
         Ok(true) => {
-            state.cache.invalidate_items();
+            state.cache.invalidate_item_at(&full);
             json_response(&serde_json::json!({"ok": true}))
         }
         Ok(false) => error_json(StatusCode::BAD_REQUEST, "cannot reorder"),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

Ship the last three items deferred from the 2026-04-24 simplify-perf audit (C-11 + C-12 + C-16), in one reviewable PR off `main` at v1.3.1.

## Changes

- **C-11 — `tracing` adoption.** Adds `tracing` to `condash-state` and `tracing` + `tracing-subscriber` to `src-tauri`. `#[instrument]` on `WorkspaceCache::get_items`, `collect_git_repos`, the `/fragment` handler, and the `run()` entry point. New `condash_lib::init_tracing()` installs a subscriber (env-filter + fmt-to-stderr) iff `CONDASH_LOG` is set — subscriber-off is the default so instrumented spans stay zero-cost. Opt in with `CONDASH_LOG=condash=debug` (or any other `EnvFilter` directive).
- **C-12 — per-item items cache.** `WorkspaceCache` now keys parsed items by their absolute README path (`HashMap<PathBuf, Item>`) with a memoized sorted `Arc<Vec<Item>>` snapshot. New `invalidate_item_at(path)` walks up to the item's README and drops one map entry, preserving everything else; the snapshot is cleared so the next `get_items` rebuilds it while reusing cached entries. Callers in `server/steps.rs` and `server/notes.rs` switched to the surgical path; rescan / watcher / config-change paths stay coarse. Three new tests cover the per-item path.
- **C-16 — lazy-load mermaid.** Removed the eager `<script src=\"/vendor/mermaid/mermaid.min.js\">` from `dashboard.html`. `note-preview.js:_renderMermaidIn` now injects the script on first encounter and memoises the promise. Saves ~3 MB of cold-start download for users who never open a note with a diagram.
- **Bump condash to v1.4.0** (minor — adds observability + a behind-the-scenes perf improvement + a lazy vendor load; no breaking UX).

## Impact

- Existing behaviour preserved across all three changes. `CONDASH_LOG` defaults to unset → no log output, no subscriber overhead.
- First-keystroke step-toggle path on a busy workspace now re-parses a single README instead of every item under `projects/`.
- Cold dashboard load pays ~3 MB less bandwidth; mermaid bytes show up only on the first note that needs them.

## Watchpoints

- Smoke-test checklist (manual): launch condash → open a project → toggle a step → open a note → save → render a note with a mermaid block (should show diagram; check devtools network for /vendor/mermaid/... fired once) → open a PDF → open the terminal → hit the manual rescan.
- Per-item invalidation correctness: cache tests (`cargo test -p condash-state cache::`) cover the single-entry-drop, note-path-accepted, and out-of-tree-fallback cases.

Closes project `2026-04-24-condash-tracing-cache-vendor-trim` on merge; tag v1.4.0 afterwards.