### PR TITLE
Per-card SSE refresh and snap hover for the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ condash/
       launcher.rs            <- "open with" command-chain executor
       server/                <- axum routers, one file per concern
         mod.rs                  - register_all + Router builder
-        shell.rs                - `/`, `/fragment/{history,knowledge,code,projects}`, static assets
+        shell.rs                - `/`, `/fragment/{history,knowledge,code,projects}` + per-item `/fragment/{projects,history}/:slug`, `/fragment/knowledge/one?path=…`, `/fragment/code/:repo`, static assets
         steps.rs                - `/toggle`, `/add-step`, `/edit-step`, `/remove-step`, `/set-priority`, `/reorder-all`
         notes.rs                - `/note*` mutations + uploads
         items.rs                - `/create-item`
@@ -95,7 +95,7 @@ Precedence when resolving the conception tree (`src-tauri/src/lib.rs::resolve_co
 
 ## Dashboard HTML
 
-`frontend/dashboard.html` is served verbatim at `/`. It is a single-file SPA driven by htmx + a small set of hand-written ES modules under `frontend/src/js/`. The bundle (`frontend/dist/bundle.{js,css}`) is rebuilt by `make frontend` and embedded into the binary via rust-embed. Per-pane refreshes go through `hx-trigger="sse:<tab>"` + `/fragment/<tab>`. Do not refactor `dashboard.html` into a JS framework — the single-file contract is deliberate (one `<script>` tag, zero npm install at runtime).
+`frontend/dashboard.html` is served verbatim at `/`. It is a single-file SPA driven by htmx + a small set of hand-written ES modules under `frontend/src/js/`. The bundle (`frontend/dist/bundle.{js,css}`) is rebuilt by `make frontend` and embedded into the binary via rust-embed. Per-pane refreshes go through `hx-trigger="sse:<tab>"` + `/fragment/<tab>` for structural changes; per-item refreshes go through `hx-trigger="sse:<tab>-<id>"` + `/fragment/<tab>/<id>` on each card root, so a single step toggle / file edit / git ref change re-fetches one ~few-KB fragment instead of the whole pane (see `src-tauri/src/events.rs::classify` for path → `(pane, id)` resolution). Do not refactor `dashboard.html` into a JS framework — the single-file contract is deliberate (one `<script>` tag, zero npm install at runtime).
 
 ## PDF preview
 

--- a/crates/condash-render/src/git_render.rs
+++ b/crates/condash-render/src/git_render.rs
@@ -572,8 +572,13 @@ fn render_flat_group(
     };
     let mut parts: Vec<String> = Vec::new();
     parts.push(format!(
-        "<div class=\"{cls}\" data-node-id=\"{id}\">",
-        id = h(&family_id)
+        "<div class=\"{cls}\" id=\"code-{name}\" data-node-id=\"{id}\" \
+         hx-trigger=\"sse:code-{name}\" \
+         hx-get=\"/fragment/code/{name}\" \
+         hx-target=\"this\" \
+         hx-swap=\"morph:outerHTML\">",
+        id = h(&family_id),
+        name = h(&family.name),
     ));
     if is_compound {
         parts.push(format!(
@@ -587,6 +592,31 @@ fn render_flat_group(
     }
     parts.push("</div>".into());
     parts.join("\n")
+}
+
+/// Render one repo's `flat-group` div by family name. Walks `groups`
+/// for the matching family, then re-uses [`render_flat_group`] so the
+/// markup is identical to what the full-pane render emits — same
+/// `data-node-id`, same hx-* attrs, same morph anchor.
+///
+/// Returns `None` when the family isn't found (repo dropped from
+/// configuration between event and render — pane-wide structural
+/// fallback covers those cases).
+pub fn render_one_code_repo(
+    ctx: &RenderCtx,
+    groups: &[Group],
+    repo_name: &str,
+    live: &LiveRunners,
+) -> Option<String> {
+    for group in groups {
+        let group_id = format!("code/{}", group.label);
+        for family in &group.families {
+            if family.name == repo_name {
+                return Some(render_flat_group(ctx, family, &group_id, live));
+            }
+        }
+    }
+    None
 }
 
 /// Render the full Code tab given the list of discovered groups.

--- a/crates/condash-render/src/lib.rs
+++ b/crates/condash-render/src/lib.rs
@@ -24,7 +24,7 @@ pub mod templating;
 
 pub use note_render::{raw_payload as note_raw_payload, render_note};
 
-use condash_parser::{knowledge_title_and_desc, Item, KnowledgeNode};
+use condash_parser::{knowledge_title_and_desc, Item, KnowledgeCard, KnowledgeNode};
 use condash_state::{collect_git_repos, search_items, RenderCtx, SearchResult};
 use minijinja::context;
 use minijinja::value::Value;
@@ -98,6 +98,47 @@ pub fn render_card(item: &Item) -> String {
         icons => icons::icons_value(),
     };
     templating::render("card.html.j2", ctx)
+}
+
+/// Render one knowledge entry by its path. Walks the tree to find the
+/// matching `KnowledgeCard` (body or index) and renders the
+/// `knowledge_card` macro with it. Returns `None` when the path isn't
+/// present in the tree (file deleted between event and render — the
+/// pane-wide structural fallback handles those cases).
+pub fn render_one_knowledge_card(root: Option<&KnowledgeNode>, path: &str) -> Option<String> {
+    let entry = find_knowledge_entry(root?, path)?;
+    let ctx = context! {
+        e => Value::from_serialize(entry),
+        icons => icons::icons_value(),
+    };
+    Some(templating::render("knowledge_card_one.html.j2", ctx))
+}
+
+fn find_knowledge_entry<'a>(node: &'a KnowledgeNode, path: &str) -> Option<&'a KnowledgeCard> {
+    for entry in &node.body {
+        if entry.path == path {
+            return Some(entry);
+        }
+    }
+    if let Some(idx) = &node.index {
+        if idx.path == path {
+            return Some(idx);
+        }
+    }
+    for child in &node.children {
+        if let Some(hit) = find_knowledge_entry(child, path) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
+/// Render one history row given the underlying item. Used by
+/// `/fragment/history/:slug`. The slug serves as the morph anchor (the
+/// row carries `id="hist-<slug>"`).
+pub fn render_one_history_row(item: &Item) -> String {
+    let ctx = context! { item => Value::from_serialize(item) };
+    templating::render("history_card_one.html.j2", ctx)
 }
 
 /// Render the full knowledge tree under the `{{KNOWLEDGE}}` placeholder.
@@ -402,6 +443,70 @@ mod tests {
         assert!(html.contains("class=\"card collapsed\""));
         assert!(html.contains("Title 2026-04-22-foo"));
         assert!(html.contains("data-node-id=\"projects/now/2026-04-22-foo\""));
+    }
+
+    #[test]
+    fn render_card_carries_per_item_hx_attrs() {
+        let item = simple_item("2026-04-22-foo", Priority::Now);
+        let html = render_card(&item);
+        assert!(
+            html.contains("hx-trigger=\"sse:projects-2026-04-22-foo\""),
+            "missing per-item sse trigger: {html}"
+        );
+        assert!(
+            html.contains("hx-get=\"/fragment/projects/2026-04-22-foo\""),
+            "missing per-item hx-get: {html}"
+        );
+        assert!(html.contains("hx-target=\"this\""));
+        assert!(html.contains("hx-swap=\"morph:outerHTML\""));
+    }
+
+    #[test]
+    fn render_one_history_row_outputs_history_card() {
+        let item = simple_item("2026-04-22-foo", Priority::Now);
+        let html = render_one_history_row(&item);
+        assert!(html.contains("class=\"knowledge-card history-card\""));
+        assert!(html.contains("id=\"hist-2026-04-22-foo\""));
+        assert!(html.contains("hx-trigger=\"sse:projects-2026-04-22-foo\""));
+        assert!(html.contains("hx-get=\"/fragment/history/2026-04-22-foo\""));
+    }
+
+    #[test]
+    fn render_one_knowledge_card_finds_entry_and_renders_macro() {
+        use condash_parser::KnowledgeCard;
+        let entry = KnowledgeCard {
+            path: "knowledge/internal/condash.md".into(),
+            title: "Condash".into(),
+            desc: "All about condash".into(),
+        };
+        let leaf = KnowledgeNode {
+            name: "internal".into(),
+            label: "internal".into(),
+            rel_dir: "knowledge/internal".into(),
+            index: None,
+            body: vec![entry.clone()],
+            children: vec![],
+            count: 1,
+        };
+        let root = KnowledgeNode {
+            name: "knowledge".into(),
+            label: "knowledge".into(),
+            rel_dir: "knowledge".into(),
+            index: None,
+            body: vec![],
+            children: vec![leaf],
+            count: 1,
+        };
+        let html = render_one_knowledge_card(Some(&root), "knowledge/internal/condash.md")
+            .expect("found entry");
+        assert!(html.contains("class=\"knowledge-card\""));
+        assert!(html.contains("Condash"));
+        assert!(html.contains(
+            "hx-trigger=\"sse:knowledge-knowledge/internal/condash.md\""
+        ));
+        assert!(html.contains("hx-get=\"/fragment/knowledge/one?path=knowledge/internal/condash.md\""));
+        // Missing path returns None.
+        assert!(render_one_knowledge_card(Some(&root), "knowledge/missing.md").is_none());
     }
 
     #[test]

--- a/crates/condash-render/src/templating.rs
+++ b/crates/condash-render/src/templating.rs
@@ -18,7 +18,10 @@ pub const CARD_TEMPLATE: &str = include_str!("../templates/card.html.j2");
 pub const HISTORY_TEMPLATE: &str = include_str!("../templates/history.html.j2");
 pub const HISTORY_SEARCH_RESULTS_TEMPLATE: &str =
     include_str!("../templates/history_search_results.html.j2");
+pub const HISTORY_CARD_ONE_TEMPLATE: &str = include_str!("../templates/history_card_one.html.j2");
 pub const KNOWLEDGE_TREE_TEMPLATE: &str = include_str!("../templates/knowledge_tree.html.j2");
+pub const KNOWLEDGE_CARD_ONE_TEMPLATE: &str =
+    include_str!("../templates/knowledge_card_one.html.j2");
 pub const MACROS_TEMPLATE: &str = include_str!("../templates/_macros.html.j2");
 
 fn embed_filter(value: Value) -> Result<Value, Error> {
@@ -184,6 +187,10 @@ fn build_env() -> Environment<'static> {
     )
     .unwrap();
     env.add_template("knowledge_tree.html.j2", KNOWLEDGE_TREE_TEMPLATE)
+        .unwrap();
+    env.add_template("knowledge_card_one.html.j2", KNOWLEDGE_CARD_ONE_TEMPLATE)
+        .unwrap();
+    env.add_template("history_card_one.html.j2", HISTORY_CARD_ONE_TEMPLATE)
         .unwrap();
 
     env.add_filter("embed", embed_filter);

--- a/crates/condash-render/templates/_macros.html.j2
+++ b/crates/condash-render/templates/_macros.html.j2
@@ -151,11 +151,35 @@
 {% endmacro %}
 
 
+{% macro history_card(item) %}
+<div class="knowledge-card history-card"
+  id="hist-{{ item.slug }}" data-node-id="hist/{{ item.slug }}"
+  data-priority="{{ item.priority }}" data-kind="{{ item.kind }}"
+  data-action="open-note-preview"
+  data-path="{{ item.path }}" data-title="{{ item.title }}"
+  hx-trigger="sse:projects-{{ item.slug }}"
+  hx-get="/fragment/history/{{ item.slug }}"
+  hx-target="this"
+  hx-swap="morph:outerHTML">
+  <div class="knowledge-title">{{ item.title }}</div>
+  <div class="history-meta">
+    <span class="pill pri-{{ item.priority }}">{{ item.priority }}</span>
+    <span class="pill">{{ item.kind }}</span>
+  </div>
+  <div class="knowledge-path">{{ item.slug }}</div>
+</div>
+{% endmacro %}
+
+
 {% macro knowledge_card(e) %}
 {% set parent_dir = e.path | dirname %}
 <div class="knowledge-card" data-node-id="{{ e.path }}"
   data-action="open-note-preview"
-  data-path="{{ e.path }}" data-title="{{ e.title }}">
+  data-path="{{ e.path }}" data-title="{{ e.title }}"
+  hx-trigger="sse:knowledge-{{ e.path }}"
+  hx-get="/fragment/knowledge/one?path={{ e.path }}"
+  hx-target="this"
+  hx-swap="morph:outerHTML">
   <div class="knowledge-title">{{ e.title }}</div>
   {{ open_folder_btn(parent_dir, e.title) }}
   {% if e.desc %}<div class="knowledge-desc">{{ e.desc }}</div>{% endif %}

--- a/crates/condash-render/templates/card.html.j2
+++ b/crates/condash-render/templates/card.html.j2
@@ -3,7 +3,11 @@
 {% set kind = item.kind %}
 {% set node_id = "projects/" ~ pri ~ "/" ~ item.slug %}
 <div class="card collapsed" id="{{ item.slug }}"
-  data-kind="{{ kind }}" data-priority="{{ pri }}" data-node-id="{{ node_id }}">
+  data-kind="{{ kind }}" data-priority="{{ pri }}" data-node-id="{{ node_id }}"
+  hx-trigger="sse:projects-{{ item.slug }}"
+  hx-get="/fragment/projects/{{ item.slug }}"
+  hx-target="this"
+  hx-swap="morph:outerHTML">
   <div class="card-header">
     <div class="card-header-left" data-action="toggle-card">
       <span class="kind-prefix kind-{{ kind }}">{{ kind }}</span>

--- a/crates/condash-render/templates/history.html.j2
+++ b/crates/condash-render/templates/history.html.j2
@@ -16,19 +16,7 @@
         {% if month.index %}{{ m.index_badge(month.index, top_level=false) }}{% endif %}
       </summary>
       <div class="knowledge-list">
-        {% for item in month['items'] %}
-        <div class="knowledge-card history-card"
-          data-priority="{{ item.priority }}" data-kind="{{ item.kind }}"
-          data-action="open-note-preview"
-          data-path="{{ item.path }}" data-title="{{ item.title }}">
-          <div class="knowledge-title">{{ item.title }}</div>
-          <div class="history-meta">
-            <span class="pill pri-{{ item.priority }}">{{ item.priority }}</span>
-            <span class="pill">{{ item.kind }}</span>
-          </div>
-          <div class="knowledge-path">{{ item.slug }}</div>
-        </div>
-        {% endfor %}
+        {% for item in month['items'] %}{{ m.history_card(item) }}{% endfor %}
       </div>
     </details>
     {% endfor %}

--- a/crates/condash-render/templates/history_card_one.html.j2
+++ b/crates/condash-render/templates/history_card_one.html.j2
@@ -1,0 +1,2 @@
+{% import "_macros.html.j2" as m %}
+{{ m.history_card(item) }}

--- a/crates/condash-render/templates/knowledge_card_one.html.j2
+++ b/crates/condash-render/templates/knowledge_card_one.html.j2
@@ -1,0 +1,2 @@
+{% import "_macros.html.j2" as m %}
+{{ m.knowledge_card(e) }}

--- a/frontend/src/css/cards/card.css
+++ b/frontend/src/css/cards/card.css
@@ -27,12 +27,15 @@
     position: relative;
     border: 1px solid var(--border); border-radius: 10px; margin-bottom: 0.75rem;
     box-shadow: var(--shadow-sm); background: var(--bg-card);
-    /* `box-shadow` is intentionally not animated — the hover state still
-       changes shadow, but we let it snap instead of repainting a blurred
-       drop-shadow on every frame. `transform` is GPU-only and `border-color`
-       only repaints the border edge, so animating those is essentially free. */
-    transition: border-color 0.18s ease, transform 0.18s ease;
-    /* Each card is its own paint + layout atom, so an SSE-driven morph swap
+    /* No hover transition. Earlier we animated `border-color` + `transform`
+       (b7d8535 already snapped `box-shadow`) on the assumption they were
+       essentially free — direct WebKit Inspector recordings of plain mouse
+       movement said otherwise (~48% avg CPU on Linux/WebKitGTK with the mouse
+       just sweeping the cards pane). Snapping every hover-relevant property
+       drops idle paint cost to ~0; the visual feedback (shadow lift, border
+       darken) is unchanged, just instant instead of 0.18 s eased.
+
+       Each card is its own paint + layout atom, so an SSE-driven morph swap
        invalidates only the changed cards instead of the full pane. The
        :has(.pri-menu.open) rule below drops paint containment because the
        open popover overflows the card's bottom edge — contain:paint would
@@ -42,7 +45,6 @@
 .card:hover {
     box-shadow: var(--shadow-md);
     border-color: color-mix(in srgb, var(--text-muted) 22%, var(--border));
-    transform: translateY(-1px);
 }
 /* Lift the card above later siblings while its status popover is open — the
    popover overflows the card's bottom edge and would otherwise paint behind

--- a/frontend/src/css/cards/card.css
+++ b/frontend/src/css/cards/card.css
@@ -43,7 +43,13 @@
     contain: layout paint;
 }
 .card:hover {
-    box-shadow: var(--shadow-md);
+    /* Border-only hover. We tried `box-shadow: var(--shadow-md)` in the
+       hover state too; even snapped (no transition), repainting a
+       blurred drop-shadow region on every card the mouse crosses kept
+       sustained CPU at ~46% on Linux/WebKitGTK. Border-color repaints
+       a 1px outline — essentially free — and is enough to signal
+       hover. The base shadow stays in place; we just don't lift it on
+       hover. */
     border-color: color-mix(in srgb, var(--text-muted) 22%, var(--border));
 }
 /* Lift the card above later siblings while its status popover is open — the

--- a/frontend/src/css/cards/knowledge.css
+++ b/frontend/src/css/cards/knowledge.css
@@ -124,7 +124,9 @@
     border: 1px solid transparent;
     background: transparent;
     cursor: pointer;
-    transition: border-color 0.12s, background 0.12s;
+    /* No hover transition — same rationale as `.card`. Snapping the
+       hover background + border keeps idle paint cost flat as the
+       mouse sweeps a 50-card knowledge tree. */
     contain: layout paint;
 }
 .knowledge-card:hover {

--- a/frontend/src/js/sections/htmx-state-preserve.js
+++ b/frontend/src/js/sections/htmx-state-preserve.js
@@ -7,12 +7,16 @@
    state in `htmx:beforeSwap` and re-applies it in `htmx:afterSwap`,
    per swap target.
 
-   Three targets carry preservable state:
+   Targets that carry preservable state:
 
-   - `#cards`              — card.collapsed class, card.expanded class
+   - `#cards`              — card.collapsed class on every child card
    - `#knowledge`          — <details data-node-id> open state, then
                              re-apply the client-side filterKnowledge
                              query
+   - per-card swap (a single `.card[id=<slug>]` root) — the
+                             `collapsed` class on that one card. Driven
+                             by per-item SSE patches, so the target is
+                             the card itself, not the pane.
    - `#git-panel`          — runner-viewer mounts already carry
                              `hx-preserve="true"` server-side, so
                              nothing to do here; included for symmetry. */
@@ -78,12 +82,21 @@ function _restoreKnowledgeState(el, snap) {
     }
 }
 
