### PR TITLE
Strip retired-Python-build references from condash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,118 +2,146 @@
 
 Standalone desktop dashboard for markdown-based conception items. Every item — project, incident, or document — lives at `projects/YYYY-MM/YYYY-MM-DD-slug/README.md` and carries a `**Kind**` field in its header. Condash renders a live view of that tree, tracks `## Steps` checklists, toggles item status, reorders steps, and opens files in your IDE — all from one native window backed by the same Markdown files the user edits by hand.
 
-The name is a contraction of *conception dashboard*. The package distributes on PyPI under `condash`; the command-line binary is also `condash`.
+The name is a contraction of *conception dashboard*.
 
 ## Project type
 
-- **Not deployed.** Per-laptop tool, distributed via PyPI (`pipx install condash`) or `uv tool install condash`.
-- **Single-user, single-window.** One NiceGUI + FastAPI process per user, launched on demand. No daemon, no multi-tenant state. The process lives as long as the window is open.
-- **No database.** The source of truth is the Markdown tree at `conception_path`. Condash parses it on every request and mutates files in place.
+- **Not deployed.** Per-laptop tool — Tauri-bundled desktop binary plus a headless `condash-serve` HTTP binary for development + Playwright e2e.
+- **Single-user, single-window.** One process per user, launched on demand. No daemon, no multi-tenant state.
+- **No database.** The source of truth is the Markdown tree at `conception_path`. Condash parses it on demand (memoized via `WorkspaceCache`) and mutates files in place.
 
 ## Stack
 
