### PR TITLE
Fix run-by-name resolving submodule over sibling top-level repo

### DIFF
--- a/src/main/config-walk.ts
+++ b/src/main/config-walk.ts
@@ -117,14 +117,28 @@ function visitOne(
  * Find a single repo entry by name. Matches both the bare name and the
  * `parent/child` display form so callers don't have to know which one came
  * from the renderer.
+ *
+ * When the search is a bare name (e.g. `foo`) and the config contains both a
+ * top-level repo `foo` and a sibling submodule `alpha/foo`, the top-level
+ * entry wins. Reaching the submodule requires the qualified `alpha/foo` form.
+ * Match priority:
+ *   1. `entry.display === name`         — exact, including qualified
+ *   2. `entry.name === name && !parent` — bare name on a top-level entry
+ *   3. `entry.name === name && parent`  — bare name on a submodule (last)
  */
 export function findRepoEntry(config: ConfigShape, name: string): RepoLookup | null {
-  let found: RepoLookup | null = null;
+  let topLevelByName: RepoLookup | null = null;
+  let submoduleByName: RepoLookup | null = null;
+  let exactByDisplay: RepoLookup | null = null;
   walkRepos(config, (entry) => {
-    if (entry.name === name || entry.display === name) {
-      found = entry;
-      return false; // stop the walk
+    if (entry.display === name) {
+      exactByDisplay = entry;
+      return false; // best possible match — stop the walk
+    }
+    if (entry.name === name) {
+      if (!entry.parent && !topLevelByName) topLevelByName = entry;
+      else if (entry.parent && !submoduleByName) submoduleByName = entry;
     }
   });
-  return found;
+  return exactByDisplay ?? topLevelByName ?? submoduleByName;
 }


### PR DESCRIPTION
## Summary

- When `repositories.primary[]` contains both a top-level `foo` and a sibling submodule `alpha/foo`, invoking the run for the bare name `foo` started the submodule because `findRepoEntry` returned the first walk-order match.
- Fixes #60.

## Changes

- `src/main/config-walk.ts`: `findRepoEntry` now ranks matches by (1) exact `display`, (2) bare name on a top-level entry, (3) bare name on a submodule. The walk still short-circuits on a `display` hit (best possible match), so qualified `alpha/foo` lookups stay O(1)-ish in the common case.

## Impact

- Bare-name lookups disambiguate towards the top-level repo. Users who were relying on the old behaviour to reach a colliding submodule by bare name need to switch to the qualified `parent/child` form (which has always worked).
- Renderer call sites are unaffected: they pass `RepoEntry.name` (which equals `display`), so they hit path (1).