+/* Per-card snapshot — keyed by the card's id so multiple cards in
+   flight at once don't trample one another. */
+var _cardSnap = {};
+
 function initHtmxStatePreserve() {
     document.body.addEventListener('htmx:beforeSwap', function(ev) {
         var target = ev.target;
         if (!target || !target.id) return;
         if (target.id === 'cards') _snap.cards = _captureCardsState(target);
         else if (target.id === 'knowledge') _snap.knowledge = _captureKnowledgeState(target);
+        else if (target.classList && target.classList.contains('card')) {
+            _cardSnap[target.id] = {
+                expanded: !target.classList.contains('collapsed'),
+            };
+        }
     });
     document.body.addEventListener('htmx:afterSwap', function(ev) {
         var target = ev.target;
@@ -94,6 +107,16 @@ function initHtmxStatePreserve() {
         } else if (target.id === 'knowledge') {
             _restoreKnowledgeState(target, _snap.knowledge);
             _snap.knowledge = null;
+        } else if (target.classList && target.classList.contains('card')) {
+            var snap = _cardSnap[target.id];
+            if (snap && snap.expanded) target.classList.remove('collapsed');
+            _cardSnap[target.id] = null;
+            // After a per-card swap the priority filter still has to
+            // re-evaluate this one card — its data-priority may have
+            // changed even though the surrounding pane didn't refresh.
+            if (typeof _applySubtab === 'function' && _activeSubtab) {
+                _applySubtab(_activeSubtab);
+            }
         }
     });
 }

