### PR TITLE
Final audit sweep: R-12/R-13 decided, F-06/F-13/F-14 trimmed (v1.4.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -25,14 +25,6 @@
 <script src="/vendor/xterm/lib/xterm.min.js" defer></script>
 <script src="/vendor/xterm/lib/xterm-addon-fit.min.js" defer></script>
 <script src="/vendor/codemirror/codemirror.min.js" defer></script>
-<!--
-  Frontend-split bundle (F1 scaffolding, 2026-04 condash-frontend-split project).
-  Built from src/condash/assets/src/{js,css}/ by `make frontend` (esbuild).
-  Empty in F1 — as each region of the inline <style> and <script> blocks
-  below is extracted (F2 for CSS, F3/F4 for JS), its content moves into
-  the bundle and the inline copy shrinks. Keep loaded in this order so
-  that during the split inline rules still win on specificity ties.
--->
 <link rel="stylesheet" href="/assets/dist/bundle.css">
 <script src="/assets/dist/bundle.js" defer></script>
 </head>
@@ -44,10 +36,10 @@
 <div id="dash-main" class="app">
 <div class="topbar">
     <div class="tabs tabs-primary">
-        <div class="tab active" data-tab="projects" data-action="switch-tab" data-tab="projects">Projects<span class="tab-count">({{COUNT_PROJECTS}})</span></div>
-        <div class="tab" data-tab="code" data-action="switch-tab" data-tab="code">Code<span class="tab-count">({{COUNT_REPOS}})</span></div>
-        <div class="tab" data-tab="knowledge" data-action="switch-tab" data-tab="knowledge">Knowledge<span class="tab-count">({{COUNT_KNOWLEDGE}})</span></div>
-        <div class="tab" data-tab="history" data-action="switch-tab" data-tab="history">History<span class="tab-count">({{COUNT_HISTORY}})</span></div>
+        <div class="tab active" data-action="switch-tab" data-tab="projects">Projects<span class="tab-count">({{COUNT_PROJECTS}})</span></div>
+        <div class="tab" data-action="switch-tab" data-tab="code">Code<span class="tab-count">({{COUNT_REPOS}})</span></div>
+        <div class="tab" data-action="switch-tab" data-tab="knowledge">Knowledge<span class="tab-count">({{COUNT_KNOWLEDGE}})</span></div>
+        <div class="tab" data-action="switch-tab" data-tab="history">History<span class="tab-count">({{COUNT_HISTORY}})</span></div>
     </div>
     <div class="header-actions">
         <span id="reconnecting-pill" class="reconnecting-pill" hidden title="Lost connection to the dashboard backend — retrying…">Reconnecting…</span>
@@ -94,10 +86,10 @@
     <button type="button" data-action="open-config-modal">Configure</button>
 </div>
 <div id="projects-subtabs" class="tabs tabs-secondary">
-    <div class="tab active" data-subtab="current" data-action="switch-subtab" data-subtab="current">Current<span class="tab-count">({{COUNT_CURRENT}})</span></div>
-    <div class="tab" data-subtab="next" data-action="switch-subtab" data-subtab="next">Next<span class="tab-count">({{COUNT_NEXT}})</span></div>
-    <div class="tab" data-subtab="backlog" data-action="switch-subtab" data-subtab="backlog">Backlog<span class="tab-count">({{COUNT_BACKLOG}})</span></div>
-    <div class="tab" data-subtab="done" data-action="switch-subtab" data-subtab="done">Done<span class="tab-count">({{COUNT_DONE}})</span></div>
+    <div class="tab active" data-action="switch-subtab" data-subtab="current">Current<span class="tab-count">({{COUNT_CURRENT}})</span></div>
+    <div class="tab" data-action="switch-subtab" data-subtab="next">Next<span class="tab-count">({{COUNT_NEXT}})</span></div>
+    <div class="tab" data-action="switch-subtab" data-subtab="backlog">Backlog<span class="tab-count">({{COUNT_BACKLOG}})</span></div>
+    <div class="tab" data-action="switch-subtab" data-subtab="done">Done<span class="tab-count">({{COUNT_DONE}})</span></div>
 </div>
 <main id="main-scroll">
     <div id="projects-pane" data-node-id="projects">
@@ -149,9 +141,9 @@
             <button class="note-modal-back" id="note-modal-back" data-action="note-nav-back" aria-label="Back" title="Back to previous note" hidden>&#9664;</button>
             <span class="note-modal-title" id="note-modal-title" ondblclick="startRenameNote()" title="Double-click to rename (notes/ files only)">Note</span>
             <div class="note-mode-toggle" id="note-mode-toggle" role="group" aria-label="Note mode">
-                <button class="note-mode-btn" data-mode="view" data-action="set-note-mode" data-mode="view" title="View (rendered)">View</button>
-                <button class="note-mode-btn" data-mode="cm" data-action="set-note-mode" data-mode="cm" title="Edit with syntax highlighting (Ctrl+E)">Edit</button>
-                <button class="note-mode-btn" data-mode="plain" data-action="set-note-mode" data-mode="plain" title="Plain textarea edit">Plain</button>
+                <button class="note-mode-btn" data-action="set-note-mode" data-mode="view" title="View (rendered)">View</button>
+                <button class="note-mode-btn" data-action="set-note-mode" data-mode="cm" title="Edit with syntax highlighting (Ctrl+E)">Edit</button>
+                <button class="note-mode-btn" data-action="set-note-mode" data-mode="plain" title="Plain textarea edit">Plain</button>
             </div>
             <div class="note-modal-actions">
                 <button id="note-save-btn" class="note-action-btn note-action-primary" data-action="save-edit" style="display:none">Save</button>

--- a/frontend/src/js/pdf-viewer.js
+++ b/frontend/src/js/pdf-viewer.js
@@ -100,8 +100,10 @@
         try {
             pdf = await pdfjsLib.getDocument(Object.assign({ url: src }, COMMON)).promise;
         } catch (e) {
-            pagesEl.innerHTML = '<div class="pdf-error">Failed to load PDF: '
-                + (e && e.message ? e.message : String(e)) + '</div>';
+            const err = document.createElement('div');
+            err.className = 'pdf-error';
+            err.textContent = 'Failed to load PDF: ' + (e && e.message ? e.message : String(e));
+            pagesEl.replaceChildren(err);
             return;
         }
 

--- a/frontend/src/js/sections/config-modal.js
+++ b/frontend/src/js/sections/config-modal.js
@@ -96,19 +96,6 @@ function switchConfigTab(name) {
     }
 }
 