-- Python 3.11+, `uv`-managed
-- Typer (CLI) + NiceGUI + FastAPI (routes on NiceGUI's embedded FastAPI instance) + pywebview[qt] (native window) + tomlkit (config round-trip preserving comments)
-- No ORM. `app.py` mixes sync (rendering + mutation helpers) and async (FastAPI routes + the WebSocket pty session) — sync helpers must not call `asyncio.run`; async handlers must not block on subprocess without `run_in_executor`.
-- Fast in-process smoke suite under `tests/` (CLI + FastAPI `TestClient`); run via `make test`.
-- Playwright browser-driven smoke suite under `tests/e2e/`; run via `make test-e2e` (uses system Chrome via `channel="chrome"`; override with `CONDASH_E2E_CHANNEL`). `make test-all` runs both.
+- Rust + Tauri 2 (native window, embedded webview, IPC for clipboard).
+- HTTP layer: axum on tokio. The Tauri webview talks to it locally; `condash-serve` exposes the same router for browser + Playwright access.
+- Templating: `minijinja` (Jinja2-compatible) for HTML rendering.
+- Asset embedding: `rust-embed` bakes `frontend/` into the binary; `CONDASH_ASSET_DIR` overrides for live-edit during development.
+- Frontend: hand-written ES modules under `frontend/src/js/` bundled to `frontend/dist/bundle.{js,css}` via esbuild. Driven by htmx (htmx-ext-sse for the live SSE stream); editor uses CodeMirror 6, terminal uses xterm.js, PDFs render via PDF.js. All vendored under `frontend/vendor/` so the bundle is `npm install`-free.
+- File watching: tokio-based debouncer in `src-tauri/src/events.rs` → SSE `tab` events that htmx panes refetch on.
+- PTY: `src-tauri/src/pty.rs` for the embedded multi-tab terminal and the `run:` dev-runner sessions.
 
 ## Architecture
 
 ```
 condash/
-  cli.py       <- Typer app (default launches the window; subcommands: init, install-desktop, uninstall-desktop, config show/path/edit)
-  config.py    <- TOML loader + writer (tomlkit round-trip) + CondashConfig dataclass + DEFAULT_CONFIG_TEMPLATE
-  context.py   <- RenderCtx dataclass + build_ctx(cfg) + favicon loader
-  state.py     <- AppState dataclass: live cfg + ctx + event bus + observer + PTY registry + config self-write TTL stamps
-  app.py       <- NiceGUI bootstrap, lifecycle hooks, run(cfg). Owns the module-level `state = AppState(...)` instance everything else closes over.
-  routes/      <- HTTP + WebSocket route subpackage. Each module exposes `build_router(state) -> APIRouter`; `routes.register_all(app, state)` wires them all onto NiceGUI's FastAPI app. Files: static, updates, fragments, notes, items, files, steps, clipboard, openers, config_, runners, terminals.
-  pty.py       <- Embedded-terminal PTY lifecycle: PtySession dataclass, spawn_session, pump_session, attach_ws, reap_all
-  clipboard.py <- Cross-platform clipboard (QClipboard → wl/xclip/xsel) + the pywebview JS bridge
-  paths.py     <- Path-traversal-safe validators for every user-supplied rel_path
-  wikilinks.py <- `[[target]]` / `[[target|label]]` resolution + pre-pandoc rewrite
-  parser.py    <- README parsing + knowledge-tree scanning + fingerprint check
-  render.py    <- HTML rendering for cards, notes, knowledge tree, git strip, full page
-  mutations.py <- File mutations: toggle checkbox, add/edit/remove step, rename/create note
-  git_scan.py  <- `workspace_path` scan + git status/worktree/fingerprint for the repo strip
-  openers.py   <- External launchers (IDE, PDF viewer, OS default, web browser)
-  desktop.py   <- XDG .desktop entry writer for `condash install-desktop` (Linux only)
-  assets/      <- dashboard.html (served verbatim at /), favicon.svg, favicon.ico
-    vendor/pdfjs/  <- Mozilla PDF.js library (pdfjs-dist legacy build) used by the in-modal PDF viewer; bump via `make update-pdfjs`
+  Cargo.toml                 <- workspace; binaries live in src-tauri/
+  src-tauri/
+    src/
+      main.rs                <- Tauri entry point (GUI binary)
+      lib.rs                 <- shared library: bootstrap + conception-path resolution
+      bin/condash_serve.rs   <- headless HTTP binary (no Tauri deps)
+      assets.rs              <- rust-embed of frontend/ + dev override via CONDASH_ASSET_DIR
+      config.rs              <- <conception>/configuration.yml loader (build_ctx)
+      user_config.rs         <- ~/.config/condash/settings.yaml loader
+      paths.rs               <- traversal-safe path validators
+      events.rs              <- filesystem watcher → SSE event bus
+      pty.rs                 <- PTY lifecycle (terminal + dev-runner)
+      runner_registry.rs     <- per-repo runner sessions (start/stop/force-stop)
+      env_hygiene.rs         <- strip sandbox-leaked env vars before spawn
+      launcher.rs            <- "open with" command-chain executor
+      server/                <- axum routers, one file per concern
+        mod.rs                  - register_all + Router builder
+        shell.rs                - `/`, `/fragment/{history,knowledge,code,projects}`, static assets
+        steps.rs                - `/toggle`, `/add-step`, `/edit-step`, `/remove-step`, `/set-priority`, `/reorder-all`
+        notes.rs                - `/note*` mutations + uploads
+        items.rs                - `/create-item`
+        events.rs               - `GET /events` SSE stream
+        terminal.rs             - `GET /ws/term` embedded terminal WebSocket
+        runners.rs              - `/api/runner/{start,stop,force-stop}` + `GET /ws/runner/{key}`
+        config_surface.rs       - `/configuration` r/w + `/config` summary
+        openers.rs              - `/open`, `/open-folder`, `/open-external`, `/open-doc`, `/recent-screenshot`
+        rescan.rs               - `/rescan` hard refresh
+  crates/
+    condash-parser/          <- README + knowledge tree parsing, regexes, deliverables, note-kind
+    condash-state/           <- RenderCtx + WorkspaceCache + git/scan + search
+    condash-render/          <- minijinja templates + render functions for cards / notes / git strip / page / history search
+    condash-mutations/       <- file-mutation helpers: steps, notes, files, create_item
+  frontend/
+    dashboard.html           <- single-file SPA, served verbatim at `/`
+    src/                     <- source ES modules + CSS (bundled by `make frontend`)
+      js/dashboard-main.js     - bundle entry point; imports section modules + registers actions
+      js/sections/*.js         - one module per UI subsystem (terminal-*, note-*, sse, steps, …)
+      css/                     - source CSS, bundled with esbuild
+    dist/                    <- built bundle (bundle.js, bundle.css) — embedded by rust-embed
+    vendor/                  <- htmx, codemirror, mermaid, pdfjs, xterm (all vendored flat)
+    favicon.{svg,ico}
+  tests/                     <- cargo workspace tests
+  tests/e2e/                 <- Playwright smoke against `condash-serve`
+  docs/                      <- mkdocs source for the docs site
 ```
 
-Import direction: `cli` → `app` → `routes/*` → {`context`, `render`, `mutations`, `git_scan`, `openers`, `pty`, `clipboard`} → {`parser`, `wikilinks`, `paths`} → {`state`, `context`}. No module globals populated by `init`; runtime state lives on the single `app.state` AppState instance, every helper that needs config takes a `RenderCtx` parameter. `git_scan._git_cache` is a module-level cache (not config-derived).
+`AppState` (built in `src-tauri/src/server/mod.rs`) holds the live `Arc<RenderCtx>` (swapped on `/configuration` POST), the `WorkspaceCache`, the SSE event bus, the runner registry, and the PTY registry. Every router takes `State<AppState>` and reads the current ctx via `state.ctx()`.
 
 ## Config
 
-Two files, two layers:
+Two YAML files, two layers:
 
-- **Per-user**: `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Flat, today a single key: `conception_path`. Points condash at the conception tree it should render. Written atomically (temp + rename), `0600` on unix. Loader: `src-tauri/src/user_config.rs`.
-- **Per-tree**: `<conception_path>/configuration.yml`. Flat YAML merging the old `config/repositories.yml` + `config/preferences.yml` — carries `workspace_path`, `worktrees_path`, `repositories.{primary,secondary}`, `open_with`, `pdf_viewer`, `terminal`. Loader: `src-tauri/src/config.rs::build_ctx`.
+- **Per-user**: `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml`. Tells condash which conception tree to render, plus per-machine preferences (`terminal`, `pdf_viewer`, `open_with`). Loader: `src-tauri/src/user_config.rs`.
+- **Per-tree**: `<conception_path>/configuration.yml`. Tree-wide defaults: `workspace_path`, `worktrees_path`, `repositories.{primary,secondary}` (with optional `run:` / `force_stop:` per repo), and the same `terminal` / `pdf_viewer` / `open_with` keys for project-wide overrides. Loader: `src-tauri/src/config.rs::build_ctx`.
 
-Precedence when resolving the conception tree (`src-tauri/src/lib.rs::resolve_conception_path`): `CONDASH_CONCEPTION_PATH` env var → `settings.yaml` → (GUI only) native folder picker → hard error. No hard-coded `~/src/vcoeur/conception` fallback — the picker replaces that.
+When the same key appears in both files, **`settings.yaml` wins**, merged field by field. Detail: `docs/reference/config.md`.
 
-- **First-run flow** (GUI): if neither env nor settings.yaml supply a path, a native folder picker opens via `rfd`. Loose validation (directory exists + contains `configuration.yml` or `projects/`). On accept, the choice is persisted to `settings.yaml` before the dashboard loads. On cancel, the app exits cleanly.
+Precedence when resolving the conception tree (`src-tauri/src/lib.rs::resolve_conception_path`): `CONDASH_CONCEPTION_PATH` env var → `settings.yaml` → (GUI only) native folder picker → hard error.
+
+- **First-run flow** (GUI): if neither env nor settings.yaml supply a path, a native folder picker opens via `rfd`. Loose validation (directory exists + contains `configuration.yml` or `projects/`). On accept, the choice is persisted to `settings.yaml`. On cancel, the app exits cleanly.
 - **Headless** (`condash-serve`): env var → settings.yaml → hard error. No prompt.
-- **In-app editor**: the gear icon opens a plain-text YAML editor (`GET /configuration` returns the raw file; `POST /configuration` validates via `serde_yaml_ng::from_str::<ConfigurationYaml>` and atomically replaces the file). The current build does not hot-swap `RenderCtx` — the modal's success message tells the user to reopen condash for changes to take effect.
-- **`[open_with.*]` slots**: three vendor-neutral launcher keys — `main_ide`, `secondary_ide`, `terminal` — each with a `label` and a `commands` fallback chain. `{path}` is substituted with the absolute path of the repo / worktree being opened. Commands are tried in order until one starts.
-- **Per-repo `run:` + `force_stop:`**: a repo entry may carry a `run:` dev-runner template and an optional `force_stop:` shell command. `run:` is spawned via the tri-state Start/Stop/Switch button on each branch row — one session per repo, scoped to the checkout that started it. `force_stop:` drives the repo-level nuclear-stop button in the card header (one per repo, not per branch) and is invoked unconditionally — unlike `/api/runner/stop` it runs even when condash has no session for the repo, so it can free a port held by a server started from another terminal. Same shell-trust level as `run:`; both are routed through `sh -c`. Loader records them in `RenderCtx::repo_run_templates` / `repo_force_stop_templates` (same key space: parent by `name`, subrepo by `<parent>--<sub>`).
-- **Split files** (`<conception_path>/config/repositories.yml` + `preferences.yml`): kept on disk for the retired Python build (`condash-python`). Condash no longer reads them. Edits via the modal land in `configuration.yml` and do not propagate to the split files — known drift hazard, accepted because condash-python is retired.
+- **In-app editor**: the gear icon opens a plain-text YAML editor of `configuration.yml` (`GET/POST /configuration`). On valid POST the file is atomically replaced and `RenderCtx` is hot-rebuilt — the open dashboard repaints without a restart.
+- **`[open_with.*]` slots**: vendor-neutral launcher keys (`main_ide`, `secondary_ide`, `terminal`, …) each with a `label` and a `commands` fallback chain. `{path}` is substituted with the absolute path of the repo / worktree being opened. Commands are tried in order until one starts.
+- **Per-repo `run:` + `force_stop:`**: `run:` is a dev-runner template spawned via the tri-state Start/Stop/Switch button on each branch row — one session per repo, scoped to the checkout that started it. `force_stop:` drives the repo-level nuclear-stop button in the card header — runs unconditionally (even when condash has no session for the repo), so it can free a port held by a server started from another terminal. Both routed through `sh -c`.
 
 ## Sandbox rules for "open in IDE"
 
-`paths._validate_open_path(ctx, path_str)` accepts a path only if it resolves inside `ctx.workspace` or `ctx.worktrees`. This is the single defence against `condash` being tricked into launching an arbitrary binary via a crafted URL parameter. When editing any "open with external tool" code path, preserve the sandbox check — never trust an absolute path that came in over HTTP.
+`paths::validate_open_path(ctx, path_str)` accepts a path only if it resolves inside `ctx.workspace` or `ctx.worktrees`. This is the single defence against condash being tricked into launching an arbitrary binary via a crafted URL parameter. When editing any "open with external tool" code path, preserve the sandbox check — never trust an absolute path that came in over HTTP.
 
 ## Dashboard HTML
 
-`assets/dashboard.html` is served verbatim at `/`. It is a single-file SPA that polls `/check-updates` for a fingerprint and re-fetches on change. The HTML template's JS calls back into the FastAPI routes registered in `app.py`; `render.render_page(ctx, items)` produces the item-list HTML that the template embeds. Do not refactor `dashboard.html` into a JS framework — the single-file contract is deliberate (zero build step, ships in the wheel via `importlib.resources`).
+`frontend/dashboard.html` is served verbatim at `/`. It is a single-file SPA driven by htmx + a small set of hand-written ES modules under `frontend/src/js/`. The bundle (`frontend/dist/bundle.{js,css}`) is rebuilt by `make frontend` and embedded into the binary via rust-embed. Per-pane refreshes go through `hx-trigger="sse:<tab>"` + `/fragment/<tab>`. Do not refactor `dashboard.html` into a JS framework — the single-file contract is deliberate (one `<script>` tag, zero npm install at runtime).
 
 ## PDF preview
 
-PDFs in project notes render inside the modal via a custom viewer built on `pdfjs-dist` (library, not the prebuilt stock `web/viewer.html`). The library is vendored under `assets/vendor/pdfjs/` and served by the `/vendor/pdfjs/{rel_path:path}` route in `app.py`. `render.py::_render_note` emits `<div class="note-pdf-host" data-pdf-src="/file/…" data-pdf-filename="…">` for `.pdf` files; the ES module at the bottom of `dashboard.html` imports `/vendor/pdfjs/build/pdf.mjs`, exposes `window.__pdfjs`, and mounts toolbar + lazy-rendered canvases on each host. To bump the vendored version, edit `PDFJS_VERSION` in the Makefile and run `make update-pdfjs`.
+PDFs in project notes render inside the modal via a custom viewer built on `pdfjs-dist` (library, not the prebuilt stock `web/viewer.html`). The library is vendored under `frontend/vendor/pdfjs/` and served at `/vendor/pdfjs/{rel_path}`. The render layer emits `<div class="note-pdf-host" data-pdf-src="/file/…" data-pdf-filename="…">` for `.pdf` files; the ES module at the bottom of `dashboard.html` imports `/vendor/pdfjs/build/pdf.mjs`, exposes `window.__pdfjs`, and mounts toolbar + lazy-rendered canvases on each host. Bump via `make update-pdfjs`.
 
-We deliberately do **not** use `<iframe src="*.pdf">` with Chromium's built-in PDF viewer: QtWebEngine ships with `PdfViewerEnabled=false` and `pywebview` doesn't flip it, so the native-window modal would just show an "Open externally" card for PDFs.
+We deliberately do **not** use `<iframe src="*.pdf">` with the embedded webview's built-in PDF viewer — Tauri's webview does not consistently expose one across platforms.
 
 ## Commands
 
 ```bash
-make dev-install                # uv sync --all-extras (install runtime + dev + e2e deps)
-make test                       # fast in-process pytest suite (tests/, skips tests/e2e/)
-make test-e2e                   # Playwright browser suite (tests/e2e/) against real condash subprocess
-make test-all                   # both suites
-make lint                       # uv run ruff check + format --check
-make format                     # uv run ruff check --fix + format
-make run                        # uv run condash (native window)
-uv run condash --version        # smoke test the entry point
-uv run condash init             # write a default config template
-uv run condash config show      # print the effective configuration
-uv run condash config path      # print the resolved config-file path
-uv run condash config edit      # open the config file in $VISUAL / $EDITOR
-uv run condash install-desktop  # register the XDG .desktop entry (Linux)
+make setup                      # install cargo-tauri into the rustup toolchain (one-shot)
+make frontend                   # bundle frontend/src/ into frontend/dist/ via esbuild
+make run                        # `cargo tauri dev` — open the native window
+make serve                      # run `condash-serve` headless (CONCEPTION= overrides path)
+make build                      # bundle Tauri release artefacts
+make check                      # cargo check + inline-handler lint guard
+make test                       # cargo test across the workspace
+make smoke                      # Playwright e2e against condash-serve
+make format                     # cargo fmt across the workspace
+make docs / docs-serve          # build / preview the mkdocs site
 ```
 
-The CLI honours `CONDASH_LOG_LEVEL` (default `INFO`) for the root logger; set to `DEBUG` to surface the clipboard fallback chain and similar low-noise events.
+The CLI honours `CONDASH_LOG_LEVEL` (default `INFO`) for logging; set to `DEBUG` to surface the clipboard fallback chain and similar low-noise events. `CONDASH_PORT` pins `condash-serve`'s port for stable Playwright fixtures.
 
 ## Workflow
 
-1. After any code change: `make format && make lint && make test` — matches the `make format` / `make test` rhythm the other vcoeur CLIs have.
-2. Manual smoke test: `make run` against a throwaway `conception_path` (e.g. `/tmp/fake-conception/` with one project README) before committing changes the automated smoke does not cover.
-3. When adding a new FastAPI route in `app.py`: add the matching fetch call in `assets/dashboard.html` and consider extending `tests/test_app_smoke.py` if the route is reachable from a `TestClient`.
-4. Every helper that needs config takes `ctx: RenderCtx` as its first argument. Pure helpers (regex gates, HTML escaping, parsers of in-memory data) stay ctx-free.
-5. When touching `config.py`: round-trip at least one fixture through `tomlkit` manually to confirm comments and key order survive the rewrite — the in-app editor depends on this.
+1. After any code change: `make format && make check && make test`.
+2. Bundle the frontend (`make frontend`) before `make run` / `make serve` / `make smoke` — the binaries serve the embedded `dist/`, not the source.
+3. `make smoke` boots `condash-serve` against a fixture conception tree and drives the dashboard via Playwright — run it before merging anything that touches routes, SSE, or the bundled JS.
+4. When adding a new route in `server/`: add the matching fetch call in `frontend/src/js/` and consider extending the smoke suite if it's reachable from the SPA.
+5. Every helper that needs config takes `ctx: &RenderCtx` (or pulls one from `state.ctx()`). Pure helpers (regex gates, HTML escaping, parsers of in-memory data) stay ctx-free.
 
 ## Key code locations
 
-- CLI entrypoint: `src/condash/cli.py` — Typer app with a root callback that launches the window and a `config` sub-app for `show / edit / path`.
-- FastAPI routes: `src/condash/routes/*.py` — one file per concern, each exporting `build_router(state) -> APIRouter`. `app.py::_register_routes` calls `routes.register_all(_ng_app, state)` to wire them all on; the live RenderCtx is read via `state.get_ctx()`.
-- Runtime state: `src/condash/state.py::AppState` (single per-process instance at `app.state`) + `src/condash/context.py::RenderCtx` + `build_ctx(cfg)`. Frozen RenderCtx carries `base_dir`, `workspace`, `worktrees`, `repo_structure`, `open_with`, `pdf_viewer`, `template`. Rebuilt on every `/config` POST.
-- Path validators: `src/condash/paths.py::_safe_resolve` is the shared traversal guard; every route-facing validator composes regex gates on top of it.
-- Parsers + renderers: `src/condash/parser.py` (README + knowledge tree), `src/condash/render.py` (HTML for cards / notes / knowledge / git strip / page).
-- History search: `src/condash/search.py::search_items` — token-AND scan of each project's README body, note/text-file content and filenames. Exposed as `GET /search-history?q=…`; the History tab's input switches to a query-mode results list (`dashboard.html::filterHistory` / `_runHistorySearch`) with a jump-to-project button.
-- File mutations: `src/condash/mutations.py` — toggle / add / edit / remove step, rename / create note, priority edit.
-- Git scan + repo strip: `src/condash/git_scan.py` — workspace scan, per-repo status, worktree listing, fingerprint cache for the `/check-updates` long-poll.
-- External launchers: `src/condash/openers.py` — open-in-IDE, PDF viewer chain, OS default opener, external URL routing.
-- Wikilinks: `src/condash/wikilinks.py` — `[[target]]` resolver called from markdown preprocess before pandoc.
-- Config dataclass + loader: `src/condash/config.py::CondashConfig` and `config.load`. `ConfigNotFoundError` vs `ConfigIncompleteError` are distinct so the CLI can suggest `init` vs `config edit`. The same module owns the editor's payload boundary (`config_to_payload` / `payload_to_config`) so every input shape — TOML, YAML, JSON — funnels through one validator (`config.parse_repo_entries`).
-- Native window launcher: `src/condash/desktop.py` — writes `~/.local/share/applications/condash.desktop` and the SVG icon. Linux only.
-- Assets shipped in the wheel: `src/condash/assets/` — referenced via `importlib.resources.files("condash") / "assets"`, never via `__file__`, so the app works when installed from a wheel.
+- GUI entrypoint: `src-tauri/src/main.rs` → `lib.rs::run` (Tauri builder, plugins, conception-path resolution + first-run picker).
+- Headless entrypoint: `src-tauri/src/bin/condash_serve.rs`.
+- Router wiring: `src-tauri/src/server/mod.rs::build_router`. Each concern is a sibling file exposing route handlers.
+- Runtime state: `src-tauri/src/server/mod.rs::AppState` — single per-process instance — and `crates/condash-state/src/ctx.rs::RenderCtx` + `build_ctx`. `RenderCtx` is frozen (`Arc`-shared); rebuilt on every `/configuration` POST.
+- Path validators: `src-tauri/src/paths.rs` — the shared traversal guard.
+- Parsers + renderers: `crates/condash-parser/` (README + knowledge tree), `crates/condash-render/` (minijinja templates + Rust render functions for cards / notes / knowledge / git strip / page).
+- History search: `crates/condash-state/src/search.rs::search_items`. Exposed as `GET /fragment/history?q=…`; the History tab's input drives it via htmx.
+- File mutations: `crates/condash-mutations/` — toggle / add / edit / remove step, set-priority, rename / create note, create-item, file uploads.
+- Git scan: `crates/condash-state/src/git/scan.rs` — workspace scan, per-repo status, worktree listing, fingerprint cache for the `/check-updates` long-poll.
+- Runner registry: `src-tauri/src/runner_registry.rs` — per-repo PTY-backed dev-runner sessions; surfaces `fingerprint_token` for the Code-tab fingerprint layer.
+- Embedded terminal: `src-tauri/src/pty.rs` (PTY lifecycle) + `src-tauri/src/server/terminal.rs` (WebSocket handler).
+- External launchers: `src-tauri/src/launcher.rs` + `src-tauri/src/server/openers.rs`.
+- Asset embedding: `src-tauri/src/assets.rs` (rust-embed of `frontend/`) + `frontend/vendor/` (vendored libraries shipped in the binary).
+- Frontend bundle entry: `frontend/src/js/dashboard-main.js`. Section modules under `frontend/src/js/sections/` — one per UI concern.
+- Inline-handler lint guard: `tools/check-inline-handlers.sh` — keeps every event handler declared as `data-action` + delegated listener rather than inline `on*=`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,8 @@ members = [
     "crates/condash-mutations",
 ]
 
-# Lints live at the workspace level so every member crate inherits them
-# via `[lints] workspace = true`. Phase-1 porting picks up here; later
-# phases can tighten this list once the Rust surface stabilises.
+# Lints live at the workspace level so every member crate inherits
+# them via `[lints] workspace = true`.
 [workspace.lints.rust]
 unsafe_code = "forbid"
 

--- a/crates/condash-mutations/src/create_item.rs
+++ b/crates/condash-mutations/src/create_item.rs
@@ -12,7 +12,7 @@ use condash_parser::{Kind, Priority};
 use regex::Regex;
 use serde::Serialize;
 
-/// Kind of a new item — mirrors `parser.KINDS`.
+/// Kind of a new item.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ItemKind {
     Project,
@@ -48,8 +48,8 @@ impl From<ItemKind> for Kind {
     }
 }
 
-/// Input spec for `create_item` — the fields the `/create-item` and
-/// `/api/items` routes collect from the new-item modal.
+/// Input spec for `create_item` — the fields the `/create-item` route
+/// collects from the new-item modal.
 #[derive(Debug, Default, Clone)]
 pub struct NewItemSpec {
     pub title: String,
@@ -302,10 +302,10 @@ pub fn create_item(
     let month_dir = projects_root.join(&month);
     let item_dir = month_dir.join(&folder_name);
 
-    // Python: item_dir.resolve().relative_to(projects_root.resolve())
-    // We replicate the invariant with a literal prefix check since the
-    // path doesn't exist yet. The slug regex already rejects traversal
-    // in practice (no `/` or `..`).
+    // Defence in depth: confirm the resolved path stays under
+    // projects/ via a literal prefix check on the canonicalised root.
+    // The slug regex already rejects traversal in practice (no `/`
+    // or `..`).
     let projects_canonical = fs::canonicalize(&projects_root).unwrap_or(projects_root.clone());
     let hypothetical = projects_canonical.join(&month).join(&folder_name);
     if !hypothetical.starts_with(&projects_canonical) {

--- a/crates/condash-mutations/src/files.rs
+++ b/crates/condash-mutations/src/files.rs
@@ -46,8 +46,8 @@ fn is_reserved_filename(name: &str) -> bool {
 // write_note
 // ---------------------------------------------------------------------
 
-/// Result of `write_note` — mirrors the `{ok, mtime | reason}` shape of
-/// `mutations.write_note`.
+/// Result of `write_note` — `{ok, mtime}` on success or
+/// `{ok: false, reason, mtime?}` on stale-mtime / IO failure.
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum WriteNoteResult {
@@ -100,8 +100,7 @@ pub fn write_note(
         }
     }
 
-    // Tmp sibling + rename for atomic replace. Python uses
-    // `full_path.with_suffix(suffix + ".tmp")` — append, don't replace.
+    // Tmp sibling + rename for atomic replace.
     let tmp = append_suffix(full_path, ".tmp");
     fs::write(&tmp, content)?;
     if let Err(e) = fs::rename(&tmp, full_path) {
@@ -115,9 +114,8 @@ pub fn write_note(
     })
 }
 
-/// Python's `Path.with_suffix(p.suffix + ".tmp")` appends `.tmp` to the
-/// existing suffix (so `foo.md` → `foo.md.tmp`). Rust's equivalent takes
-/// a couple of lines.
+/// Append `extra` to the path as a string suffix (so `foo.md` →
+/// `foo.md.tmp`), without replacing the existing extension.
 fn append_suffix(path: &Path, extra: &str) -> PathBuf {
     let mut s = path.as_os_str().to_os_string();
     s.push(extra);
@@ -128,8 +126,8 @@ fn append_suffix(path: &Path, extra: &str) -> PathBuf {
 // rename_note
 // ---------------------------------------------------------------------
 
-/// `{ok, path, mtime}` / `{ok: false, reason}` — mirrors
-/// `mutations.rename_note`.
+/// `{ok, path, mtime}` on success / `{ok: false, reason}` on conflict
+/// or IO failure.
 #[derive(Debug, Serialize)]
 #[serde(untagged)]
 pub enum RenameResult {
@@ -395,8 +393,8 @@ pub fn store_uploads<R: Read>(
     max_bytes_per_file: u64,
 ) -> io::Result<StoreUploadsResult> {
     if subdir_was_supplied && !target_dir.exists() {
-        // Python's `store_uploads` returns an ok=False with reason in
-        // this case; the route handler short-circuits to a 400.
+        // Caller supplied a subdir that doesn't exist — return ok=false
+        // so the route handler can surface a 400.
         return Ok(StoreUploadsResult {
             ok: false,
             stored: vec![],

--- a/crates/condash-mutations/src/steps.rs
+++ b/crates/condash-mutations/src/steps.rs
@@ -1,14 +1,10 @@
-//! Step-level mutations on an item README: toggle / add / remove / edit /
-//! set-priority / reorder-all. 1:1 with the `_toggle_checkbox`,
-//! `_remove_step`, `_edit_step`, `_add_step`, `_set_priority`, and
-//! `_reorder_all` helpers in `mutations.py`.
+//! Step-level mutations on an item README: toggle / add / remove /
+//! edit / set-priority / reorder-all.
 //!
-//! Every function reads the file as UTF-8, splits on `\n`, mutates the line
-//! slice in place, and re-joins with `\n` before writing. Python's
-//! `str.split("\n")` + `"\n".join(...)` round-trips a trailing newline
-//! because the split produces an empty final element; the Rust port uses
-//! the same primitives (`str::split('\n')` + `Vec::join("\n")`) and so
-//! preserves the trailing newline byte-for-byte.
+//! Every function reads the file as UTF-8, splits on `\n`, mutates
+//! the line slice in place, and re-joins with `\n` before writing.
+//! `str::split('\n')` + `Vec::join("\n")` round-trips a trailing
+//! newline because the split produces an empty final element.
 
 use std::fs;
 use std::io;
@@ -20,11 +16,9 @@ use condash_parser::sections::CheckboxStatus;
 use condash_parser::Priority;
 use regex::Regex;
 
-/// `## Steps` — matches exactly what Python's
-/// `re.match(r"^##\s+Steps", line, re.IGNORECASE)` matches: line starts
-/// with `##`, at least one whitespace, then `Steps` (case-insensitive).
-/// No `\b` anchor on purpose — Python's `re.match` doesn't either, so
-/// a heading like `## Steps (draft)` still counts as the Steps section.
+/// `## Steps` heading: line starts with `##`, at least one whitespace,
+/// then `Steps` (case-insensitive). No `\b` anchor — `## Steps (draft)`
+/// also counts as the Steps section.
 static STEPS_HEADING_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^##\s+Steps").expect("STEPS_HEADING_RE compiles"));
 
@@ -47,10 +41,9 @@ static ANY_HEADING_LEVEL_RE: LazyLock<Regex> =
 static ANY_HEADING_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(#{2,})\s+").expect("ANY_HEADING_RE compiles"));
 
-/// The literal string checkbox patterns Python's `_toggle_checkbox` tests
-/// against. Kept as separate `&str`s (rather than a regex) because the
-/// Python reference implementation also uses plain `in` / `str.replace`,
-/// and we want byte-identical behaviour.
+/// Literal checkbox markers. Kept as separate `&str`s (rather than
+/// a regex) so toggle is a plain substring `replace` — exactly the
+/// substring boundaries the on-disk markdown uses.
 const OPEN_MARK: &str = "- [ ]";
 const DONE_MARK_X: &str = "- [x]";
 const DONE_MARK_BIG_X: &str = "- [X]";
@@ -108,10 +101,9 @@ pub fn set_priority(path: &Path, priority: &str) -> io::Result<bool> {
     Ok(true)
 }
 
-/// Flip one checkbox line through the open → done → progress → abandoned
-/// → open cycle. Returns `Ok(None)` if `line_num` is out of bounds or the
-/// line isn't a recognised checkbox — same contract as Python's
-/// `_toggle_checkbox`, which returns `None` in both cases.
+/// Flip one checkbox line through the open → done → progress →
+/// abandoned → open cycle. Returns `Ok(None)` if `line_num` is out
+/// of bounds or the line isn't a recognised checkbox.
 pub fn toggle_checkbox(path: &Path, line_num: usize) -> io::Result<Option<CheckboxStatus>> {
     let text = fs::read_to_string(path)?;
     let mut lines: Vec<String> = text.split('\n').map(|s| s.to_string()).collect();
@@ -312,9 +304,8 @@ pub fn add_step(path: &Path, text: &str, section_heading: Option<&str>) -> io::R
 /// line exactly where it was and shuffles only the checkbox rows among
 /// themselves.
 ///
-/// Every element of `order` must be an in-bounds checkbox line or the
-/// whole reorder aborts without writing — same contract as Python's
-/// `_reorder_all`.
+/// Every element of `order` must be an in-bounds checkbox line or
+/// the whole reorder aborts without writing.
 pub fn reorder_all(path: &Path, order: &[usize]) -> io::Result<bool> {
     let text = fs::read_to_string(path)?;
     let mut lines: Vec<String> = text.split('\n').map(|s| s.to_string()).collect();
@@ -563,8 +554,8 @@ mod tests {
 
     #[test]
     fn add_step_falls_through_to_steps_when_heading_missing() {
-        // Explicit heading that doesn't exist — Python falls through to
-        // the Steps path rather than erroring.
+        // Explicit heading that doesn't exist — fall through to the
+        // Steps path rather than erroring.
         let (_dir, p) = tmp("# T\n\n## Steps\n\n- [ ] s1\n\n## Notes\n");
         let line = add_step(&p, "new", Some("Nonexistent")).unwrap();
         let got = fs::read_to_string(&p).unwrap();

--- a/crates/condash-parser/src/deliverables.rs
+++ b/crates/condash-parser/src/deliverables.rs
@@ -1,9 +1,7 @@
 //! `## Deliverables` PDF link extraction.
 //!
-//! Port of `_parse_deliverables`. `full_path` is *not* filled in here —
-//! Python's `parse_readme` prepends the item directory after the fact. The
-//! caller that owns the item's on-disk path handles that in the phase-2
-//! wrapper.
+//! `full_path` is *not* filled in here — the caller that owns the
+//! item's on-disk path prepends the item directory after the fact.
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/condash-parser/src/knowledge.rs
+++ b/crates/condash-parser/src/knowledge.rs
@@ -32,12 +32,11 @@ pub struct KnowledgeNode {
     pub count: usize,
 }
 
-/// Pick a human label + short description from one `.md` file. Mirrors
-/// `_knowledge_title_and_desc`: first `# heading` wins as title (or the
-/// filename as fallback with `-` / `_` turned into spaces), first
-/// non-blank non-heading non-frontmatter line becomes the description.
-/// Description is trimmed of a trailing dot and capped at 220 *bytes*
-/// to match Python's `str[:220]` slicing.
+/// Pick a human label + short description from one `.md` file. The
+/// first `# heading` wins as title (or the filename as fallback with
+/// `-` / `_` turned into spaces); the first non-blank non-heading
+/// non-frontmatter line becomes the description. Description is
+/// trimmed of a trailing dot and capped at `DESC_MAX` codepoints.
 pub fn knowledge_title_and_desc(path: &Path) -> (String, String) {
     let stem = path
         .file_stem()
@@ -51,7 +50,7 @@ pub fn knowledge_title_and_desc(path: &Path) -> (String, String) {
         Ok(b) => b,
         Err(_) => return (title, desc),
     };
-    // Python's `read_text(errors="replace")` maps invalid bytes to U+FFFD.
+    // Invalid bytes map to U+FFFD rather than failing the whole read.
     let text = String::from_utf8_lossy(&bytes);
     let mut title_taken = false;
     for raw in text.split('\n') {
@@ -73,9 +72,8 @@ pub fn knowledge_title_and_desc(path: &Path) -> (String, String) {
         desc = line.trim_end_matches('.').to_string();
         break;
     }
-    // Python's `desc[:220]` slices by codepoint in py3 `str`, which
-    // for ASCII is the same as bytes. Use chars() to stay safe with
-    // non-ASCII descriptions.
+    // Slice by codepoint, not byte, so non-ASCII descriptions don't
+    // get cut mid-character.
     if desc.chars().count() > DESC_MAX {
         desc = desc.chars().take(DESC_MAX).collect();
     }
@@ -83,7 +81,7 @@ pub fn knowledge_title_and_desc(path: &Path) -> (String, String) {
 }
 
 /// Scan `<base_dir>/knowledge/` recursively; returns `None` if the
-/// directory is missing. Wrapper matching Python's `collect_knowledge`.
+/// directory is missing.
 pub fn collect_knowledge(base_dir: &Path) -> Option<KnowledgeNode> {
     collect_tree(base_dir, "knowledge", "Knowledge")
 }
@@ -170,9 +168,9 @@ fn build_node(base_dir: &Path, root_dir: &Path, d: &Path, root_label: &str) -> K
     }
 }
 
-/// `name.replace('_', ' ').replace('-', ' ').title()` — Python's
-/// `str.title()` uppercases the first letter of each word and lowercases
-/// the rest, with word boundaries at non-letter characters.
+/// Replace `_` and `-` with spaces, then title-case: uppercase the
+/// first letter of each word and lowercase the rest, with word
+/// boundaries at non-letter characters.
 fn title_case_segments(name: &str) -> String {
     let spaced = name.replace(['_', '-'], " ");
     let mut out = String::with_capacity(spaced.len());
@@ -297,7 +295,7 @@ mod tests {
     }
 
     #[test]
-    fn tree_shape_matches_python_contract() {
+    fn tree_shape_contract() {
         let td = tempfile::tempdir().unwrap();
         let base = td.path();
         write(

--- a/crates/condash-parser/src/note_kind.rs
+++ b/crates/condash-parser/src/note_kind.rs
@@ -57,10 +57,9 @@ pub fn note_kind(path: &Path) -> &'static str {
         return "binary";
     };
     let lower = name.to_ascii_lowercase();
-    // Python's Path.suffix only looks at the segment after the last dot;
-    // for dotfiles like ".gitignore" the suffix is empty and the file
-    // classifies as binary. Mirror that behavior rather than matching on
-    // bare filename.
+    // Dotfiles (`.gitignore`) have no suffix and classify as binary.
+    // We treat the segment after the *last* dot as the extension, so
+    // `foo.tar.gz` reads as `.gz`.
     let ext = match lower.rfind('.') {
         Some(0) | None => return "binary",
         Some(i) => &lower[i..],

--- a/crates/condash-parser/src/readme.rs
+++ b/crates/condash-parser/src/readme.rs
@@ -154,16 +154,10 @@ fn parse_header(lines: &[&str]) -> (HashMap<String, String>, Option<usize>) {
     (meta, first_section_idx)
 }
 
-/// Parse the `**Apps**:` (or `**Composant**:`) value into a list of app
-/// names. Python:
-///
-/// ```python
-/// [a.strip().strip("`").split("(")[0].strip()
-///  for a in apps_raw.split(",") if a.strip()]
-/// ```
-///
-/// Note that `a.strip("`")` strips *every* leading/trailing backtick, not
-/// just one — e.g. `` "``vcoeur``" `` becomes `"vcoeur"`.
+/// Parse the `**Apps**:` (or `**Composant**:`) value into a list of
+/// app names. Splits on `,`, trims, strips *every* leading/trailing
+/// backtick (so `` ``vcoeur`` `` becomes `vcoeur`), and drops anything
+/// from the first `(` onward so `` `app (note)` `` becomes `app`.
 fn split_apps(apps_raw: &str) -> Vec<String> {
     apps_raw
         .split(',')
@@ -178,8 +172,8 @@ fn split_apps(apps_raw: &str) -> Vec<String> {
 
 /// Extract the first paragraph of body text after the first `## heading`,
 /// skipping fenced code blocks, tables, and blank lines before content.
-/// Truncated to `SUMMARY_MAX` codepoints with a `...` tail when longer —
-/// matching Python's `summary[:297] + "..."` which slices by codepoint.
+/// Truncated to `SUMMARY_MAX` codepoints (not bytes) with a `...`
+/// tail when longer.
 fn extract_summary(lines: &[&str], first_section_idx: Option<usize>) -> String {
     let Some(idx) = first_section_idx else {
         return String::new();
@@ -449,8 +443,8 @@ Second paragraph should not appear.
 
     #[test]
     fn summary_truncated_at_300_codepoints_with_ellipsis() {
-        // 400 'é' characters (2 bytes each in UTF-8) — forces codepoint
-        // (not byte) counting to match Python.
+        // 400 'é' characters (2 bytes each in UTF-8) — forces
+        // codepoint (not byte) counting.
         let long: String = "é".repeat(400);
         let md = format!("# T\n\n## Goal\n\n{long}\n");
         let r = parse(&md);

--- a/crates/condash-parser/src/regexes.rs
+++ b/crates/condash-parser/src/regexes.rs
@@ -26,8 +26,8 @@ pub static HEADING2_RE: LazyLock<Regex> =
 pub static HEADING3_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^###\s+(.+)$").expect("HEADING3_RE compiles"));
 
-/// `**Status**: …` metadata line. Case-insensitive to match Python's
-/// `re.IGNORECASE` — used by callers that just need to test presence.
+/// `**Status**: …` metadata line. Case-insensitive — used by callers
+/// that just need to test presence.
 pub static STATUS_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^\*\*Status\*\*\s*:\s*.*$").expect("STATUS_RE compiles"));
 
@@ -57,8 +57,8 @@ mod tests {
     fn metadata_non_greedy_key() {
         // When more than one `**…**:` appears on the same line, the
         // non-greedy `.+?` pairs with the *first* closing `**:` it can
-        // reach — so the key is the first bolded segment, not everything
-        // up to the last bolded segment. Python's `re` does the same.
+        // reach — so the key is the first bolded segment, not
+        // everything up to the last bolded segment.
         let caps = METADATA_RE
             .captures("**First**: value **Second**: other")
             .unwrap();

--- a/crates/condash-parser/src/sections.rs
+++ b/crates/condash-parser/src/sections.rs
@@ -9,10 +9,10 @@ use crate::regexes::{CHECKBOX_RE, HEADING2_RE};
 
 /// Resolved checkbox state.
 ///
-/// The Python parser maps the raw character inside `[…]` to one of four
-/// logical states; `done` and `abandoned` both count as "completed" for
-/// the done/total tally the dashboard shows, which is why `SectionItem`
-/// carries a boolean `done` *and* the richer `status`.
+/// The raw character inside `[…]` maps to one of four logical states;
+/// `done` and `abandoned` both count as "completed" for the done/total
+/// tally the dashboard shows, which is why `SectionItem` carries a
+/// boolean `done` *and* the richer `status`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum CheckboxStatus {
@@ -44,7 +44,7 @@ pub struct SectionItem {
     pub text: String,
     pub done: bool,
     pub status: CheckboxStatus,
-    /// Zero-based line index in the source README. Matches Python.
+    /// Zero-based line index in the source README.
     pub line: usize,
 }
 

--- a/crates/condash-parser/src/tree.rs
+++ b/crates/condash-parser/src/tree.rs
@@ -44,7 +44,7 @@ const DEFAULT_MAX_DEPTH: usize = 3;
 /// entries (`.…`) and the item's top-level `README.md` are skipped.
 /// Empty subdirectories are kept so a freshly-created folder shows up
 /// immediately as an empty group. Walks up to `max_depth` levels
-/// (default 3, matching Python's signature).
+/// (default 3).
 pub fn list_item_tree(base_dir: &Path, item_dir: &Path) -> ItemTree {
     list_item_tree_with_depth(base_dir, item_dir, DEFAULT_MAX_DEPTH)
 }
@@ -117,16 +117,15 @@ fn walk(
     ItemTree { files, groups }
 }
 
-/// `path` relative to `base`, rendered with forward slashes (matching
-/// Python's `str(PosixPath)` on Linux).
+/// `path` relative to `base`, rendered with forward slashes.
 fn rel_to(base: &Path, path: &Path) -> String {
     path.strip_prefix(base)
         .map(|r| r.to_string_lossy().replace('\\', "/"))
         .unwrap_or_else(|_| path.to_string_lossy().into_owned())
 }
 
-/// Flatten a tree to its file paths in depth-first order. Mirrors
-/// Python's `_flatten_tree_paths` — used by the fingerprint helpers.
+/// Flatten a tree to its file paths in depth-first order. Used by
+/// the fingerprint helpers.
 pub fn flatten_tree_paths(tree: &ItemTree) -> Vec<String> {
     let mut out: Vec<String> = tree.files.iter().map(|f| f.path.clone()).collect();
     for g in &tree.groups {
@@ -212,9 +211,8 @@ mod tests {
         touch(&item.join("a/b/c/deep.txt"));
 
         let tree = list_item_tree_with_depth(td.path(), &item, 2);
-        // With max_depth=2, the recursive walker enters `a/` (depth 1 → 2)
-        // but skips `b/` entirely (`depth >= max_depth`), matching Python's
-        // `if depth >= max_depth: continue`.
+        // With max_depth=2, the recursive walker enters `a/` (depth
+        // 1 → 2) but skips `b/` entirely (`depth >= max_depth`).
         let a = &tree.groups[0];
         assert_eq!(a.label, "a");
         assert!(a.groups.is_empty());

--- a/crates/condash-render/src/git_render.rs
+++ b/crates/condash-render/src/git_render.rs
@@ -53,8 +53,8 @@ fn runner_key_for_member(family: &Family, member: &Member) -> String {
 }
 
 /// The "Open with …" split button — primary icon + caret → popover
-/// picker. Phase 2 rendering is static; the interactive JS lives in
-/// the bundled dashboard frontend.
+/// picker. Server-rendered as static markup; the interactive JS lives
+/// in the bundled dashboard frontend.
 pub fn render_open_with(ctx: &RenderCtx, path: &str) -> String {
     let path_h = h(path);
     let primary_slot = "main_ide";
@@ -244,9 +244,9 @@ fn branch_status_cell(info: &Checkout) -> String {
 }
 
 fn branch_status_cell_member(info: &Member) -> String {
-    // Python shares `_branch_status_cell` across Member + Checkout via
-    // dict-key access — our two types differ, so mirror the logic
-    // against `Member` explicitly.
+    // Same status-cell logic as `branch_status_cell` above; duplicated
+    // because Member and Checkout don't share a trait for `missing` /
+    // `dirty` / `changed`.
     if info.missing {
         "<span class=\"branch-missing\">missing</span>".into()
     } else if info.dirty {
@@ -451,7 +451,7 @@ fn render_peer_card(
     let is_live = !is_missing && session.map(|s| s.exit_code.is_none()).unwrap_or(false);
     // Emit the mount (exited or running) whenever a session is anchored
     // here — so the "exited: N" state survives until the user clicks
-    // Stop. Matches Python's `_render_runner_mount` truth table.
+    // Stop.
     let has_session_here = !is_missing && session.is_some();
     let head_tag = if is_live {
         format!("{head_tag}<span class=\"peer-tag peer-tag-live\">live</span>")

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -61,9 +61,8 @@ pub fn priorities() -> [&'static str; 6] {
     ]
 }
 
-/// First pending step across all sections, or `None`. Mirrors
-/// `_next_step` — "pending" = `open` or `progress`; `abandoned` isn't
-/// "next".
+/// First pending step across all sections, or `None`. "Pending" =
+/// `open` or `progress`; `abandoned` isn't "next".
 fn next_step(item: &Item) -> Option<Value> {
     use condash_parser::sections::CheckboxStatus;
     for sec in &item.readme.sections {
@@ -76,9 +75,9 @@ fn next_step(item: &Item) -> Option<Value> {
     None
 }
 
-/// Recursive file count for a group (Python's `_subtree_count`). Used
-/// by the card template via the `subtree_count` filter — but also by
-/// `_render_card` directly to compute the top-level total.
+/// Recursive file count for a group. Used by the card template via
+/// the `subtree_count` filter and by `_render_card` directly to
+/// compute the top-level total.
 fn subtree_count(group: &condash_parser::GroupEntry) -> usize {
     group.files.len() + group.groups.iter().map(subtree_count).sum::<usize>()
 }
@@ -150,8 +149,7 @@ pub fn render_history(ctx: &RenderCtx, items: &[Item]) -> String {
     let mut months: Vec<serde_json::Value> = Vec::with_capacity(month_names.len());
     for name in month_names {
         let mut month_items = by_month.remove(&name).unwrap();
-        // slug[:10] desc — Python uses `key=lambda x: x["slug"]` with
-        // reverse=True (no slug trimming); use whole slug.
+        // Sort by full slug, descending — newer items first within a month.
         month_items.sort_by(|a, b| b.readme.slug.cmp(&a.readme.slug));
         let items_json: Vec<serde_json::Value> = month_items
             .iter()
@@ -177,10 +175,9 @@ pub fn render_history(ctx: &RenderCtx, items: &[Item]) -> String {
     templating::render("history.html.j2", tctx)
 }
 
-/// HTML for the History pane's search-results fragment. Mirrors the
-/// shape that `_renderHistoryResults` used to build client-side, so
-/// existing CSS and `data-action` wiring (`open-history-hit`,
-/// `jump-to-project`) keep working unchanged.
+/// HTML for the History pane's search-results fragment. Emits the
+/// markup the History pane's CSS + `data-action` wiring
+/// (`open-history-hit`, `jump-to-project`) expects.
 pub fn render_history_search_results(results: &[SearchResult], q: &str) -> String {
     let ctx = context! {
         results => Value::from_serialize(results),
@@ -319,8 +316,7 @@ pub fn render_page(
         &all_items.iter().map(|&i| i.clone()).collect::<Vec<_>>(),
     );
 
-    // Placeholder substitution — use `replace` (all occurrences) to
-    // mirror Python's `str.replace` semantics.
+    // Placeholder substitution — `replace` swaps every occurrence.
     let mut out = ctx.template.clone();
     out = out.replace("{{CARDS}}", &cards);
     out = out.replace("{{GIT_REPOS}}", &git_html);

--- a/crates/condash-render/src/templating.rs
+++ b/crates/condash-render/src/templating.rs
@@ -33,10 +33,10 @@ fn embed_filter(value: Value) -> Result<Value, Error> {
 
 /// Embed a JSON-serializable value as an HTML-attribute-safe literal.
 ///
-/// Matches Python's `json.dumps(obj).replace("'", "\\'").replace('"', "'")`:
-/// the outer quotes become `'`, JSON's `\"` escaping vanishes, and any
-/// single quote inside the value is backslash-escaped. Safe to drop
-/// inside a double-quoted attribute like `onclick="foo({{…}})"`.
+/// JSON-encodes `value`, then swaps the outer double quotes for single
+/// quotes and backslash-escapes any single quote inside the value.
+/// Safe to drop inside a double-quoted attribute like
+/// `onclick="foo({{…}})"`.
 pub fn embed_attr<T: serde::Serialize>(value: &T) -> String {
     let json = serde_json::to_string(value).expect("serialise for embed");
     embed_json_string(&json)

--- a/crates/condash-render/templates/history_search_results.html.j2
+++ b/crates/condash-render/templates/history_search_results.html.j2
@@ -1,7 +1,6 @@
 {# History search results fragment — emitted by /fragment/history when q is non-empty.
-   Matches the structure that `_renderHistoryResults` / `_historyResultBlock`
-   used to build client-side, so existing CSS + data-action wiring (see
-   `open-history-hit`, `jump-to-project`) keeps working. #}
+   Matches the markup the History pane's CSS + data-action wiring
+   (`open-history-hit`, `jump-to-project`) expects. #}
 {% if not results %}
 <p class="history-empty">No projects match "{{ q }}".</p>
 {% else %}

--- a/crates/condash-state/src/cache.rs
+++ b/crates/condash-state/src/cache.rs
@@ -1,7 +1,7 @@
 //! Filesystem-walk memoization.
 //!
 //! Without a cache every request re-walks the conception tree: `/`,
-//! `/check-updates`, `/fragment`, and `/search-history` all call
+//! `/check-updates`, and the `/fragment/*` routes all call
 //! `collect_items` (which parses every `README.md` under `projects/`)
 //! and `collect_knowledge` (which walks `knowledge/` recursively).
 //!
@@ -164,9 +164,9 @@ impl WorkspaceCache {
     }
 
     /// Return the memoized knowledge tree, warming on first access.
-    /// The outer `Arc` layer makes the `Option<KnowledgeNode>` cheap to
-    /// share; the inner `Option` mirrors Python's "directory missing"
-    /// case.
+    /// The outer `Arc` makes the `Option<KnowledgeNode>` cheap to
+    /// share; the inner `Option` is `None` when no `knowledge/`
+    /// directory exists.
     pub fn get_knowledge(&self, ctx: &RenderCtx) -> Arc<Option<KnowledgeNode>> {
         if let Some(k) = self.inner.read().unwrap().knowledge.clone() {
             return k;

--- a/crates/condash-state/src/ctx.rs
+++ b/crates/condash-state/src/ctx.rs
@@ -63,17 +63,12 @@ pub struct RenderCtx {
     pub repo_structure: Vec<RepoSection>,
     /// "Open with …" slots keyed by slot name (`main_ide`,
     /// `secondary_ide`, `terminal`, …). Only the `label` is consumed
-    /// here; the command list itself lives on the mutations side and
-    /// lands in Phase 3+.
+    /// here; the command list itself lives on the openers side.
     pub open_with: HashMap<String, OpenWithSlot>,
     /// Names of repo checkouts that carry a configured dev-runner.
     /// Parent repos use their `name`; subrepos use `<parent>--<sub>`.
-    /// Matches the keyspace of Python's `ctx.repo_run`. Used by the
-    /// Code-tab node fingerprint to emit `|run:<token>` fragments for
-    /// configured rows and `""` for unconfigured ones — runner state
-    /// itself is Phase 4+ territory, but the fingerprint needs to
-    /// agree *now* so `/check-updates` stays consistent across the
-    /// Python / Rust builds.
+    /// Used by the Code-tab node fingerprint to emit `|run:<token>`
+    /// fragments for configured rows and `""` for unconfigured ones.
     pub repo_run_keys: std::collections::HashSet<String>,
     /// Runner command template per repo key. Populated from
     /// `repositories.yml`'s `run:` fields alongside [`Self::repo_run_keys`].
@@ -82,7 +77,7 @@ pub struct RenderCtx {
     /// A key present in `repo_run_keys` but missing here means the
     /// config layer hasn't populated templates yet — the runner
     /// `/api/runner/start` handler treats that as "no command
-    /// configured" and 404s, matching Python.
+    /// configured" and 404s.
     pub repo_run_templates: HashMap<String, String>,
     /// Optional per-repo "nuclear" stop command. Same keyspace as
     /// [`Self::repo_run_templates`] (parent: `name`, subrepo:
@@ -92,8 +87,8 @@ pub struct RenderCtx {
     /// key = no force-stop button rendered for that repo.
     pub repo_force_stop_templates: HashMap<String, String>,
     /// PDF-viewer command fallback chain (e.g. `["evince {path}",
-    /// "okular {path}"]`). Empty = use the built-in chain. Consumed by
-    /// the openers layer (Phase 3+).
+    /// "okular {path}"]`). Empty = use the built-in chain. Consumed
+    /// by the openers layer.
     pub pdf_viewer: Vec<String>,
     /// Embedded-terminal preferences. All fields optional; absent ones
     /// fall back to the renderer's built-in defaults.

--- a/crates/condash-state/src/git/scan.rs
+++ b/crates/condash-state/src/git/scan.rs
@@ -1,12 +1,9 @@
 //! Git repo discovery + status for the dashboard's Code tab.
 //!
-//! Rust port of `src/condash/git_scan.py`. Shells out to `git` via
-//! `std::process::Command` — same binary, same `--porcelain` output —
-//! so the parsed result is byte-for-byte identical to the Python side.
-//! (Switching to libgit2 would be faster, but would risk subtle
-//! divergence on porcelain flags, worktree-list formatting, and
-//! sandbox-stub detection. Staying on the CLI is the conservative
-//! move for a direct port.)
+//! Shells out to `git` via `std::process::Command` rather than using
+//! libgit2 — the CLI's `--porcelain` output is the documented stable
+//! contract and avoids surprises around worktree-list formatting and
+//! sandbox-stub detection.
 //!
 //! The public surface:
 //!
@@ -48,10 +45,9 @@ fn stamp_for(repo_dir: &Path) -> RepoStamp {
 static REPO_CACHE: Mutex<Option<HashMap<PathBuf, (RepoStamp, ScannedRepo)>>> = Mutex::new(None);
 
 /// One checkout (main repo or worktree) — shared shape used by both
-/// worktree entries and the top-level repo dict. Python's dict always
-/// carries a `missing` key on worktree entries returned by
-/// `_parent_member` / `_subrepo_member`; matching that literally means
-/// emitting `missing: false` on every row rather than omitting it.
+/// worktree entries and the top-level repo entry. `missing` is always
+/// emitted (defaulting to `false`) so the JSON schema is uniform
+/// across rows.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Checkout {
     pub key: String,
@@ -64,7 +60,6 @@ pub struct Checkout {
 }
 
 /// One member of a family — the parent repo or a promoted subrepo.
-/// Matches Python's dict shape one-for-one.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Member {
     pub name: String,
@@ -94,7 +89,7 @@ pub struct Group {
 }
 
 /// Return `true` for harness-synthesized stub files that should not
-/// count as real repo changes. Rust port of `_is_sandbox_stub`.
+/// count as real repo changes.
 ///
 /// When condash runs inside a sandbox (Claude Code's bwrap harness),
 /// the runtime binds zero-byte read-only copies of the user's home
@@ -132,7 +127,8 @@ fn is_sandbox_stub(repo_path: &Path, status: &str, rel: &str) -> bool {
         if md.size() != 0 {
             return false;
         }
-        // Writable? Python: `st.st_mode & 0o222` is truthy → real file.
+        // Writable? Any write bit set means a real file (sandbox-stub
+        // detection — true sandbox stubs are read-only).
         if md.mode() & 0o222 != 0 {
             return false;
         }
@@ -146,8 +142,8 @@ fn is_sandbox_stub(repo_path: &Path, status: &str, rel: &str) -> bool {
 }
 
 /// `(branch, dirty, changed_count, changed_files)` for a repo/worktree.
-/// Shell-out to `git rev-parse` and `git status --porcelain`, same as
-/// Python. Failures collapse to `("?", false, 0, [])`.
+/// Shells out to `git rev-parse` and `git status --porcelain`. Failures
+/// collapse to `("?", false, 0, [])`.
 fn git_status(path: &Path) -> (String, bool, usize, Vec<String>) {
     let Ok(branch_out) = Command::new("git")
         .arg("-C")
@@ -198,8 +194,8 @@ fn resolve_str(path: &Path) -> String {
 }
 
 /// Parse `git worktree list --porcelain` output into [`Checkout`]s.
-/// Main checkout is elided (matches Python) — the caller already has
-/// it from the top-level repo scan.
+/// Main checkout is elided — the caller already has it from the
+/// top-level repo scan.
 fn git_worktrees(repo_path: &Path) -> Vec<Checkout> {
     let Ok(out) = Command::new("git")
         .arg("-C")

--- a/crates/condash-state/src/search.rs
+++ b/crates/condash-state/src/search.rs
@@ -45,7 +45,7 @@ fn status_to_subtab(status: condash_parser::Priority) -> &'static str {
     }
 }
 
-/// One hit within a project. Matches Python's dict fields.
+/// One hit within a project.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Hit {
     pub source: String,
@@ -82,7 +82,7 @@ fn tokenise(q: &str) -> Vec<String> {
     out
 }
 
-/// HTML-escape — mirrors Python's `html.escape(quote=True)`.
+/// HTML-escape `<`, `>`, `&`, `"`, `'`.
 fn html_escape(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
     for c in s.chars() {
@@ -140,10 +140,9 @@ fn build_snippet(text: &str, tokens: &[String], radius: usize) -> String {
     let mut end_c = (pos + hit_len + radius).min(text_chars.len());
 
     if start_c > 0 {
-        // Python: ws = text.rfind(" ", 0, start)  — returns -1 on no match.
-        // Then `if 0 <= start - ws < 20: start = ws + 1`. When ws is -1,
-        // `start - (-1) = start + 1`, so short snippets (start < 19)
-        // snap to start = 0 rather than keep the leading `…`.
+        // If a word-boundary space is within 20 chars to the left,
+        // snap there (or to 0 when none, so short snippets don't
+        // start with a stray `…`).
         let ws_i32: i32 = text_chars[..start_c]
             .iter()
             .rposition(|&c| c == ' ')
@@ -155,9 +154,8 @@ fn build_snippet(text: &str, tokens: &[String], radius: usize) -> String {
         }
     }
     if end_c < text_chars.len() {
-        // Python: we = text.find(" ", end) — returns -1 on no match, in
-        // which case the `if we >= 0 and we - end < 20` check is false,
-        // so no snap. Rust mirrors via `None` → don't snap.
+        // Same idea on the right edge: snap to a space within 20
+        // chars; if none, leave end_c alone.
         if let Some(offset) = text_chars[end_c..].iter().position(|&c| c == ' ') {
             let we = end_c + offset;
             if we - end_c < 20 {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,7 +18,7 @@ The tree-level file is versioned: commit it and every teammate who pulls picks u
 
 ### Precedence on overlap
 
-For backwards compatibility, `configuration.yml` still accepts `terminal`, `pdf_viewer`, and `open_with` keys. When the same key appears in both files, **`settings.yaml` wins**, merged field by field:
+`terminal`, `pdf_viewer`, and `open_with` are valid in **either** file — set them in `configuration.yml` for tree-wide defaults teammates pick up automatically, or in `settings.yaml` for per-machine overrides. When the same key appears in both files, **`settings.yaml` wins**, merged field by field:
 
 - `terminal.<field>` — each field set in `settings.yaml` replaces the tree's value; missing fields fall through.
 - `pdf_viewer` — a non-empty list in `settings.yaml` replaces the tree's; empty / missing falls through.

--- a/docs/reference/mutations.md
+++ b/docs/reference/mutations.md
@@ -38,7 +38,7 @@ The header **New item** button opens a small modal asking only the fields needed
 
 | Action | HTTP | Trigger | Effect |
 |---|---|---|---|
-| Create item | `POST /api/items` | Header "+" button → modal | Writes `projects/<YYYY-MM>/<YYYY-MM-DD>-<slug>/README.md` + empty `notes/` with a minimal seeded body per-kind; `touch projects/.index-dirty`. |
+| Create item | `POST /create-item` | Header "+" button → modal | Writes `projects/<YYYY-MM>/<YYYY-MM-DD>-<slug>/README.md` + empty `notes/` with a minimal seeded body per-kind; `touch projects/.index-dirty`. |
 
 Body (`application/json`):
 

--- a/frontend/src/js/dashboard-main.js
+++ b/frontend/src/js/dashboard-main.js
@@ -1,18 +1,12 @@
-/* Bundled dashboard script — migrated from the classic inline `<script>`
-   block in dashboard.html on 2026-04-22 (F3/F4 of condash-frontend-split).
-   Originally kept as one big file because the 247 declarations coexisted
-   as globals in the inline script; region-level splitting into
-   `sections/*.js` is now in progress (P-07..P-10 of
-   conception/projects/2026-04-23-condash-frontend-extraction).
+/* Bundled dashboard entry point. Imports + side-effect inits below
+   are the contract with the rest of the bundle.
 
-   The terminal-tab subsystem lives across three sibling modules under
-   `sections/terminal-{pointer,lifecycle,shortcuts}.js` (the C10 split of
-   the 2026-04-25 architecture-hardening sweep, replacing the former
-   962-LOC `tab-drag.js` monolith). Each owns one focused concern; the
-   imports + side-effect inits below are the contract with the rest of
-   the bundle. The cycle (each terminal-* module imports from at least
-   one other) is safe because every cross-module reference is contained
-   inside a function body — see notes/01-p07-tab-drag-split.md §D2. */
+   The terminal-tab subsystem is split across three sibling modules
+   under `sections/terminal-{pointer,lifecycle,shortcuts}.js`; each
+   owns one focused concern. The cycle (each terminal-* module imports
+   from at least one other) is safe because every cross-module
+   reference is contained inside a function body, keeping the imports
+   TDZ-safe. */
 
 import {
     toggleTerminal, termNewTab, termNewLauncherTab,
@@ -122,10 +116,10 @@ var PRIMARY_TABS = ['projects', 'code', 'knowledge', 'history'];
 var SUBTABS = ['current', 'next', 'backlog', 'done'];
 export var _activeTab = 'projects';
 export var _activeSubtab = 'current';
-// Map legacy `?tab=current` style URLs onto the new (primary, sub) pair.
-// History used to be a Projects sub-tab; legacy `?tab=projects&sub=history`
-// or `?tab=history-subtab` links land on the new History primary tab.
-var LEGACY_TAB_ALIAS = {
+// Map shorthand `?tab=current` URLs onto the canonical (primary, sub)
+// pair so a deep link from an external doc still lands on the right
+// pane.
+var TAB_ALIAS = {
     current: ['projects', 'current'],
     next: ['projects', 'next'],
     backlog: ['projects', 'backlog'],
@@ -207,11 +201,9 @@ document.addEventListener('DOMContentLoaded', function() {
     var params = new URLSearchParams(location.search);
     var tab = params.get('tab') || '';
     var sub = params.get('sub') || '';
-    // Legacy URL support: old ?tab=current links land on Projects/Current.
-    var alias = LEGACY_TAB_ALIAS[tab];
+    var alias = TAB_ALIAS[tab];
     if (alias) { tab = alias[0]; sub = alias[1] || sub; }
-    // History was a Projects sub-tab — legacy `?tab=projects&sub=history`
-    // lands on the new History primary tab.
+    // `?tab=projects&sub=history` is shorthand for the History primary tab.
     if (tab === 'projects' && sub === 'history') { tab = 'history'; sub = ''; }
     if (PRIMARY_TABS.indexOf(tab) === -1) tab = 'projects';
     if (tab === 'projects' && SUBTABS.indexOf(sub) !== -1) _activeSubtab = sub;
@@ -349,23 +341,9 @@ async function createNotesSubdir(readmePath, parentRelToItem) {
 
 // Per-pane refreshes are driven entirely by htmx — each pane carries
 // `hx-trigger="sse:<tab>"` and refetches its `/fragment/<tab>` on the
-// matching server-sent event. The hard-refresh button still fires a
-// real reload via `refreshAll` from `sections/refresh-all.js`. The
-// legacy `_reloadInPlace` / `reloadNode` pathway and its supporting
-// `dom-swap` / `local-subtree-reload` / `reload-guards` /
-// `reload-hooks` / `stale-poll` modules are gone. The classic
-// EventSource lifecycle in `sections/sse.js` is also gone — htmx-ext-sse
-// owns the connection; that module is now a thin bridge for the
-// reconnecting pill + note-modal reconcile.
+// matching server-sent event. The hard-refresh button fires a real
+// reload via `refreshAll` from `sections/refresh-all.js`.
 
-// The "Tab drag" region that used to live here (pointer-event drag,
-// tab create/close/rename, splitter drag, pane-resize drag, shortcuts,
-// restore-on-reload) was first relocated to `sections/tab-drag.js`
-// (P-07 of conception/projects/2026-04-23-condash-frontend-extraction)
-// and then decomposed into the three focused modules now imported at
-// the top of this file (C10 of 2026-04-25-condash-architecture-hardening-finish).
-// Register their DOM-level side effects now that every module has
-// finished evaluating.
 /* Register all click actions rendered by the server as `data-action`
    attrs. Keep this block in one place so the inventory is obvious — one
    registerAction call per distinct action name, grouped by subsystem. */
@@ -518,10 +496,11 @@ initHtmxStatePreserve();
 })();
 
 /* Bridge non-click inline-handler equivalents to delegated listeners.
-   Every former `on*=` attribute is now a `data-*` tag in dashboard.html
-   or _macros.html.j2; the CI guard in `tools/check-inline-handlers.sh`
-   keeps it that way. Listeners are document-level so htmx-morphed
-   markup is automatically covered without a re-bind step. */
+   Every `on*=` equivalent is expressed as a `data-*` tag in
+   dashboard.html or _macros.html.j2; the CI guard in
+   `tools/check-inline-handlers.sh` keeps it that way. Listeners are
+   document-level so htmx-morphed markup is automatically covered
+   without a re-bind step. */
 function initInlineHandlerBridges() {
     document.addEventListener('input', function(ev) {
         var t = ev.target;

--- a/frontend/src/js/sections/about-modal.js
+++ b/frontend/src/js/sections/about-modal.js
@@ -1,12 +1,9 @@
 /* About modal — open/close + the "links open in host browser" shim.
    Static content (version baked in at render time, links hit the host
-   browser via /open-external because pywebview swallows target=_blank).
-
-   Extracted from dashboard-main.js on 2026-04-24 (P-08 of
-   conception/projects/2026-04-23-condash-frontend-extraction). No
-   cross-module references — the document-level click listener is
-   registered from initAboutModalSideEffects(), called from
-   dashboard-main.js's tail. */
+   browser via /open-external because the embedded webview swallows
+   target=_blank). The document-level click listener is registered
+   from initAboutModalSideEffects(), called from dashboard-main.js's
+   tail. */
 
 function openAboutModal() {
     document.getElementById('about-modal').style.display = 'flex';

--- a/frontend/src/js/sections/cm6-mount.js
+++ b/frontend/src/js/sections/cm6-mount.js
@@ -6,12 +6,10 @@
    buildTheme} and calls window.__cm6OnReady(). Before that, the "Edit"
    toggle stays disabled.
 
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 of
-   conception/projects/2026-04-23-condash-frontend-extraction). Reaches
-   into three symbols from the note-modal sections (as of P-09 cut 4):
-   _noteModal + _setDirty from note-preview.js (object-field writes),
-   saveEdit from note-mode.js. All references are inside function
-   bodies; no top-level side effects. */
+   Reaches into three symbols from the note-modal sections: _noteModal
+   + _setDirty from note-preview.js (object-field writes), saveEdit
+   from note-mode.js. All references are inside function bodies; no
+   top-level side effects. */
 
 import { _noteModal, _setDirty } from './note-preview.js';
 import { saveEdit } from './note-mode.js';

--- a/frontend/src/js/sections/cm6-theme-sync.js
+++ b/frontend/src/js/sections/cm6-theme-sync.js
@@ -5,10 +5,9 @@
    attribute and retheme the live EditorView (no remount) so the
    markdown editor picks up the new palette in the same frame.
 
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 of
-   conception/projects/2026-04-23-condash-frontend-extraction). The
-   MutationObserver registration is a top-level side effect, wrapped
-   in initCm6ThemeSyncSideEffects() per the discipline note 01 §D3. */
+   The MutationObserver registration is wrapped in
+   initCm6ThemeSyncSideEffects() so it runs after the imported
+   _cmRetheme is fully initialised. */
 
 import { _cmRetheme } from './cm6-mount.js';
 

--- a/frontend/src/js/sections/config-modal.js
+++ b/frontend/src/js/sections/config-modal.js
@@ -1,9 +1,5 @@
 /* Configuration modal — YAML-backed editor for `configuration.yml`.
 
-   Extracted from `dashboard-main.js` as part of C-08 of the
-   `2026-04-24-condash-dashboard-main-split` project. Pure behaviour-
-   preserving move — same logic, same public surface.
-
    The module owns:
    - `openConfigModal` / `closeConfigModal` — show and hide the modal,
      fetch the current YAML body on open.

--- a/frontend/src/js/sections/git-actions.js
+++ b/frontend/src/js/sections/git-actions.js
@@ -1,16 +1,13 @@
-/* Git row actions — "open in IDEA / VS Code / terminal / Files" handlers
-   for the buttons rendered next to every git status row and every card.
+/* Git row actions — "open in IDEA / VS Code / terminal / Files"
+   handlers for the buttons rendered next to every git status row and
+   every card.
 
-   Extracted from dashboard-main.js on 2026-04-24 (P-08 of
-   conception/projects/2026-04-23-condash-frontend-extraction).
-
-   openInTerminal and workOn reach into the terminal-tab subsystem —
-   import _termSyncOpenFlag + _termCreateTab from the lifecycle module
-   (post-C10 split of the original tab-drag.js) and _termActiveTab +
-   _termSendResize + termState from terminal.js. All cross-module
-   references sit inside function bodies, so the circular import
-   (dashboard-main → git-actions → dashboard-main) is safe under the
-   same TDZ rules documented in notes/01-p07-tab-drag-split.md §D2. */
+   openInTerminal and workOn reach into the terminal-tab subsystem
+   (_termSyncOpenFlag + _termCreateTab from terminal-lifecycle.js,
+   _termActiveTab + _termSendResize + termState from terminal.js).
+   All cross-module references sit inside function bodies, keeping
+   the circular import (dashboard-main → git-actions → dashboard-main)
+   TDZ-safe. */
 
 import { _termCreateTab, _termSyncOpenFlag } from './terminal-lifecycle.js';
 import { termState, _termActiveTab, _termSendResize } from './terminal.js';
@@ -107,11 +104,9 @@ function workOn(ev, slug) {
 /* Code tab · "open with" popover.
 
    The code-tab's per-repo strip renders a dropdown of IDE launchers
-   (IDEA, VS Code, etc.) behind a "⋯" button. Click toggles the popover;
-   a click outside closes every open popover; Escape does the same. Used
-   to live at the tail of the runner-viewers region in dashboard-main.js
-   — moved here on 2026-04-24 (P-09 cut 2) because it's pure git-row
-   wiring, not a runner concern. */
+   (IDEA, VS Code, etc.) behind a "⋯" button. Click toggles the
+   popover; a click outside closes every open popover; Escape does
+   the same. */
 function gitToggleOpenPopover(ev, btn) {
     if (ev) { ev.stopPropagation(); ev.preventDefault(); }
     var grp = btn.closest('.open-grp');

--- a/frontend/src/js/sections/in-note-search.js
+++ b/frontend/src/js/sections/in-note-search.js
@@ -9,10 +9,7 @@
 
    Also owns the Ctrl+E mode-toggle shortcut because it's registered
    from the same capture-phase keydown listener and would double-bind
-   if the two shortcuts lived in separate listeners.
-
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 cut 4 of
-   conception/projects/2026-04-23-condash-frontend-extraction). */
+   if the two shortcuts lived in separate listeners. */
 
 import { _noteModal } from './note-preview.js';
 import { setNoteMode } from './note-mode.js';

--- a/frontend/src/js/sections/new-item-modal.js
+++ b/frontend/src/js/sections/new-item-modal.js
@@ -1,15 +1,13 @@
 /* New-item modal — lives next to the gear button. Collects the minimal
    fields the README parser cares about (kind, status, title, slug, apps
-   + kind-specific extras) and POSTs /api/items. Everything else — goal,
-   scope, steps, body prose — the user types in their editor.
+   + kind-specific extras) and POSTs /create-item. Everything else —
+   goal, scope, steps, body prose — the user types in their editor.
 
-   Extracted from dashboard-main.js on 2026-04-24 (P-08 of
-   conception/projects/2026-04-23-condash-frontend-extraction). The
-   form-wiring IIFE becomes initNewItemModalSideEffects() per the
-   circular-import discipline (see notes/01-p07-tab-drag-split.md §D2
-   + §D3). submitNewItem's post-create tab-switch calls switchTab /
-   switchSubtab via imports; both are referenced inside a function
-   body so the cycle remains TDZ-safe. */
+   The form-wiring runs through initNewItemModalSideEffects() rather
+   than a top-level IIFE because submitNewItem references switchTab /
+   switchSubtab from dashboard-main.js, and dashboard-main.js imports
+   from this module — referencing them inside a function body keeps
+   the cycle TDZ-safe. */
 
 import { switchTab, switchSubtab } from '../dashboard-main.js';
 
@@ -113,7 +111,7 @@ async function submitNewItem(ev) {
     var submitBtn = form.querySelector('button[type="submit"]');
     if (submitBtn) submitBtn.disabled = true;
     try {
-        var res = await fetch('/api/items', {
+        var res = await fetch('/create-item', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify(payload),

--- a/frontend/src/js/sections/note-mode.js
+++ b/frontend/src/js/sections/note-mode.js
@@ -9,12 +9,9 @@
    server returns 409 and we surface the error banner.
 
    Also owns `createNoteFor` (create + drop into edit mode) and
-   `startRenameNote` (double-click-to-rename on the modal title) — both
-   of them chain into note-preview via `openNotePreview` / `_noteModal`,
-   but they're editing-flow concerns, not view concerns.
-
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 cut 4 of
-   conception/projects/2026-04-23-condash-frontend-extraction). */
+   `startRenameNote` (double-click-to-rename on the modal title) —
+   both chain into note-preview via `openNotePreview` / `_noteModal`,
+   but they're editing-flow concerns, not view concerns. */
 
 import { _noteModal, _setDirty, openNotePreview, _reloadNotePreview } from './note-preview.js';
 import { _cm, _mountCm } from './cm6-mount.js';

--- a/frontend/src/js/sections/note-preview.js
+++ b/frontend/src/js/sections/note-preview.js
@@ -1,15 +1,13 @@
 /* Note preview modal — open / close / navigate + link wiring + server
    render mount (markdown, mermaid, PDF).
 
-   Owner of the shared `_noteModal` state object and the `_noteNavStack`
-   back-stack. The three sibling note-modal modules (note-mode.js,
-   in-note-search.js, note-reconcile.js) all read/write `_noteModal`
-   through this module — `_noteModal` is a plain object, so the ESM
-   live-binding limit on reassigning `var`/`let` exports doesn't apply
-   (no caller ever reassigns `_noteModal` itself, only its fields).
-
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 cut 4 of
-   conception/projects/2026-04-23-condash-frontend-extraction). */
+   Owner of the shared `_noteModal` state object and the
+   `_noteNavStack` back-stack. The three sibling note-modal modules
+   (note-mode.js, in-note-search.js, note-reconcile.js) all read/write
+   `_noteModal` through this module — `_noteModal` is a plain object,
+   so the ESM live-binding limit on reassigning `var`/`let` exports
+   doesn't apply (no caller ever reassigns `_noteModal` itself, only
+   its fields). */
 
 import { _destroyCm } from './cm6-mount.js';
 import { _syncSaveButton, _captureActiveBuffer, _syncModeControls, _setNoteModeAttr, _hideSaveError } from './note-mode.js';

--- a/frontend/src/js/sections/note-reconcile.js
+++ b/frontend/src/js/sections/note-reconcile.js
@@ -1,4 +1,4 @@
-/* Note modal reconcile (Phase 7).
+/* Note modal reconcile.
 
    When /events signals a filesystem change, any open note may now
    diverge from its on-disk content. `_reconcileNoteModal` compares the
@@ -10,11 +10,7 @@
    detected (so the user who keeps editing isn't re-nagged).
 
    `reconcileState.suppressedUntilMtime` is reset from note-preview.js
-   whenever a note is opened or closed — same live-binding-safe pattern
-   as termState / sseState.
-
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 cut 4 of
-   conception/projects/2026-04-23-condash-frontend-extraction). */
+   whenever a note is opened or closed. */
 
 import { _noteModal, _setDirty, _reloadNotePreview } from './note-preview.js';
 import { _captureActiveBuffer } from './note-mode.js';

--- a/frontend/src/js/sections/notes-tree-state.js
+++ b/frontend/src/js/sections/notes-tree-state.js
@@ -1,16 +1,13 @@
 /* Notes-tree per-subdir collapsed/expanded state.
 
    Each <details data-subdir-key="<slug>/<rel_dir>"> remembers its open
-   state in localStorage. On render (full reload, in-place reload, or
-   after a card fragment swap) we walk every notes-group <details> and
-   restore the saved state — defaulting to closed.
+   state in localStorage. After every render (full reload or fragment
+   swap) we walk every notes-group <details> and restore the saved
+   state — defaulting to closed.
 
-   Extracted from dashboard-main.js on 2026-04-24 (P-08 of
-   conception/projects/2026-04-23-condash-frontend-extraction). The
-   _NOTES_OPEN_KEY constant is re-exported because uploadToNotes and
-   createNotesSubdir in dashboard-main.js seed localStorage entries for
-   freshly-created subdirs by hand. The document-level toggle listener
-   becomes initNotesTreeStateSideEffects(). */
+   _NOTES_OPEN_KEY is exported because uploadToNotes and
+   createNotesSubdir in dashboard-main.js seed localStorage entries
+   for freshly-created subdirs by hand. */
 
 const _NOTES_OPEN_KEY = 'condash:notes-open:';
 

--- a/frontend/src/js/sections/sse.js
+++ b/frontend/src/js/sections/sse.js
@@ -1,29 +1,20 @@
 /* SSE side-effect bridge.
 
-   The dashboard SSE stream (`/events`) is now opened by htmx — the
+   The dashboard SSE stream (`/events`) is opened by htmx via the
    `sse-connect="/events"` attribute on `<body>` and the SSE extension
    loaded in `dashboard.html`. Per-pane `hx-trigger="sse:<tab>"`
    listeners drive the per-tab fragment refreshes directly.
 
-   What's left for this module is the connection-lifecycle UI plus the
-   "any disk change might affect the open note modal" reconcile pass.
-   We hang both off the htmx SSE events:
+   This module owns the connection-lifecycle UI plus the "any disk
+   change might affect the open note modal" reconcile pass. Both hang
+   off the htmx SSE events:
 
    - `htmx:sseOpen`    → hide the reconnecting pill
    - `htmx:sseError`   → show the reconnecting pill
    - `htmx:sseClose`   → show the reconnecting pill
    - `htmx:sseMessage` → run `_reconcileNoteModal` so the open-note
                          modal refreshes if its underlying file just
-                         changed on disk.
-
-   This replaces the hand-rolled EventSource lifecycle that used to
-   live here (own EventSource, exponential-backoff reconnect, separate
-   addEventListener per tab name, dispatch into stale-poll's
-   `_scheduleCheckUpdates`) — htmx's extension owns the connection +
-   retry now, and per-tab refreshes go through `hx-trigger="sse:<tab>"`
-   directly without round-tripping through stale-poll. The export
-   shape (`initSseSideEffects`) is unchanged so `dashboard-main.js`
-   doesn't need to know. */
+                         changed on disk. */
 
 import { _reconcileNoteModal } from './note-reconcile.js';
 

--- a/frontend/src/js/sections/steps.js
+++ b/frontend/src/js/sections/steps.js
@@ -1,10 +1,6 @@
 /* Steps subsystem — the check/cycle/add/remove/reorder actions + the
    drag-reorder machinery + section folding + inline text editing.
 
-   Extracted from `dashboard-main.js` as part of C-08 of the
-   `2026-04-24-condash-dashboard-main-split` project. Pure behaviour-
-   preserving move.
-
    The module owns:
    - `cycle` — advance a step through its state machine.
    - `removeStep` — delete a step line.

--- a/frontend/src/js/sections/terminal-lifecycle.js
+++ b/frontend/src/js/sections/terminal-lifecycle.js
@@ -4,12 +4,10 @@
    Wires the per-tab xterm + pty WebSocket and routes incoming protocol
    frames into the right behaviour (info / exit / session-expired).
 
-   Extracted from sections/tab-drag.js (former 962 LOC monolith) — the
-   audit's C10 split. Companion files: sections/terminal-pointer.js
-   (drag/splitter/pane-resize) and sections/terminal-shortcuts.js
-   (keybindings + screenshot paste). Cross-module references stay inside
-   function bodies so the cycle remains TDZ-safe — see
-   notes/01-p07-tab-drag-split.md §D2 for the original design rules. */
+   Companion files: sections/terminal-pointer.js (drag/splitter/
+   pane-resize) and sections/terminal-shortcuts.js (keybindings +
+   screenshot paste). Cross-module references stay inside function
+   bodies so the cycles remain TDZ-safe. */
 
 import {
     termState,

--- a/frontend/src/js/sections/terminal-pointer.js
+++ b/frontend/src/js/sections/terminal-pointer.js
@@ -4,12 +4,10 @@
    pane-vertical-resize drag — plus the helpers that keep the split layout
    consistent (_termShowSide, _termApplySplitRatio).
 
-   Extracted from sections/tab-drag.js (former 962 LOC monolith) — the
-   audit's C10 split. The companion files are sections/terminal-lifecycle.js
-   (tab create/close/rename/restore) and sections/terminal-shortcuts.js
-   (keybindings + screenshot paste). Cross-module references are kept inside
-   function bodies so the cycle stays TDZ-safe — see
-   notes/01-p07-tab-drag-split.md §D2 for the original design rules. */
+   Companion files: sections/terminal-lifecycle.js (tab create/close/
+   rename/restore) and sections/terminal-shortcuts.js (keybindings +
+   screenshot paste). Cross-module references are kept inside function
+   bodies so the cycles stay TDZ-safe. */
 
 import {
     termState,
@@ -19,10 +17,10 @@ import {
 } from './terminal.js';
 
 /* --- Tab drag (pointer-event based) -----------------------------------
-   The HTML5 drag-and-drop API crashes pywebview: QtWebEngine tries to
-   snapshot the dragged element for the native drag image and segfaults
-   the whole process on dragstart. We do drag ourselves with pointer
-   events, which stays entirely in the page — no native Qt involvement.
+   We implement drag with pointer events rather than the HTML5
+   drag-and-drop API so the gesture stays entirely in the page —
+   no native drag-image snapshotting that some embedded webviews
+   handle badly.
 
    Flow:
      - pointerdown on chip → arm a pending drag (don't start yet, so we

--- a/frontend/src/js/sections/terminal-shortcuts.js
+++ b/frontend/src/js/sections/terminal-shortcuts.js
@@ -5,12 +5,10 @@
    per-xterm key handler can read the current values without importing
    each spec individually.
 
-   Extracted from sections/tab-drag.js (former 962 LOC monolith) — the
-   audit's C10 split. Companion files: sections/terminal-pointer.js
-   (drag/splitter/pane-resize) and sections/terminal-lifecycle.js
-   (tab create/close/rename/restore). Cross-module references stay
-   inside function bodies so the cycle remains TDZ-safe — see
-   notes/01-p07-tab-drag-split.md §D2 for the original design rules. */
+   Companion files: sections/terminal-pointer.js (drag/splitter/
+   pane-resize) and sections/terminal-lifecycle.js (tab create/close/
+   rename/restore). Cross-module references stay inside function
+   bodies so the cycles remain TDZ-safe. */
 
 import { _termActiveTab, termState } from './terminal.js';
 import {

--- a/frontend/src/js/sections/terminal.js
+++ b/frontend/src/js/sections/terminal.js
@@ -5,17 +5,11 @@
    Closing the last tab hides the pane. The pane's × and the toggle
    shortcut hide/show the pane while leaving the tabs intact.
 
-   Extracted from dashboard-main.js on 2026-04-24 (P-09 cut 2 of
-   conception/projects/2026-04-23-condash-frontend-extraction). The
-   pre-2026-04-25 sister file `sections/tab-drag.js` was split into
-   three focused modules (terminal-pointer, terminal-lifecycle,
-   terminal-shortcuts) by C10 of the architecture-hardening sweep;
-   this module remains the cross-cutting state + low-level DOM
-   helpers everyone else reaches for. The circular imports
-   (terminal.js ↔ terminal-{pointer,lifecycle,shortcuts}.js) stay
-   safe under the TDZ rules documented in
-   notes/01-p07-tab-drag-split.md §D2 — every cross-module reference
-   is contained inside a function body. */
+   This module owns the cross-cutting termState + low-level DOM
+   helpers; terminal-pointer / terminal-lifecycle / terminal-shortcuts
+   handle pointer-event drag, tab create/close/rename, and keybindings
+   respectively. Cross-module references are all inside function
+   bodies, keeping the cycles TDZ-safe. */
 
 import { _termChipPointerDown } from './terminal-pointer.js';
 import {
@@ -23,15 +17,15 @@ import {
 } from './terminal-lifecycle.js';
 
 /* Clipboard bridge — Tauri 2 exposes an IPC `invoke` under
-   `window.__TAURI__.core.invoke` (requires `withGlobalTauri: true` plus a
-   capability covering this origin and the `clipboard-manager:allow-*-text`
-   permissions; see src-tauri/src/lib.rs::run). We call the plugin's
-   commands directly rather than importing `@tauri-apps/plugin-clipboard-manager`
-   so the frontend bundle stays `npm install`-free — same reasoning as
+   `window.__TAURI__.core.invoke` (requires `withGlobalTauri: true`
+   plus a capability covering this origin and the
+   `clipboard-manager:allow-*-text` permissions; see
+   src-tauri/src/lib.rs::run). We call the plugin's commands directly
+   rather than importing `@tauri-apps/plugin-clipboard-manager` so the
+   frontend bundle stays `npm install`-free — same reasoning as
    xterm/mermaid/pdfjs, which are vendored flat. Browser-mode
-   (`condash-serve`) has no IPC, so `_tauriInvoke` returns null there and
-   paste becomes a no-op; that's acceptable — the HTTP `/clipboard` route
-   was dropped with the Python build. */
+   (`condash-serve`) has no IPC, so `_tauriInvoke` returns null and
+   paste becomes a no-op. */
 function _tauriInvoke() {
     if (typeof window === 'undefined') return null;
     var g = window.__TAURI__;
@@ -64,11 +58,9 @@ function _termClipboardRead() {
 }
 
 /* Shared cross-module state for the terminal-tab subsystem. Lives on
-   one object so tab-drag can mutate fields in-place — ESM live bindings
-   disallow reassigning imported primitive `let` exports from the
-   importer side. See
-   projects/2026-04-23-condash-frontend-extraction/notes/01-p07-tab-drag-split.md
-   §D1 for the design rationale. */
+   one object so the sibling terminal-* modules can mutate fields in
+   place — ESM live bindings disallow reassigning imported primitive
+   `let` exports from the importer side. */
 const termState = {
     tabs: [],                               // [{id, side, term, fit, ws, mount, button, shell}]
     active: { left: null, right: null },

--- a/frontend/src/js/sections/theme.js
+++ b/frontend/src/js/sections/theme.js
@@ -1,16 +1,15 @@
-/* Theme toggle + persistence. Extracted from dashboard-main.js on
-   2026-04-24 (P-08 of conception/projects/2026-04-23-condash-frontend-extraction).
+/* Theme toggle + persistence.
 
    Reads the saved preference from localStorage, falls back to the
    system colour-scheme, and writes the chosen value back on every
    toggle. Also live-swaps any mounted CodeMirror editors so their
    colour scheme tracks the dashboard's.
 
-   Circular-import rule (see notes/01-p07-tab-drag-split.md §D2): the
-   CodeMirror bindings (_cmViews, _currentCmTheme) are referenced only
-   inside applyTheme's function body, never at top level. Side-effect
-   registration (the first applyTheme call) is deferred to
-   initThemeSideEffects(), invoked from dashboard-main.js's tail. */
+   The CodeMirror bindings (_cmViews, _currentCmTheme) are referenced
+   only inside applyTheme's function body, keeping the cycle with
+   config-modal.js TDZ-safe. Side-effect registration (the first
+   applyTheme call) is deferred to initThemeSideEffects(), invoked
+   from dashboard-main.js's tail. */
 
 import { _cmViews, _currentCmTheme } from './config-modal.js';
 

--- a/src-tauri/src/assets.rs
+++ b/src-tauri/src/assets.rs
@@ -4,9 +4,8 @@
 //!
 //! The dashboard shell (`dashboard.html`), the bundled dashboard JS
 //! (`dist/`), the vendored frontend libraries (`vendor/`), and the
-//! favicon all ship baked into the binary by default — Phase 5 step 1 of
-//! the packaging scope change (see `notes/packaging.md`). A self-
-//! contained binary is the prerequisite for every other packaging step.
+//! favicon all ship baked into the binary by default so the wheel is
+//! self-contained.
 
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};

--- a/src-tauri/src/bin/condash_serve.rs
+++ b/src-tauri/src/bin/condash_serve.rs
@@ -1,8 +1,8 @@
 //! Headless dashboard server — same HTTP surface the Tauri webview
-//! uses, but without the window. Handy for hitting the Rust build
+//! uses, but without the window. Handy for hitting the dashboard
 //! from curl / Playwright / a regular browser during development,
-//! and the natural driver for Phase 2's e2e exit gate before the
-//! GUI-dependent Tauri bootstrap runs.
+//! and the natural driver for the Playwright e2e suite which can't
+//! attach to the embedded webview.
 //!
 //! Flags: reads the same env vars the Tauri host reads
 //! (`CONDASH_CONCEPTION_PATH`, `CONDASH_ASSET_DIR`). Also accepts

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -94,11 +94,9 @@ struct RepoBuckets {
     secondary: Vec<RepoEntryYaml>,
 }
 
-/// One entry under `repositories.primary` / `secondary`. Accepts either
-/// a bare string (repo name) or a mapping with `name`, `submodules`,
-/// `run` — Python's config parser has the same flexibility. We skip
-/// `run` for Phase 2 and just remember that the key exists so the
-/// fingerprint layer emits `|run:off` for those rows.
+/// One entry under `repositories.primary` / `secondary`. Accepts
+/// either a bare string (repo name) or a mapping with `name`,
+/// `submodules`, `run`, `force_stop`.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum RepoEntryYaml {
@@ -107,9 +105,9 @@ enum RepoEntryYaml {
         name: String,
         #[serde(default)]
         submodules: Vec<SubmoduleYaml>,
-        /// Present iff the user configured a `run:` command on this repo.
-        /// We record it as a runner key; the command value is consumed
-        /// by the runners module (Phase 4).
+        /// Present iff the user configured a `run:` command on this
+        /// repo. We record it as a runner key; the command value is
+        /// consumed by the runners module.
         #[serde(default)]
         run: Option<String>,
         /// Optional "nuclear" stop command. Invoked by the force-stop

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -123,10 +123,9 @@ impl Debouncer {
     }
 }
 
-/// Should the filename (leaf) be ignored? Same rules as Python's
-/// `_DebouncedHandler.on_any_event`: swap files (`foo.md~`), hidden
-/// files (`.foo`), and editor scratch files start with `.` or end with
-/// `~`.
+/// Should the filename (leaf) be ignored? Swap files (`foo.md~`),
+/// hidden files (`.foo`), and editor scratch files all start with `.`
+/// or end with `~`.
 fn is_noise(leaf: &str) -> bool {
     leaf.is_empty() || leaf.starts_with('.') || leaf.ends_with('~')
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,8 +250,8 @@ impl std::error::Error for ConceptionPathUnset {}
 /// Resolve the conception tree from (in order): `CONDASH_CONCEPTION_PATH`
 /// env var → user config at `~/.config/condash/settings.yaml` → absent.
 ///
-/// The GUI binary wraps `Err(ConceptionPathUnset)` into a folder picker
-/// (Phase 3); `condash-serve` and other headless callers surface the
+/// The GUI binary wraps `Err(ConceptionPathUnset)` into a folder
+/// picker; `condash-serve` and other headless callers surface the
 /// error verbatim.
 pub fn resolve_conception_path() -> Result<PathBuf, ConceptionPathUnset> {
     resolve_from(

--- a/src-tauri/src/pty.rs
+++ b/src-tauri/src/pty.rs
@@ -20,9 +20,8 @@ use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize}
 use rand::Rng;
 use tokio::sync::{mpsc, watch};
 
-/// Cap on the per-session scrollback ring buffer. 256 KiB — enough for a
-/// few screens of output. Larger pastes trim from the head. Matches
-/// Python's `_BUFFER_CAP`.
+/// Cap on the per-session scrollback ring buffer. 256 KiB — enough
+/// for a few screens of output. Larger pastes trim from the head.
 pub const BUFFER_CAP: usize = 256 * 1024;
 
 /// Bytes emitted by the PTY pump. `Data(b)` is raw output; `Exit` is
@@ -76,8 +75,8 @@ impl PtySession {
         self.buffer.lock().expect("buffer mutex").clone()
     }
     /// Attach a viewer to this session. Replaces any existing viewer's
-    /// sender (the old one is dropped so its receiver ends, mirroring
-    /// Python's "displace the old viewer" behaviour).
+    /// sender (the old one is dropped so its receiver ends — only one
+    /// viewer per session).
     pub fn attach_viewer(&self) -> mpsc::UnboundedReceiver<PumpMessage> {
         let (tx, rx) = mpsc::unbounded_channel();
         // Push the buffer first so the new viewer sees scrollback.
@@ -232,12 +231,10 @@ impl PtyRegistry {
 pub enum SpawnMode {
     /// Login shell (`<shell> -l`) — the normal `/ws/term` flow.
     LoginShell { shell: String },
-    /// Arbitrary argv parsed from `terminal.launcher_command` — mirrors
-    /// Python's `use_launcher=True` path.
+    /// Arbitrary argv parsed from `terminal.launcher_command`.
     Launcher { argv: Vec<String> },
-    /// `<shell> -lc <template-with-path-replaced>` — the runner flow
-    /// (Phase 4 slice 2). Kept on this enum so a single spawn path
-    /// covers every caller.
+    /// `<shell> -lc <template-with-path-replaced>` — the runner flow.
+    /// Kept on this enum so a single spawn path covers every caller.
     RunnerCommand {
         shell: String,
         template: String,
@@ -407,7 +404,7 @@ pub fn supports_pty() -> bool {
 }
 
 /// Resolve the shell to launch for `/ws/term`. Priority:
-/// 1. Explicit `override_shell` from the config layer (Phase 4 slice 2).
+/// 1. Explicit `override_shell` from the config layer.
 /// 2. `$SHELL` environment variable.
 /// 3. `/bin/bash`.
 pub fn resolve_terminal_shell(override_shell: Option<&str>) -> String {

--- a/src-tauri/src/runner_registry.rs
+++ b/src-tauri/src/runner_registry.rs
@@ -284,7 +284,7 @@ pub async fn stop(
 }
 
 /// Short token describing the session's visible state — used by the
-/// Code-tab fingerprint layer. Matches Python's `fingerprint_token`.
+/// Code-tab fingerprint layer.
 pub fn fingerprint_token(runners: &RunnerRegistry, key: &str) -> String {
     match runners.get(key) {
         None => "off".into(),
@@ -295,8 +295,7 @@ pub fn fingerprint_token(runners: &RunnerRegistry, key: &str) -> String {
     }
 }
 
-/// Drop an exited session without SIGTERM (no-op if live). Mirrors
-/// Python's `clear_exited`.
+/// Drop an exited session without SIGTERM (no-op if live).
 pub fn clear_exited(runners: &RunnerRegistry, key: &str) -> bool {
     let Some(session) = runners.get(key) else {
         return false;

--- a/src-tauri/src/server/config_surface.rs
+++ b/src-tauri/src/server/config_surface.rs
@@ -1,4 +1,5 @@
-//! Configuration modal (`/configuration`) + legacy `/config` summary.
+//! Configuration HTTP surface — `/configuration` (full r/w) and
+//! `/config` (small summary).
 //!
 //! - `GET /configuration` returns the raw `<conception>/configuration.yml`
 //!   contents so the modal populates a single `<textarea>`.
@@ -9,9 +10,9 @@
 //!   workspace cache is fully flushed, and SSE refresh events are
 //!   republished for every primary tab so the open dashboard repaints
 //!   without a restart.
-//! - `GET /config` is the small legacy summary the bundled frontend
-//!   polls for setup-banner detection and terminal-shortcut loading.
-//!   Returns only `conception_path` + the `terminal` block.
+//! - `GET /config` returns a small JSON summary the frontend polls
+//!   on load for setup-banner detection and terminal-shortcut wiring.
+//!   Body: `conception_path` + the `terminal` block only.
 //!
 //! `settings.yaml` is not written by any route — it is hand-edited on
 //! disk and re-read on the next launch.

--- a/src-tauri/src/server/events.rs
+++ b/src-tauri/src/server/events.rs
@@ -28,9 +28,9 @@ pub(super) async fn events_stream(
                 // Emit a named SSE event matching the payload's `tab`
                 // field (`projects` / `knowledge` / `code`) so htmx
                 // listeners can target a specific tab via
-                // `hx-trigger="sse:projects"`. The legacy `onmessage`
-                // path in `sse.js` doesn't gate on event name and
-                // continues to receive every frame as before.
+                // `hx-trigger="sse:projects"`. The generic
+                // `htmx:sseMessage` handler in `sse.js` still fires
+                // for every frame regardless of name.
                 Some(Ok::<_, std::convert::Infallible>(
                     SseEvent::default().event(payload.tab.clone()).data(data),
                 ))

--- a/src-tauri/src/server/items.rs
+++ b/src-tauri/src/server/items.rs
@@ -1,5 +1,5 @@
-//! `POST /create-item` (and its `/api/items` alias) — scaffolds a new
-//! project / incident / document under the conception tree.
+//! `POST /create-item` — scaffolds a new project / incident / document
+//! under the conception tree.
 
 use axum::extract::State;
 use axum::http::StatusCode;

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -18,12 +18,12 @@
 //!                       `/edit-step`, `/set-priority`, `/reorder-all`
 //! - [`notes`]         — `/note`, `/note-raw`, `/note/rename`,
 //!                       `/note/create`, `/note/mkdir`, `/note/upload`
-//! - [`items`]         — `/create-item`, `/api/items`
+//! - [`items`]         — `/create-item`
 //! - [`events`]        — `GET /events` SSE stream
 //! - [`terminal`]      — `GET /ws/term` embedded-terminal WebSocket
 //! - [`runners`]       — `/api/runner/{start,stop,force-stop}`,
 //!                       `GET /ws/runner/{key}`
-//! - [`config_surface`] — `/configuration` r/w + legacy `/config`
+//! - [`config_surface`] — `/configuration` r/w + `/config` summary
 //! - [`openers`]       — `/open`, `/open-folder`, `/open-external`,
 //!                       `/open-doc`, `/recent-screenshot`
 //! - [`rescan`]        — `/rescan`
@@ -180,19 +180,15 @@ pub fn build_router(state: AppState) -> Router {
         .route("/note/mkdir", post(notes::post_note_mkdir))
         .route("/note/upload", post(notes::post_note_upload))
         .route("/create-item", post(items::post_create_item))
-        // `/api/items` is the legacy path the bundled frontend still
-        // calls for the New Item modal. Kept as an alias so the modal
-        // works without a frontend rebuild; semantically identical.
-        .route("/api/items", post(items::post_create_item))
         // Configuration modal — plain-text YAML editor of
         // <conception>/configuration.yml.
         .route(
             "/configuration",
             get(config_surface::get_configuration).post(config_surface::post_configuration),
         )
-        // Legacy config summary — used by the frontend for setup-banner
-        // detection and terminal shortcut loading. Returns a small
-        // JSON dict with `conception_path` + `terminal` fields only.
+        // Small config summary the frontend polls on load for
+        // setup-banner detection and terminal-shortcut wiring.
+        // Returns `conception_path` + the `terminal` block only.
         .route("/config", get(config_surface::get_config_summary))
         // Open-path surface — these four dispatch the user-visible
         // "Open with", "Open folder", "Open external", "Open doc"

--- a/src-tauri/src/server/shell.rs
+++ b/src-tauri/src/server/shell.rs
@@ -39,8 +39,7 @@ pub(super) struct HistoryFragmentQuery {
 /// HTML fragment for the History pane content. Empty `q` returns the
 /// month-grouped tree; non-empty `q` returns the search-results list.
 /// Driven by the htmx attributes on `#history-content` in
-/// `dashboard.html` — replaces the legacy JSON-returning
-/// `/search-history` + client-side renderer.
+/// `dashboard.html`.
 pub(super) async fn fragment_history(
     State(state): State<AppState>,
     Query(s): Query<HistoryFragmentQuery>,


### PR DESCRIPTION
## Summary

- Code-simplification pass: remove references to the retired Python build, drop a compat shim whose referenced thing no longer exists, and trim historical refactor narration so code/comments describe only the current version.
- 53 files touched, +392 / -498. No behaviour changes other than the /api/items → /create-item rename (caller updated in the same commit).

## Changes

- **CLAUDE.md** rewritten end-to-end. The previous file still described the retired Python (Typer / NiceGUI / FastAPI / pywebview) stack; the new one documents the actual Rust + Tauri implementation — workspace crate layout, axum router map, the htmx-driven frontend bundle, and the real `make` targets.
- **`/api/items` alias dropped.** `frontend/src/js/sections/new-item-modal.js` now POSTs the canonical `/create-item` directly. Removed the alias route in `src-tauri/src/server/mod.rs`, the alias mention in `server/items.rs`, the docstring in `crates/condash-mutations/src/create_item.rs`, and the entry in `docs/reference/mutations.md`.
- **Frontend section files** trimmed of dated provenance headers ("Extracted from dashboard-main.js on 2026-04-24 (P-09 cut N)", "former 962-LOC tab-drag.js monolith", etc.). The substantive design rationale — TDZ-safe import cycles, ESM live-binding patterns, why pointer-events not HTML5 drag, the named-SSE-event contract — is preserved.
- **Rust parity comments** pruned across `crates/` and `src-tauri/src/`: ~40 "Matches Pythons …" / "Mirrors Pythons …" / "Rust port of …" markers either deleted (where they were pure parity claims) or rephrased into language-agnostic specs (where the Python expression encoded a real contract — codepoint-vs-byte slicing, regex corner cases, exit-code shape).
- **`server/config_surface.rs`** module doc + route comment in `server/mod.rs` reframe `/config` as a current API summary endpoint instead of "legacy summary". Both `/configuration` and `/config` are intentional surface.
- **`LEGACY_TAB_ALIAS` → `TAB_ALIAS`** in `dashboard-main.js`. Behaviour kept (inbound `?tab=current` shorthand still maps to the canonical (primary, sub) pair), but the misleading "legacy" framing went — the shorthand is documented current behaviour.
- **Phase-N planning vestiges** ("lands in Phase 3+", "Phase 4 slice 2", "Phase-1 porting picks up here", "Phase 5 step 1 of the packaging scope change") removed from `crates/condash-state/src/ctx.rs`, `src-tauri/src/assets.rs`, `src-tauri/src/pty.rs`, `src-tauri/src/lib.rs`, `src-tauri/src/bin/condash_serve.rs`, `crates/condash-render/src/git_render.rs`, `src-tauri/src/config.rs`, and `Cargo.toml`. The phases are all done.
- **`docs/reference/config.md`** reworded the misleading "For backwards compatibility, configuration.yml still accepts terminal / pdf_viewer / open_with" — those keys are part of the current dual-file API, not a compat layer.
- **`sse.js`** and **`server/events.rs`** comments updated: the prior `EventSource` lifecycle and `onmessage` references were stale; described the current htmx-driven design instead.

## Impact

- **Wire change**: `POST /api/items` no longer exists. The bundled frontend is the only known caller and was updated in the same commit. External consumers (if any) would need to switch to `POST /create-item`.
- No other behaviour changes — every other edit is comments, docs, or a same-behaviour rename.

## Watchpoints

- **New Item modal**: confirm it still scaffolds an item end-to-end after the route swap. The smoke suite under `tests/smoke/` does not exercise the modal, so this needs a manual click-through.