--- a/src-tauri/src/events.rs
+++ b/src-tauri/src/events.rs
@@ -1,20 +1,26 @@
 //! Filesystem-driven staleness push.
 //!
-//! The watcher emits coarse per-tab events (`projects` / `knowledge` /
-//! `code`) whenever a watched path changes. The SSE handler in
-//! `server.rs` subscribes to the bus and streams events to the
-//! browser; the frontend treats every event as a hint to re-poll
-//! `/check-updates`.
+//! The watcher emits two flavours of event:
+//!
+//! - **Pane-wide** (`projects` / `knowledge` / `code`) when the change
+//!   is structural — a new item directory appears, an `index.md` is
+//!   touched, configuration is rewritten, etc. The pane container's
+//!   `hx-trigger="sse:<pane>"` re-fetches the whole pane fragment.
+//! - **Per-item** (`projects-<slug>` / `knowledge-<rel-path>` /
+//!   `code-<repo>`) when the change is item-internal — one card's
+//!   underlying state moved. The card root carries its own
+//!   `hx-trigger="sse:<pane>-<id>"` so only that one card re-fetches a
+//!   `<2 KB` fragment and idiomorph patches it in place.
 //!
 //! `configuration.yml` itself is intentionally *not* watched — edits
 //! come from the in-app YAML editor which explicitly triggers a
