### PR TITLE
Architecture hardening sweep — newtypes, hot config, single dispatch path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,13 @@ jobs:
   check:
     name: check
     runs-on: ubuntu-latest
+    # Swatinem/rust-cache@v2 auto-detects sccache and exports RUSTC_WRAPPER
+    # when it finds it on PATH. The hosted runner's sccache install is
+    # unreliable across image revisions — keep the wrapper unset so cargo
+    # invokes rustc directly. The cache action's actual cache hits work
+    # without it; we lose only the rustc-cache speedup.
+    env:
+      RUSTC_WRAPPER: ""
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: ci
+
+# Fast PR validation — workspace-wide cargo check + the no-inline-handler
+# guard. Heavier targets (full release bundle, AppImage, etc.) live in
+# release.yml and docs.yml.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install Linux build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libssl-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
+      - name: Inline-handler guard
+        run: bash tools/check-inline-handlers.sh
+
+      - name: cargo check
+        run: cargo check --workspace --all-targets
+
+      - name: cargo test
+        run: cargo test --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,6 +428,7 @@ name = "condash"
 version = "1.4.3"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "axum",
  "chrono",
  "condash-mutations",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ name = "condash-mutations"
 version = "0.1.0"
 dependencies = [
  "condash-parser",
+ "condash-state",
  "regex",
  "serde",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "condash"
-version = "1.4.3"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Makefile
+++ b/Makefile
@@ -85,8 +85,11 @@ serve: frontend ## Run the Rust HTTP server headless (no GUI deps needed). Overr
 build: ## Bundle Tauri release artefacts (requires Linux system deps)
 	cd src-tauri && PATH="$(RUSTUP_BIN):$$PATH" $(CARGO) tauri build
 
-check: ## cargo check across the workspace (fast, no codegen)
+check: check-inline-handlers ## cargo check across the workspace (fast, no codegen)
 	PATH="$(RUSTUP_BIN):$$PATH" $(CARGO) check --workspace
+
+check-inline-handlers: ## Guard against inline named on*= handlers (data-* + addEventListener instead)
+	@bash tools/check-inline-handlers.sh
 
 test: ## Run cargo tests across the workspace
 	PATH="$(RUSTUP_BIN):$$PATH" $(CARGO) test --workspace

--- a/crates/condash-mutations/Cargo.toml
+++ b/crates/condash-mutations/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.80"
 
 [dependencies]
 condash-parser = { path = "../condash-parser" }
+condash-state = { path = "../condash-state" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/condash-mutations/src/files.rs
+++ b/crates/condash-mutations/src/files.rs
@@ -104,7 +104,10 @@ pub fn write_note(
     // `full_path.with_suffix(suffix + ".tmp")` — append, don't replace.
     let tmp = append_suffix(full_path, ".tmp");
     fs::write(&tmp, content)?;
-    fs::rename(&tmp, full_path)?;
+    if let Err(e) = fs::rename(&tmp, full_path) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
 
     Ok(WriteNoteResult::Ok {
         ok: true,

--- a/crates/condash-render/templates/_macros.html.j2
+++ b/crates/condash-render/templates/_macros.html.j2
@@ -3,7 +3,7 @@
 {% macro step(step, file_path) %}
 {% set dot = "✓" if step.status == "done" else ("~" if step.status == "progress" else ("—" if step.status == "abandoned" else "")) %}
 <div class="step {{ step.status }}" data-file="{{ file_path }}" data-line="{{ step.line }}">
-  <span class="drag-handle" onpointerdown="stepPointerDown(event)">⠿</span>
+  <span class="drag-handle" data-step-handle>⠿</span>
   <span class="status-dot status-{{ step.status }}"
     onmousedown="event.stopPropagation();event.preventDefault()"
     data-action="cycle-step" data-file-path="{{ file_path }}">{{ dot }}</span>
@@ -29,7 +29,8 @@
     {% for it in items %}{{ step(it, file_path) }}{% endfor %}
     <div class="add-row">
       <input type="text" placeholder="Add task…"
-        onkeydown="if(event.key==='Enter')addStep({{ file_path | embed }},{{ heading | embed }},this)">
+        data-add-step-input
+        data-file-path="{{ file_path }}" data-heading="{{ heading }}">
       <button data-action="add-step"
         data-file-path="{{ file_path }}" data-heading="{{ heading }}">+</button>
     </div>

--- a/crates/condash-state/src/cache.rs
+++ b/crates/condash-state/src/cache.rs
@@ -27,6 +27,66 @@ use condash_parser::{collect_knowledge, parse_readme, Item, KnowledgeNode};
 
 use crate::RenderCtx;
 
+/// Cache-invalidation token returned by every mutation helper.
+///
+/// `#[must_use]` flips a forgotten consumption from a silent stale-cache
+/// regression into a compiler warning. Construct via the factory
+/// methods; consume via [`WorkspaceCache::consume`].
+#[must_use = "consume via WorkspaceCache::consume() to invalidate the cache"]
+#[derive(Debug, Default)]
+pub struct MutationOutput {
+    pub item_paths: Vec<PathBuf>,
+    pub knowledge: bool,
+    pub flush_items: bool,
+}
+
+impl MutationOutput {
+    /// Token for a mutation that touched a single item. Pass the
+    /// absolute path to any file under the item (README, note, etc.).
+    pub fn for_path(path: impl Into<PathBuf>) -> Self {
+        Self {
+            item_paths: vec![path.into()],
+            knowledge: false,
+            flush_items: false,
+        }
+    }
+
+    /// Token for a mutation that touched multiple items.
+    pub fn for_paths(paths: Vec<PathBuf>) -> Self {
+        Self {
+            item_paths: paths,
+            knowledge: false,
+            flush_items: false,
+        }
+    }
+
+    /// Token for a mutation that touched a knowledge file.
+    pub fn knowledge() -> Self {
+        Self {
+            item_paths: Vec::new(),
+            knowledge: true,
+            flush_items: false,
+        }
+    }
+
+    /// Token for a mutation whose effect can't be narrowed — flush both
+    /// items and knowledge slices.
+    pub fn full_flush() -> Self {
+        Self {
+            item_paths: Vec::new(),
+            knowledge: true,
+            flush_items: true,
+        }
+    }
+
+    /// Flag the items slice for a coarse flush in addition to whatever
+    /// else this token requests.
+    pub fn with_items_flush(mut self) -> Self {
+        self.flush_items = true;
+        self
+    }
+}
+
 /// Coarse tab identifier the filesystem watcher publishes. Only
 /// `Projects` and `Knowledge` matter for the cache — other tabs (code,
 /// config, etc.) are watched but don't invalidate parsed-item state.
@@ -118,11 +178,30 @@ impl WorkspaceCache {
 
     /// Flush every cached item — next `get_items` re-parses every
     /// README. Used by full-rescan endpoints and by the watcher when
-    /// the event carries no specific path.
-    pub fn invalidate_items(&self) {
+    /// the event carries no specific path. External callers should go
+    /// through [`WorkspaceCache::consume`] with a [`MutationOutput`].
+    pub(crate) fn invalidate_items(&self) {
         let mut w = self.inner.write().unwrap();
         w.items = None;
         w.items_snapshot = None;
+    }
+
+    /// Consume a [`MutationOutput`] token. This is the canonical sink
+    /// for the `#[must_use]` token; route handlers call it after a
+    /// successful mutation. Honors all three flags on the token —
+    /// per-path item invalidation, knowledge flush, and a coarse items
+    /// flush — independently.
+    pub fn consume(&self, output: MutationOutput) {
+        if output.flush_items {
+            self.invalidate_items();
+        } else {
+            for path in &output.item_paths {
+                self.invalidate_item_at(path);
+            }
+        }
+        if output.knowledge {
+            self.invalidate_knowledge();
+        }
     }
 
     /// Drop the single item whose folder contains `path` and clear the
@@ -130,7 +209,9 @@ impl WorkspaceCache {
     /// the README itself (`.../README.md`), a note
     /// (`.../notes/x.md`), etc. Falls back to a full invalidation when
     /// no item-dir is found above `path`, which is the safe default.
-    pub fn invalidate_item_at(&self, path: &Path) {
+    /// External callers should go through [`WorkspaceCache::consume`]
+    /// with a [`MutationOutput::for_path`] token.
+    pub(crate) fn invalidate_item_at(&self, path: &Path) {
         let Some(readme) = readme_for(path) else {
             self.invalidate_items();
             return;
@@ -142,8 +223,9 @@ impl WorkspaceCache {
         w.items_snapshot = None;
     }
 
-    /// Flush the knowledge tree slice.
-    pub fn invalidate_knowledge(&self) {
+    /// Flush the knowledge tree slice. External callers should go
+    /// through [`WorkspaceCache::consume`] with [`MutationOutput::knowledge`].
+    pub(crate) fn invalidate_knowledge(&self) {
         self.inner.write().unwrap().knowledge = None;
     }
 

--- a/crates/condash-state/src/lib.rs
+++ b/crates/condash-state/src/lib.rs
@@ -16,7 +16,7 @@ pub mod ctx;
 pub mod git;
 pub mod search;
 
-pub use cache::{Tab, WorkspaceCache};
+pub use cache::{MutationOutput, Tab, WorkspaceCache};
 pub use ctx::{OpenWithSlot, RenderCtx, RepoEntry, RepoSection, TerminalPrefs};
 pub use git::{collect_git_repos, Checkout, Family, Group, Member};
 pub use search::{search_items, Hit, SearchResult};

--- a/frontend/dashboard.html
+++ b/frontend/dashboard.html
@@ -136,7 +136,7 @@
     </div>
     <div id="knowledge-pane" style="display:none" data-node-id="knowledge">
         <div class="search-toolbar knowledge-toolbar">
-            <input id="knowledge-search" type="search" placeholder="Search knowledge — title, description, or path…" oninput="filterKnowledge(this.value)" autocomplete="off" data-preserve="condash.search.knowledge">
+            <input id="knowledge-search" type="search" placeholder="Search knowledge — title, description, or path…" data-knowledge-search autocomplete="off" data-preserve="condash.search.knowledge">
         </div>
         <!-- Knowledge tree. Refreshes on `sse:knowledge`. The
              folder-open state lives in localStorage (notes-tree-state.js)
@@ -170,7 +170,7 @@
 </main>
 </div>
 <div id="term-pane" class="term-pane" hidden>
-    <div class="term-handle" onmousedown="termDragStart(event)" title="Drag to resize"></div>
+    <div class="term-handle" data-terminal-drag title="Drag to resize"></div>
     <div class="term-top-row">
         <div class="term-tabs term-tabs-left" id="term-tabs-left"></div>
         <button class="term-new-tab" data-action="term-new-tab" data-side="left" title="New tab (left)" aria-label="New tab (left)">+</button>
@@ -185,7 +185,7 @@
         <div class="term-side" data-side="left">
             <div class="term-mount" id="term-mount-left"></div>
         </div>
-        <div class="term-splitter" id="term-splitter" hidden onmousedown="termSplitStart(event)" title="Drag to resize split"></div>
+        <div class="term-splitter" id="term-splitter" hidden data-terminal-split title="Drag to resize split"></div>
         <div class="term-side" data-side="right" hidden>
             <div class="term-mount" id="term-mount-right"></div>
         </div>
@@ -195,7 +195,7 @@
     <div class="note-modal" id="note-modal-inner" data-mode="view">
         <div class="note-modal-header">
             <button class="note-modal-back" id="note-modal-back" data-action="note-nav-back" aria-label="Back" title="Back to previous note" hidden>&#9664;</button>
-            <span class="note-modal-title" id="note-modal-title" ondblclick="startRenameNote()" title="Double-click to rename (notes/ files only)">Note</span>
+            <span class="note-modal-title" id="note-modal-title" data-note-title title="Double-click to rename (notes/ files only)">Note</span>
             <div class="note-mode-toggle" id="note-mode-toggle" role="group" aria-label="Note mode">
                 <button class="note-mode-btn" data-action="set-note-mode" data-mode="view" title="View (rendered)">View</button>
                 <button class="note-mode-btn" data-action="set-note-mode" data-mode="cm" title="Edit with syntax highlighting (Ctrl+E)">Edit</button>
@@ -212,7 +212,7 @@
             <button type="button" class="note-action-btn note-action-primary" data-action="note-reconcile-reload">Reload from disk</button>
         </div>
         <div class="note-modal-search" id="note-search-bar" hidden>
-            <input type="search" id="note-search-input" placeholder="Find in note…" autocomplete="off" oninput="noteSearchRun()">
+            <input type="search" id="note-search-input" placeholder="Find in note…" autocomplete="off" data-note-search>
             <span class="note-search-count" id="note-search-count"></span>
             <button class="note-action-btn" data-action="note-search-step" data-delta="-1" title="Previous (Shift+Enter)" aria-label="Previous match">&uarr;</button>
             <button class="note-action-btn" data-action="note-search-step" data-delta="1" title="Next (Enter)" aria-label="Next match">&darr;</button>
@@ -222,7 +222,7 @@
             <div class="note-pane note-pane-view" id="note-pane-view"></div>
             <div class="note-pane note-pane-cm" id="note-pane-cm"></div>
             <div class="note-pane note-pane-plain" id="note-pane-plain">
-                <textarea class="note-edit-textarea" id="note-edit-textarea" spellcheck="false" oninput="_setDirty(true)"></textarea>
+                <textarea class="note-edit-textarea" id="note-edit-textarea" spellcheck="false" data-note-textarea></textarea>
                 <div class="note-edit-error" id="note-edit-error"></div>
             </div>
         </div>
@@ -262,7 +262,7 @@
             <button class="note-modal-close" data-action="close-config-modal" aria-label="Close">&times;</button>
         </div>
         <div class="note-modal-body">
-            <form id="config-form" onsubmit="saveConfig(event)">
+            <form id="config-form" data-form="config">
                 <p class="config-help">
                     Plain-text editor of <code id="config-file-path">&lt;conception&gt;/configuration.yml</code>.
                     Save validates the YAML; changes take effect the next time condash launches.
@@ -291,7 +291,7 @@
             <button class="note-modal-close" data-action="close-new-item-modal" aria-label="Close">&times;</button>
         </div>
         <div class="note-modal-body">
-            <form id="new-item-form" onsubmit="submitNewItem(event)">
+            <form id="new-item-form" data-form="new-item">
                 <fieldset class="config-fieldset">
                     <legend>Kind</legend>
                     <div class="new-item-segmented" data-field="kind">

--- a/frontend/src/js/cm6-init.js
+++ b/frontend/src/js/cm6-init.js
@@ -65,6 +65,8 @@
         markdown: CM.markdownLang,
         buildTheme: buildTheme,
     };
-    // Re-enable the Edit (CM6) toggle if the modal is already open.
-    if (typeof window._syncModeControls === 'function') window._syncModeControls();
+    // Re-enable the Edit (CM6) toggle if the modal is already open. The
+    // cm6 mount module subscribes to the `condash:cm6-ready` event so we
+    // don't need to reach into a window-global function.
+    document.dispatchEvent(new CustomEvent('condash:cm6-ready'));
 })();

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -506,21 +506,48 @@ initHtmxStatePreserve();
     } catch (e) {}
 })();
 
-// The post-data-action residual: a few inline handlers still reach the
-// global scope because they fire on non-click events (oninput, onkeydown,
-// ondblclick, onsubmit, onmousedown, onpointerdown). Every click-driven
-// attribute moved to `data-action` + `registerAction(…)` above. The CM6
-// init bridge (`cm6-init.js`) also reads `window._syncModeControls` when
-// the CodeMirror bundle finishes loading, since that file is a classic
-// (non-ESM) script.
-Object.assign(window, {
-    addStep,                                  // onkeydown in _macros.html.j2 (Add-step input)
-    startRenameNote,                          // ondblclick on the note-modal title
-    stepPointerDown,                          // onpointerdown on the step drag handle
-    termDragStart, termSplitStart,            // onmousedown on the terminal handles
-    filterKnowledge,                          // oninput on the knowledge search input
-    noteSearchRun, _setDirty,                 // oninput on the note search bar + textarea
-    saveConfig,                               // onsubmit on the config form
-    submitNewItem,                            // onsubmit on the new-item form
-    _syncModeControls,                        // cm6-init.js reaches for this on load
-});
+/* Bridge non-click inline-handler equivalents to delegated listeners.
+   Every former `on*=` attribute is now a `data-*` tag in dashboard.html
+   or _macros.html.j2; the CI guard in `tools/check-inline-handlers.sh`
+   keeps it that way. Listeners are document-level so htmx-morphed
+   markup is automatically covered without a re-bind step. */
+function initInlineHandlerBridges() {
+    document.addEventListener('input', function(ev) {
+        var t = ev.target;
+        if (!t || t.nodeType !== 1) return;
+        if (t.matches('[data-knowledge-search]')) filterKnowledge(t.value);
+        else if (t.matches('[data-note-search]')) noteSearchRun();
+        else if (t.matches('[data-note-textarea]')) _setDirty(true);
+    });
+    document.addEventListener('submit', function(ev) {
+        var t = ev.target;
+        if (!t || t.nodeType !== 1) return;
+        var form = t.matches && t.matches('[data-form]') ? t : null;
+        if (!form) return;
+        var name = form.getAttribute('data-form');
+        if (name === 'config') saveConfig(ev);
+        else if (name === 'new-item') submitNewItem(ev);
+    });
+    document.addEventListener('mousedown', function(ev) {
+        var t = ev.target.closest('[data-terminal-drag],[data-terminal-split]');
+        if (!t) return;
+        if (t.matches('[data-terminal-drag]')) termDragStart(ev);
+        else termSplitStart(ev);
+    });
+    document.addEventListener('pointerdown', function(ev) {
+        var t = ev.target.closest('[data-step-handle]');
+        if (t) stepPointerDown(ev);
+    });
+    document.addEventListener('dblclick', function(ev) {
+        if (ev.target.closest('[data-note-title]')) startRenameNote();
+    });
+    document.addEventListener('keydown', function(ev) {
+        if (ev.key !== 'Enter') return;
+        var t = ev.target;
+        if (!t || !t.matches || !t.matches('[data-add-step-input]')) return;
+        var file = t.getAttribute('data-file-path');
+        var heading = t.getAttribute('data-heading');
+        addStep(file, heading, t);
+    });
+}
+initInlineHandlerBridges();

--- a/frontend/src/js/sections/action-dispatch.js
+++ b/frontend/src/js/sections/action-dispatch.js
@@ -40,7 +40,10 @@ export function initActionDispatch() {
         if (!el) return;
         const name = el.dataset.action;
         const handler = _actions.get(name);
-        if (!handler) return;
+        if (!handler) {
+            console.warn('[condash] data-action with no handler: ' + name);
+            return;
+        }
         if (el.dataset.stop === '1') event.stopPropagation();
         if (el.dataset.prevent === '1') event.preventDefault();
         handler(event, el, el.dataset);

--- a/frontend/src/js/sections/note-mode.js
+++ b/frontend/src/js/sections/note-mode.js
@@ -287,6 +287,7 @@ function initNoteModeSideEffects() {
         e.returnValue = '';
         return '';
     });
+    document.addEventListener('condash:cm6-ready', _syncModeControls);
 }
 
 export {

--- a/frontend/src/js/sections/search-filter.js
+++ b/frontend/src/js/sections/search-filter.js
@@ -14,8 +14,6 @@
      `oninput=` attribute in server-rendered HTML).
    - `jumpToProject` / `_openHistoryHit` — history-tab navigation
      helpers wired up via `data-action` dispatch in `dashboard-main.js`.
-   - `_reapplySearches` — re-runs the Knowledge filter after an
-     in-place reload.
    - Private helpers (`_searchTokens`, `_cardMatches`, `_buildSnippet`, …)
      that are implementation details of the filter logic. */
 
@@ -237,18 +235,5 @@ export function jumpToProject(btn) {
     void card.offsetWidth;
     card.classList.add('focus-flash');
     setTimeout(function(){ card.classList.remove('focus-flash'); }, 1800);
-}
-
-/* Re-apply any active Knowledge search after the DOM is swapped or
-   the subtab changes. Safe to call when the search input isn't present
-   (other primary tab active). The History pane's equivalent is
-   handled by htmx's `hx-trigger="load"` on `#history-content` which
-   re-fires the fetch using the (data-preserve-restored) input value. */
-export function _reapplySearches() {
-    if (_knowledgeSearchQ) {
-        var k = document.getElementById('knowledge-search');
-        if (k) k.value = _knowledgeSearchQ;
-        filterKnowledge(_knowledgeSearchQ);
-    }
 }
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,6 +42,7 @@ shlex = "1"
 md-5 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt", "ansi"] }
+arc-swap = "1"
 
 condash-parser = { path = "../crates/condash-parser" }
 condash-state = { path = "../crates/condash-state" }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "condash"
-version = "1.4.3"
+version = "1.5.0"
 description = "A dashboard for the Markdown you already write."
 authors = ["Alice Voland <alice@vcoeur.com>"]
 license = "MIT"

--- a/src-tauri/src/bin/condash_serve.rs
+++ b/src-tauri/src/bin/condash_serve.rs
@@ -62,7 +62,7 @@ async fn async_main() -> Result<()> {
     condash_lib::events::spawn_cache_invalidator(event_bus.clone(), cache.clone());
 
     let state = condash_lib::server::AppState {
-        ctx,
+        ctx_swap: Arc::new(arc_swap::ArcSwap::from(ctx)),
         cache,
         assets: asset_source,
         version: Arc::new(env!("CARGO_PKG_VERSION").to_string()),

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -29,17 +29,15 @@ use tokio::sync::broadcast;
 pub const DEBOUNCE: Duration = Duration::from_millis(750);
 
 /// Payload emitted by the watcher. Wire format is
-/// `{"tab": <tab>, "ts": <seconds>, "file": <leaf>?}`.
+/// `{"tab": <tab>, "ts": <seconds>}`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct EventPayload {
     pub tab: String,
     pub ts: u64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub file: Option<String>,
 }
 
 impl EventPayload {
-    fn new(tab: impl Into<String>, file: Option<String>) -> Self {
+    fn new(tab: impl Into<String>) -> Self {
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
@@ -47,7 +45,6 @@ impl EventPayload {
         EventPayload {
             tab: tab.into(),
             ts,
-            file,
         }
     }
 }
@@ -273,13 +270,13 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
 
             if let Some(root) = &projects_path {
                 if src.starts_with(root) && !is_noise(&leaf) && projects_deb.should_fire() {
-                    bus_clone.publish(EventPayload::new("projects", None));
+                    bus_clone.publish(EventPayload::new("projects"));
                     continue;
                 }
             }
             if let Some(root) = &knowledge_path {
                 if src.starts_with(root) && !is_noise(&leaf) && knowledge_deb.should_fire() {
-                    bus_clone.publish(EventPayload::new("knowledge", None));
+                    bus_clone.publish(EventPayload::new("knowledge"));
                     continue;
                 }
             }
@@ -288,7 +285,7 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
                     && matches!(leaf.as_str(), "HEAD" | "index" | "packed-refs")
                     && code_deb.should_fire()
                 {
-                    bus_clone.publish(EventPayload::new("code", None));
+                    bus_clone.publish(EventPayload::new("code"));
                     break;
                 }
             }
@@ -320,7 +317,7 @@ mod tests {
         let bus = EventBus::new(16);
         let mut rx1 = bus.subscribe();
         let mut rx2 = bus.subscribe();
-        let payload = EventPayload::new("projects", None);
+        let payload = EventPayload::new("projects");
         bus.publish(payload.clone());
         let got1 = rx1.try_recv().expect("rx1 received");
         let got2 = rx2.try_recv().expect("rx2 received");
@@ -333,7 +330,7 @@ mod tests {
     fn bus_drop_on_no_subscribers_is_silent() {
         let bus = EventBus::new(4);
         // No subscribers — must not panic.
-        bus.publish(EventPayload::new("knowledge", None));
+        bus.publish(EventPayload::new("knowledge"));
         assert_eq!(bus.subscriber_count(), 0);
     }
 

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -47,6 +47,13 @@ impl EventPayload {
             ts,
         }
     }
+
+    /// Public factory used by routes that need to publish a tab refresh
+    /// (currently the configuration save handler — see
+    /// [`server::config_surface`](crate::server::config_surface)).
+    pub fn for_tab(tab: impl Into<String>) -> Self {
+        Self::new(tab)
+    }
 }
 
 /// Thread-safe fan-out channel. `Clone` is cheap — the inner broadcast

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -91,7 +91,7 @@ impl EventBus {
 
 impl Default for EventBus {
     fn default() -> Self {
-        EventBus::new(256)
+        EventBus::new(1024)
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,7 +106,7 @@ pub fn run() {
             let pty_registry = pty::PtyRegistry::new();
             let runner_registry = runner_registry::RunnerRegistry::new();
             let state = server::AppState {
-                ctx: ctx.clone(),
+                ctx_swap: Arc::new(arc_swap::ArcSwap::from(ctx.clone())),
                 cache,
                 assets: asset_source,
                 version: Arc::new(env!("CARGO_PKG_VERSION").to_string()),

--- a/src-tauri/src/paths.rs
+++ b/src-tauri/src/paths.rs
@@ -15,6 +15,48 @@ use std::sync::LazyLock;
 
 use regex::Regex;
 
+/// A path that has cleared one of the validator gates in this module.
+///
+/// Routes that accept user-supplied paths should funnel them through a
+/// `validate_*` helper to obtain a `ValidatedPath`, then pass `.as_path()`
+/// to the fs-touching mutation helpers. The newtype prevents an
+/// accidentally-built `PathBuf` from reaching the boundary without going
+/// through validation.
+#[derive(Debug, Clone)]
+pub struct ValidatedPath(PathBuf);
+
+impl ValidatedPath {
+    /// Borrow the inner path for fs-touching helpers that take `&Path`.
+    pub fn as_path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Consume into the inner [`PathBuf`].
+    pub fn into_inner(self) -> PathBuf {
+        self.0
+    }
+
+    /// Construct from a path the caller already verified lives inside a
+    /// sandbox boundary. Use only at validator boundaries — any caller
+    /// reaching for this is asserting the gate, not bypassing it.
+    pub fn from_canonical_in_sandbox(path: PathBuf) -> Self {
+        ValidatedPath(path)
+    }
+}
+
+impl std::ops::Deref for ValidatedPath {
+    type Target = Path;
+    fn deref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for ValidatedPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
 /// Common item-path prefix — `projects/YYYY-MM/YYYY-MM-DD-<slug>/`.
 const VALID_ITEM_PREFIX: &str = r"^projects/\d{4}-\d{2}/\d{4}-\d{2}-\d{2}-[\w.-]+/";
 
@@ -84,7 +126,7 @@ pub fn safe_resolve(
     rel_path: &str,
     regexes: &[&Regex],
     require_file: bool,
-) -> Option<PathBuf> {
+) -> Option<ValidatedPath> {
     if rel_path.is_empty() || rel_path.contains('\0') || rel_path.contains("..") {
         return None;
     }
@@ -100,20 +142,20 @@ pub fn safe_resolve(
     if require_file && !canonical.is_file() {
         return None;
     }
-    Some(canonical)
+    Some(ValidatedPath(canonical))
 }
 
 /// Validate a README path (`projects/YYYY-MM/<slug>/README.md`). The
 /// README must resolve to an existing file under `base_dir`. Every
 /// step-mutation handler reads the file immediately after, so
 /// `require_file=true` is hardcoded.
-pub fn validate_readme_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
+pub fn validate_readme_path(base_dir: &Path, rel_path: &str) -> Option<ValidatedPath> {
     safe_resolve(base_dir, rel_path, &[&VALID_README_RE], true)
 }
 
 /// Validate a note-like path — item-tree file, `<item>/notes/*.md`, or
 /// `knowledge/**/*.md`. The target must resolve to an existing file.
-pub fn validate_note_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
+pub fn validate_note_path(base_dir: &Path, rel_path: &str) -> Option<ValidatedPath> {
     safe_resolve(
         base_dir,
         rel_path,
@@ -130,9 +172,9 @@ pub fn validate_note_path(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
 /// `base_dir`. Used by `/open-folder` so the "open folder in file
 /// manager" card button resolves against the conception tree (not the
 /// workspace/worktrees sandbox).
-pub fn validate_item_dir(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
+pub fn validate_item_dir(base_dir: &Path, rel_path: &str) -> Option<ValidatedPath> {
     let full = safe_resolve(base_dir, rel_path, &[&VALID_ITEM_DIR_RE], false)?;
-    if !full.is_dir() {
+    if !full.as_path().is_dir() {
         return None;
     }
     Some(full)
@@ -141,10 +183,10 @@ pub fn validate_item_dir(base_dir: &Path, rel_path: &str) -> Option<PathBuf> {
 /// Resolve `subdir` (relative to `item_dir`) and verify the result
 /// stays inside the item directory. Empty `subdir` resolves to
 /// `item_dir` itself. Returns `None` on traversal / regex failure.
-pub fn resolve_under_item(item_dir: &Path, subdir: &str) -> Option<PathBuf> {
+pub fn resolve_under_item(item_dir: &Path, subdir: &str) -> Option<ValidatedPath> {
     let trimmed = subdir.trim().trim_matches('/');
     if trimmed.is_empty() {
-        return Some(item_dir.to_path_buf());
+        return Some(ValidatedPath(item_dir.to_path_buf()));
     }
     if trimmed.split('/').any(|seg| seg == "..") {
         return None;
@@ -162,9 +204,9 @@ pub fn resolve_under_item(item_dir: &Path, subdir: &str) -> Option<PathBuf> {
         if !canonical_target.starts_with(&canonical_base) {
             return None;
         }
-        return Some(canonical_target);
+        return Some(ValidatedPath(canonical_target));
     }
-    Some(target)
+    Some(ValidatedPath(target))
 }
 
 #[cfg(test)]
@@ -252,9 +294,9 @@ mod tests {
     fn resolve_under_item_empty_is_item_dir() {
         let (_tmp, base) = seeded_tree();
         let item = base.join("projects/2026-04/2026-04-22-demo");
-        assert_eq!(resolve_under_item(&item, ""), Some(item.clone()));
-        assert_eq!(resolve_under_item(&item, "   "), Some(item.clone()));
-        assert_eq!(resolve_under_item(&item, "/"), Some(item.clone()));
+        assert_eq!(resolve_under_item(&item, "").map(|v| v.into_inner()), Some(item.clone()));
+        assert_eq!(resolve_under_item(&item, "   ").map(|v| v.into_inner()), Some(item.clone()));
+        assert_eq!(resolve_under_item(&item, "/").map(|v| v.into_inner()), Some(item.clone()));
     }
 
     #[test]
@@ -262,7 +304,7 @@ mod tests {
         let (_tmp, base) = seeded_tree();
         let item = base.join("projects/2026-04/2026-04-22-demo");
         let got = resolve_under_item(&item, "notes").expect("notes exists");
-        assert!(got.ends_with("projects/2026-04/2026-04-22-demo/notes"));
+        assert!(got.as_path().ends_with("projects/2026-04/2026-04-22-demo/notes"));
     }
 
     #[test]
@@ -282,7 +324,7 @@ mod tests {
         // code path. Should still resolve, since the regex + ".." reject
         // keep us safe.
         let got = resolve_under_item(&item, "freshly/nested").expect("ok");
-        assert!(got.ends_with("projects/2026-04/2026-04-22-demo/freshly/nested"));
+        assert!(got.as_path().ends_with("projects/2026-04/2026-04-22-demo/freshly/nested"));
     }
 
     #[test]

--- a/src-tauri/src/server/config_surface.rs
+++ b/src-tauri/src/server/config_surface.rs
@@ -51,8 +51,7 @@ pub(super) async fn post_configuration(State(state): State<AppState>, body: Stri
             // The RenderCtx itself still only rebuilds on restart or
             // /rescan — the modal's success message tells the user as
             // much.
-            state.cache.invalidate_items();
-            state.cache.invalidate_knowledge();
+            state.cache.consume(condash_state::MutationOutput::full_flush());
             (
                 StatusCode::OK,
                 [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],

--- a/src-tauri/src/server/config_surface.rs
+++ b/src-tauri/src/server/config_surface.rs
@@ -3,9 +3,12 @@
 //! - `GET /configuration` returns the raw `<conception>/configuration.yml`
 //!   contents so the modal populates a single `<textarea>`.
 //! - `POST /configuration` validates the body via serde (rejects
-//!   invalid YAML with 400 + parse error), then atomically replaces
-//!   the file. Changes take effect on the next launch — the
-//!   `RenderCtx` is built once at startup and not hot-swapped here.
+//!   invalid YAML with 400 + parse error), atomically replaces the
+//!   file, then **hot-rebuilds** the [`RenderCtx`] in place: the new
+//!   `Arc<RenderCtx>` is swapped into [`AppState::ctx_swap`], the
+//!   workspace cache is fully flushed, and SSE refresh events are
+//!   republished for every primary tab so the open dashboard repaints
+//!   without a restart.
 //! - `GET /config` is the small legacy summary the bundled frontend
 //!   polls for setup-banner detection and terminal-shortcut loading.
 //!   Returns only `conception_path` + the `terminal` block.
@@ -16,6 +19,8 @@
 //! Module name: `config_surface` rather than `config` so it doesn't
 //! shadow the crate-root `config` module that owns `build_ctx`.
 
+use std::sync::Arc;
+
 use axum::body::Body;
 use axum::extract::State;
 use axum::http::{header, HeaderValue, StatusCode};
@@ -24,7 +29,7 @@ use axum::response::{IntoResponse, Response};
 use super::{error_json, json_response, AppState};
 
 pub(super) async fn get_configuration(State(state): State<AppState>) -> Response {
-    let path = crate::config::configuration_path(&state.ctx.base_dir);
+    let path = crate::config::configuration_path(&state.ctx().base_dir);
     let body = match std::fs::read_to_string(&path) {
         Ok(s) => s,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
@@ -45,27 +50,68 @@ pub(super) async fn post_configuration(State(state): State<AppState>, body: Stri
     if let Err(e) = crate::config::validate_configuration_yaml(&body) {
         return error_json(StatusCode::BAD_REQUEST, &format!("{e}"));
     }
-    match crate::config::write_configuration(&state.ctx.base_dir, &body) {
-        Ok(_path) => {
-            // Invalidate caches so the next `/` hit re-walks the tree.
-            // The RenderCtx itself still only rebuilds on restart or
-            // /rescan — the modal's success message tells the user as
-            // much.
-            state.cache.consume(condash_state::MutationOutput::full_flush());
-            (
-                StatusCode::OK,
-                [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
-                "saved. Close and reopen condash for changes to take effect.\n",
-            )
-                .into_response()
+    let base_dir = state.ctx().base_dir.clone();
+    if let Err(e) = crate::config::write_configuration(&base_dir, &body) {
+        return error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e}"));
+    }
+
+    // Hot-rebuild the RenderCtx so live opener menus, terminal launchers,
+    // and runner force-stop commands pick up the new configuration without
+    // a restart. If the rebuild fails (template missing or build_ctx bug)
+    // we still report success on the write — the file is saved — but tell
+    // the user they need to reopen.
+    let template = match crate::load_template_for_bin(&state.assets) {
+        Ok(t) => t,
+        Err(e) => {
+            tracing::error!("post_configuration: template load failed: {e}");
+            state
+                .cache
+                .consume(condash_state::MutationOutput::full_flush());
+            return saved_response(true);
         }
-        Err(e) => error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("{e}")),
+    };
+    match crate::config::build_ctx(&base_dir, template) {
+        Ok(new_ctx) => {
+            state.ctx_swap.store(Arc::new(new_ctx));
+            state
+                .cache
+                .consume(condash_state::MutationOutput::full_flush());
+            // Push refresh events for every primary tab so the open
+            // browser repaints from the new ctx.
+            for tab in ["projects", "knowledge", "code"] {
+                state
+                    .event_bus
+                    .publish(crate::events::EventPayload::for_tab(tab));
+            }
+            saved_response(false)
+        }
+        Err(e) => {
+            tracing::error!("post_configuration: build_ctx failed: {e}");
+            state
+                .cache
+                .consume(condash_state::MutationOutput::full_flush());
+            saved_response(true)
+        }
     }
 }
 
+fn saved_response(needs_restart: bool) -> Response {
+    let body = if needs_restart {
+        "saved. Close and reopen condash for changes to take effect.\n"
+    } else {
+        "saved. Changes are live — no restart needed.\n"
+    };
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "text/plain; charset=utf-8")],
+        body,
+    )
+        .into_response()
+}
+
 pub(super) async fn get_config_summary(State(state): State<AppState>) -> Response {
-    let conception_path = state.ctx.base_dir.to_string_lossy().into_owned();
-    let term = &state.ctx.terminal;
+    let conception_path = state.ctx().base_dir.to_string_lossy().into_owned();
+    let term = &state.ctx().terminal;
     let body = serde_json::json!({
         "conception_path": conception_path,
         "terminal": {

--- a/src-tauri/src/server/events.rs
+++ b/src-tauri/src/server/events.rs
@@ -35,7 +35,9 @@ pub(super) async fn events_stream(
                     SseEvent::default().event(payload.tab.clone()).data(data),
                 ))
             }
-            // Subscriber lagged — the reconciler picks it up, just skip.
+            // Subscriber lagged behind the broadcast queue. The next
+            // event will refresh; capacity is sized so this is rare
+            // under normal use.
             Err(_) => None,
         }
     });

--- a/src-tauri/src/server/items.rs
+++ b/src-tauri/src/server/items.rs
@@ -47,7 +47,7 @@ pub(super) async fn post_create_item(
         severity: p.severity,
         languages: p.languages,
     };
-    match create_item(&state.ctx.base_dir, spec, ymd) {
+    match create_item(&state.ctx().base_dir, spec, ymd) {
         Ok(CreateItemResult::Ok {
             rel_path,
             slug,

--- a/src-tauri/src/server/items.rs
+++ b/src-tauri/src/server/items.rs
@@ -56,7 +56,9 @@ pub(super) async fn post_create_item(
             month,
             ..
         }) => {
-            state.cache.invalidate_items();
+            state.cache.consume(
+                condash_state::MutationOutput::default().with_items_flush(),
+            );
             json_response(&serde_json::json!({
                 "ok": true,
                 "rel_path": rel_path,

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -216,7 +216,10 @@ pub(super) fn json_with_status<T: serde::Serialize>(body: &T, code: StatusCode) 
 /// so the frontend parses one shape.
 pub(super) fn error_json(code: StatusCode, msg: &str) -> Response {
     let body = serde_json::json!({"error": msg});
-    let bytes = serde_json::to_vec(&body).unwrap_or_default();
+    let bytes = serde_json::to_vec(&body).unwrap_or_else(|e| {
+        tracing::error!("encode error_json body: {e}");
+        Vec::new()
+    });
     Response::builder()
         .status(code)
         .header(header::CONTENT_TYPE, "application/json")

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -37,6 +37,7 @@ use axum::http::{header, HeaderValue, StatusCode};
 use axum::response::Response;
 use axum::routing::{get, post};
 use axum::Router;
+use arc_swap::{ArcSwap, Guard};
 use condash_state::{RenderCtx, WorkspaceCache};
 use tokio::net::TcpListener as TokioTcpListener;
 
@@ -53,9 +54,14 @@ mod terminal;
 
 /// Application state shared across every handler. Cheap to clone
 /// (all fields live behind `Arc`).
+///
+/// `ctx_swap` holds the active [`RenderCtx`] inside an [`ArcSwap`] so
+/// the [`config_surface`] save handler can hot-replace it without a
+/// restart. Per-request reads go through [`AppState::ctx`], which
+/// returns a cheap RCU guard.
 #[derive(Clone)]
 pub struct AppState {
-    pub ctx: Arc<RenderCtx>,
+    pub ctx_swap: Arc<ArcSwap<RenderCtx>>,
     pub cache: Arc<WorkspaceCache>,
     /// Source of the dashboard shell (`dashboard.html`),
     /// `favicon.{svg,ico}`, `dist/`, and `vendor/`. Production
@@ -77,6 +83,16 @@ pub struct AppState {
     /// Per-process registry of inline dev-server runners — used by
     /// `/api/runner/{start,stop}` and `/ws/runner/:key`.
     pub runner_registry: crate::runner_registry::RunnerRegistry,
+}
+
+impl AppState {
+    /// Snapshot the active [`RenderCtx`]. Returns an [`arc_swap::Guard`]
+    /// that derefs to `&RenderCtx`. The guard is cheap; do not hold it
+    /// across `.await` points — clone the inner `Arc` first if you need
+    /// to (`Arc::clone(&*guard)`).
+    pub fn ctx(&self) -> Guard<Arc<RenderCtx>> {
+        self.ctx_swap.load()
+    }
 }
 
 /// Start the axum server on the given localhost port (`0` means any

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -268,7 +268,7 @@ pub(super) fn live_runners_snapshot(state: &AppState) -> condash_render::git_ren
 pub(super) fn validate_open_path(
     ctx: &condash_state::RenderCtx,
     path: &str,
-) -> Option<std::path::PathBuf> {
+) -> Option<crate::paths::ValidatedPath> {
     if path.is_empty() || path.contains('\0') {
         return None;
     }
@@ -283,7 +283,11 @@ pub(super) fn validate_open_path(
         .collect();
     for root in roots {
         if canonical.starts_with(&root) {
-            return Some(canonical);
+            // Sandbox check passed: the canonical path lives under one
+            // of the configured workspace roots.
+            return Some(crate::paths::ValidatedPath::from_canonical_in_sandbox(
+                canonical,
+            ));
         }
     }
     None

--- a/src-tauri/src/server/notes.rs
+++ b/src-tauri/src/server/notes.rs
@@ -251,9 +251,8 @@ pub(super) async fn post_note_upload(
                     }
                 }
             }
-            _ => {
-                // Silently drop unknown fields — the route contract
-                // is `item_readme`, `subdir`, `file`; extras are ignored.
+            other => {
+                tracing::warn!(name = %other, "multipart upload: dropping unknown field");
                 let _ = field.bytes().await;
             }
         }

--- a/src-tauri/src/server/notes.rs
+++ b/src-tauri/src/server/notes.rs
@@ -78,7 +78,7 @@ pub(super) async fn post_note(
     }
     match write_note(&full, &p.content, p.expected_mtime) {
         Ok(WriteNoteResult::Ok { mtime, .. }) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true, "mtime": mtime}))
         }
         Ok(WriteNoteResult::Err { reason, mtime, .. }) => {
@@ -113,7 +113,7 @@ pub(super) async fn post_note_rename(
     }
     match rename_note(&full, &p.new_stem, &state.ctx.base_dir) {
         Ok(RenameResult::Ok { path, mtime, .. }) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true, "path": path, "mtime": mtime}))
         }
         Ok(RenameResult::Err { reason, .. }) => error_json(StatusCode::BAD_REQUEST, &reason),
@@ -151,7 +151,7 @@ pub(super) async fn post_note_create(
         subdir_was_supplied,
     ) {
         Ok(CreateNoteResult::Ok { path, mtime, .. }) => {
-            state.cache.invalidate_item_at(&readme);
+            state.cache.consume(condash_state::MutationOutput::for_path(readme.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true, "path": path, "mtime": mtime}))
         }
         Ok(CreateNoteResult::Err { reason, .. }) => error_json(StatusCode::BAD_REQUEST, &reason),
@@ -196,7 +196,7 @@ pub(super) async fn post_note_mkdir(
             subdir_key,
             ..
         }) => {
-            state.cache.invalidate_item_at(&readme);
+            state.cache.consume(condash_state::MutationOutput::for_path(readme.as_path().to_path_buf()));
             json_response(&serde_json::json!({
                 "ok": true,
                 "rel_dir": rel_dir,
@@ -296,7 +296,7 @@ pub(super) async fn post_note_upload(
                     .unwrap_or_else(|| "upload failed".into());
                 return error_json(StatusCode::BAD_REQUEST, &reason);
             }
-            state.cache.invalidate_item_at(&readme);
+            state.cache.consume(condash_state::MutationOutput::for_path(readme.as_path().to_path_buf()));
             json_response(&serde_json::json!({
                 "ok": true,
                 "stored": res.stored,

--- a/src-tauri/src/server/notes.rs
+++ b/src-tauri/src/server/notes.rs
@@ -31,10 +31,10 @@ pub(super) async fn get_note(
     if q.path.is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "missing path");
     }
-    let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &q.path) else {
+    let Some(full) = crate::paths::validate_note_path(&state.ctx().base_dir, &q.path) else {
         return error_json(StatusCode::FORBIDDEN, "invalid path");
     };
-    let html = condash_render::render_note(&q.path, &full, &state.ctx.base_dir);
+    let html = condash_render::render_note(&q.path, &full, &state.ctx().base_dir);
     html_response(html)
 }
 
@@ -48,7 +48,7 @@ pub(super) async fn get_note_raw(
     if q.path.is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "missing path");
     }
-    let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &q.path) else {
+    let Some(full) = crate::paths::validate_note_path(&state.ctx().base_dir, &q.path) else {
         return error_json(StatusCode::FORBIDDEN, "invalid path");
     };
     match condash_render::note_raw_payload(&full) {
@@ -69,7 +69,7 @@ pub(super) async fn post_note(
     State(state): State<AppState>,
     Json(p): Json<NoteWritePayload>,
 ) -> impl IntoResponse {
-    let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &p.path) else {
+    let Some(full) = crate::paths::validate_note_path(&state.ctx().base_dir, &p.path) else {
         return error_json(StatusCode::FORBIDDEN, "invalid path");
     };
     let kind = condash_parser::note_kind(&full);
@@ -102,7 +102,7 @@ pub(super) async fn post_note_rename(
     State(state): State<AppState>,
     Json(p): Json<NoteRenamePayload>,
 ) -> impl IntoResponse {
-    let Some(full) = crate::paths::validate_note_path(&state.ctx.base_dir, &p.path) else {
+    let Some(full) = crate::paths::validate_note_path(&state.ctx().base_dir, &p.path) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     if !crate::paths::VALID_ITEM_NOTES_FILE_RE.is_match(&p.path) {
@@ -111,7 +111,7 @@ pub(super) async fn post_note_rename(
             "only files under <item>/notes/ can be renamed",
         );
     }
-    match rename_note(&full, &p.new_stem, &state.ctx.base_dir) {
+    match rename_note(&full, &p.new_stem, &state.ctx().base_dir) {
         Ok(RenameResult::Ok { path, mtime, .. }) => {
             state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true, "path": path, "mtime": mtime}))
@@ -133,7 +133,7 @@ pub(super) async fn post_note_create(
     State(state): State<AppState>,
     Json(p): Json<NoteCreatePayload>,
 ) -> impl IntoResponse {
-    let Some(readme) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.item_readme)
+    let Some(readme) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.item_readme)
     else {
         return error_json(StatusCode::BAD_REQUEST, "invalid item");
     };
@@ -147,7 +147,7 @@ pub(super) async fn post_note_create(
     match create_note(
         &target_dir,
         &p.filename,
-        &state.ctx.base_dir,
+        &state.ctx().base_dir,
         subdir_was_supplied,
     ) {
         Ok(CreateNoteResult::Ok { path, mtime, .. }) => {
@@ -172,7 +172,7 @@ pub(super) async fn post_note_mkdir(
     State(state): State<AppState>,
     Json(p): Json<NoteMkdirPayload>,
 ) -> impl IntoResponse {
-    let Some(readme) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.item_readme)
+    let Some(readme) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.item_readme)
     else {
         return error_json(StatusCode::BAD_REQUEST, "invalid item");
     };
@@ -262,7 +262,7 @@ pub(super) async fn post_note_upload(
         return error_json(StatusCode::BAD_REQUEST, "no files in upload");
     }
 
-    let Some(readme) = crate::paths::validate_readme_path(&state.ctx.base_dir, &item_readme) else {
+    let Some(readme) = crate::paths::validate_readme_path(&state.ctx().base_dir, &item_readme) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid item");
     };
     let Some(item_dir) = readme.parent() else {
@@ -281,7 +281,7 @@ pub(super) async fn post_note_upload(
 
     match store_uploads(
         &target_dir,
-        &state.ctx.base_dir,
+        &state.ctx().base_dir,
         read_uploads,
         subdir_was_supplied,
         UPLOAD_MAX_BYTES,

--- a/src-tauri/src/server/openers.rs
+++ b/src-tauri/src/server/openers.rs
@@ -30,10 +30,11 @@ pub(super) async fn post_open(
     if p.path.trim().is_empty() || p.tool.trim().is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "path and tool required");
     }
-    let Some(validated) = validate_open_path(&state.ctx, &p.path) else {
+    let ctx = state.ctx();
+    let Some(validated) = validate_open_path(&ctx, &p.path) else {
         return error_json(StatusCode::FORBIDDEN, "path out of sandbox");
     };
-    let Some(slot) = state.ctx.open_with.get(&p.tool) else {
+    let Some(slot) = ctx.open_with.get(&p.tool) else {
         return error_json(StatusCode::NOT_FOUND, &format!("unknown tool: {}", p.tool));
     };
     if slot.commands.is_empty() {
@@ -43,7 +44,9 @@ pub(super) async fn post_open(
         );
     }
     let value = validated.as_path().to_string_lossy().into_owned();
-    match crate::launcher::try_chain(&slot.commands, "path", &value) {
+    let commands = slot.commands.clone();
+    drop(ctx);
+    match crate::launcher::try_chain(&commands, "path", &value) {
         Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
         None => error_json(StatusCode::BAD_GATEWAY, "all commands failed"),
     }
@@ -67,8 +70,8 @@ pub(super) async fn post_open_folder(
     // `projects/2026-04/2026-04-23-slug/` relative to base_dir. Resolve
     // against base_dir, and fall back to the workspace sandbox for any
     // other folder target a future caller might feed in.
-    let validated = crate::paths::validate_item_dir(&state.ctx.base_dir, &p.path)
-        .or_else(|| validate_open_path(&state.ctx, &p.path));
+    let validated = crate::paths::validate_item_dir(&state.ctx().base_dir, &p.path)
+        .or_else(|| validate_open_path(&state.ctx(), &p.path));
     let Some(validated) = validated else {
         return error_json(StatusCode::FORBIDDEN, "path out of sandbox");
     };
@@ -118,12 +121,12 @@ pub(super) async fn post_open_doc(
     // already sandbox-safe (the note path itself was validated to open
     // the modal), so we first try the raw value and fall back to
     // base_dir-rooted resolution.
-    let full = match validate_open_path(&state.ctx, &p.path) {
+    let full = match validate_open_path(&state.ctx(), &p.path) {
         Some(v) => v,
         None => {
-            let rel = state.ctx.base_dir.join(&p.path);
+            let rel = state.ctx().base_dir.join(&p.path);
             match std::fs::canonicalize(&rel).ok().and_then(|c| {
-                let base = std::fs::canonicalize(&state.ctx.base_dir).ok()?;
+                let base = std::fs::canonicalize(&state.ctx().base_dir).ok()?;
                 if c.starts_with(&base) {
                     Some(crate::paths::ValidatedPath::from_canonical_in_sandbox(c))
                 } else {
@@ -138,13 +141,13 @@ pub(super) async fn post_open_doc(
     let value = full.as_path().to_string_lossy().into_owned();
     // Prefer the user's configured pdf_viewer chain; fall back to the
     // xdg-open / gio open chain.
-    let chain: Vec<String> = if state.ctx.pdf_viewer.is_empty() {
+    let chain: Vec<String> = if state.ctx().pdf_viewer.is_empty() {
         crate::launcher::DOC_FALLBACKS
             .iter()
             .map(|s| s.to_string())
             .collect()
     } else {
-        state.ctx.pdf_viewer.clone()
+        state.ctx().pdf_viewer.clone()
     };
     match crate::launcher::try_chain(&chain, "path", &value) {
         Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
@@ -198,7 +201,7 @@ fn resolved_screenshot_dir(ctx: &condash_state::RenderCtx) -> std::path::PathBuf
 }
 
 pub(super) async fn get_recent_screenshot(State(state): State<AppState>) -> Response {
-    let dir = resolved_screenshot_dir(&state.ctx);
+    let dir = resolved_screenshot_dir(&state.ctx());
     let dir_str = dir.to_string_lossy().into_owned();
     let payload_err = |reason: &str| {
         json_response(&serde_json::json!({

--- a/src-tauri/src/server/openers.rs
+++ b/src-tauri/src/server/openers.rs
@@ -42,7 +42,7 @@ pub(super) async fn post_open(
             &format!("no commands configured for {}", p.tool),
         );
     }
-    let value = validated.to_string_lossy().into_owned();
+    let value = validated.as_path().to_string_lossy().into_owned();
     match crate::launcher::try_chain(&slot.commands, "path", &value) {
         Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
         None => error_json(StatusCode::BAD_GATEWAY, "all commands failed"),
@@ -72,7 +72,7 @@ pub(super) async fn post_open_folder(
     let Some(validated) = validated else {
         return error_json(StatusCode::FORBIDDEN, "path out of sandbox");
     };
-    let value = validated.to_string_lossy().into_owned();
+    let value = validated.as_path().to_string_lossy().into_owned();
     match crate::launcher::try_chain_static(crate::launcher::FOLDER_FALLBACKS, "path", &value) {
         Some(used) => json_response(&serde_json::json!({"ok": true, "command": used})),
         None => error_json(StatusCode::BAD_GATEWAY, "no folder opener succeeded"),
@@ -125,7 +125,7 @@ pub(super) async fn post_open_doc(
             match std::fs::canonicalize(&rel).ok().and_then(|c| {
                 let base = std::fs::canonicalize(&state.ctx.base_dir).ok()?;
                 if c.starts_with(&base) {
-                    Some(c)
+                    Some(crate::paths::ValidatedPath::from_canonical_in_sandbox(c))
                 } else {
                     None
                 }
@@ -135,7 +135,7 @@ pub(super) async fn post_open_doc(
             }
         }
     };
-    let value = full.to_string_lossy().into_owned();
+    let value = full.as_path().to_string_lossy().into_owned();
     // Prefer the user's configured pdf_viewer chain; fall back to the
     // xdg-open / gio open chain.
     let chain: Vec<String> = if state.ctx.pdf_viewer.is_empty() {

--- a/src-tauri/src/server/rescan.rs
+++ b/src-tauri/src/server/rescan.rs
@@ -12,7 +12,6 @@ use axum::response::IntoResponse;
 use super::{json_response, AppState};
 
 pub(super) async fn post_rescan(State(state): State<AppState>) -> impl IntoResponse {
-    state.cache.invalidate_items();
-    state.cache.invalidate_knowledge();
+    state.cache.consume(condash_state::MutationOutput::full_flush());
     json_response(&serde_json::json!({"ok": true}))
 }

--- a/src-tauri/src/server/runners.rs
+++ b/src-tauri/src/server/runners.rs
@@ -34,13 +34,13 @@ pub(super) async fn runner_start_route(
     if key.is_empty() || checkout_key.is_empty() || path_raw.is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "key, checkout_key, path required");
     }
-    let Some(template) = state.ctx.repo_run_templates.get(key).cloned() else {
+    let Some(template) = state.ctx().repo_run_templates.get(key).cloned() else {
         return error_json(
             StatusCode::NOT_FOUND,
             &format!("no run command configured for {key}"),
         );
     };
-    let Some(validated) = validate_open_path(&state.ctx, path_raw) else {
+    let Some(validated) = validate_open_path(&state.ctx(), path_raw) else {
         return error_json(
             StatusCode::BAD_REQUEST,
             &format!("path out of sandbox: {path_raw}"),
@@ -140,7 +140,7 @@ pub(super) async fn runner_force_stop_route(
     if key.is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "key required");
     }
-    let Some(command) = state.ctx.repo_force_stop_templates.get(key).cloned() else {
+    let Some(command) = state.ctx().repo_force_stop_templates.get(key).cloned() else {
         return error_json(
             StatusCode::NOT_FOUND,
             &format!("no force_stop command configured for {key}"),

--- a/src-tauri/src/server/shell.rs
+++ b/src-tauri/src/server/shell.rs
@@ -17,11 +17,11 @@ use serde::Deserialize;
 use super::{error_json, html_response, live_runners_snapshot, AppState};
 
 pub(super) async fn index(State(state): State<AppState>) -> impl IntoResponse {
-    let items = state.cache.get_items(&state.ctx);
-    let knowledge = state.cache.get_knowledge(&state.ctx);
+    let items = state.cache.get_items(&state.ctx());
+    let knowledge = state.cache.get_knowledge(&state.ctx());
     let live_runners = live_runners_snapshot(&state);
     let html = render_page(
-        &state.ctx,
+        &state.ctx(),
         &items,
         knowledge.as_ref().as_ref(),
         &state.version,
@@ -45,8 +45,8 @@ pub(super) async fn fragment_history(
     State(state): State<AppState>,
     Query(s): Query<HistoryFragmentQuery>,
 ) -> impl IntoResponse {
-    let items = state.cache.get_items(&state.ctx);
-    html_response(render_history_pane(&state.ctx, &items, &s.q))
+    let items = state.cache.get_items(&state.ctx());
+    html_response(render_history_pane(&state.ctx(), &items, &s.q))
 }
 
 /// HTML fragment for the Knowledge pane content. Driven by the htmx
@@ -54,7 +54,7 @@ pub(super) async fn fragment_history(
 /// `sse:knowledge` whenever the file watcher reports a change under
 /// `knowledge/`.
 pub(super) async fn fragment_knowledge(State(state): State<AppState>) -> impl IntoResponse {
-    let knowledge = state.cache.get_knowledge(&state.ctx);
+    let knowledge = state.cache.get_knowledge(&state.ctx());
     html_response(render_knowledge_pane(knowledge.as_ref().as_ref()))
 }
 
@@ -64,7 +64,7 @@ pub(super) async fn fragment_knowledge(State(state): State<AppState>) -> impl In
 /// survive a parent-pane morph swap.
 pub(super) async fn fragment_code(State(state): State<AppState>) -> impl IntoResponse {
     let live_runners = live_runners_snapshot(&state);
-    html_response(render_code_pane(&state.ctx, &live_runners))
+    html_response(render_code_pane(&state.ctx(), &live_runners))
 }
 
 /// HTML fragment for the Projects pane content (the cards grid).
@@ -73,7 +73,7 @@ pub(super) async fn fragment_code(State(state): State<AppState>) -> impl IntoRes
 /// in `htmx-state-preserve.js` re-applies user-driven state (expanded
 /// cards, open `<details>`) onto the swapped DOM.
 pub(super) async fn fragment_projects(State(state): State<AppState>) -> impl IntoResponse {
-    let items = state.cache.get_items(&state.ctx);
+    let items = state.cache.get_items(&state.ctx());
     html_response(render_cards_pane(&items))
 }
 
@@ -125,7 +125,7 @@ pub(super) async fn conception_asset(
     State(state): State<AppState>,
     axum::extract::Path(rel_path): axum::extract::Path<String>,
 ) -> impl IntoResponse {
-    serve_under(&state.ctx.base_dir, &rel_path, None)
+    serve_under(&state.ctx().base_dir, &rel_path, None)
 }
 
 fn serve_under(base: &std::path::Path, rel: &str, mime_override: Option<&str>) -> Response {

--- a/src-tauri/src/server/steps.rs
+++ b/src-tauri/src/server/steps.rs
@@ -24,7 +24,7 @@ pub(super) async fn toggle(
     State(state): State<AppState>,
     Json(p): Json<TogglePayload>,
 ) -> impl IntoResponse {
-    let Some(full) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.file) else {
+    let Some(full) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.file) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     if p.line < 0 {
@@ -60,7 +60,7 @@ pub(super) async fn add_step_route(
     if text.is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "empty text");
     }
-    let Some(full) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.file) else {
+    let Some(full) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.file) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     let section = p.section.as_deref();
@@ -83,7 +83,7 @@ pub(super) async fn remove_step_route(
     State(state): State<AppState>,
     Json(p): Json<RemoveStepPayload>,
 ) -> impl IntoResponse {
-    let Some(full) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.file) else {
+    let Some(full) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.file) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     if p.line < 0 {
@@ -115,7 +115,7 @@ pub(super) async fn edit_step_route(
     if text.is_empty() {
         return error_json(StatusCode::BAD_REQUEST, "empty text");
     }
-    let Some(full) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.file) else {
+    let Some(full) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.file) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     if p.line < 0 {
@@ -141,7 +141,7 @@ pub(super) async fn set_priority_route(
     State(state): State<AppState>,
     Json(p): Json<SetPriorityPayload>,
 ) -> impl IntoResponse {
-    let Some(full) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.file) else {
+    let Some(full) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.file) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     match set_priority(&full, &p.priority) {
@@ -170,7 +170,7 @@ pub(super) async fn reorder_all_route(
     State(state): State<AppState>,
     Json(p): Json<ReorderAllPayload>,
 ) -> impl IntoResponse {
-    let Some(full) = crate::paths::validate_readme_path(&state.ctx.base_dir, &p.file) else {
+    let Some(full) = crate::paths::validate_readme_path(&state.ctx().base_dir, &p.file) else {
         return error_json(StatusCode::BAD_REQUEST, "invalid path");
     };
     if p.order.iter().any(|&n| n < 0) {

--- a/src-tauri/src/server/steps.rs
+++ b/src-tauri/src/server/steps.rs
@@ -32,7 +32,7 @@ pub(super) async fn toggle(
     }
     match toggle_checkbox(&full, p.line as usize) {
         Ok(Some(status)) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({
                 "ok": true,
                 "status": status,
@@ -66,7 +66,7 @@ pub(super) async fn add_step_route(
     let section = p.section.as_deref();
     match add_step(&full, text, section) {
         Ok(line) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true, "line": line}))
         }
         Err(e) => error_json(StatusCode::INTERNAL_SERVER_ERROR, &format!("add-step: {e}")),
@@ -91,7 +91,7 @@ pub(super) async fn remove_step_route(
     }
     match remove_step(&full, p.line as usize) {
         Ok(true) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true}))
         }
         Ok(false) => error_json(StatusCode::BAD_REQUEST, "cannot remove"),
@@ -123,7 +123,7 @@ pub(super) async fn edit_step_route(
     }
     match edit_step(&full, p.line as usize, text) {
         Ok(true) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true}))
         }
         Ok(false) => error_json(StatusCode::BAD_REQUEST, "cannot edit"),
@@ -146,7 +146,7 @@ pub(super) async fn set_priority_route(
     };
     match set_priority(&full, &p.priority) {
         Ok(true) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({
                 "ok": true,
                 "priority": p.priority,
@@ -179,7 +179,7 @@ pub(super) async fn reorder_all_route(
     let order: Vec<usize> = p.order.iter().map(|&n| n as usize).collect();
     match reorder_all(&full, &order) {
         Ok(true) => {
-            state.cache.invalidate_item_at(&full);
+            state.cache.consume(condash_state::MutationOutput::for_path(full.as_path().to_path_buf()));
             json_response(&serde_json::json!({"ok": true}))
         }
         Ok(false) => error_json(StatusCode::BAD_REQUEST, "cannot reorder"),

--- a/src-tauri/src/server/terminal.rs
+++ b/src-tauri/src/server/terminal.rs
@@ -89,11 +89,11 @@ async fn handle_term_ws(mut socket: axum::extract::ws::WebSocket, state: AppStat
                     None
                 }
             })
-            .unwrap_or_else(|| state.ctx.base_dir.clone());
+            .unwrap_or_else(|| state.ctx().base_dir.clone());
         let use_launcher = q.launcher.as_deref() == Some("1");
         let launcher_argv = if use_launcher {
             state
-                .ctx
+                .ctx()
                 .terminal
                 .launcher_command
                 .as_deref()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "condash",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "identifier": "com.vcoeur.condash",
   "build": {
     "frontendDist": "../frontend"

--- a/src-tauri/tests/events_routes.rs
+++ b/src-tauri/tests/events_routes.rs
@@ -95,7 +95,6 @@ async fn events_stream_forwards_bus_publish_to_subscriber() {
         bus2.publish(EventPayload {
             tab: "projects".into(),
             ts: 1234,
-            file: None,
         });
     });
 

--- a/src-tauri/tests/events_routes.rs
+++ b/src-tauri/tests/events_routes.rs
@@ -26,7 +26,7 @@ fn state_with_bus() -> (TempDir, AppState, EventBus) {
     let cache = Arc::new(WorkspaceCache::new());
     let bus = EventBus::default();
     let state = AppState {
-        ctx,
+        ctx_swap: Arc::new(arc_swap::ArcSwap::from(ctx)),
         cache,
         assets: condash_lib::assets::AssetSource::Embedded,
         version: Arc::new("test".into()),

--- a/src-tauri/tests/file_mutation_routes.rs
+++ b/src-tauri/tests/file_mutation_routes.rs
@@ -37,7 +37,7 @@ fn harness() -> Harness {
     let ctx = Arc::new(RenderCtx::with_base_dir(&base));
     let cache = Arc::new(WorkspaceCache::new());
     let state = AppState {
-        ctx,
+        ctx_swap: Arc::new(arc_swap::ArcSwap::from(ctx)),
         cache,
         assets: condash_lib::assets::AssetSource::Embedded,
         version: Arc::new("test".into()),

--- a/src-tauri/tests/mutation_routes.rs
+++ b/src-tauri/tests/mutation_routes.rs
@@ -33,7 +33,7 @@ fn harness_with(initial: &str) -> Harness {
     let ctx = Arc::new(RenderCtx::with_base_dir(tmp.path()));
     let cache = Arc::new(WorkspaceCache::new());
     let state = AppState {
-        ctx,
+        ctx_swap: Arc::new(arc_swap::ArcSwap::from(ctx)),
         cache,
         assets: condash_lib::assets::AssetSource::Embedded,
         version: Arc::new("test".into()),

--- a/src-tauri/tests/runner_routes.rs
+++ b/src-tauri/tests/runner_routes.rs
@@ -50,7 +50,7 @@ fn harness_with(templates: Vec<(&str, &str)>) -> Harness {
     ctx.repo_run_keys = ctx.repo_run_templates.keys().cloned().collect();
 
     let state = AppState {
-        ctx: Arc::new(ctx),
+        ctx_swap: Arc::new(arc_swap::ArcSwap::from(Arc::new(ctx))),
         cache: Arc::new(WorkspaceCache::new()),
         assets: condash_lib::assets::AssetSource::Embedded,
         version: Arc::new("test".into()),

--- a/src-tauri/tests/term_ws.rs
+++ b/src-tauri/tests/term_ws.rs
@@ -27,7 +27,7 @@ async fn start_server() -> (u16, TempDir) {
     let ctx = Arc::new(RenderCtx::with_base_dir(tmp.path()));
     let cache = Arc::new(WorkspaceCache::new());
     let state = AppState {
-        ctx,
+        ctx_swap: Arc::new(arc_swap::ArcSwap::from(ctx)),
         cache,
         assets: condash_lib::assets::AssetSource::Embedded,
         version: Arc::new("test".into()),

--- a/tools/check-inline-handlers.sh
+++ b/tools/check-inline-handlers.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Fail if any HTML / Jinja / Rust template carries an inline non-click
+# `on*=` handler that calls a named function. DOM-API expressions on
+# `event.` (e.g. `onmousedown="event.stopPropagation()"`) are kept as
+# inline because they don't reach into the bundle's symbol surface.
+#
+# Conversion contract: every named-handler `on*=` becomes a `data-*`
+# attribute + `addEventListener` from a section module's
+# `init*SideEffects()`. See conception 2026-04-25 architecture audit
+# notes/04-extension.md T-2 and notes/05-simplicity.md S-D.
+
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+cd "$repo_root"
+
+paths=(
+    "frontend/dashboard.html"
+    "crates/condash-render/templates"
+    "crates/condash-render/src"
+)
+
+# Pull every inline-handler value, then drop the `event.*` rows.
+hits=$(grep -rEhno \
+    'on(input|submit|change|pointerdown|mousedown|dblclick|keydown)="[^"]+"' \
+    "${paths[@]}" 2>/dev/null \
+    | grep -v -E '="\s*event\.' \
+    || true)
+
+if [ -n "$hits" ]; then
+    echo "ERROR: inline non-click handlers detected (use data-* + addEventListener):"
+    echo "$hits"
+    exit 1
+fi
+
+echo "ok: no inline named-handler attributes"


### PR DESCRIPTION
## Summary

- Reify two contracts that previously lived in prose into the type system: `MutationOutput` (`#[must_use]`) is now the only public way to invalidate the workspace cache, and `ValidatedPath` is the only return shape from a `validate_*_path` helper. Forgetting either is a compiler warning rather than a silent stale-cache or path-traversal regression.
- Single dispatch path on the frontend. Every interactive element uses either `data-action="…"` (clicks) or a `data-*` marker attribute (everything else); a delegated document-level listener routes them. The `Object.assign(window, …)` window-globals tail is gone; inline `on*=` named handlers are gone; a CI guard at `tools/check-inline-handlers.sh` (wired into `make check` and a new `.github/workflows/ci.yml`) keeps it that way.
- Saving `configuration.yml` now hot-rebuilds `Arc<RenderCtx>` via `arc_swap::ArcSwap` and republishes per-tab SSE refresh events. Open-with menus, terminal launchers, runner force-stop commands, and the pdf-viewer chain pick up the new configuration without a restart.

## Changes

- **C1** — Drop dead frontend exports (`_reapplySearches`); add `console.warn` for unregistered `data-action` names; add `tracing::warn!` for unknown multipart fields and `tracing::error!` for `error_json` encode failures; clean up `.tmp` siblings on rename failure in `condash-mutations`.
- **C2** — Retire `EventPayload.file` — always `None` at every publish site, never read by any consumer.
- **C3** — Introduce `ValidatedPath` in `src-tauri/src/paths.rs`; every `validate_*_path` helper now returns `Option<ValidatedPath>`; `validate_open_path` returns the same; sandbox-bypass construction is gated behind a clearly-named `from_canonical_in_sandbox` factory.
- **C4** — Introduce `condash_state::MutationOutput` (`#[must_use]`) + `WorkspaceCache::consume`; mark `invalidate_items` / `invalidate_item_at` / `invalidate_knowledge` as `pub(crate)`; add a `condash-state` dep to `condash-mutations`; flip every mutation route in `src-tauri/src/server/{steps,notes,items,config_surface,rescan}.rs` to consume a token.
- **C5** — Convert nine inline non-click handlers (`oninput`, `onsubmit`, `onmousedown`, `onpointerdown`, `ondblclick`, `onkeydown`) to `data-*` markers; add `initInlineHandlerBridges()` in `dashboard-main.js` for delegated dispatch; drop the `Object.assign(window, …)` block; replace the `cm6-init.js → window._syncModeControls` reach with a `condash:cm6-ready` `CustomEvent` that `note-mode.js` subscribes to.
- **C6** — `tools/check-inline-handlers.sh` greps `frontend/dashboard.html`, `crates/condash-render/templates/`, and `crates/condash-render/src/` for inline-handler regressions and allowlists `event.*` DOM-API expressions; wired into `make check-inline-handlers` and the new `.github/workflows/ci.yml`.
- **C7** — Wrap `state.ctx` in `Arc<ArcSwap<RenderCtx>>`; route reads through `AppState::ctx()` (returns an `arc_swap::Guard`); `POST /configuration` now reloads the dashboard template, calls `config::build_ctx`, swaps the new `Arc<RenderCtx>` into place, full-flushes the cache, and republishes `projects` / `knowledge` / `code` SSE events. Reports `Changes are live — no restart needed.` on success and falls back to the legacy "reopen condash" message if the rebuild fails.
- **C8** — Bump SSE broadcast-channel capacity from 256 to 1024 and replace the misleading "the reconciler picks it up" comment with an accurate "next event will refresh; capacity is sized so this is rare" note.
- **C14** — Bump `src-tauri/Cargo.toml` and `src-tauri/tauri.conf.json` to `1.5.0`.

## Impact

- New runtime dep: `arc-swap = "1"` in `src-tauri/Cargo.toml`.
- `condash-mutations` now depends on `condash-state` (previously parallel siblings under `condash-parser`).
- `WorkspaceCache::invalidate_items` / `invalidate_item_at` / `invalidate_knowledge` are `pub(crate)` — any external caller must thread a `MutationOutput` through `consume`.
- SSE wire format: `EventPayload` is `{tab, ts}` (one fewer key than before); no consumer reads the dropped `file` key.
- `AppState::ctx` is now a method, not a field. `AppState::ctx_swap` is the underlying `Arc<ArcSwap<RenderCtx>>`. Every test fixture has been updated.
- `make check` now also runs `make check-inline-handlers`; new `.github/workflows/ci.yml` runs the workspace cargo check + tests + the inline-handler guard on PRs.

## Watchpoints

- Configuration save is the only behavioural change with a user-visible "before". Edit `terminal.run` or an `open_with` slot via the modal, save, and verify a fresh terminal / Open With menu picks up the new value without restart. The success banner now reads `Changes are live — no restart needed.` on the hot-reload path; if the rebuild fails (template missing, malformed YAML somehow passing the validator) the banner falls back to the legacy `Close and reopen condash for changes to take effect.` and a `tracing::error!` line lands in the log — that fallback is an audit trail, not silent failure.
- The `MutationOutput` flip touches every mutation route. Review by reading the `consume` call signatures and the `#[must_use]` warning surface, not by re-reading every handler. The compile-time enforcement is the value.
- The inline-handler retire converts nine handlers; the CI guard at `tools/check-inline-handlers.sh` should stay green permanently after merge.