### PR TITLE
Settings modal: revamp UX, move terminal prefs to settings.json

### DIFF
--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -115,7 +115,9 @@ export const configSchema = z
       })
       .strict()
       .optional(),
-    pdf_viewer: z.array(z.string()).optional(),
+    /** @deprecated Terminal preferences live in settings.json now. Kept here
+     * so existing files validate during the boot-time migration; do not
+     * read or write this block from new code. */
     terminal: terminalSettings.optional(),
   })
   .strict();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import { autoUpdater } from 'electron-updater';
 import { join } from 'node:path';
 
 import { detectConceptionState, initConception } from './conception-init';
-import { readSettings, writeSettings } from './settings';
+import { readSettings, settingsPath, writeSettings } from './settings';
 import { findProjectReadmes } from './walk';
 import { parseReadme } from './parse';
 import { setWatchedConception } from './watcher';
@@ -23,8 +23,10 @@ import {
   getTerminalPrefs,
   killAll,
   listTerminalSessions,
+  migrateTerminalFromConfigIfNeeded,
   resizeTerminal,
   setSessionSide,
+  setTerminalPrefs,
   spawnTerminal,
   writeTerminal,
 } from './terminals';
@@ -352,8 +354,14 @@ function registerIpc(): void {
   ipcMain.handle('term.setSide', (_, id: string, side: 'my' | 'code') => setSessionSide(id, side));
 
   ipcMain.handle('term.getPrefs', async () => {
-    const { conceptionPath } = await readSettings();
-    return (await getTerminalPrefs(conceptionPath)) ?? {};
+    return (await getTerminalPrefs()) ?? {};
+  });
+
+  ipcMain.handle('term.setPrefs', async (_, prefs: unknown) => {
+    if (!prefs || typeof prefs !== 'object') {
+      throw new Error('term.setPrefs: payload must be an object');
+    }
+    await setTerminalPrefs(prefs as Parameters<typeof setTerminalPrefs>[0]);
   });
 
   ipcMain.handle('term.latestScreenshot', async (_, dir: string) => {
@@ -376,6 +384,8 @@ function registerIpc(): void {
     const { theme } = await readSettings();
     return theme;
   });
+
+  ipcMain.handle('getSettingsPath', () => settingsPath());
 
   ipcMain.handle('setTheme', async (_, theme: Theme) => {
     if (!THEMES.has(theme)) throw new Error(`Unknown theme: ${theme}`);
@@ -466,6 +476,11 @@ function registerIpc(): void {
 
 app.whenReady().then(async () => {
   registerIpc();
+  // One-shot: copy any pre-existing terminal block out of configuration.json
+  // and into settings.json. Idempotent — does nothing once settings owns
+  // the data. Runs before window creation so the renderer's first
+  // term.getPrefs always sees the post-migration state.
+  await migrateTerminalFromConfigIfNeeded();
   const { conceptionPath } = await readSettings();
   await setWatchedConception(conceptionPath);
   buildMenu();

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -5,9 +5,9 @@ import type { Settings } from '../shared/types';
 
 const FILE_NAME = 'settings.json';
 
-const empty: Settings = { conceptionPath: null, theme: 'system' };
+const empty: Settings = { conceptionPath: null, theme: 'system', terminal: {} };
 
-function settingsPath(): string {
+export function settingsPath(): string {
   return join(app.getPath('userData'), FILE_NAME);
 }
 

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -3,8 +3,9 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { BrowserWindow, type WebContents } from 'electron';
 import * as pty from 'node-pty';
-import type { TermSession, TermSide, TermSpawnRequest } from '../shared/types';
+import type { TermSession, TermSide, TermSpawnRequest, TerminalPrefs } from '../shared/types';
 import { findRepoEntry, type ConfigShape } from './config-walk';
+import { readSettings, writeSettings } from './settings';
 
 interface Session {
   id: string;
@@ -77,18 +78,10 @@ function makeId(): string {
   return `t${Date.now().toString(36)}-${nextId++}`;
 }
 
-interface RawConfigShape extends ConfigShape {
-  terminal?: {
-    shell?: string;
-    launcher_command?: string;
-    screenshot_dir?: string;
-  };
-}
-
-async function readRawConfig(conceptionPath: string): Promise<RawConfigShape> {
+async function readRawConfig(conceptionPath: string): Promise<ConfigShape> {
   try {
     const raw = await fs.readFile(join(conceptionPath, 'configuration.json'), 'utf8');
-    return JSON.parse(raw) as RawConfigShape;
+    return JSON.parse(raw) as ConfigShape;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
     throw err;
@@ -108,7 +101,8 @@ export async function spawnTerminal(
   request: TermSpawnRequest,
 ): Promise<{ id: string; cwd: string }> {
   const config = conceptionPath ? await readRawConfig(conceptionPath) : {};
-  const shell = defaultShell(config.terminal?.shell);
+  const settings = await readSettings();
+  const shell = defaultShell(settings.terminal?.shell);
 
   let cwd = request.cwd ?? process.env.HOME ?? '/';
   let argv: string[] = [];
@@ -317,12 +311,51 @@ export function closeSession(id: string): Promise<void> {
   return stopSession(id);
 }
 
-export async function getTerminalPrefs(
-  conceptionPath: string | null,
-): Promise<RawConfigShape['terminal']> {
-  if (!conceptionPath) return {};
-  const config = await readRawConfig(conceptionPath);
-  return config.terminal ?? {};
+/** Read terminal prefs from settings.json. As of 2026-05-01 these live
+ * per-machine, not in the conception's configuration.json — the boot-time
+ * migration in main/index.ts copies any pre-existing block. */
+export async function getTerminalPrefs(): Promise<TerminalPrefs> {
+  const settings = await readSettings();
+  return settings.terminal ?? {};
+}
+
+/** Replace the persisted terminal prefs in settings.json. The patch is a
+ * full merge against the existing block; pass `{}` to clear. */
+export async function setTerminalPrefs(patch: TerminalPrefs): Promise<void> {
+  const settings = await readSettings();
+  settings.terminal = patch;
+  await writeSettings(settings);
+}
+
+/** One-shot migration: if settings.json has no terminal block but the
+ * pre-existing configuration.json carries one, copy it over and strip
+ * configuration.json. Idempotent — does nothing once settings.json owns
+ * the data. */
+export async function migrateTerminalFromConfigIfNeeded(): Promise<void> {
+  const settings = await readSettings();
+  if (settings.terminal && Object.keys(settings.terminal).length > 0) return;
+  if (!settings.conceptionPath) return;
+  const configFile = join(settings.conceptionPath, 'configuration.json');
+  let raw: string;
+  try {
+    raw = await fs.readFile(configFile, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+    throw err;
+  }
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    return;
+  }
+  const legacy = parsed.terminal as TerminalPrefs | undefined;
+  if (!legacy || Object.keys(legacy).length === 0) return;
+  settings.terminal = legacy;
+  await writeSettings(settings);
+  delete parsed.terminal;
+  const next = JSON.stringify(parsed, null, 2) + '\n';
+  await fs.writeFile(configFile, next, 'utf8');
 }
 
 /** Kill every session (or every session attached to `forWebContents`) via the

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,7 @@ const api: CondashApi = {
   initConception: (path) => ipcRenderer.invoke('initConception', path),
   getTheme: () => ipcRenderer.invoke('getTheme'),
   setTheme: (theme) => ipcRenderer.invoke('setTheme', theme),
+  getSettingsPath: () => ipcRenderer.invoke('getSettingsPath'),
   toggleStep: (path, lineIndex, expectedMarker, newMarker) =>
     ipcRenderer.invoke('step.toggle', path, lineIndex, expectedMarker, newMarker),
   editStepText: (path, lineIndex, expectedText, newText) =>
@@ -43,6 +44,7 @@ const api: CondashApi = {
   termResize: (id, cols, rows) => ipcRenderer.invoke('term.resize', id, cols, rows),
   termClose: (id) => ipcRenderer.invoke('term.close', id),
   termGetPrefs: () => ipcRenderer.invoke('term.getPrefs'),
+  termSetPrefs: (prefs) => ipcRenderer.invoke('term.setPrefs', prefs),
   termLatestScreenshot: (dir) => ipcRenderer.invoke('term.latestScreenshot', dir),
   termList: () => ipcRenderer.invoke('term.list'),
   termAttach: (id) => ipcRenderer.invoke('term.attach', id),

--- a/src/renderer/modals.css
+++ b/src/renderer/modals.css
@@ -222,29 +222,318 @@
   font-weight: 500;
 }
 
-/* ---- Settings: Terminal tab ------------------------------------------- */
+/* ---- Settings modal (full-viewport revamp) ----------------------------- */
 
-.settings-terminal h3 {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-faint);
-  margin: 14px 0 6px;
-  font-weight: 600;
+/* The Settings modal owns the whole window — backdrop has no padding so the
+ * panel can fill 100vw / 100vh, and the close (Esc / outside-click) still
+ * works because the backdrop captures clicks outside the panel. */
+.modal-backdrop.settings-modal-backdrop {
+  padding: 0;
+  align-items: stretch;
+  justify-content: stretch;
 }
 
-.settings-terminal h3:first-of-type {
-  margin-top: 4px;
+/* Two-class selector raises specificity above the base `.modal` rule that
+ * caps width at min(1100px, 100%) — note-modal.css loads after modals.css,
+ * so without the doubled class it wins on source order. */
+.settings-modal.settings-modal--full {
+  width: 100%;
+  height: 100%;
+  max-width: none;
+  max-height: none;
+  border-radius: 0;
+  border: none;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
+
+.settings-head {
+  flex-shrink: 0;
+  gap: 8px;
+}
+
+.settings-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 4px 8px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.settings-back:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.settings-back-arrow {
+  font-size: 16px;
+  line-height: 1;
+}
+
+.settings-head-spacer {
+  flex: 1;
+}
+
+.modal-saving {
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.settings-shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
+.settings-rail {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: 14px 0 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+
+.settings-rail-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-rail-group + .settings-rail-group {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+
+.settings-rail-group-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  padding: 2px 14px 6px;
+}
+
+.settings-rail-group-label {
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.settings-rail-group-heading code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  letter-spacing: 0;
+  text-transform: none;
+}
+
+.settings-rail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-rail-list li {
+  margin: 0;
+  padding: 0;
+}
+
+.settings-rail-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-left: 2px solid transparent;
+  border-radius: 0;
+  padding: 7px 14px 7px 22px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-family: var(--font-ui);
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings-rail-item:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.settings-rail-item.active {
+  background: var(--bg-subtle);
+  color: var(--text);
+  border-left-color: var(--accent);
+}
+
+.settings-scroll {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: 16px 28px 64px;
+  background: var(--bg);
+}
+
+/* Cap content for readability on ultrawide displays — the scroll viewport
+ * still spans the full window (so the scrollbar hugs the right edge), but
+ * dividers / sections / forms stay left-aligned and don't grow past 1200 px
+ * of useful column width. */
+.settings-scroll > * {
+  max-width: 1200px;
+}
+
+.settings-group-divider {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 18px 18px 12px;
+  margin: 28px 0 16px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  position: relative;
+}
+
+.settings-group-divider::before {
+  content: '';
+  position: absolute;
+  left: -28px;
+  right: 0;
+  top: -16px;
+  height: 1px;
+  background: var(--border);
+}
+
+.settings-group-divider:first-of-type {
+  margin-top: 0;
+}
+
+.settings-group-divider:first-of-type::before {
+  display: none;
+}
+
+.settings-group-divider h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.005em;
+  color: var(--text);
+  text-transform: none;
+}
+
+.settings-group-divider code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-muted);
+  background: var(--bg-subtle);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.settings-group-divider-hint {
+  color: var(--text-faint);
+  font-size: 12px;
+  flex-basis: 100%;
+}
+
+.settings-group-divider-actions {
+  display: inline-flex;
+  gap: 6px;
+  margin-left: auto;
+  align-items: center;
+}
+
+.settings-section {
+  padding: 8px 0 32px;
+  border-bottom: 1px solid var(--border);
+  scroll-margin-top: 16px;
+}
+
+.settings-section:last-child {
+  border-bottom: none;
+}
+
+.settings-section h2 {
+  margin: 0 0 14px;
+  font-family: var(--font-display);
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--text);
+}
+
+.settings-section h3 {
+  margin: 18px 0 8px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.settings-section h3:first-of-type {
+  margin-top: 6px;
+}
+
+.settings-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.settings-field-label {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 500;
+}
+
+.settings-field-hint {
+  color: var(--text-faint);
+  font-size: 11px;
+}
+
+.settings-hint {
+  margin: 0 0 12px;
+  font-size: 12px;
+  color: var(--text-muted);
 }
 
 .settings-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  gap: 8px 14px;
+  gap: 10px 14px;
+}
+
+.settings-grid--wide {
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
 }
 
 .settings-grid label,
-.settings-color {
+.settings-color,
+.settings-open-with {
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -254,7 +543,10 @@
 
 .settings-grid input,
 .settings-grid select,
-.settings-color input {
+.settings-color input,
+.settings-open-with input,
+.settings-list-row input,
+.settings-repo-row input {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
   border-radius: 4px;
@@ -262,11 +554,15 @@
   color: var(--text);
   font-family: var(--font-mono);
   font-size: 12px;
+  min-width: 0;
 }
 
 .settings-grid input:focus,
 .settings-grid select:focus,
-.settings-color input:focus {
+.settings-color input:focus,
+.settings-open-with input:focus,
+.settings-list-row input:focus,
+.settings-repo-row input:focus {
   outline: none;
   border-color: var(--accent);
 }
@@ -281,65 +577,6 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
   gap: 6px 14px;
-}
-
-/* ---- Settings modal ---------------------------------------------------- */
-
-.settings-modal {
-  width: min(880px, 92vw);
-  max-height: 85vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.settings-tabs {
-  display: flex;
-  gap: 0;
-  padding: 0 14px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-elevated);
-  flex-shrink: 0;
-}
-
-.settings-tab {
-  background: transparent;
-  border: none;
-  padding: 8px 14px 9px;
-  margin-bottom: -1px;
-  cursor: pointer;
-  color: var(--text-muted);
-  font-family: var(--font-ui);
-  font-size: 12.5px;
-  font-weight: 500;
-  border-bottom: 2px solid transparent;
-}
-
-.settings-tab:hover {
-  color: var(--text);
-}
-
-.settings-tab.active {
-  color: var(--text);
-  border-bottom-color: var(--text);
-}
-
-.settings-body {
-  flex: 1;
-  min-height: 320px;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  padding: 16px;
-}
-
-.settings-section h3 {
-  margin: 0 0 10px;
-  font-family: var(--font-ui);
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--text-muted);
 }
 
 .settings-radio-group {
@@ -360,74 +597,146 @@
   margin: 0;
 }
 
-.settings-config {
-  flex: 1;
+/* Repositories ----------------------------------------------------------- */
+
+.settings-bucket {
+  margin-bottom: 16px;
+}
+
+.settings-repo-row {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  padding: 8px;
+  margin-bottom: 6px;
   display: flex;
   flex-direction: column;
-  min-height: 280px;
   gap: 8px;
-  overflow: hidden;
 }
 
-.settings-config-toolbar {
+.settings-repo-row-head {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
-.settings-config-path {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  color: var(--text-muted);
-  margin-left: auto;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  max-width: 60%;
-}
-
-.settings-cm-host {
+.settings-repo-name {
   flex: 1;
-  min-height: 280px;
+  min-width: 0;
+}
+
+.settings-repo-row-detail {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 8px 14px;
+  padding: 4px 4px 2px;
+}
+
+.settings-repo-submodules {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 4px 0 0 18px;
+  padding-left: 12px;
+  border-left: 2px solid var(--border);
+}
+
+.settings-repo-submodules > .settings-field-label {
+  margin-bottom: 2px;
+}
+
+.settings-repo-submodules .settings-repo-row {
+  background: var(--bg-subtle);
+}
+
+.settings-repo-row-detail label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.settings-list-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.settings-list-row input {
+  flex: 1;
+}
+
+.settings-list-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+/* Text-bearing buttons inside the settings modal need the natural-width
+ * variant — `.modal-button` defaults to a 32 × 32 icon square (note-modal
+ * head action), which clips multi-word labels like "+ with run / label". */
+.settings-modal--full .settings-list-actions .modal-button,
+.settings-modal--full .settings-group-divider-actions .modal-button,
+.settings-modal--full .settings-confirm-actions .modal-button,
+.settings-modal--full .settings-conception-path .modal-button {
+  width: auto;
+  height: auto;
+  padding: 5px 12px;
+  border-radius: 6px;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  white-space: nowrap;
+  line-height: 1.2;
+}
+
+/* Open-with rows: label + command stacked */
+.settings-open-with input + input {
+  margin-top: 4px;
+}
+
+/* Close-confirm overlay (3-button inline modal inside settings) */
+.settings-confirm-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.settings-confirm {
+  background: var(--bg-elevated);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg);
-  overflow: hidden;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.32);
+  width: min(420px, 90vw);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
 }
 
-.settings-cm-host .cm-editor {
-  height: 100%;
+.settings-confirm h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: 15px;
+  font-weight: 600;
 }
 
-.settings-shortcuts {
-  border-collapse: collapse;
-  width: 100%;
+.settings-confirm p {
+  margin: 0;
+  color: var(--text-muted);
   font-size: 13px;
 }
 
-.settings-shortcuts th {
-  text-align: left;
-  padding: 6px 12px 6px 0;
-  font-weight: 500;
-  color: var(--text-muted);
-  width: 50%;
-}
-
-.settings-shortcuts td {
-  padding: 6px 0;
-}
-
-.settings-shortcuts code {
-  background: var(--bg-subtle);
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 12px;
-}
-
-.settings-hint {
-  margin: 0 0 12px;
-  font-size: 12px;
-  color: var(--text-muted);
+.settings-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
 }
 
 /* ---- Quit-confirm modal ------------------------------------------------ */

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -1,30 +1,58 @@
-import {
-  createEffect,
-  createMemo,
-  createResource,
-  createSignal,
-  For,
-  onCleanup,
-  onMount,
-  Show,
-} from 'solid-js';
-import type { TerminalXtermPrefs, Theme } from '@shared/types';
-import type { MountedEditor } from './editor';
+import { createMemo, createResource, createSignal, For, Show } from 'solid-js';
+import { onMount, onCleanup } from 'solid-js';
+import type { TerminalPrefs, TerminalXtermPrefs, Theme } from '@shared/types';
+import type { RawRepo } from '../main/config-schema';
 
 /**
- * Tabbed Settings modal. Replaces the previous gear-icon shortcut that opened
- * NoteModal directly on `configuration.json` — settings now live under three
- * topical tabs:
+ * Full-viewport Settings modal. Every persisted preference has its own
+ * editable control — there is no in-modal JSON editor. Power users get a
+ * single "Open configuration.json externally" button in the header that
+ * shells out via `window.condash.openExternal`.
  *
- *  - **General** — theme picker (replaces the in-toolbar cycle button).
- *  - **configuration.json** — CodeMirror-backed JSON editor with parse-on-save.
- *  - **Shortcuts** — read-only display of the current `terminal.*_shortcut`
- *    values pulled from configuration.json.
- *
- * The configuration tab wires through the same note.read / note.write IPC the
- * NoteModal used so persistence behaviour and validation are unchanged.
+ * Writes are funnelled through `patchConfig`, which parses the live file,
+ * applies a mutator, drops empty leaves, and round-trips through the
+ * `note.write` IPC's atomic CAS so the schema-validation path stays the
+ * same.
  */
-type Tab = 'general' | 'terminal' | 'config' | 'shortcuts';
+type Section = 'workspace' | 'repositories' | 'open-with' | 'terminal' | 'appearance';
+
+type SectionGroup = 'config' | 'machine';
+
+interface SectionMeta {
+  id: Section;
+  label: string;
+  group: SectionGroup;
+}
+
+const SECTIONS: SectionMeta[] = [
+  { id: 'appearance', label: 'Appearance', group: 'machine' },
+  { id: 'terminal', label: 'Terminal', group: 'machine' },
+  { id: 'workspace', label: 'Workspace', group: 'config' },
+  { id: 'repositories', label: 'Repositories', group: 'config' },
+  { id: 'open-with', label: 'Open with', group: 'config' },
+];
+
+interface GroupMeta {
+  id: SectionGroup;
+  label: string;
+  file: string;
+  hint: string;
+}
+
+const GROUPS: GroupMeta[] = [
+  {
+    id: 'machine',
+    label: 'Global Condash Settings',
+    file: 'settings.json',
+    hint: 'Stored in ~/.config/condash/ on this machine only — not synced.',
+  },
+  {
+    id: 'config',
+    label: 'Conception Configuration',
+    file: 'configuration.json',
+    hint: 'Lives in the conception repo and is shared across machines.',
+  },
+];
 
 interface ColorEntry {
   key: keyof NonNullable<TerminalXtermPrefs['colors']>;
@@ -67,17 +95,95 @@ const THEME_OPTIONS: { value: Theme; label: string }[] = [
   { value: 'dark', label: 'Dark' },
 ];
 
-const SHORTCUT_FIELDS: { key: string; label: string; fallback: string }[] = [
-  { key: 'shortcut', label: 'Toggle terminal pane', fallback: 'Ctrl+`' },
-  { key: 'move_tab_left_shortcut', label: 'Move tab left', fallback: 'Ctrl+Left' },
-  { key: 'move_tab_right_shortcut', label: 'Move tab right', fallback: 'Ctrl+Right' },
-  { key: 'screenshot_paste_shortcut', label: 'Paste latest screenshot path', fallback: '(unset)' },
+const OPEN_WITH_SLOTS: { key: 'main_ide' | 'secondary_ide' | 'terminal'; label: string }[] = [
+  { key: 'main_ide', label: 'Main IDE' },
+  { key: 'secondary_ide', label: 'Secondary IDE' },
+  { key: 'terminal', label: 'Terminal' },
 ];
 
-let editorModulePromise: Promise<typeof import('./editor')> | null = null;
-function loadEditor(): Promise<typeof import('./editor')> {
-  if (!editorModulePromise) editorModulePromise = import('./editor');
-  return editorModulePromise;
+const TERMINAL_STRING_FIELDS: {
+  key:
+    | 'shell'
+    | 'shortcut'
+    | 'screenshot_dir'
+    | 'screenshot_paste_shortcut'
+    | 'launcher_command'
+    | 'move_tab_left_shortcut'
+    | 'move_tab_right_shortcut';
+  label: string;
+  placeholder: string;
+  hint?: string;
+}[] = [
+  { key: 'shell', label: 'Shell', placeholder: '/bin/bash' },
+  {
+    key: 'launcher_command',
+    label: 'Launcher command',
+    placeholder: 'claude',
+    hint: 'Run on terminal-tab open before any user input.',
+  },
+  {
+    key: 'screenshot_dir',
+    label: 'Screenshot directory',
+    placeholder: '/home/alice/Pictures/Screenshots',
+  },
+  { key: 'shortcut', label: 'Toggle terminal pane', placeholder: 'Ctrl+`' },
+  {
+    key: 'screenshot_paste_shortcut',
+    label: 'Paste latest screenshot path',
+    placeholder: 'Ctrl+Shift+V',
+  },
+  { key: 'move_tab_left_shortcut', label: 'Move tab left', placeholder: 'Ctrl+Left' },
+  { key: 'move_tab_right_shortcut', label: 'Move tab right', placeholder: 'Ctrl+Right' },
+];
+
+interface RawConfig {
+  $schema_doc?: string;
+  workspace_path?: string;
+  worktrees_path?: string;
+  repositories?: { primary?: RawRepo[]; secondary?: RawRepo[] };
+  open_with?: Record<string, { label?: string; command?: string }>;
+}
+
+/**
+ * Repository entries that carry only `{ name }` (no label / run / force_stop /
+ * submodules) collapse back to the bare-string shape on save. The full
+ * editor renders both shapes the same way, but configuration.json keeps its
+ * compact form for entries that don't need extra fields.
+ */
+function compactRepos(repos: RawRepo[]): RawRepo[] {
+  return repos.map((entry) => {
+    if (typeof entry === 'string') return entry;
+    const copy: Exclude<RawRepo, string> = { ...entry };
+    if (copy.submodules) {
+      copy.submodules = compactRepos(copy.submodules);
+      if (copy.submodules.length === 0) delete copy.submodules;
+    }
+    const extras = (Object.keys(copy) as (keyof typeof copy)[]).filter(
+      (k) => k !== 'name' && copy[k] !== undefined && copy[k] !== '',
+    );
+    if (extras.length === 0) return copy.name;
+    return copy;
+  });
+}
+
+/** Strip undefined / empty-string / null leaves so the JSON file stays clean. */
+function pruneEmpty(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(pruneEmpty).filter((v) => v !== undefined);
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      const pruned = pruneEmpty(v);
+      if (pruned === undefined || pruned === '' || pruned === null) continue;
+      if (typeof pruned === 'object' && !Array.isArray(pruned)) {
+        if (Object.keys(pruned as Record<string, unknown>).length === 0) continue;
+      }
+      out[k] = pruned;
+    }
+    return out;
+  }
+  return value;
 }
 
 export function SettingsModal(props: {
@@ -86,300 +192,490 @@ export function SettingsModal(props: {
   onChangeTheme: (theme: Theme) => void;
   onClose: () => void;
 }) {
-  const [tab, setTab] = createSignal<Tab>('general');
-  const [draft, setDraft] = createSignal('');
-  const [dirty, setDirty] = createSignal(false);
+  const [section, setSection] = createSignal<Section>('appearance');
   const [error, setError] = createSignal<string | null>(null);
   const [savedAt, setSavedAt] = createSignal<number | null>(null);
+  const [pending, setPending] = createSignal(false);
 
-  const [content, { mutate: mutateContent, refetch }] = createResource(
+  // Buffered text-input drafts. Each text field updates a draft on `onInput`
+  // and commits on `onChange` (blur / Enter). The dirty signal drives the
+  // back-arrow confirm dialog: drafts present means there are typed-but-
+  // unblurred edits that haven't reached disk yet.
+  const [drafts, setDrafts] = createSignal<Record<string, string>>({});
+  const [closeConfirm, setCloseConfirm] = createSignal(false);
+
+  const isDirty = (): boolean => Object.keys(drafts()).length > 0;
+
+  const [content, { mutate: mutateContent }] = createResource(
     () => props.configurationPath,
     (path) => window.condash.readNote(path),
   );
 
-  const handleKeydown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape') {
-      if (dirty() && !window.confirm('Unsaved changes — close anyway?')) {
-        e.preventDefault();
-        return;
-      }
-      e.preventDefault();
-      props.onClose();
+  const attemptClose = (): void => {
+    if (isDirty()) {
+      setCloseConfirm(true);
       return;
     }
-    if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 's' && tab() === 'config') {
+    props.onClose();
+  };
+
+  const handleKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape') {
       e.preventDefault();
-      void save();
+      if (closeConfirm()) {
+        setCloseConfirm(false);
+        return;
+      }
+      attemptClose();
     }
   };
 
   onMount(() => document.addEventListener('keydown', handleKeydown, true));
-  onCleanup(() => {
-    document.removeEventListener('keydown', handleKeydown, true);
-    if (editor) editor.destroy();
-  });
+  onCleanup(() => document.removeEventListener('keydown', handleKeydown, true));
 
-  let editorParent: HTMLDivElement | undefined;
-  let editor: MountedEditor | null = null;
-  let mounting = false;
-
-  createEffect(() => {
+  const parsed = createMemo<RawConfig>(() => {
     const text = content();
-    if (tab() === 'config' && editorParent && text != null && !editor && !mounting) {
-      mounting = true;
-      const parent = editorParent;
-      const initial = text;
-      void loadEditor()
-        .then(({ mountEditor }) => {
-          if (tab() !== 'config') {
-            mounting = false;
-            return;
-          }
-          editor = mountEditor({
-            parent,
-            initial,
-            language: 'json',
-            onSave: () => void save(),
-            onChange: (next) => {
-              setDraft(next);
-              setDirty(next !== content());
-            },
-          });
-          setDraft(initial);
-          setDirty(false);
-          mounting = false;
-        })
-        .catch((err) => {
-          mounting = false;
-          setError(`Failed to load editor: ${(err as Error).message}`);
-        });
-    }
-    if (tab() !== 'config' && editor) {
-      editor.destroy();
-      editor = null;
+    if (!text) return {};
+    try {
+      return JSON.parse(text) as RawConfig;
+    } catch {
+      return {};
     }
   });
 
-  const save = async (): Promise<void> => {
-    if (tab() !== 'config') return;
-    const expected = content() ?? '';
-    const next = draft();
-    setError(null);
+  const parseError = createMemo<string | null>(() => {
+    const text = content();
+    if (!text) return null;
     try {
-      JSON.parse(next);
+      JSON.parse(text);
+      return null;
     } catch (err) {
-      setError(`Invalid JSON: ${(err as Error).message}`);
+      return (err as Error).message;
+    }
+  });
+
+  /**
+   * Apply `mutator` to the parsed configuration, drop empty leaves, and
+   * persist via the same atomic CAS path the JSON-editor tab used.
+   */
+  const patchConfig = async (mutator: (config: RawConfig) => void): Promise<void> => {
+    const text = content() ?? '';
+    let parsedConfig: RawConfig;
+    try {
+      parsedConfig = (text ? JSON.parse(text) : {}) as RawConfig;
+    } catch (err) {
+      setError(
+        `configuration.json is invalid: ${(err as Error).message}. Open it externally to repair.`,
+      );
       return;
     }
+    mutator(parsedConfig);
+    const pruned = pruneEmpty(parsedConfig) as RawConfig;
+    if (pruned.repositories?.primary) {
+      pruned.repositories.primary = compactRepos(pruned.repositories.primary);
+    }
+    if (pruned.repositories?.secondary) {
+      pruned.repositories.secondary = compactRepos(pruned.repositories.secondary);
+    }
+    const next = JSON.stringify(pruned, null, 2) + '\n';
+    if (next === text) return;
+    setError(null);
+    setPending(true);
     try {
-      await window.condash.writeNote(props.configurationPath, expected, next);
+      await window.condash.writeNote(props.configurationPath, text, next);
       mutateContent(next);
-      setDirty(false);
       setSavedAt(Date.now());
       setTimeout(() => setSavedAt((t) => (t && Date.now() - t > 1200 ? null : t)), 1500);
     } catch (err) {
       setError((err as Error).message);
+    } finally {
+      setPending(false);
     }
   };
 
-  const reload = async (): Promise<void> => {
-    setError(null);
-    setDirty(false);
-    if (editor) {
-      editor.destroy();
-      editor = null;
-    }
-    await refetch();
+  const openConfigExternally = (): void => {
+    void window.condash.openExternal(props.configurationPath);
   };
 
-  const handleBackdropClose = (): void => {
-    if (dirty() && !window.confirm('Unsaved changes — close anyway?')) return;
+  const [settingsPath] = createResource(() => window.condash.getSettingsPath());
+
+  const openSettingsExternally = (): void => {
+    const path = settingsPath();
+    if (path) void window.condash.openExternal(path);
+  };
+
+  // --- Draft-buffered text input -------------------------------------
+
+  // Maps each text-field id to its current commit handler so that the
+  // close-confirm "Save and close" path can flush all uncommitted drafts
+  // in one go without re-deriving each field's save logic.
+  const draftSavers = new Map<string, (value: string) => Promise<void>>();
+
+  /**
+   * Bind a text input to the draft buffer + commit-on-blur flow.
+   * Returns the props an `<input>` should spread: value, onInput, onChange.
+   */
+  const bindText = (
+    id: string,
+    persisted: () => string | undefined,
+    save: (value: string) => Promise<void>,
+  ): {
+    value: string;
+    onInput: (e: InputEvent & { currentTarget: HTMLInputElement }) => void;
+    onChange: (e: Event & { currentTarget: HTMLInputElement }) => void;
+  } => {
+    draftSavers.set(id, save);
+    return {
+      value: drafts()[id] ?? persisted() ?? '',
+      onInput: (e) => {
+        const next = e.currentTarget.value;
+        setDrafts((d) => ({ ...d, [id]: next }));
+      },
+      onChange: (e) => {
+        const next = e.currentTarget.value;
+        setDrafts((d) => {
+          const copy = { ...d };
+          delete copy[id];
+          return copy;
+        });
+        void save(next);
+      },
+    };
+  };
+
+  /** Flush every draft to disk in parallel; resolve once all writes settle. */
+  const flushDrafts = async (): Promise<void> => {
+    const snapshot = drafts();
+    const ids = Object.keys(snapshot);
+    if (ids.length === 0) return;
+    setDrafts({});
+    await Promise.all(
+      ids.map((id) => {
+        const saver = draftSavers.get(id);
+        return saver ? saver(snapshot[id]) : Promise.resolve();
+      }),
+    );
+  };
+
+  const handleSaveAndClose = async (): Promise<void> => {
+    setCloseConfirm(false);
+    await flushDrafts();
     props.onClose();
   };
 
-  // Best-effort: parse the current configuration.json (after any pending edits
-  // are saved this matches disk) to surface the shortcut values. We re-run on
-  // every content() change so reload picks up an external edit.
-  const shortcuts = (): Record<string, string> => {
-    const text = content();
-    if (!text) return {};
-    try {
-      const parsed = JSON.parse(text) as { terminal?: Record<string, string> };
-      return parsed.terminal ?? {};
-    } catch {
-      return {};
-    }
+  const handleDiscardAndClose = (): void => {
+    setDrafts({});
+    setCloseConfirm(false);
+    props.onClose();
   };
 
-  // Parse `terminal.xterm` from the live config so the Terminal tab can edit
-  // it without going through the JSON editor. Updates round-trip through the
-  // same `note.write` IPC the configuration tab uses.
-  const xtermPrefs = createMemo<TerminalXtermPrefs>(() => {
-    const text = content();
-    if (!text) return {};
-    try {
-      const parsed = JSON.parse(text) as { terminal?: { xterm?: TerminalXtermPrefs } };
-      return parsed.terminal?.xterm ?? {};
-    } catch {
-      return {};
-    }
-  });
+  // --- Workspace -------------------------------------------------------
 
-  /** Apply a partial update to `terminal.xterm` and persist to disk. */
-  const updateXterm = async (patch: Partial<TerminalXtermPrefs>): Promise<void> => {
-    const text = content() ?? '';
-    let parsed: Record<string, unknown>;
-    try {
-      parsed = (text ? JSON.parse(text) : {}) as Record<string, unknown>;
-    } catch (err) {
-      setError(`Invalid JSON in configuration.json — fix it before editing terminal settings.`);
-      return;
-    }
-    const terminal = (parsed.terminal as Record<string, unknown> | undefined) ?? {};
-    const xterm = (terminal.xterm as TerminalXtermPrefs | undefined) ?? {};
-    const merged: TerminalXtermPrefs = { ...xterm, ...patch };
-    if (patch.colors) {
-      merged.colors = { ...(xterm.colors ?? {}), ...patch.colors };
-    }
-    // Drop empty/undefined leaves so the JSON file stays clean.
-    for (const k of Object.keys(merged) as (keyof TerminalXtermPrefs)[]) {
-      const v = merged[k];
-      if (v === undefined || v === '' || v === null) delete merged[k];
-    }
-    if (merged.colors) {
-      for (const k of Object.keys(merged.colors)) {
-        const v = (merged.colors as Record<string, string | undefined>)[k];
-        if (v === undefined || v === '') delete (merged.colors as Record<string, unknown>)[k];
+  const setWorkspacePath = (value: string): Promise<void> =>
+    patchConfig((c) => {
+      c.workspace_path = value || undefined;
+    });
+
+  const setWorktreesPath = (value: string): Promise<void> =>
+    patchConfig((c) => {
+      c.worktrees_path = value || undefined;
+    });
+
+  // --- Repositories ----------------------------------------------------
+
+  type RepoBucket = 'primary' | 'secondary';
+
+  const repos = (bucket: RepoBucket): RawRepo[] => parsed().repositories?.[bucket] ?? [];
+
+  const updateRepos = (
+    bucket: RepoBucket,
+    mutate: (entries: RawRepo[]) => RawRepo[],
+  ): Promise<void> =>
+    patchConfig((c) => {
+      const repositories = (c.repositories ?? {}) as {
+        primary?: RawRepo[];
+        secondary?: RawRepo[];
+      };
+      const current = (repositories[bucket] ?? []).slice();
+      repositories[bucket] = mutate(current);
+      c.repositories = repositories;
+    });
+
+  const addRepo = (bucket: RepoBucket): Promise<void> =>
+    updateRepos(bucket, (entries) => [...entries, { name: '' }]);
+
+  const removeRepo = (bucket: RepoBucket, index: number): Promise<void> =>
+    updateRepos(bucket, (entries) => entries.filter((_, i) => i !== index));
+
+  const moveRepo = (bucket: RepoBucket, index: number, delta: -1 | 1): Promise<void> =>
+    updateRepos(bucket, (entries) => {
+      const target = index + delta;
+      if (target < 0 || target >= entries.length) return entries;
+      const next = entries.slice();
+      const [removed] = next.splice(index, 1);
+      next.splice(target, 0, removed);
+      return next;
+    });
+
+  const updateRepoEntry = (
+    bucket: RepoBucket,
+    index: number,
+    patch: (entry: RawRepo) => RawRepo,
+  ): Promise<void> =>
+    updateRepos(bucket, (entries) => entries.map((e, i) => (i === index ? patch(e) : e)));
+
+  // --- Open with -------------------------------------------------------
+
+  const updateOpenWithSlot = (
+    key: 'main_ide' | 'secondary_ide' | 'terminal',
+    patch: { label?: string; command?: string },
+  ): Promise<void> =>
+    patchConfig((c) => {
+      const openWith = (c.open_with ?? {}) as Record<string, { label?: string; command?: string }>;
+      const current = openWith[key] ?? {};
+      const merged = { ...current, ...patch };
+      if (!merged.command) {
+        delete openWith[key];
+      } else {
+        openWith[key] = merged;
       }
-      if (Object.keys(merged.colors).length === 0) delete merged.colors;
-    }
-    const nextTerminal = { ...terminal, xterm: merged };
-    if (Object.keys(merged).length === 0) delete (nextTerminal as Record<string, unknown>).xterm;
-    const next = { ...parsed, terminal: nextTerminal };
-    const serialised = JSON.stringify(next, null, 2) + '\n';
+      c.open_with = openWith;
+    });
+
+  // --- Terminal (settings.json — per-machine) -------------------------
+
+  const [terminalRes, { mutate: mutateTerminal }] = createResource<TerminalPrefs>(() =>
+    window.condash.termGetPrefs(),
+  );
+
+  const terminalPrefs = (): TerminalPrefs => terminalRes() ?? {};
+
+  /**
+   * Apply `mutator` to the persisted terminal prefs in settings.json,
+   * drop empty leaves, and round-trip through `term.setPrefs`.
+   */
+  const patchTerminal = async (mutator: (prefs: TerminalPrefs) => TerminalPrefs): Promise<void> => {
+    const next = mutator({ ...terminalPrefs() });
+    const pruned = (pruneEmpty(next) as TerminalPrefs) ?? {};
     setError(null);
+    setPending(true);
     try {
-      await window.condash.writeNote(props.configurationPath, text, serialised);
-      mutateContent(serialised);
+      await window.condash.termSetPrefs(pruned);
+      mutateTerminal(pruned);
       setSavedAt(Date.now());
       setTimeout(() => setSavedAt((t) => (t && Date.now() - t > 1200 ? null : t)), 1500);
     } catch (err) {
       setError((err as Error).message);
+    } finally {
+      setPending(false);
     }
   };
 
-  const updateColor = (key: ColorEntry['key'], value: string) =>
+  const setTerminalString = (
+    key: (typeof TERMINAL_STRING_FIELDS)[number]['key'],
+    value: string,
+  ): Promise<void> =>
+    patchTerminal((p) => {
+      const next = { ...p } as Record<string, unknown>;
+      next[key] = value || undefined;
+      return next as TerminalPrefs;
+    });
+
+  const xtermPrefs = createMemo<TerminalXtermPrefs>(() => terminalPrefs().xterm ?? {});
+
+  const updateXterm = (patch: Partial<TerminalXtermPrefs>): Promise<void> =>
+    patchTerminal((p) => {
+      const xterm = (p.xterm ?? {}) as TerminalXtermPrefs;
+      const merged: TerminalXtermPrefs = { ...xterm, ...patch };
+      if (patch.colors) {
+        merged.colors = { ...(xterm.colors ?? {}), ...patch.colors };
+      }
+      return { ...p, xterm: merged };
+    });
+
+  const updateColor = (key: ColorEntry['key'], value: string): void =>
     void updateXterm({ colors: { [key]: value || undefined } as never });
 
+  const scrollToSection = (id: Section): void => {
+    setSection(id);
+    const el = document.getElementById(`settings-section-${id}`);
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
   return (
-    <div class="modal-backdrop" onClick={handleBackdropClose}>
+    <div class="modal-backdrop settings-modal-backdrop" onClick={attemptClose}>
       <div
-        class="modal settings-modal"
+        class="modal settings-modal settings-modal--full"
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
         onClick={(e) => e.stopPropagation()}
       >
-        <header class="modal-head">
+        <header class="modal-head settings-head">
+          <button class="settings-back" onClick={attemptClose} title="Back (Esc)" aria-label="Back">
+            <span class="settings-back-arrow" aria-hidden="true">
+              ←
+            </span>
+            <span>Back</span>
+          </button>
           <span class="modal-title">Settings</span>
-          <span class="modal-head-spacer" />
-          <Show when={dirty()}>
-            <span class="modal-dirty" title="Unsaved changes">
-              ●
+          <Show when={pending()}>
+            <span class="modal-saving" title="Saving">
+              …
             </span>
           </Show>
-          <Show when={savedAt() !== null}>
+          <Show when={savedAt() !== null && !pending()}>
             <span class="modal-saved" title="Saved">
               ✓
             </span>
           </Show>
-          <button
-            class="modal-button"
-            onClick={handleBackdropClose}
-            title="Close (Esc)"
-            aria-label="Close"
-          >
-            ×
-          </button>
+          <Show when={isDirty() && !pending()}>
+            <span class="modal-dirty" title="Unsaved edits in a focused field">
+              ●
+            </span>
+          </Show>
+          <span class="settings-head-spacer" />
         </header>
-        <nav class="settings-tabs" role="tablist">
-          <button
-            class="settings-tab"
-            classList={{ active: tab() === 'general' }}
-            role="tab"
-            aria-selected={tab() === 'general'}
-            onClick={() => setTab('general')}
-          >
-            General
-          </button>
-          <button
-            class="settings-tab"
-            classList={{ active: tab() === 'terminal' }}
-            role="tab"
-            aria-selected={tab() === 'terminal'}
-            onClick={() => setTab('terminal')}
-          >
-            Terminal
-          </button>
-          <button
-            class="settings-tab"
-            classList={{ active: tab() === 'config' }}
-            role="tab"
-            aria-selected={tab() === 'config'}
-            onClick={() => setTab('config')}
-          >
-            configuration.json
-          </button>
-          <button
-            class="settings-tab"
-            classList={{ active: tab() === 'shortcuts' }}
-            role="tab"
-            aria-selected={tab() === 'shortcuts'}
-            onClick={() => setTab('shortcuts')}
-          >
-            Shortcuts
-          </button>
-        </nav>
+        <Show when={parseError()}>
+          <div class="modal-error">
+            configuration.json failed to parse — {parseError()}. Edit it externally to repair.
+          </div>
+        </Show>
         <Show when={error()}>
           <div class="modal-error">{error()}</div>
         </Show>
-        <div class="settings-body">
-          <Show when={tab() === 'general'}>
-            <section class="settings-section">
-              <h3>Theme</h3>
-              <div class="settings-radio-group" role="radiogroup">
-                <For each={THEME_OPTIONS}>
-                  {(opt) => (
-                    <label class="settings-radio">
+        <div class="settings-shell">
+          <nav class="settings-rail" aria-label="Settings sections">
+            <For each={GROUPS}>
+              {(g) => (
+                <div class="settings-rail-group">
+                  <div class="settings-rail-group-heading">
+                    <span class="settings-rail-group-label">{g.label}</span>
+                    <code>{g.file}</code>
+                  </div>
+                  <ul class="settings-rail-list">
+                    <For each={SECTIONS.filter((s) => s.group === g.id)}>
+                      {(s) => (
+                        <li>
+                          <button
+                            class="settings-rail-item"
+                            classList={{ active: section() === s.id }}
+                            onClick={() => scrollToSection(s.id)}
+                          >
+                            {s.label}
+                          </button>
+                        </li>
+                      )}
+                    </For>
+                  </ul>
+                </div>
+              )}
+            </For>
+          </nav>
+          <div
+            class="settings-scroll"
+            onScroll={(e) => {
+              const top = e.currentTarget.scrollTop + 8;
+              let active: Section = 'appearance';
+              for (const s of SECTIONS) {
+                const el = document.getElementById(`settings-section-${s.id}`);
+                if (el && el.offsetTop - e.currentTarget.offsetTop <= top) {
+                  active = s.id;
+                }
+              }
+              if (active !== section()) setSection(active);
+            }}
+          >
+            {/* Group: settings.json (machine, first) -------------------- */}
+            <header class="settings-group-divider">
+              <h2>Global Condash Settings</h2>
+              <code>settings.json</code>
+              <span class="settings-group-divider-actions">
+                <button
+                  class="modal-button"
+                  onClick={() => void flushDrafts()}
+                  disabled={!isDirty()}
+                  title="Flush any focused-but-unblurred edits to disk"
+                >
+                  Save
+                </button>
+                <button
+                  class="modal-button"
+                  onClick={openSettingsExternally}
+                  title="Open settings.json with the OS default editor"
+                >
+                  Open externally
+                </button>
+              </span>
+              <span class="settings-group-divider-hint">
+                Stored in <code>~/.config/condash/</code>; per-machine, not synced.
+              </span>
+            </header>
+
+            {/* Appearance ----------------------------------------------- */}
+            <section id="settings-section-appearance" class="settings-section">
+              <h2>Appearance</h2>
+              <div class="settings-field">
+                <span class="settings-field-label">Theme</span>
+                <div class="settings-radio-group" role="radiogroup">
+                  <For each={THEME_OPTIONS}>
+                    {(opt) => (
+                      <label class="settings-radio">
+                        <input
+                          type="radio"
+                          name="theme"
+                          checked={props.theme === opt.value}
+                          onChange={() => props.onChangeTheme(opt.value)}
+                        />
+                        <span>{opt.label}</span>
+                      </label>
+                    )}
+                  </For>
+                </div>
+              </div>
+            </section>
+
+            {/* Terminal (settings.json — per-machine) ------------------ */}
+            <section id="settings-section-terminal" class="settings-section">
+              <h2>Terminal</h2>
+              <h3>Behaviour &amp; shortcuts</h3>
+              <div class="settings-grid">
+                <For each={TERMINAL_STRING_FIELDS}>
+                  {(field) => (
+                    <label>
+                      <span>{field.label}</span>
                       <input
-                        type="radio"
-                        name="theme"
-                        checked={props.theme === opt.value}
-                        onChange={() => props.onChangeTheme(opt.value)}
+                        type="text"
+                        placeholder={field.placeholder}
+                        {...bindText(
+                          `terminal.${field.key}`,
+                          () =>
+                            (terminalPrefs() as Record<string, unknown>)[field.key] as
+                              | string
+                              | undefined,
+                          (v) => setTerminalString(field.key, v),
+                        )}
                       />
-                      <span>{opt.label}</span>
+                      <Show when={field.hint}>
+                        <small class="settings-field-hint">{field.hint}</small>
+                      </Show>
                     </label>
                   )}
                 </For>
               </div>
-            </section>
-          </Show>
-          <Show when={tab() === 'terminal'}>
-            <section class="settings-section settings-terminal">
-              <p class="settings-hint">
-                Live-edits the <code>terminal.xterm</code> block in configuration.json. Changes
-                apply to <strong>new</strong> terminal tabs; existing tabs keep their original
-                settings until they're closed and reopened.
-              </p>
+
               <h3>Font</h3>
               <div class="settings-grid">
                 <label>
                   <span>Font family</span>
                   <input
                     type="text"
-                    value={xtermPrefs().font_family ?? ''}
                     placeholder="ui-monospace, Menlo, Consolas, monospace"
-                    onChange={(e) => void updateXterm({ font_family: e.currentTarget.value })}
+                    {...bindText(
+                      'xterm.font_family',
+                      () => xtermPrefs().font_family,
+                      (v) => updateXterm({ font_family: v || undefined }),
+                    )}
                   />
                 </label>
                 <label>
@@ -437,26 +733,34 @@ export function SettingsModal(props: {
                   <span>Font weight</span>
                   <input
                     type="text"
-                    value={String(xtermPrefs().font_weight ?? '')}
                     placeholder="normal | 400 | 500"
-                    onChange={(e) =>
-                      void updateXterm({ font_weight: e.currentTarget.value || undefined })
-                    }
+                    {...bindText(
+                      'xterm.font_weight',
+                      () =>
+                        xtermPrefs().font_weight !== undefined
+                          ? String(xtermPrefs().font_weight)
+                          : undefined,
+                      (v) => updateXterm({ font_weight: v || undefined }),
+                    )}
                   />
                 </label>
                 <label>
                   <span>Bold weight</span>
                   <input
                     type="text"
-                    value={String(xtermPrefs().font_weight_bold ?? '')}
                     placeholder="bold | 600 | 700"
-                    onChange={(e) =>
-                      void updateXterm({ font_weight_bold: e.currentTarget.value || undefined })
-                    }
+                    {...bindText(
+                      'xterm.font_weight_bold',
+                      () =>
+                        xtermPrefs().font_weight_bold !== undefined
+                          ? String(xtermPrefs().font_weight_bold)
+                          : undefined,
+                      (v) => updateXterm({ font_weight_bold: v || undefined }),
+                    )}
                   />
                 </label>
               </div>
-              <h3>Cursor & buffer</h3>
+              <h3>Cursor &amp; buffer</h3>
               <div class="settings-grid">
                 <label>
                   <span>Cursor style</span>
@@ -521,68 +825,325 @@ export function SettingsModal(props: {
                       <span>{entry.label}</span>
                       <input
                         type="text"
-                        value={xtermPrefs().colors?.[entry.key] ?? ''}
                         placeholder="—"
-                        onChange={(e) => updateColor(entry.key, e.currentTarget.value)}
+                        {...bindText(
+                          `xterm.colors.${entry.key}`,
+                          () => xtermPrefs().colors?.[entry.key],
+                          (v) => {
+                            updateColor(entry.key, v);
+                            return Promise.resolve();
+                          },
+                        )}
                       />
                     </label>
                   )}
                 </For>
               </div>
             </section>
-          </Show>
-          <Show when={tab() === 'config'}>
-            <div class="settings-config">
-              <div class="settings-config-toolbar">
+
+            {/* Group: configuration.json (conception, second) ----------- */}
+            <header class="settings-group-divider">
+              <h2>Conception Configuration</h2>
+              <code>configuration.json</code>
+              <span class="settings-group-divider-actions">
                 <button
                   class="modal-button"
-                  onClick={() => void save()}
-                  disabled={!dirty()}
-                  title="Save (Ctrl+S)"
+                  onClick={() => void flushDrafts()}
+                  disabled={!isDirty()}
+                  title="Flush any focused-but-unblurred edits to disk"
                 >
                   Save
                 </button>
-                <button class="modal-button" onClick={() => void reload()} title="Reload from disk">
-                  Reload
+                <button
+                  class="modal-button"
+                  onClick={openConfigExternally}
+                  title="Open configuration.json with the OS default editor"
+                >
+                  Open externally
                 </button>
-                <span class="settings-config-path" title={props.configurationPath}>
-                  {props.configurationPath}
-                </span>
+              </span>
+              <span class="settings-group-divider-hint">
+                Lives in the conception repo; shared across machines.
+              </span>
+            </header>
+
+            {/* Workspace ------------------------------------------------ */}
+            <section id="settings-section-workspace" class="settings-section">
+              <h2>Workspace</h2>
+              <div class="settings-grid settings-grid--wide">
+                <label>
+                  <span>Workspace path</span>
+                  <input
+                    type="text"
+                    placeholder="/home/you/src/vcoeur"
+                    {...bindText('workspace_path', () => parsed().workspace_path, setWorkspacePath)}
+                  />
+                </label>
+                <label>
+                  <span>Worktrees path</span>
+                  <input
+                    type="text"
+                    placeholder="/home/you/src/worktrees"
+                    {...bindText('worktrees_path', () => parsed().worktrees_path, setWorktreesPath)}
+                  />
+                </label>
               </div>
-              <Show when={content.loading}>
-                <div class="empty">Loading…</div>
-              </Show>
-              <Show when={content.error}>
-                <div class="empty warn">Failed to read: {(content.error as Error).message}</div>
-              </Show>
-              <Show when={!content.loading && !content.error}>
-                <div class="cm-host settings-cm-host" ref={(el) => (editorParent = el)} />
-              </Show>
-            </div>
-          </Show>
-          <Show when={tab() === 'shortcuts'}>
-            <section class="settings-section">
-              <p class="settings-hint">
-                Read-only — edit them in the <code>terminal</code> section of the configuration.json
-                tab.
-              </p>
-              <table class="settings-shortcuts">
-                <tbody>
-                  <For each={SHORTCUT_FIELDS}>
-                    {(row) => (
-                      <tr>
-                        <th>{row.label}</th>
-                        <td>
-                          <code>{shortcuts()[row.key] ?? row.fallback}</code>
-                        </td>
-                      </tr>
-                    )}
-                  </For>
-                </tbody>
-              </table>
             </section>
-          </Show>
+
+            {/* Repositories -------------------------------------------- */}
+            <section id="settings-section-repositories" class="settings-section">
+              <h2>Repositories</h2>
+              <p class="settings-hint">
+                Each entry is either just a name (resolved against <code>workspace_path</code>) or
+                an object with optional <code>label</code>, <code>run</code>,{' '}
+                <code>force_stop</code>, and <code>submodules</code>.
+              </p>
+              <For each={['primary', 'secondary'] as const}>
+                {(bucket) => (
+                  <div class="settings-bucket">
+                    <h3>{bucket === 'primary' ? 'Primary' : 'Secondary'}</h3>
+                    <For each={repos(bucket)}>
+                      {(entry, index) => (
+                        <RepoRow
+                          entry={entry}
+                          idPrefix={`repo.${bucket}[${index()}]`}
+                          index={index()}
+                          total={repos(bucket).length}
+                          bindText={bindText}
+                          onMove={(delta) => void moveRepo(bucket, index(), delta)}
+                          onRemove={() => void removeRepo(bucket, index())}
+                          onPatch={(next) => updateRepoEntry(bucket, index(), () => next)}
+                        />
+                      )}
+                    </For>
+                    <div class="settings-list-actions">
+                      <button class="modal-button" onClick={() => void addRepo(bucket)}>
+                        + Add repo
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </For>
+            </section>
+
+            {/* Open with ----------------------------------------------- */}
+            <section id="settings-section-open-with" class="settings-section">
+              <h2>Open with</h2>
+              <p class="settings-hint">
+                Three slots used by the per-folder &quot;Open in…&quot; menu.{' '}
+                <code>{'{path}'}</code> is substituted with the absolute path. Clear the command to
+                remove the slot.
+              </p>
+              <div class="settings-grid settings-grid--wide">
+                <For each={OPEN_WITH_SLOTS}>
+                  {(slot) => {
+                    const current = (): { label?: string; command?: string } =>
+                      parsed().open_with?.[slot.key] ?? {};
+                    return (
+                      <div class="settings-open-with">
+                        <span class="settings-field-label">{slot.label}</span>
+                        <input
+                          type="text"
+                          placeholder={`Open in ${slot.label.toLowerCase()}`}
+                          {...bindText(
+                            `open_with.${slot.key}.label`,
+                            () => current().label,
+                            (v) => updateOpenWithSlot(slot.key, { label: v }),
+                          )}
+                        />
+                        <input
+                          type="text"
+                          placeholder="idea {path}"
+                          {...bindText(
+                            `open_with.${slot.key}.command`,
+                            () => current().command,
+                            (v) => updateOpenWithSlot(slot.key, { command: v }),
+                          )}
+                        />
+                      </div>
+                    );
+                  }}
+                </For>
+              </div>
+            </section>
+          </div>
         </div>
+        <Show when={closeConfirm()}>
+          <div class="settings-confirm-backdrop" onClick={() => setCloseConfirm(false)}>
+            <div
+              class="settings-confirm"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Unsaved edits"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <h3>Save before closing?</h3>
+              <p>You have edits in a focused field that haven't been written yet.</p>
+              <div class="settings-confirm-actions">
+                <button class="modal-button" onClick={() => setCloseConfirm(false)}>
+                  Cancel
+                </button>
+                <button class="modal-button" onClick={handleDiscardAndClose}>
+                  Discard
+                </button>
+                <button class="modal-button" onClick={() => void handleSaveAndClose()}>
+                  Save and close
+                </button>
+              </div>
+            </div>
+          </div>
+        </Show>
+      </div>
+    </div>
+  );
+}
+
+type BindTextFn = (
+  id: string,
+  persisted: () => string | undefined,
+  save: (value: string) => Promise<void>,
+) => {
+  value: string;
+  onInput: (e: InputEvent & { currentTarget: HTMLInputElement }) => void;
+  onChange: (e: Event & { currentTarget: HTMLInputElement }) => void;
+};
+
+function moveItem<T>(arr: T[], index: number, delta: -1 | 1): T[] {
+  const target = index + delta;
+  if (target < 0 || target >= arr.length) return arr;
+  const next = arr.slice();
+  const [removed] = next.splice(index, 1);
+  next.splice(target, 0, removed);
+  return next;
+}
+
+/**
+ * One row in a repositories list. Always shows the full editable surface
+ * (name, label, run, force_stop, sub repos) regardless of how the entry
+ * is currently serialized — string-form entries are coerced to object on
+ * render. The recursive `submodules` UI lets a parent repo carry its own
+ * nested list with the same shape.
+ */
+function RepoRow(props: {
+  entry: RawRepo;
+  idPrefix: string;
+  index: number;
+  total: number;
+  bindText: BindTextFn;
+  onMove: (delta: -1 | 1) => void;
+  onRemove: () => void;
+  onPatch: (next: RawRepo) => Promise<void>;
+}) {
+  const obj = (): Exclude<RawRepo, string> =>
+    typeof props.entry === 'string' ? { name: props.entry } : props.entry;
+
+  const patchObj = (patch: Partial<Exclude<RawRepo, string>>): Promise<void> =>
+    props.onPatch({ ...obj(), ...patch });
+
+  const submodules = (): RawRepo[] => obj().submodules ?? [];
+
+  const updateSubmodules = (mutate: (subs: RawRepo[]) => RawRepo[]): Promise<void> =>
+    patchObj({ submodules: mutate(submodules()) });
+
+  return (
+    <div class="settings-repo-row">
+      <div class="settings-repo-row-head">
+        <input
+          type="text"
+          class="settings-repo-name"
+          placeholder="repo-name"
+          {...props.bindText(
+            `${props.idPrefix}.name`,
+            () => obj().name,
+            (v) => patchObj({ name: v }),
+          )}
+        />
+        <button
+          class="modal-button"
+          title="Move up"
+          disabled={props.index === 0}
+          onClick={() => props.onMove(-1)}
+        >
+          ↑
+        </button>
+        <button
+          class="modal-button"
+          title="Move down"
+          disabled={props.index === props.total - 1}
+          onClick={() => props.onMove(1)}
+        >
+          ↓
+        </button>
+        <button class="modal-button" title="Remove" onClick={() => props.onRemove()}>
+          ×
+        </button>
+      </div>
+      <div class="settings-repo-row-detail">
+        <label>
+          <span>Label</span>
+          <input
+            type="text"
+            placeholder="Friendly subtitle"
+            {...props.bindText(
+              `${props.idPrefix}.label`,
+              () => obj().label,
+              (v) => patchObj({ label: v || undefined }),
+            )}
+          />
+        </label>
+        <label>
+          <span>Run command</span>
+          <input
+            type="text"
+            placeholder="make dev"
+            {...props.bindText(
+              `${props.idPrefix}.run`,
+              () => obj().run,
+              (v) => patchObj({ run: v || undefined }),
+            )}
+          />
+        </label>
+        <label>
+          <span>Force stop</span>
+          <input
+            type="text"
+            placeholder="fuser -k 5600/tcp"
+            {...props.bindText(
+              `${props.idPrefix}.force_stop`,
+              () => obj().force_stop,
+              (v) => patchObj({ force_stop: v || undefined }),
+            )}
+          />
+        </label>
+      </div>
+      <Show when={submodules().length > 0}>
+        <div class="settings-repo-submodules">
+          <span class="settings-field-label">Sub repos</span>
+          <For each={submodules()}>
+            {(sub, idx) => (
+              <RepoRow
+                entry={sub}
+                idPrefix={`${props.idPrefix}.sub[${idx()}]`}
+                index={idx()}
+                total={submodules().length}
+                bindText={props.bindText}
+                onMove={(delta) => void updateSubmodules((all) => moveItem(all, idx(), delta))}
+                onRemove={() => void updateSubmodules((all) => all.filter((_, i) => i !== idx()))}
+                onPatch={(next) =>
+                  updateSubmodules((all) => all.map((e, i) => (i === idx() ? next : e)))
+                }
+              />
+            )}
+          </For>
+        </div>
+      </Show>
+      <div class="settings-list-actions">
+        <button
+          class="modal-button"
+          onClick={() => void updateSubmodules((all) => [...all, { name: '' }])}
+        >
+          + Add sub repo
+        </button>
       </div>
     </div>
   );

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -44,6 +44,9 @@ export interface CondashApi {
   initConception(path: string): Promise<{ created: string[] }>;
   getTheme(): Promise<Theme>;
   setTheme(theme: Theme): Promise<void>;
+  /** Absolute path to `~/.config/condash/settings.json` (or platform equivalent),
+   * for the settings modal's "Open externally" button. */
+  getSettingsPath(): Promise<string>;
   toggleStep(
     path: string,
     lineIndex: number,
@@ -77,6 +80,9 @@ export interface CondashApi {
   termResize(id: string, cols: number, rows: number): Promise<void>;
   termClose(id: string): Promise<void>;
   termGetPrefs(): Promise<TerminalPrefs>;
+  /** Replace the persisted terminal prefs in settings.json. The patch is a
+   * full replacement; pass `{}` to clear back to defaults. */
+  termSetPrefs(prefs: TerminalPrefs): Promise<void>;
   termLatestScreenshot(dir: string): Promise<string | null>;
   /** Snapshot of currently-tracked sessions (live or recently exited). */
   termList(): Promise<TermSession[]>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -66,6 +66,9 @@ export type Theme = 'light' | 'dark' | 'system';
 export interface Settings {
   conceptionPath: string | null;
   theme: Theme;
+  /** Per-machine terminal prefs. Moved here from configuration.json so each
+   * laptop carries its own font/screenshot/keybinding choices. */
+  terminal?: TerminalPrefs;
 }
 
 /** One row of `git status --porcelain=v1` output, normalised for the renderer. */


### PR DESCRIPTION
## Summary

- Replace the cramped 880 px tabbed Settings with a full-viewport modal: two top-level groups (Global Condash Settings → settings.json, Conception Configuration → configuration.json), back-arrow + draft buffer + per-group action bars.
- Move every persisted terminal pref (font, cursor, scrollback, ligatures, 21 colours, shell, screenshot dir, launcher, four shortcuts) from configuration.json to settings.json — these are per-machine concerns, not per-conception.
- Drop the in-modal CodeMirror JSON editor and the dead `pdf_viewer` field; surface every persisted setting as its own form control.

## Changes

- Renderer: full-viewport `.settings-modal--full` (specificity-bumped above the base `.modal` width cap), grouped side-rail, group-divider chapter cards, draft-buffered `bindText` helper with Save / Discard / Cancel close-confirm (`src/renderer/settings-modal.tsx`, `src/renderer/modals.css`).
- Repo editor: drop the "+ name only" / "+ with run / label" split; one full-form editor per entry, empty fields permitted. New `compactRepos` post-process collapses `{ name }`-only entries back to the bare-string shape on save. Recursive sub-repo editor with a per-entry `+ Add sub repo` button.
- Terminal schema move: extended `Settings.terminal` (`src/shared/types.ts`); new `term.setPrefs` and `getSettingsPath` IPCs; `term.getPrefs` reads from settings.json; `migrateTerminalFromConfigIfNeeded()` runs once at `app.whenReady()` to copy + strip any pre-existing block (`src/main/terminals.ts`, `src/main/index.ts`, `src/preload/index.ts`, `src/shared/api.ts`).
- Schema: drop `pdf_viewer` from `configSchema`; keep `terminal` as `@deprecated` so files mid-migration still validate (`src/main/config-schema.ts`).
- Modal header: remove the global `Open externally` / `Reload` buttons in favour of per-file action bars on each group divider; `←` Back replaces the `×` close, with a confirm dialog if there are unsaved drafts.

## Impact

- First-launch migration writes `~/.config/condash/settings.json` and rewrites `<conception>/configuration.json` to drop the `terminal` block. Idempotent — runs only when settings.json has no `terminal` and configuration.json has one.
- Any direct read of `configuration.terminal.*` outside `getTerminalPrefs()` is broken. `getTerminalPrefs()` is now the only sanctioned reader and returns from settings.json.
- `pdf_viewer` was only declared, never consumed (`pdf-modal.tsx` renders via `<webview>`). It's no longer in the schema, so future writes that include it would fail Zod validation — leave it alone or remove it from existing files manually.

## Watchpoints

- Verify on a machine with pre-existing `terminal.*` data in configuration.json that the boot migration cleanly moves the block. After first launch, terminal prefs should round-trip via the modal's Terminal section under Global Condash Settings.
- Draft → Save flow: type into a text field, click `← Back` without blurring, confirm dialog should fire; "Save and close" must persist the typed value before the modal closes.