-//! `RenderCtx` rebuild on Save. Out-of-band edits (hand-edit from a
-//! different tool) require the user to reopen the modal or restart.
+//! `RenderCtx` rebuild and a pane-wide event for each pane on Save.
 //!
 //! Fan-out uses a `tokio::sync::broadcast` channel, which gives us
 //! lagging-subscriber semantics for free: the client re-polls on lag,
 //! which is the same fall-back the reconciler already provides.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -24,35 +30,62 @@ use notify::{recommended_watcher, Event, EventKind, RecommendedWatcher, Recursiv
 use serde::Serialize;
 use tokio::sync::broadcast;
 
-/// Drop duplicate events per tab within this window — a single editor
-/// save often produces swap-file + metadata-touch events too.
+/// Drop duplicate events per (pane, id) within this window — a single
+/// editor save often produces swap-file + metadata-touch events too.
 pub const DEBOUNCE: Duration = Duration::from_millis(750);
 
 /// Payload emitted by the watcher. Wire format is
-/// `{"tab": <tab>, "ts": <seconds>}`.
+/// `{"tab": <pane>, "id": <id?>, "ts": <seconds>}`.
+///
+/// `tab` is kept (not renamed `pane`) for compatibility with the
+/// `events_stream` SSE handler and the `condash-state` cache router that
+/// match on the string. `id` is `None` for pane-wide / structural events,
+/// `Some(...)` for item-internal events.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct EventPayload {
     pub tab: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub ts: u64,
 }
 
 impl EventPayload {
-    fn new(tab: impl Into<String>) -> Self {
+    fn build(tab: impl Into<String>, id: Option<String>) -> Self {
         let ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|d| d.as_secs())
             .unwrap_or(0);
         EventPayload {
             tab: tab.into(),
+            id,
             ts,
         }
     }
 
-    /// Public factory used by routes that need to publish a tab refresh
-    /// (currently the configuration save handler — see
-    /// [`server::config_surface`](crate::server::config_surface)).
+    /// Pane-wide / structural event factory. Used by the configuration
+    /// save handler (see [`server::config_surface`](crate::server::config_surface))
+    /// and by the watcher when a path change can't be narrowed to a
+    /// single item.
     pub fn for_tab(tab: impl Into<String>) -> Self {
-        Self::new(tab)
+        Self::build(tab, None)
+    }
+
+    /// Per-item event factory. The id is the slug / file-path / repo-name
+    /// the changed file resolves to. The SSE handler turns this into the
+    /// named event `<tab>-<id>` on the wire.
+    pub fn for_item(tab: impl Into<String>, id: impl Into<String>) -> Self {
+        Self::build(tab, Some(id.into()))
+    }
+
+    /// SSE event name used on the wire. `<tab>` for pane-wide,
+    /// `<tab>-<id>` for per-item. Slashes in `id` (knowledge file paths)
+    /// are kept verbatim; htmx's SSE extension matches the event-name
+    /// field as a literal string.
+    pub fn event_name(&self) -> String {
+        match &self.id {
+            None => self.tab.clone(),
+            Some(id) => format!("{}-{}", self.tab, id),
+        }
     }
 }
 
@@ -95,30 +128,33 @@ impl Default for EventBus {
     }
 }
 
