### PR TITLE
Make the per-branch dirty badge clickable + auto-refresh on Code tab

### DIFF
--- a/src/main/git-details.ts
+++ b/src/main/git-details.ts
@@ -1,0 +1,109 @@
+// Detailed dirty-status lookup for the Code-tab popover.
+//
+// `getDirtyCount` (in `git-status-cache.ts`) returns the badge number; this
+// module returns the full breakdown shown when the user clicks that badge:
+// every porcelain-v1 line parsed into `{code, path}`, plus a `git diff --stat`
+// snippet so the user can see roughly *how big* each tracked change is
+// without leaving the dashboard.
+
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { simpleGit } from 'simple-git';
+
+const DIFFSTAT_LINE_LIMIT = 20;
+
+export interface DirtyFile {
+  /** Two-character porcelain status (e.g. ` M`, `??`, `R `). Whitespace
+   * preserved so the renderer can pad / colour by index/worktree column. */
+  code: string;
+  /** Path relative to the worktree root. Rename arrows (`old -> new`) are
+   * collapsed to the new path. */
+  path: string;
+}
+
+export interface DirtyDetails {
+  files: DirtyFile[];
+  /** Truncated `git diff --stat HEAD` output. Empty when there are no
+   * tracked changes (only untracked files), which the renderer can
+   * detect to skip the diffstat block entirely. */
+  diffstat: string;
+  /** True when the diffstat had to be truncated to fit DIFFSTAT_LINE_LIMIT
+   * lines. Renderer surfaces a "+N more" hint. */
+  diffstatTruncated: boolean;
+}
+
+interface DirtyDetailsOptions {
+  /** Mirror `getDirtyCount`'s scopeToSubtree: when true, both `git status`
+   * and `git diff --stat` are restricted to `.` so a submodule entry that
+   * shares its .git with the parent doesn't bleed parent-repo paths. */
+  scopeToSubtree?: boolean;
+}
+
+/** Same zero-byte filter as the count path — sandbox runtime artifacts
+ *  (empty placeholder files in untracked state) don't surface as dirty
+ *  on the badge, so they shouldn't surface in the popover either. */
+async function isZeroByteUntracked(line: string, cwd: string): Promise<boolean> {
+  if (!line.startsWith('?? ')) return false;
+  const rel = line.slice(3).trim();
+  if (!rel) return false;
+  try {
+    const stat = await fs.stat(join(cwd, rel));
+    return stat.isFile() && stat.size === 0;
+  } catch {
+    return false;
+  }
+}
+
+function parseFile(line: string): DirtyFile {
+  const code = line.slice(0, 2);
+  let rest = line.slice(3);
+  // Renames look like `R  old -> new`; collapse to the new path.
+  const arrow = rest.indexOf(' -> ');
+  if (arrow !== -1) rest = rest.slice(arrow + 4);
+  return { code, path: rest };
+}
+
+export async function getDirtyDetails(
+  path: string,
+  opts: DirtyDetailsOptions = {},
+): Promise<DirtyDetails | null> {
+  try {
+    const git = simpleGit({ baseDir: path });
+    const statusArgs = ['status', '--porcelain=v1'];
+    const diffArgs = ['diff', '--stat', 'HEAD'];
+    if (opts.scopeToSubtree) {
+      statusArgs.push('--', '.');
+      diffArgs.push('--', '.');
+    }
+
+    const statusOut = await git.raw(statusArgs);
+    const files: DirtyFile[] = [];
+    for (const line of statusOut.split('\n')) {
+      if (line.length === 0) continue;
+      if (await isZeroByteUntracked(line, path)) continue;
+      files.push(parseFile(line));
+    }
+
+    let diffstat = '';
+    let diffstatTruncated = false;
+    // `git diff --stat HEAD` is meaningless when HEAD doesn't exist (fresh
+    // repo) or when nothing tracked has changed; swallow the error / empty
+    // output, the renderer just hides the block.
+    try {
+      const diffOut = await git.raw(diffArgs);
+      const lines = diffOut.split('\n').filter((l) => l.length > 0);
+      if (lines.length > DIFFSTAT_LINE_LIMIT) {
+        diffstat = lines.slice(0, DIFFSTAT_LINE_LIMIT).join('\n');
+        diffstatTruncated = true;
+      } else {
+        diffstat = lines.join('\n');
+      }
+    } catch {
+      diffstat = '';
+    }
+
+    return { files, diffstat, diffstatTruncated };
+  } catch {
+    return null;
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import { createProjectNote, readNote } from './note';
 import { search } from './search';
 import { listRepos } from './repos';
 import { invalidateAll } from './git-status-cache';
+import { getDirtyDetails } from './git-details';
 import { forceStopRepo, launchOpenWith, listOpenWith } from './launchers';
 import {
   attachTerminal,
@@ -267,6 +268,13 @@ function registerIpc(): void {
   // button so explicit user requests always see fresh data, while ambient
   // re-renders (tab switch, tree-events) still benefit from the TTL cache.
   ipcMain.handle('invalidateGitStatus', () => invalidateAll());
+
+  // Click-to-inspect on the per-branch dirty badge. Returns the parsed
+  // `git status` line set + a `git diff --stat HEAD` snippet so the user
+  // can see what's dirty without dropping into a shell.
+  ipcMain.handle('getDirtyDetails', (_, path: string, opts?: { scopeToSubtree?: boolean }) =>
+    getDirtyDetails(path, opts ?? {}),
+  );
 
   ipcMain.handle('listOpenWith', async () => {
     const { conceptionPath } = await readSettings();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,7 @@ const api: CondashApi = {
   search: (query) => ipcRenderer.invoke('search', query),
   listRepos: () => ipcRenderer.invoke('listRepos'),
   invalidateGitStatus: () => ipcRenderer.invoke('invalidateGitStatus'),
+  getDirtyDetails: (path, opts) => ipcRenderer.invoke('getDirtyDetails', path, opts),
   listOpenWith: () => ipcRenderer.invoke('listOpenWith'),
   launchOpenWith: (slot, path) => ipcRenderer.invoke('launchOpenWith', slot, path),
   forceStopRepo: (repoName) => ipcRenderer.invoke('forceStopRepo', repoName),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,5 +1,6 @@
 import { render } from 'solid-js/web';
 import {
+  createEffect,
   createMemo,
   createResource,
   createSignal,
@@ -402,6 +403,22 @@ function App() {
     void window.condash.invalidateGitStatus();
     setRefreshKey((k) => k + 1);
   };
+
+  // Periodic auto-refresh while the Code tab is visible. Drops the
+  // git-status cache and bumps refreshKey on a fixed interval so the
+  // per-branch dirty count + running indicators don't go stale silently.
+  // Pauses (clears the interval) the moment the user switches away —
+  // re-creates a fresh interval on the next visit so the first tick after
+  // switching back lands within CODE_TAB_REFRESH_MS, not later.
+  const CODE_TAB_REFRESH_MS = 15_000;
+  createEffect(() => {
+    if (tab() !== 'code') return;
+    const id = window.setInterval(() => {
+      void window.condash.invalidateGitStatus();
+      setRefreshKey((k) => k + 1);
+    }, CODE_TAB_REFRESH_MS);
+    onCleanup(() => window.clearInterval(id));
+  });
 
   const handleTreeEvents = async (events: TreeEvent[]): Promise<void> => {
     let knowledgeOrConfigDirty = false;

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1397,6 +1397,132 @@ button:hover {
   font-variant-numeric: tabular-nums;
   font-size: 11px;
   color: var(--col-later);
+  /* Reset button defaults — the badge is rendered as a `<button>` so it can
+   * open the click-to-inspect popover, but should still read as a small
+   * inline pill rather than an OS-styled control. */
+  background: transparent;
+  border: none;
+  padding: 1px 4px;
+  border-radius: 3px;
+  cursor: pointer;
+  font-weight: 500;
+}
+
+.branch-dirty:hover {
+  background: color-mix(in srgb, var(--col-later) 14%, transparent);
+}
+
+.branch-dirty:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--col-later) 60%, transparent);
+  outline-offset: 1px;
+}
+
+/* Click-to-inspect popover anchored to the dirty badge. Same `position: fixed`
+ * portal recipe as the open_with menu so it always paints above neighbouring
+ * cards, but wider and with a scrollable file list. */
+.branch-dirty-popover {
+  position: fixed;
+  z-index: 1000;
+  width: min(440px, calc(100vw - 24px));
+  max-height: min(440px, calc(100vh - 80px));
+  overflow: auto;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  box-shadow: var(--shadow-lift);
+  padding: 8px 10px 10px;
+  font-size: 11.5px;
+  color: var(--text);
+}
+
+.branch-dirty-popover-head {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 6px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border);
+}
+
+.branch-dirty-popover-branch {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.branch-dirty-popover-path {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.branch-dirty-popover-files {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.branch-dirty-popover-files li {
+  display: grid;
+  grid-template-columns: 24px 1fr;
+  gap: 8px;
+  align-items: baseline;
+  padding: 2px 4px;
+  border-radius: 3px;
+}
+
+.branch-dirty-popover-files li:nth-child(odd) {
+  background: color-mix(in srgb, var(--text) 4%, transparent);
+}
+
+.branch-dirty-popover-code {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--col-later);
+  white-space: pre;
+}
+
+.branch-dirty-popover-file {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  word-break: break-all;
+}
+
+.branch-dirty-popover-empty {
+  margin: 6px 4px 0;
+  font-size: 11px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.branch-dirty-popover-error {
+  margin: 0 4px 6px;
+  font-size: 11px;
+  color: var(--warn);
+}
+
+.branch-dirty-popover-diffstat {
+  margin: 8px 0 0;
+  padding: 6px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.branch-dirty-popover-truncated {
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .branch-live-dot {

--- a/src/renderer/tabs/code.tsx
+++ b/src/renderer/tabs/code.tsx
@@ -1,5 +1,11 @@
 import { createSignal, For, onCleanup, onMount, Show } from 'solid-js';
-import type { OpenWithSlotKey, OpenWithSlots, RepoEntry, Worktree } from '@shared/types';
+import type {
+  DirtyDetails,
+  OpenWithSlotKey,
+  OpenWithSlots,
+  RepoEntry,
+  Worktree,
+} from '@shared/types';
 
 type RepoStatus = 'missing' | 'unknown' | 'clean' | 'dirty';
 
@@ -162,7 +168,7 @@ export function RepoRow(props: {
               <span class="branch-dot" aria-hidden="true" />
               <span class="branch-name">{wt.branch ?? '(detached)'}</span>
               <Show when={(wt.dirty ?? 0) > 0}>
-                <span class="branch-dirty">{wt.dirty} dirty</span>
+                <DirtyBadge worktree={wt} subtreeScoped={!!props.repo.parent} />
               </Show>
               <Show when={props.live && (props.liveBranch ?? null) === (wt.branch ?? null)}>
                 <span class="branch-live-dot" title="Running" aria-label="Running" />
@@ -327,5 +333,147 @@ function BranchActions(props: {
         </div>
       </Show>
     </div>
+  );
+}
+
+/**
+ * Per-branch dirty pill that opens a popover listing every dirty path
+ * (`git status -s`) plus a `git diff --stat HEAD` snippet. The popover is
+ * a portaled `position: fixed` overlay so it always paints above
+ * neighbouring cards (same recipe as the open_with menu).
+ */
+function DirtyBadge(props: { worktree: Worktree; subtreeScoped: boolean }) {
+  const [open, setOpen] = createSignal(false);
+  const [details, setDetails] = createSignal<DirtyDetails | null>(null);
+  const [anchor, setAnchor] = createSignal<{ top: number; left: number } | null>(null);
+  const [error, setError] = createSignal<string | null>(null);
+  let triggerRef: HTMLButtonElement | undefined;
+  let popoverRef: HTMLDivElement | undefined;
+
+  const positionPopover = (): void => {
+    if (!triggerRef) return;
+    const rect = triggerRef.getBoundingClientRect();
+    setAnchor({ top: rect.bottom + 4, left: rect.left });
+  };
+
+  const close = (): void => {
+    setOpen(false);
+    setError(null);
+  };
+
+  const onDocClick = (e: MouseEvent): void => {
+    if (!open()) return;
+    const target = e.target as Node;
+    if (triggerRef?.contains(target)) return;
+    if (popoverRef?.contains(target)) return;
+    close();
+  };
+
+  const onScrollOrResize = (): void => {
+    if (open()) positionPopover();
+  };
+
+  const onKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && open()) close();
+  };
+
+  onMount(() => {
+    document.addEventListener('click', onDocClick, true);
+    document.addEventListener('keydown', onKeyDown);
+    window.addEventListener('resize', onScrollOrResize, true);
+    window.addEventListener('scroll', onScrollOrResize, true);
+  });
+  onCleanup(() => {
+    document.removeEventListener('click', onDocClick, true);
+    document.removeEventListener('keydown', onKeyDown);
+    window.removeEventListener('resize', onScrollOrResize, true);
+    window.removeEventListener('scroll', onScrollOrResize, true);
+  });
+
+  const toggle = async (e: MouseEvent): Promise<void> => {
+    e.stopPropagation();
+    if (open()) {
+      close();
+      return;
+    }
+    positionPopover();
+    setOpen(true);
+    setError(null);
+    try {
+      const next = await window.condash.getDirtyDetails(props.worktree.path, {
+        scopeToSubtree: props.subtreeScoped,
+      });
+      setDetails(next);
+      if (!next) setError('git status failed for this path');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <>
+      <button
+        ref={(el) => (triggerRef = el)}
+        type="button"
+        class="branch-dirty"
+        onClick={(e) => void toggle(e)}
+        aria-haspopup="dialog"
+        aria-expanded={open()}
+        title="Show dirty files"
+      >
+        {props.worktree.dirty} dirty
+      </button>
+      <Show when={open() && anchor()}>
+        <div
+          ref={(el) => (popoverRef = el)}
+          class="branch-dirty-popover"
+          role="dialog"
+          aria-label={`Dirty files in ${props.worktree.branch ?? '(detached)'}`}
+          style={{
+            top: `${anchor()!.top}px`,
+            left: `${anchor()!.left}px`,
+          }}
+        >
+          <header class="branch-dirty-popover-head">
+            <span class="branch-dirty-popover-branch">{props.worktree.branch ?? '(detached)'}</span>
+            <span class="branch-dirty-popover-path" title={props.worktree.path}>
+              {props.worktree.path}
+            </span>
+          </header>
+          <Show when={error()}>
+            <p class="branch-dirty-popover-error">{error()}</p>
+          </Show>
+          <Show when={details()}>
+            {(d) => (
+              <>
+                <Show
+                  when={d().files.length > 0}
+                  fallback={<p class="branch-dirty-popover-empty">No dirty files.</p>}
+                >
+                  <ul class="branch-dirty-popover-files">
+                    <For each={d().files}>
+                      {(f) => (
+                        <li>
+                          <span class="branch-dirty-popover-code">{f.code}</span>
+                          <span class="branch-dirty-popover-file">{f.path}</span>
+                        </li>
+                      )}
+                    </For>
+                  </ul>
+                </Show>
+                <Show when={d().diffstat}>
+                  <pre class="branch-dirty-popover-diffstat">
+                    {d().diffstat}
+                    <Show when={d().diffstatTruncated}>
+                      <span class="branch-dirty-popover-truncated">{'\n… (truncated)'}</span>
+                    </Show>
+                  </pre>
+                </Show>
+              </>
+            )}
+          </Show>
+        </div>
+      </Show>
+    </>
   );
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,5 +1,6 @@
 import type {
   ConceptionInitState,
+  DirtyDetails,
   KnowledgeNode,
   OpenWithSlotKey,
   OpenWithSlots,
@@ -27,6 +28,10 @@ export interface CondashApi {
    * listRepos() runs `git status` everywhere instead of returning TTL-
    * cached values. */
   invalidateGitStatus(): Promise<void>;
+  /** Detailed `git status -s` + `git diff --stat HEAD` for a worktree path.
+   * Powers the click-to-inspect popover on the per-branch `N dirty` badge.
+   * Returns null when the path is missing or not a git repo. */
+  getDirtyDetails(path: string, opts?: { scopeToSubtree?: boolean }): Promise<DirtyDetails | null>;
   listOpenWith(): Promise<OpenWithSlots>;
   launchOpenWith(slot: OpenWithSlotKey, path: string): Promise<void>;
   forceStopRepo(repoName: string): Promise<void>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -68,6 +68,27 @@ export interface Settings {
   theme: Theme;
 }
 
+/** One row of `git status --porcelain=v1` output, normalised for the renderer. */
+export interface DirtyFile {
+  /** Two-character porcelain status (e.g. ` M`, `??`, `R `). Whitespace
+   * preserved so the renderer can render the column verbatim. */
+  code: string;
+  /** Path relative to the worktree root. Rename arrows are collapsed to the
+   * new path (rename targets are usually the more interesting filename). */
+  path: string;
+}
+
+/** Click-to-inspect payload for the per-branch dirty badge. */
+export interface DirtyDetails {
+  files: DirtyFile[];
+  /** `git diff --stat HEAD` output (truncated to a fixed line cap so the
+   * popover doesn't blow up on huge changesets). Empty when no tracked
+   * files have changed; the renderer hides the block in that case. */
+  diffstat: string;
+  /** True when the diffstat had to be truncated to fit the line cap. */
+  diffstatTruncated: boolean;
+}
+
 export interface Worktree {
   /** Absolute path on disk. */
   path: string;


### PR DESCRIPTION
## Summary

- Clicking the `N dirty` pill on a branch row now opens a popover listing every dirty path (status code + path) plus a `git diff --stat HEAD` snippet truncated to 20 lines, so the user can see *what* changed without leaving the dashboard.
- A 15 s auto-refresh while the Code tab is visible drops the git-status cache and re-runs the per-worktree status pass, so dirty counts stop going stale silently.
- Fixes #62.

## Changes

- `src/main/git-details.ts` (new): `getDirtyDetails(path, opts)` parses `git status --porcelain=v1` into `{code, path}` rows (collapsing rename arrows to the new path), then runs `git diff --stat HEAD` capped at 20 lines. Honours the same `scopeToSubtree` flag as `getDirtyCount` so a SUB sharing its `.git` with a parent doesn't surface the parent's dirty paths. Drops the same zero-byte-untracked sandbox-runtime files the count path drops.
- `src/main/index.ts`, `src/preload/index.ts`, `src/shared/api.ts`, `src/shared/types.ts`: wire the new IPC + `DirtyDetails` shape.
- `src/renderer/tabs/code.tsx`: dirty badge becomes a `<button>` that toggles a portaled `position: fixed` popover (Esc / outside-click / scroll closes; matches the open_with menu's stacking recipe).
- `src/renderer/main.tsx`: `createEffect` gated on `tab() === 'code'` starts a 15 s `setInterval` that calls `invalidateGitStatus()` then bumps `refreshKey`. `onCleanup` clears the interval the moment the tab changes, so the timer doesn't run while the user is on Projects/Knowledge.
- `src/renderer/styles.css`: badge is now button-styled inline (transparent bg, hover tint, focus ring); popover has its own block (header w/ branch + path, scrollable file list with monospaced status column, diffstat block at the bottom, truncated marker).

## Impact

- Adds one new `git status` + one new `git diff --stat` invocation per badge click — cheap relative to the existing per-worktree status fan-out, and only fires when the user actually opens a popover.
- Auto-refresh adds N `git status` calls every 15 s while the Code tab is open (N = total worktrees across all configured repos). Previous behaviour ran the same calls on every Refresh click and on chokidar tree-events; this just adds a steady cadence.

## Watchpoints

- The popover uses `position: fixed` anchored to the badge's bounding rect. If a future card-level transform or filter establishes a containing block for fixed-positioned descendants, the popover will start positioning relative to that ancestor rather than the viewport — same caveat as the open_with menu.