-function _setYamlSourceHint(elId, source, expected, label) {
-    var el = document.getElementById(elId);
-    if (!el) return;
-    if (source) {
-        el.innerHTML = 'These fields are stored in <code>' + source + '</code>.';
-    } else if (expected) {
-        el.innerHTML = 'These fields migrate to <code>' + expected + '</code> on the next Save.';
-    } else {
-        el.innerHTML = 'Set a <code>conception_path</code> on the General tab to move these fields into <code>' + label + '</code>.';
-    }
-    el.style.display = '';
-}
-
 export async function openConfigModal() {
     var modal = document.getElementById('config-modal');
     var ta = document.getElementById('config-yaml');

--- a/frontend/src/js/sections/stale-poll.js
+++ b/frontend/src/js/sections/stale-poll.js
@@ -12,12 +12,12 @@
    Extracted from dashboard-main.js on 2026-04-24 (P-09 cut 3 of
    conception/projects/2026-04-23-condash-frontend-extraction).
 
-   The seven module-level stale bindings (_nodeBaseline, _dirtyNodes,
-   _lastFingerprint, _lastGitFingerprint, _itemsStale, _gitStale,
-   _knowledgeStale) are exposed as a single `staleState` object — same
-   trick as termState + reloadState — so callers in dashboard-main.js
-   can write `staleState.dirtyNodes = new Set()` without the ESM
-   live-binding limit on reassigning `var`/`let` exports.
+   The five module-level stale bindings (_nodeBaseline, _dirtyNodes,
+   _itemsStale, _gitStale, _knowledgeStale) are exposed as a single
+   `staleState` object — same trick as termState + reloadState — so
+   callers in dashboard-main.js can write `staleState.dirtyNodes = new
+   Set()` without the ESM live-binding limit on reassigning
+   `var`/`let` exports.
 
    reloadNode + refreshAll live here too: both are primarily about
    reconciling the baseline + dirty set after a DOM swap, and both are
@@ -34,8 +34,6 @@ import { restoreNotesTreeState } from './notes-tree-state.js';
 const staleState = {
     nodeBaseline: null,     // Object id → hash (null until first poll)
     dirtyNodes: new Set(),  // ids whose current hash != baseline, or present on only one side
-    lastFingerprint: null,  // kept for back-compat with pickPriority/switchTab
-    lastGitFingerprint: null,
     itemsStale: false,
     gitStale: false,
     knowledgeStale: false,
@@ -52,17 +50,6 @@ function _deriveLegacyFlags() {
     staleState.itemsStale = items;
     staleState.gitStale = git;
     staleState.knowledgeStale = knowledge;
-}
-
-function _ancestorsOf(id) {
-    // "projects/now/slug" → ["projects/now", "projects"]. Splits on '/';
-    // subtree IDs like wt:foo or sub:bar are single segments so this is safe.
-    var parts = id.split('/');
-    var out = [];
-    for (var i = parts.length - 1; i > 0; i--) {
-        out.push(parts.slice(0, i).join('/'));
-    }
-    return out;
 }
 
 function _renderStale() {
@@ -142,8 +129,6 @@ async function checkUpdates() {
         var current = data.nodes || {};
         if (staleState.nodeBaseline === null) {
             staleState.nodeBaseline = current;
-            staleState.lastFingerprint = data.fingerprint;
-            staleState.lastGitFingerprint = data.git_fingerprint;
         } else {
             // Once a node is marked dirty, it stays dirty until a local or
             // global reload updates the baseline — so the user can see there
@@ -231,8 +216,6 @@ async function updateBaseline() {
         var data = await res.json();
         staleState.nodeBaseline = data.nodes || {};
         staleState.dirtyNodes = new Set();
-        staleState.lastFingerprint = data.fingerprint;
-        staleState.lastGitFingerprint = data.git_fingerprint;
         _renderStale();
     } catch (e) {}
 }
@@ -249,8 +232,6 @@ function refreshAll() {
     _clearShadowCache();
     reloadState.pendingNodes.clear();
     reloadState.pendingInPlace = false;
-    staleState.lastFingerprint = null;
-    staleState.lastGitFingerprint = null;
     // Force-invalidate the server-side items/knowledge caches before
     // reloading so the next GET / re-walks the tree from disk. Best
     // effort: reload unconditionally even if the POST errors, since
@@ -351,7 +332,7 @@ async function _refreshBaselineFor(nodeId) {
 
 export {
     staleState,
-    _deriveLegacyFlags, _ancestorsOf, _renderStale, _diffNodes,
+    _deriveLegacyFlags, _renderStale, _diffNodes,
     _scheduleCheckUpdates, checkUpdates,
     _activeTabPrefix, _idInTab, _tabForNodeId,
     _autoReloadActiveTab, _minimalRoots,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.4.0"
+version = "1.4.1"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"


### PR DESCRIPTION
## Summary

Last five items from the 2026-04-24 simplify-perf audit's "Deferred / measure-first" band. Two measure-first calls resolved as "leave alone" with written rationale; three audit items landed as small, focused cuts. No behaviour change.

## Changes

- **R-12 — `fingerprint.rs` simplification: declined.** Current `PyValue::repr_into(&mut String)` already uses a pre-allocated sink; a streaming `Hasher` rewrite saves one allocation per `compute_fingerprint` call, which is dominated at ~200 items by the parser walk that produced the input. Breaking the Python-`repr` byte-compat would also cache-bust every live client. Documented in `projects/2026-04/2026-04-24-condash-audit-final/notes/01-measure-first-decisions.md`. **No code change.**
- **R-13 — `PtyRegistry` / `RunnerRegistry` `DashMap` swap: declined.** Every public method holds the `Mutex<HashMap<...>>` for a single HashMap op (`get`/`insert`/`remove`/`len`), then drops it — all real work happens on the returned `Arc<Session>` outside the lock. No contention surface to swap. Documented in the same note. **No code change.**
- **F-06 — `innerHTML =` audit (34 sites).** Catalogued in `notes/02-innerhtml-audit.md`. No real XSS surface; most sites are clear-to-empty, static HTML, trusted server-rendered fragments, or already `_escapeHtml`'d. Two concrete findings landed:
  - Removed dead `_setYamlSourceHint` in `sections/config-modal.js` (orphan from the pre-unified-config era; three `innerHTML = '...' + source + '...'` branches that were never called).
  - Switched `pdf-viewer.js:103` PDF-load error message from `innerHTML` with unescaped `e.message` to `createElement` + `textContent`.
- **F-13 — `stale-poll.js` dead-code prune.** The audit's claim of 50–100 LOC "overlap with note-reconcile.js" was off — the two modules handle separate concerns (tab-level fingerprint staleness vs. note-modal mtime reconciliation). What did exist: `_ancestorsOf` was defined + exported but never called anywhere, and `staleState.lastFingerprint` / `lastGitFingerprint` were assigned in three places and read in zero. Dropped both. **358 → 341 LOC.**
- **F-14 — `dashboard.html` trim.** Removed 10 duplicate `data-tab` / `data-subtab` / `data-mode` attributes left over from the C-05 migration (HTML parser silently kept only the first copy, so browser behaviour is unchanged; the source was just misleading) and the stale "F1 scaffolding" comment block. **314 → 306 LOC.** The audit's "drops to 200 LOC" target was speculative; C-05 had already migrated most of the onclick surface, and the remaining inline handlers (`oninput`/`ondblclick`/`onmousedown`/`onsubmit`) are intentionally kept as `window.*` globals per the dispatcher's documented boundary.
- **Bump condash to v1.4.1** (patch — two measured decisions + three small cuts; zero behaviour change).

## Impact

Pure hygiene. No runtime differences expected. Closes the simplify-perf audit's open queue — the remaining R-14 (inline SVG → files) and F-16 (circular import) are out of scope by design (cosmetic / very-low priority).

## Watchpoints

- Smoke: launch condash → tabs switch, sub-tabs switch, note modal opens (view / Edit / Plain), new-item modal opens, search inputs still filter, terminal drag + split still work. Every one of these relies on an attribute that was touched by F-14 or a helper touched by F-13.
- `cargo test --workspace` passes locally.

Closes project `2026-04-24-condash-audit-final` on merge; tag v1.4.1 afterwards.