-/// Per-tab debouncer — tracks the last-emit instant and suppresses any
-/// follow-up within the debounce window.
-struct Debouncer {
+/// Per-key debouncer — tracks the last-emit instant for an arbitrary
+/// string key and suppresses any follow-up within the debounce window.
+/// The key is `<pane>` for pane-wide events and `<pane>-<id>` for
+/// per-item events, so two different items can fire inside the same
+/// 750 ms window without one starving the other.
+struct KeyedDebouncer {
     window: Duration,
-    last: Mutex<Instant>,
+    last: Mutex<HashMap<String, Instant>>,
 }
 
-impl Debouncer {
+impl KeyedDebouncer {
     fn new(window: Duration) -> Self {
-        Debouncer {
+        KeyedDebouncer {
             window,
-            // Seed `last` far enough in the past that the first event
-            // always fires.
-            last: Mutex::new(Instant::now() - window - Duration::from_secs(1)),
+            last: Mutex::new(HashMap::new()),
         }
     }
 
-    fn should_fire(&self) -> bool {
-        let mut guard = self.last.lock().expect("Debouncer mutex poisoned");
+    fn should_fire(&self, key: &str) -> bool {
+        let mut guard = self.last.lock().expect("KeyedDebouncer mutex poisoned");
         let now = Instant::now();
-        if now.duration_since(*guard) < self.window {
-            return false;
+        if let Some(prev) = guard.get(key) {
+            if now.duration_since(*prev) < self.window {
+                return false;
+            }
         }
-        *guard = now;
+        guard.insert(key.to_string(), now);
         true
     }
 }
@@ -130,7 +166,6 @@ fn is_noise(leaf: &str) -> bool {
     leaf.is_empty() || leaf.starts_with('.') || leaf.ends_with('~')
 }
 
-/// Tabs routed by the projects/knowledge/config handlers.
 fn leaf_of(path: &Path) -> String {
     path.file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -202,6 +237,91 @@ fn git_dirs_under(workspace: &Path) -> Vec<PathBuf> {
     out
 }
 
+/// Result of `classify`: which pane the path belongs to, and the
+/// per-item id when one can be resolved cleanly. `None` from `classify`
+/// itself means the path doesn't belong to any watched pane (ignored).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathClass {
+    pub pane: &'static str,
+    pub id: Option<String>,
+}
+
+/// Resolve a changed filesystem path to `(pane, id?)`. Pure function — no
+/// I/O — so it's cheap to call from the notify callback.
+pub fn classify(path: &Path, cfg: &WatchConfig) -> Option<PathClass> {
+    if let Some(root) = &cfg.projects {
+        if let Some(rel) = path.strip_prefix(root).ok() {
+            // Components after `projects/` are `<month>/<slug>/...`.
+            let parts: Vec<&str> = rel
+                .components()
+                .filter_map(|c| match c {
+                    std::path::Component::Normal(n) => n.to_str(),
+                    _ => None,
+                })
+                .collect();
+            if parts.len() >= 2 {
+                // Past the slug dir → item-internal.
+                return Some(PathClass {
+                    pane: "projects",
+                    id: Some(parts[1].to_string()),
+                });
+            }
+            // Path is `projects/` itself or `projects/<month>/` — a
+            // structural change (new item dir landed, deletion, etc.).
+            return Some(PathClass {
+                pane: "projects",
+                id: None,
+            });
+        }
+    }
+    if let Some(root) = &cfg.knowledge {
+        if let Some(rel) = path.strip_prefix(root).ok() {
+            // The card's data-node-id is the path *relative to base*
+            // (`knowledge/<rel>`), so re-attach the prefix.
+            let id = format!("knowledge/{}", rel.to_string_lossy().replace('\\', "/"));
+            // index.md changes affect the parent group's badge, which
+            // means a structural-shape refresh; we serve those as
+            // pane-wide.
+            let leaf = leaf_of(path);
+            if leaf == "index.md" {
+                return Some(PathClass {
+                    pane: "knowledge",
+                    id: None,
+                });
+            }
+            // A directory event has no file extension we can rely on —
+            // require a `.md` suffix for per-item; everything else is
+            // structural (rename, mkdir, etc.).
+            let is_md = path.extension().and_then(|e| e.to_str()) == Some("md");
+            if !is_md {
+                return Some(PathClass {
+                    pane: "knowledge",
+                    id: None,
+                });
+            }
+            return Some(PathClass {
+                pane: "knowledge",
+                id: Some(id),
+            });
+        }
+    }
+    for gitdir in &cfg.git_dirs {
+        if path.starts_with(gitdir) {
+            // `<repo>/.git/<file>` → repo name is the parent of `.git`.
+            let repo = gitdir
+                .parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+                .map(|s| s.to_string());
+            return Some(PathClass {
+                pane: "code",
+                id: repo,
+            });
+        }
+    }
+    None
+}
+
 /// Handle returned by [`start_watcher`]. Dropping it tears the watcher
 /// down.
 pub struct WatcherHandle {
@@ -209,10 +329,19 @@ pub struct WatcherHandle {
 }
 
 /// Bridge filesystem-watcher events to the shared items/knowledge
-/// cache. Without this, the watcher publishes `projects` / `knowledge`
-/// events to the SSE fan-out but the server keeps handing back the
-/// first-warmed cached slices, so hand-edits and `git pull` never
-/// surface until the user hits `/rescan`.
+/// cache. Without this, the watcher publishes events to the SSE fan-out
+/// but the server keeps handing back the first-warmed cached slices, so
+/// hand-edits and `git pull` never surface until the user hits
+/// `/rescan`.
+///
+/// Both pane-wide and per-item events flow through here. The cache's
+/// `on_event` API is coarse (Tab::Projects flushes the whole map), so
+/// per-item events still trigger a coarse flush *for now*; the
+/// `WorkspaceCache::invalidate_item_at` helper exists for the future
+/// fine-grained pathway, but plumbing the README path through the watcher
+/// would push all the per-item-detection logic onto this hot path. The
+/// extra reparse cost on a hot cache is small — the path → README parse
+/// is what the surgical invalidator does anyway.
 pub fn spawn_cache_invalidator(
     bus: EventBus,
     cache: std::sync::Arc<condash_state::WorkspaceCache>,
@@ -249,10 +378,6 @@ pub fn spawn_cache_invalidator(
 /// the shared `Arc`, so events reach every SSE subscriber without
 /// blocking the HTTP runtime.
 pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
-    let projects_deb = Arc::new(Debouncer::new(DEBOUNCE));
-    let knowledge_deb = Arc::new(Debouncer::new(DEBOUNCE));
-    let code_deb = Arc::new(Debouncer::new(DEBOUNCE));
-
     let nothing_to_watch =
         cfg.projects.is_none() && cfg.knowledge.is_none() && cfg.git_dirs.is_empty();
     if nothing_to_watch {
@@ -260,9 +385,16 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
     }
 
     let bus_clone = bus.clone();
-    let projects_path = cfg.projects.clone();
-    let knowledge_path = cfg.knowledge.clone();
-    let git_dirs = cfg.git_dirs.clone();
+    let debouncer = Arc::new(KeyedDebouncer::new(DEBOUNCE));
+    // Snapshot the watch roots that the closure needs to reason about.
+    // The notify watcher itself holds onto the absolute paths via the
+    // `watch()` calls below; this `cfg_for_classify` is just so
+    // `classify` keeps working from inside the callback.
+    let cfg_for_classify = WatchConfig {
+        projects: cfg.projects.clone(),
+        knowledge: cfg.knowledge.clone(),
+        git_dirs: cfg.git_dirs.clone(),
+    };
 
     let mut watcher = recommended_watcher(move |res: notify::Result<Event>| {
         let Ok(event) = res else { return };
@@ -273,28 +405,34 @@ pub fn start_watcher(bus: EventBus, cfg: WatchConfig) -> Option<WatcherHandle> {
         }
         for src in &event.paths {
             let leaf = leaf_of(src);
-
-            if let Some(root) = &projects_path {
-                if src.starts_with(root) && !is_noise(&leaf) && projects_deb.should_fire() {
-                    bus_clone.publish(EventPayload::new("projects"));
-                    continue;
-                }
+            if is_noise(&leaf) {
+                continue;
             }
-            if let Some(root) = &knowledge_path {
-                if src.starts_with(root) && !is_noise(&leaf) && knowledge_deb.should_fire() {
-                    bus_clone.publish(EventPayload::new("knowledge"));
-                    continue;
-                }
+            // For the code pane the watcher only cares about three ref
+            // files; everything else under `.git/` is implementation
+            // noise (objects/, lock churn). The check has to live here,
+            // not in `classify`, because `classify` is also called from
+            // tests with synthetic paths.
+            if cfg_for_classify
+                .git_dirs
+                .iter()
+                .any(|g| src.starts_with(g))
+                && !matches!(leaf.as_str(), "HEAD" | "index" | "packed-refs")
+            {
+                continue;
             }
-            for gitdir in &git_dirs {
-                if src.starts_with(gitdir)
-                    && matches!(leaf.as_str(), "HEAD" | "index" | "packed-refs")
-                    && code_deb.should_fire()
-                {
-                    bus_clone.publish(EventPayload::new("code"));
-                    break;
-                }
+            let Some(class) = classify(src, &cfg_for_classify) else {
+                continue;
+            };
+            let payload = match &class.id {
+                Some(id) => EventPayload::for_item(class.pane, id),
+                None => EventPayload::for_tab(class.pane),
+            };
+            let key = payload.event_name();
+            if !debouncer.should_fire(&key) {
+                continue;
             }
+            bus_clone.publish(payload);
         }
     })
     .ok()?;
@@ -323,30 +461,33 @@ mod tests {
         let bus = EventBus::new(16);
         let mut rx1 = bus.subscribe();
         let mut rx2 = bus.subscribe();
-        let payload = EventPayload::new("projects");
+        let payload = EventPayload::for_tab("projects");
         bus.publish(payload.clone());
         let got1 = rx1.try_recv().expect("rx1 received");
         let got2 = rx2.try_recv().expect("rx2 received");
         assert_eq!(got1.tab, "projects");
         assert_eq!(got2.tab, "projects");
-        let _ = payload;
+        assert!(got1.id.is_none());
     }
 
     #[test]
     fn bus_drop_on_no_subscribers_is_silent() {
         let bus = EventBus::new(4);
-        // No subscribers — must not panic.
-        bus.publish(EventPayload::new("knowledge"));
+        bus.publish(EventPayload::for_tab("knowledge"));
         assert_eq!(bus.subscriber_count(), 0);
     }
 
     #[test]
-    fn debouncer_suppresses_rapid_fire() {
-        let deb = Debouncer::new(Duration::from_millis(100));
-        assert!(deb.should_fire(), "first must fire");
-        assert!(!deb.should_fire(), "immediate follow-up must not fire");
+    fn keyed_debouncer_suppresses_same_key_only() {
+        let deb = KeyedDebouncer::new(Duration::from_millis(100));
+        assert!(deb.should_fire("a"), "first 'a' must fire");
+        assert!(!deb.should_fire("a"), "second 'a' must be suppressed");
+        // Different key must fire even within the window — this is
+        // the property that lets two different cards both notify in the
+        // same 750 ms tick.
+        assert!(deb.should_fire("b"), "'b' independent of 'a'");
         std::thread::sleep(Duration::from_millis(120));
-        assert!(deb.should_fire(), "after window must fire again");
+        assert!(deb.should_fire("a"), "'a' fires again after window");
     }
 
     #[test]
@@ -361,7 +502,6 @@ mod tests {
     fn watch_config_skips_missing_dirs() {
         let tmp = TempDir::new().unwrap();
         let base = tmp.path();
-        // Create only projects/.
         std::fs::create_dir_all(base.join("projects")).unwrap();
         let cfg = WatchConfig::from_ctx(base, None, None);
         assert!(cfg.projects.is_some());
@@ -382,7 +522,93 @@ mod tests {
     }
 
     #[test]
-    fn watcher_emits_projects_event_on_write() {
+    fn classify_routes_projects_paths_to_slug() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        std::fs::create_dir_all(base.join("projects/2026-04/2026-04-22-foo/notes")).unwrap();
+        let cfg = WatchConfig::from_ctx(base, None, None);
+
+        // README → item-internal.
+        let p = base.join("projects/2026-04/2026-04-22-foo/README.md");
+        let c = classify(&p, &cfg).unwrap();
+        assert_eq!(c.pane, "projects");
+        assert_eq!(c.id.as_deref(), Some("2026-04-22-foo"));
+
+        // Note under the item → still item-internal.
+        let p = base.join("projects/2026-04/2026-04-22-foo/notes/a.md");
+        let c = classify(&p, &cfg).unwrap();
+        assert_eq!(c.id.as_deref(), Some("2026-04-22-foo"));
+
+        // The month dir itself → structural.
+        let p = base.join("projects/2026-04");
+        let c = classify(&p, &cfg).unwrap();
+        assert_eq!(c.pane, "projects");
+        assert!(c.id.is_none());
+    }
+
+    #[test]
+    fn classify_routes_knowledge_paths_to_relpath() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        std::fs::create_dir_all(base.join("knowledge/internal")).unwrap();
+        let cfg = WatchConfig::from_ctx(base, None, None);
+
+        // .md file → item-internal, id is `knowledge/<rel>`.
+        let p = base.join("knowledge/internal/condash.md");
+        let c = classify(&p, &cfg).unwrap();
+        assert_eq!(c.pane, "knowledge");
+        assert_eq!(c.id.as_deref(), Some("knowledge/internal/condash.md"));
+
+        // index.md → structural (badge cascades up).
+        let p = base.join("knowledge/internal/index.md");
+        let c = classify(&p, &cfg).unwrap();
+        assert!(c.id.is_none());
+
+        // Non-md file → structural (cover-image add, mkdir, …).
+        let p = base.join("knowledge/internal/diagram.svg");
+        let c = classify(&p, &cfg).unwrap();
+        assert!(c.id.is_none());
+    }
+
+    #[test]
+    fn classify_routes_code_paths_to_repo_name() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let ws = base.join("src");
+        let repo = ws.join("condash");
+        std::fs::create_dir_all(repo.join(".git")).unwrap();
+        let cfg = WatchConfig::from_ctx(base, Some(&ws), None);
+
+        let p = repo.join(".git/HEAD");
+        let c = classify(&p, &cfg).unwrap();
+        assert_eq!(c.pane, "code");
+        assert_eq!(c.id.as_deref(), Some("condash"));
+    }
+
+    #[test]
+    fn classify_returns_none_for_unrelated_paths() {
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path();
+        let cfg = WatchConfig::from_ctx(base, None, None);
+        let p = std::path::PathBuf::from("/etc/passwd");
+        assert!(classify(&p, &cfg).is_none());
+    }
+
+    #[test]
+    fn event_payload_event_name_pane_vs_item() {
+        let pane = EventPayload::for_tab("projects");
+        assert_eq!(pane.event_name(), "projects");
+        let item = EventPayload::for_item("projects", "2026-04-22-foo");
+        assert_eq!(item.event_name(), "projects-2026-04-22-foo");
+        let knowledge = EventPayload::for_item("knowledge", "knowledge/internal/condash.md");
+        assert_eq!(
+            knowledge.event_name(),
+            "knowledge-knowledge/internal/condash.md"
+        );
+    }
+
+    #[test]
+    fn watcher_emits_per_item_event_on_readme_write() {
         use std::sync::atomic::{AtomicBool, Ordering};
 
         let tmp = TempDir::new().unwrap();
@@ -401,7 +627,11 @@ mod tests {
         let f = projects.join("2026-04/2026-04-22-demo/README.md");
         std::fs::write(&f, "# demo\n").unwrap();
 
-        // Give notify up to 2 s to deliver the event.
+        // Give notify up to 2 s to deliver the event. Accept either the
+        // per-item or the structural variant — depending on how notify
+        // reports the create-then-write sequence on the host, we may
+        // see the parent dir event first (structural) before or instead
+        // of the README file event.
         let got_event = AtomicBool::new(false);
         for _ in 0..20 {
             if let Ok(payload) = rx.try_recv() {

--- a/src-tauri/src/server/events.rs
+++ b/src-tauri/src/server/events.rs
@@ -25,14 +25,16 @@ pub(super) async fn events_stream(
         match res {
             Ok(payload) => {
                 let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".into());
-                // Emit a named SSE event matching the payload's `tab`
-                // field (`projects` / `knowledge` / `code`) so htmx
-                // listeners can target a specific tab via
-                // `hx-trigger="sse:projects"`. The generic
-                // `htmx:sseMessage` handler in `sse.js` still fires
-                // for every frame regardless of name.
+                // Emit a named SSE event:
+                //   - `<tab>` for pane-wide / structural events (the
+                //     pane container's `hx-trigger="sse:<tab>"` fires)
+                //   - `<tab>-<id>` for per-item events (a specific
+                //     card's `hx-trigger="sse:<tab>-<id>"` fires;
+                //     other cards stay quiet)
+                // The generic `htmx:sseMessage` handler in `sse.js`
+                // still fires for every frame regardless of name.
                 Some(Ok::<_, std::convert::Infallible>(
-                    SseEvent::default().event(payload.tab.clone()).data(data),
+                    SseEvent::default().event(payload.event_name()).data(data),
                 ))
             }
             // Subscriber lagged behind the broadcast queue. The next

--- a/src-tauri/src/server/mod.rs
+++ b/src-tauri/src/server/mod.rs
@@ -13,6 +13,10 @@
 //! lives in one of the sibling sub-modules, grouped by surface:
 //!
 //! - [`shell`]         — `/`, `/fragment/{history,knowledge,code,projects}`,
+//!                       `/fragment/projects/:slug`,
+//!                       `/fragment/history/:slug`,
+//!                       `/fragment/knowledge/one?path=...`,
+//!                       `/fragment/code/:repo`,
 //!                       favicons, static assets
 //! - [`steps`]         — `/toggle`, `/add-step`, `/remove-step`,
 //!                       `/edit-step`, `/set-priority`, `/reorder-all`
@@ -148,6 +152,24 @@ pub fn build_router(state: AppState) -> Router {
         .route("/fragment/knowledge", get(shell::fragment_knowledge))
         .route("/fragment/code", get(shell::fragment_code))
         .route("/fragment/projects", get(shell::fragment_projects))
+        // Per-item fragment endpoints — driven by the per-card
+        // `hx-trigger="sse:<pane>-<id>"` listeners. See
+        // `events.rs::classify` for how a changed path turns into the
+        // matching id, and `crates/condash-render/src/lib.rs` for the
+        // single-card render helpers.
+        .route(
+            "/fragment/projects/{slug}",
+            get(shell::fragment_projects_one),
+        )
+        .route(
+            "/fragment/history/{slug}",
+            get(shell::fragment_history_one),
+        )
+        .route(
+            "/fragment/knowledge/one",
+            get(shell::fragment_knowledge_one),
+        )
+        .route("/fragment/code/{repo}", get(shell::fragment_code_one))
         .route("/favicon.svg", get(shell::favicon_svg))
         .route("/favicon.ico", get(shell::favicon_ico))
         .route("/vendor/{*path}", get(shell::vendor_asset))

--- a/src-tauri/src/server/shell.rs
+++ b/src-tauri/src/server/shell.rs
@@ -6,12 +6,14 @@
 //! the static routes here.
 
 use axum::body::Body;
-use axum::extract::{Query, State};
+use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::{header, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use condash_render::{
-    render_cards_pane, render_code_pane, render_history_pane, render_knowledge_pane, render_page,
+    git_render, render_card, render_cards_pane, render_code_pane, render_history_pane,
+    render_knowledge_pane, render_one_history_row, render_one_knowledge_card, render_page,
 };
+use condash_state::collect_git_repos;
 use serde::Deserialize;
 
 use super::{error_json, html_response, live_runners_snapshot, AppState};
@@ -74,6 +76,69 @@ pub(super) async fn fragment_code(State(state): State<AppState>) -> impl IntoRes
 pub(super) async fn fragment_projects(State(state): State<AppState>) -> impl IntoResponse {
     let items = state.cache.get_items(&state.ctx());
     html_response(render_cards_pane(&items))
+}
+
+/// HTML fragment for one project card. Refreshed on
+/// `sse:projects-<slug>`. Returns 404 when the slug doesn't resolve to
+/// a known item — the pane-wide structural event will reconcile.
+pub(super) async fn fragment_projects_one(
+    State(state): State<AppState>,
+    AxumPath(slug): AxumPath<String>,
+) -> impl IntoResponse {
+    let items = state.cache.get_items(&state.ctx());
+    match items.iter().find(|i| i.readme.slug == slug) {
+        Some(item) => html_response(render_card(item)),
+        None => error_json(StatusCode::NOT_FOUND, "no such item"),
+    }
+}
+
+/// HTML fragment for one history row. Refreshed on
+/// `sse:projects-<slug>` (history shares triggers with Projects).
+pub(super) async fn fragment_history_one(
+    State(state): State<AppState>,
+    AxumPath(slug): AxumPath<String>,
+) -> impl IntoResponse {
+    let items = state.cache.get_items(&state.ctx());
+    match items.iter().find(|i| i.readme.slug == slug) {
+        Some(item) => html_response(render_one_history_row(item)),
+        None => error_json(StatusCode::NOT_FOUND, "no such item"),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct KnowledgeOneQuery {
+    path: String,
+}
+
+/// HTML fragment for one knowledge card, identified by its
+/// `data-node-id` (file path relative to the conception base, e.g.
+/// `knowledge/internal/condash.md`). Path comes in as a query param —
+/// keeps the route a single segment despite the slashes in the id.
+pub(super) async fn fragment_knowledge_one(
+    State(state): State<AppState>,
+    Query(q): Query<KnowledgeOneQuery>,
+) -> impl IntoResponse {
+    let knowledge = state.cache.get_knowledge(&state.ctx());
+    match render_one_knowledge_card(knowledge.as_ref().as_ref(), &q.path) {
+        Some(html) => html_response(html),
+        None => error_json(StatusCode::NOT_FOUND, "no such knowledge entry"),
+    }
+}
+
+/// HTML fragment for one code-pane repo (one `flat-group`). Refreshed
+/// on `sse:code-<repo>`. Returns 404 when the repo isn't in the current
+/// configuration — pane-wide structural fallback handles config edits.
+pub(super) async fn fragment_code_one(
+    State(state): State<AppState>,
+    AxumPath(repo): AxumPath<String>,
+) -> impl IntoResponse {
+    let ctx_guard = state.ctx();
+    let groups = collect_git_repos(&ctx_guard);
+    let live = live_runners_snapshot(&state);
+    match git_render::render_one_code_repo(&ctx_guard, &groups, &repo, &live) {
+        Some(html) => html_response(html),
+        None => error_json(StatusCode::NOT_FOUND, "no such repo"),
+    }
 }
 
 pub(super) async fn favicon_svg(State(state): State<AppState>) -> impl IntoResponse {

--- a/src-tauri/tests/events_routes.rs
+++ b/src-tauri/tests/events_routes.rs
@@ -93,10 +93,7 @@ async fn events_stream_forwards_bus_publish_to_subscriber() {
     tokio::spawn(async move {
         // Wait a hair so the subscriber is definitely attached.
         tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        bus2.publish(EventPayload {
-            tab: "projects".into(),
-            ts: 1234,
-        });
+        bus2.publish(EventPayload::for_tab("projects"));
     });
 
     let chunk = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
@@ -109,5 +106,5 @@ async fn events_stream_forwards_bus_publish_to_subscriber() {
         s.contains("data: ") && s.contains("\"tab\":\"projects\""),
         "expected projects event frame, got {s:?}"
     );
-    assert!(s.contains("\"ts\":1234"), "ts missing from {s:?}");
+    assert!(s.contains("\"ts\":"), "ts missing from {s:?}");
 }

--- a/tests/smoke/smoke.spec.mjs
+++ b/tests/smoke/smoke.spec.mjs
@@ -106,6 +106,85 @@ test('dashboard renders a card grid + reacts to fs events + dispatches actions',
     expect(leakedGlobals, 'old inline-handler names leaked back onto window').toEqual([]);
 });
 
+test('item-internal change triggers per-card fragment refresh, not pane-wide', async ({ page }) => {
+    // Per-card SSE patches contract:
+    //  - touching a single project's README must produce exactly one
+    //    GET /fragment/projects/<slug> (the card's per-item endpoint)
+    //  - and zero GET /fragment/projects (pane-wide)
+    //  - and the htmx swap target must be that one card, not #cards
+    //
+    // The pane-level trigger remains as the structural fallback path —
+    // a separate test (or future: deletion of an item folder) covers
+    // that case. Touching one README is the most common item-internal
+    // change.
+
+    const requests = [];
+    page.on('request', (req) => {
+        const u = new URL(req.url());
+        if (u.pathname.startsWith('/fragment/')) {
+            requests.push({ method: req.method(), path: u.pathname, query: u.search });
+        }
+    });
+
+    await page.goto('/');
+    const cards = page.locator('#cards');
+    await expect(cards.locator('.card').first()).toBeVisible();
+    const firstCard = cards.locator('.card').first();
+    const slug = await firstCard.getAttribute('id');
+    expect(slug, 'first card must carry id=<slug>').toBeTruthy();
+
+    // The card root must carry per-item htmx wiring (template invariant).
+    await expect(firstCard).toHaveAttribute(
+        'hx-trigger',
+        new RegExp(`^sse:projects-${slug}$`),
+    );
+    await expect(firstCard).toHaveAttribute(
+        'hx-get',
+        new RegExp(`^/fragment/projects/${slug}$`),
+    );
+
+    // Reset the request log so we only count fragment fetches caused by
+    // the SSE-driven swap (not the initial page load's morph-target
+    // fetches).
+    requests.length = 0;
+
+    const swapTargetIds = page.evaluate(
+        () =>
+            new Promise((resolve) => {
+                const ids = [];
+                const handler = (ev) => {
+                    const t = ev.detail && ev.detail.target;
+                    ids.push(t ? (t.id || t.tagName) : null);
+                };
+                document.body.addEventListener('htmx:afterSwap', handler);
+                setTimeout(() => {
+                    document.body.removeEventListener('htmx:afterSwap', handler);
+                    resolve(ids);
+                }, 4000);
+            }),
+    );
+    // Touch the README of the *first* card's slug so the watcher emits
+    // `sse:projects-<slug>` (matching the per-item trigger we just
+    // asserted is on that card).
+    const targetReadme = await readmeForSlug(FIXTURE, slug);
+    const buf = await fs.readFile(targetReadme);
+    await fs.writeFile(targetReadme, buf);
+    const ids = await swapTargetIds;
+    expect(
+        ids.includes(slug),
+        `expected an htmx swap targeting card #${slug}; saw ${JSON.stringify(ids)}`,
+    ).toBe(true);
+
+    // The per-item fragment must have been hit; the pane-wide one
+    // must not (for this single-README touch).
+    const perItem = requests.filter((r) => r.path === `/fragment/projects/${slug}`);
+    const paneWide = requests.filter((r) => r.path === '/fragment/projects');
+    expect(perItem.length, `expected ≥1 per-item fetch; saw ${JSON.stringify(requests)}`)
+        .toBeGreaterThanOrEqual(1);
+    expect(paneWide.length, `expected zero pane-wide fetches; saw ${JSON.stringify(paneWide)}`)
+        .toBe(0);
+});
+
 // Locate the first README under projects/ in the fixture so we can
 // touch it to trigger the SSE pulse.
 async function firstReadme(root) {
@@ -127,4 +206,21 @@ async function firstReadme(root) {
     const found = await walk(path.join(root, 'projects'));
     if (!found) throw new Error(`no README under ${root}/projects`);
     return found;
+}
+
+// Locate the README of a specific item slug under projects/<month>/<slug>/.
+async function readmeForSlug(root, slug) {
+    const projectsRoot = path.join(root, 'projects');
+    const months = await fs.readdir(projectsRoot, { withFileTypes: true });
+    for (const m of months) {
+        if (!m.isDirectory()) continue;
+        const candidate = path.join(projectsRoot, m.name, slug, 'README.md');
+        try {
+            await fs.stat(candidate);
+            return candidate;
+        } catch {
+            // not in this month
+        }
+    }
+    throw new Error(`no README for slug ${slug} under ${projectsRoot}`);
 }


### PR DESCRIPTION
## Summary

- Cuts dashboard idle CPU on plain mouse-move from 47.9 % avg / High energy to 25.8 % / Medium (Linux/WebKitGTK) by snapping card hover styles instead of animating + repainting the box-shadow region per hovered card.
- Cuts the per-refresh payload from a 1.85 MB pane fetch + pane-wide morph to a 1–14 KB per-card fetch + per-card morph: every changed file (README, knowledge note, git ref) now produces exactly one named SSE event whose subscriber is the matching card root, not the whole pane.
- Two independent fixes for two cost surfaces — refresh path and idle paint — bundled because they fell out of the same WebKit Inspector profiling pass and shipping the SSE half alone left the user-felt cost untouched.

## Changes

- `src-tauri/src/events.rs` — new `classify(path) -> Option<(pane, id)>` resolver, keyed debouncer (per-key so two different cards changing in the same 750 ms window both fire), `EventPayload { tab, id: Option<String>, ts }` with `for_tab` / `for_item` / `event_name()` helpers. Watcher emits `<pane>-<id>` for item-internal paths, falls back to `<pane>` for structural ones.
- `src-tauri/src/server/events.rs` — SSE handler uses `event_name()` so `projects-<slug>` / `knowledge-<rel-path>` / `code-<repo>` flow on the wire.
- `src-tauri/src/server/shell.rs` + `mod.rs` — four new endpoints: `GET /fragment/projects/:slug`, `GET /fragment/history/:slug`, `GET /fragment/knowledge/one?path=<rel>` (query param avoids slashes in the path segment), `GET /fragment/code/:repo`. Each returns one item's outer HTML.
- `crates/condash-render/src/lib.rs` — `render_one_history_row`, `render_one_knowledge_card` (walks the tree, finds the entry by path).
- `crates/condash-render/src/git_render.rs` — `render_one_code_repo` (walks groups for the matching family, re-uses `render_flat_group` so per-item markup is identical to pane-wide markup).
- `crates/condash-render/templates/{card,_macros,history}.html.j2` + new `knowledge_card_one.html.j2` / `history_card_one.html.j2` — card / knowledge-card / history-card / flat-group roots carry `hx-trigger="sse:<pane>-<id>"` + `hx-get="/fragment/<pane>/<id>"` + `hx-target="this"` + `hx-swap="morph:outerHTML"`. Pane-level `hx-trigger="sse:<pane>"` listeners stay for structural fallback.
- `frontend/src/js/sections/htmx-state-preserve.js` — per-card hook so a single card's collapsed/expanded state and the active subtab filter survive a per-card morph.
- `frontend/src/css/cards/card.css` — strip the 0.18 s `border-color` + `transform` hover transition; drop the `translateY(-1px)` and the `box-shadow: var(--shadow-md)` lift on `.card:hover`. Border-color alone signals hover. The base `box-shadow: var(--shadow-sm)` stays.
- `frontend/src/css/cards/knowledge.css` — strip the 0.12 s `background` + `border-color` transition on `.knowledge-card`. Hover styles still apply, just instant.
- Tests: 7 new Rust unit tests (`classify_*`, `keyed_debouncer_*`, `event_payload_event_name_*`, `render_one_history_row_*`, `render_one_knowledge_card_*`, `render_card_carries_per_item_hx_attrs`) and a Playwright e2e that touches one card's README and asserts exactly one per-item fragment fetch + zero pane-wide fetches. Existing `events_routes.rs` updated to construct payloads via the new factory.

## Impact

- New SSE event names on the wire (`<pane>-<id>` alongside existing `<pane>`). Any external SSE consumer would need to handle the extra event names; today only the htmx ext-sse subscriber in `dashboard.html` consumes the stream, so no external impact.
- Wire payload field added: `EventPayload.id` (`null` for pane-wide). `tab` field unchanged.
- Per-refresh HTTP traffic shape changes: file edits now hit `/fragment/<pane>/<id>` instead of `/fragment/<pane>`. The pane-wide route is still served (config edits, item add/delete, `index.md` changes still hit it).

## Watchpoints

- The path → item-id classifier silently falls back to a pane-wide event on any path it can't narrow (deep-nested mkdir under `projects/`, non-`.md` knowledge files, `index.md` edits). If a refresh feels off after merge, check the `/events` stream — a steady stream of `<pane>` events where `<pane>-<id>` was expected means the resolver is misclassifying.
- Per-card morph swaps a single card's outer HTML; `hx-preserve="true"` on the runner-term-mount inside Code peer-cards is what keeps xterm + WebSocket attached across the swap. If a future template change drops `hx-preserve`, terminal sessions will tear down on every git ref change.
- The hover-style change is visual: cards no longer lift on hover, just darken the border. If the design intent of the lift was load-bearing, that conversation reopens.