### PR TITLE
Replace tab switcher with composite layout + edge-handle toggles

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -4,7 +4,7 @@ import { autoUpdater } from 'electron-updater';
 import { join } from 'node:path';
 
 import { detectConceptionState, initConception } from './conception-init';
-import { readSettings, settingsPath, writeSettings } from './settings';
+import { DEFAULT_LAYOUT, readSettings, settingsPath, writeSettings } from './settings';
 import { findProjectReadmes } from './walk';
 import { parseReadme } from './parse';
 import { setWatchedConception } from './watcher';
@@ -33,6 +33,7 @@ import {
 import { latestScreenshot } from './screenshot';
 import { readHelpDoc } from './help';
 import type {
+  LayoutState,
   OpenWithSlotKey,
   Project,
   StepMarker,
@@ -154,13 +155,16 @@ async function createWindow(initialPath: string | null): Promise<BrowserWindow> 
 }
 
 /**
- * Build the application menu. The toolbar in the renderer is stripped to
- * just the tab bar — every previously-toolbar action lives here as a
- * proper menu item with an accelerator. No Quit accelerator on purpose:
- * Ctrl+Q is too easy to hit by accident, and `File → Quit` routes through
- * a renderer-side confirmation modal anyway.
+ * Build the application menu. The View submenu mirrors the unified
+ * layout's pane-visibility state — Show/Hide Projects + Show/Hide
+ * Terminal as toggles, plus a three-state group (Code | Knowledge |
+ * neither) for the right-slot working surface. Pass the current layout
+ * so check marks line up with what's actually shown; rebuild the menu
+ * after any layout change so the marks refresh. No Quit accelerator on
+ * purpose: Ctrl+Q is too easy to hit by accident, and File → Quit
+ * routes through a renderer-side confirmation modal anyway.
  */
-function buildMenu(): void {
+function buildMenu(layout: LayoutState = DEFAULT_LAYOUT): void {
   const send = (command: string): void => {
     mainWindow?.webContents.send('menu-command', command);
   };
@@ -196,10 +200,36 @@ function buildMenu(): void {
 
   const viewSubmenu: MenuItemConstructorOptions[] = [
     {
+      label: 'Show Projects',
+      type: 'checkbox',
+      checked: layout.projects,
+      click: () => send('toggle-projects'),
+    },
+    {
+      label: 'Show Code',
+      type: 'checkbox',
+      checked: layout.working === 'code',
+      click: () => send('show-code'),
+    },
+    {
+      label: 'Show Knowledge',
+      type: 'checkbox',
+      checked: layout.working === 'knowledge',
+      click: () => send('show-knowledge'),
+    },
+    {
+      label: 'Hide working surface',
+      enabled: layout.working !== null,
+      click: () => send('hide-working'),
+    },
+    {
       label: 'Show Terminal',
+      type: 'checkbox',
+      checked: layout.terminal,
       accelerator: 'CommandOrControl+`',
       click: () => send('toggle-terminal'),
     },
+    { type: 'separator' },
     {
       label: 'Refresh',
       accelerator: 'F5',
@@ -394,6 +424,20 @@ function registerIpc(): void {
     await writeSettings(next);
   });
 
+  ipcMain.handle('getLayout', async () => {
+    const { layout } = await readSettings();
+    return layout ?? DEFAULT_LAYOUT;
+  });
+
+  ipcMain.handle('setLayout', async (_, layout: LayoutState) => {
+    const next = await readSettings();
+    next.layout = layout;
+    await writeSettings(next);
+    // Application menu reflects layout state — rebuild so the View
+    // submenu's check marks line up with the new state.
+    buildMenu(layout);
+  });
+
   ipcMain.handle(
     'step.toggle',
     (_, path: string, lineIndex: number, expectedMarker: StepMarker, newMarker: StepMarker) =>
@@ -481,9 +525,9 @@ app.whenReady().then(async () => {
   // the data. Runs before window creation so the renderer's first
   // term.getPrefs always sees the post-migration state.
   await migrateTerminalFromConfigIfNeeded();
-  const { conceptionPath } = await readSettings();
+  const { conceptionPath, layout } = await readSettings();
   await setWatchedConception(conceptionPath);
-  buildMenu();
+  buildMenu(layout ?? DEFAULT_LAYOUT);
   mainWindow = await createWindow(conceptionPath);
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,11 +1,23 @@
 import { app } from 'electron';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
-import type { Settings } from '../shared/types';
+import type { LayoutState, Settings } from '../shared/types';
 
 const FILE_NAME = 'settings.json';
 
-const empty: Settings = { conceptionPath: null, theme: 'system', terminal: {} };
+export const DEFAULT_LAYOUT: LayoutState = {
+  projects: true,
+  working: 'code',
+  terminal: true,
+  projectsWidth: 320,
+};
+
+const empty: Settings = {
+  conceptionPath: null,
+  theme: 'system',
+  terminal: {},
+  layout: DEFAULT_LAYOUT,
+};
 
 export function settingsPath(): string {
   return join(app.getPath('userData'), FILE_NAME);
@@ -16,7 +28,13 @@ export async function readSettings(): Promise<Settings> {
   try {
     const raw = await fs.readFile(settingsPath(), 'utf8');
     const parsed = JSON.parse(raw) as Partial<Settings>;
-    onDisk = { ...empty, ...parsed };
+    // Layout is an object — shallow-merge with the default so an older
+    // settings file that lacks a freshly-added field still resolves.
+    onDisk = {
+      ...empty,
+      ...parsed,
+      layout: { ...DEFAULT_LAYOUT, ...(parsed.layout ?? {}) },
+    };
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') onDisk = { ...empty };
     else throw err;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -20,6 +20,8 @@ const api: CondashApi = {
   initConception: (path) => ipcRenderer.invoke('initConception', path),
   getTheme: () => ipcRenderer.invoke('getTheme'),
   setTheme: (theme) => ipcRenderer.invoke('setTheme', theme),
+  getLayout: () => ipcRenderer.invoke('getLayout'),
+  setLayout: (layout) => ipcRenderer.invoke('setLayout', layout),
   getSettingsPath: () => ipcRenderer.invoke('getSettingsPath'),
   toggleStep: (path, lineIndex, expectedMarker, newMarker) =>
     ipcRenderer.invoke('step.toggle', path, lineIndex, expectedMarker, newMarker),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -10,6 +10,7 @@ import {
 } from 'solid-js';
 import type {
   Deliverable,
+  LayoutState,
   OpenWithSlotKey,
   OpenWithSlots,
   Project,
@@ -18,6 +19,7 @@ import type {
   TermSession,
   TerminalPrefs,
   Theme,
+  WorkingSurface,
   Worktree,
 } from '@shared/types';
 import { NoteModal, type ModalState } from './note-modal';
@@ -43,7 +45,7 @@ import { matchesShortcut, parseShortcut } from './keymap';
 import { createModalRouter } from './modal-router';
 import { createTerminalBridge } from './terminal-bridge';
 import { applyTreeEvents } from './tree-events';
-import { QuitConfirmModal, type Tab, Toolbar } from './toolbar';
+import { QuitConfirmModal } from './toolbar';
 import { AboutModal } from './about-modal';
 import './styles.css';
 import './modals.css';
@@ -64,19 +66,22 @@ function App() {
   const [refreshKey, setRefreshKey] = createSignal(0);
   const [theme, setTheme] = createSignal<Theme>('system');
   const [toast, setToast] = createSignal<string | null>(null);
-  const [tab, setTab] = createSignal<Tab>('projects');
+  // Composite-layout state — replaces the prior single-`tab` selector.
+  // Default mirrors the persisted server-side default until the real
+  // value loads (avoids a frame of empty UI).
+  const [layout, setLayoutState] = createSignal<LayoutState>({
+    projects: true,
+    working: 'code',
+    terminal: true,
+    projectsWidth: 320,
+  });
   const [modal, setModal] = createSignal<ModalState>(null);
   const [previewPath, setPreviewPath] = createSignal<string | null>(null);
   const [pdfPath, setPdfPath] = createSignal<string | null>(null);
   const [helpDoc, setHelpDoc] = createSignal<HelpDoc | null>(null);
-  const [terminalOpen, setTerminalOpen] = createSignal(false);
   const [searchModalOpen, setSearchModalOpen] = createSignal(false);
   const [settingsOpen, setSettingsOpen] = createSignal(false);
   const [aboutOpen, setAboutOpen] = createSignal(false);
-  // Shared search input — owned here so the Toolbar (which renders the
-  // box) and the active tab view (which consumes the value) read from one
-  // place. Empty value → tabs render their default grouped layout.
-  const [searchInput, setSearchInput] = createSignal('');
   const [quitConfirmOpen, setQuitConfirmOpen] = createSignal(false);
   const [promptState, setPromptState] = createSignal<PromptModalState | null>(null);
 
@@ -96,6 +101,22 @@ function App() {
     setTheme(t);
     applyTheme(t);
   });
+  void window.condash.getLayout().then(setLayoutState);
+
+  /** Apply a layout patch and persist it. The persistence is fire-and-
+   * forget: any settings.json write failure surfaces as a toast but the
+   * UI state is the source of truth for the session. */
+  const updateLayout = (patch: Partial<LayoutState>): void => {
+    const next = { ...layout(), ...patch };
+    setLayoutState(next);
+    void window.condash.setLayout(next).catch((err) => {
+      flashToast(`Could not persist layout: ${(err as Error).message}`);
+    });
+  };
+
+  const toggleProjects = (): void => updateLayout({ projects: !layout().projects });
+  const toggleTerminal = (): void => updateLayout({ terminal: !layout().terminal });
+  const selectWorking = (next: WorkingSurface): void => updateLayout({ working: next });
 
   const unsubscribe = window.condash.onTreeEvents((events) => {
     void applyTreeEvents(events, {
@@ -156,17 +177,17 @@ function App() {
   );
 
   const [knowledge] = createResource(
-    () => [conceptionPath(), refreshKey(), tab()] as const,
-    async ([path, , currentTab]) => {
-      if (!path || currentTab !== 'knowledge') return null;
+    () => [conceptionPath(), refreshKey(), layout().working] as const,
+    async ([path, , working]) => {
+      if (!path || working !== 'knowledge') return null;
       return window.condash.readKnowledgeTree();
     },
   );
 
   const [repos] = createResource(
-    () => [conceptionPath(), refreshKey(), tab()] as const,
-    async ([path, , currentTab]) => {
-      if (!path || currentTab !== 'code') return [] as RepoEntry[];
+    () => [conceptionPath(), refreshKey(), layout().working] as const,
+    async ([path, , working]) => {
+      if (!path || working !== 'code') return [] as RepoEntry[];
       return window.condash.listRepos();
     },
   );
@@ -190,7 +211,7 @@ function App() {
   );
 
   const ensureTerminalOpen = (): void => {
-    if (!terminalOpen()) setTerminalOpen(true);
+    if (!layout().terminal) updateLayout({ terminal: true });
   };
 
   const router = createModalRouter({
@@ -250,12 +271,12 @@ function App() {
     const toggle = parseShortcut(prefs.shortcut ?? 'Ctrl+`');
     if (matchesShortcut(event, toggle)) {
       event.preventDefault();
-      setTerminalOpen((v) => !v);
+      toggleTerminal();
       return;
     }
 
     // Move-tab shortcuts only fire when the pane is open.
-    if (!terminalOpen() || !terminalHandle) return;
+    if (!layout().terminal || !terminalHandle) return;
     const left = parseShortcut(prefs.move_tab_left_shortcut ?? 'Ctrl+Left');
     const right = parseShortcut(prefs.move_tab_right_shortcut ?? 'Ctrl+Right');
     if (matchesShortcut(event, left)) {
@@ -307,7 +328,23 @@ function App() {
       return;
     }
     if (command === 'toggle-terminal') {
-      setTerminalOpen((v) => !v);
+      toggleTerminal();
+      return;
+    }
+    if (command === 'toggle-projects') {
+      toggleProjects();
+      return;
+    }
+    if (command === 'show-code') {
+      selectWorking(layout().working === 'code' ? null : 'code');
+      return;
+    }
+    if (command === 'show-knowledge') {
+      selectWorking(layout().working === 'knowledge' ? null : 'knowledge');
+      return;
+    }
+    if (command === 'hide-working') {
+      selectWorking(null);
       return;
     }
     if (command === 'refresh') {
@@ -556,91 +593,221 @@ function App() {
     }
   };
 
+  // The top band visibility is "any of the three top-band panes is on"
+  // — when all three are off, only the Terminal renders, and the top
+  // band collapses entirely.
+  const topBandVisible = (): boolean => layout().projects || layout().working !== null;
+
+  // Grid columns inside the top band. Three states:
+  //   - both Projects and working surface visible: split with the user-
+  //     resizable Projects width on the left.
+  //   - one of them hidden: the other fills.
+  //   - none visible: top band is collapsed (handled at the wrapper).
+  const topBandStyle = (): Record<string, string> => {
+    const l = layout();
+    if (l.projects && l.working !== null) {
+      return { 'grid-template-columns': `${l.projectsWidth}px 4px 1fr` };
+    }
+    return { 'grid-template-columns': '1fr' };
+  };
+
+  // Drag the Projects ↔ working-surface splitter. We resize against the
+  // top-band element's left edge, clamped to a sensible range so the
+  // user can't drag a pane below its minimum visible width.
+  let topBandRef: HTMLDivElement | undefined;
+  const startSplitterDrag = (event: MouseEvent): void => {
+    if (!topBandRef) return;
+    event.preventDefault();
+    const rect = topBandRef.getBoundingClientRect();
+    const min = 160;
+    const onMove = (e: MouseEvent): void => {
+      const desired = e.clientX - rect.left;
+      const clamped = Math.max(min, Math.min(rect.width - min - 4, desired));
+      updateLayout({ projectsWidth: Math.round(clamped) });
+    };
+    const onUp = (): void => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  };
+
+  const onCodeHandleClick = (): void => {
+    selectWorking(layout().working === 'code' ? null : 'code');
+  };
+  const onKnowledgeHandleClick = (): void => {
+    selectWorking(layout().working === 'knowledge' ? null : 'knowledge');
+  };
+  const handlesEnabled = (): boolean => !!conceptionPath();
+
   return (
     <div class="app">
-      <Toolbar
-        tab={tab()}
-        conceptionPath={conceptionPath()}
-        searchValue={searchInput()}
-        onSearchInput={setSearchInput}
-        onTabChange={setTab}
+      <div class="workspace">
+        {/* Left strip — Projects handle. Always visible so a hidden
+            pane can be summoned back. Disabled until a conception path
+            is picked, since there is no Projects content to show. */}
+        <aside class="edge-strip edge-strip-left">
+          <button
+            class="edge-handle edge-handle-vertical"
+            classList={{ active: layout().projects }}
+            aria-pressed={layout().projects}
+            onClick={toggleProjects}
+            disabled={!handlesEnabled()}
+            title={layout().projects ? 'Hide Projects' : 'Show Projects'}
+          >
+            <span class="edge-handle-label">Projects</span>
+          </button>
+        </aside>
+
+        <div class="workspace-center">
+          <Show
+            when={conceptionPath()}
+            fallback={
+              <div class="empty">
+                <p>Pick a conception directory to list its projects.</p>
+                <button onClick={handlePick}>Choose folder…</button>
+              </div>
+            }
+          >
+            <Show when={topBandVisible()}>
+              <div class="top-band" ref={(el) => (topBandRef = el)} style={topBandStyle()}>
+                <Show when={layout().projects}>
+                  <section class="pane pane-projects">
+                    <Suspense fallback={<div class="empty">Loading…</div>}>
+                      <Show
+                        when={(projects() ?? []).length > 0}
+                        fallback={<div class="empty">No projects found under projects/.</div>}
+                      >
+                        <ProjectsView
+                          buckets={groupByStatus(projects() ?? [])}
+                          searchInput=""
+                          onOpen={handleOpenProject}
+                          onToggleStep={handleToggleStep}
+                          onDropProject={handleDropOnColumn}
+                          onWorkOn={(p) => void bridge.handleWorkOn(p)}
+                        />
+                      </Show>
+                    </Suspense>
+                  </section>
+                </Show>
+
+                <Show when={layout().projects && layout().working !== null}>
+                  <div
+                    class="top-band-splitter"
+                    onMouseDown={startSplitterDrag}
+                    title="Drag to resize"
+                  />
+                </Show>
+
+                <Show when={layout().working === 'knowledge'}>
+                  <section class="pane pane-working">
+                    <Suspense fallback={<div class="empty">Loading…</div>}>
+                      <Show
+                        when={knowledge()}
+                        fallback={
+                          <div class="empty">
+                            No knowledge/ directory under the selected conception path.
+                          </div>
+                        }
+                      >
+                        <KnowledgeView
+                          root={knowledge()!}
+                          searchInput=""
+                          onOpen={handleOpenKnowledgeFile}
+                        />
+                      </Show>
+                    </Suspense>
+                  </section>
+                </Show>
+
+                <Show when={layout().working === 'code'}>
+                  <section class="pane pane-working">
+                    <Suspense fallback={<div class="empty">Loading…</div>}>
+                      <Show
+                        when={(repos() ?? []).length > 0}
+                        fallback={
+                          <div class="empty">
+                            No repositories listed. Add <code>repositories.primary</code> /{' '}
+                            <code>secondary</code> to <code>configuration.json</code> via the gear.
+                          </div>
+                        }
+                      >
+                        <CodeView
+                          repos={repos() ?? []}
+                          groups={repoGroups()}
+                          slots={openWithSlots() ?? {}}
+                          liveRepos={liveRepos()}
+                          liveSessionCwds={liveSessionCwds()}
+                          codeRunSessions={codeRunSessions()}
+                          xtermPrefs={terminalPrefs()?.xterm}
+                          onOpen={handleOpenInEditor}
+                          onLaunch={(slot, path) => void handleLaunch(slot, path)}
+                          onForceStop={(r) => void handleForceStop(r)}
+                          onStop={handleStopRepo}
+                          onRun={(r, wt) => void handleRunRepo(r, wt)}
+                          onOpenInTerm={(r, wt) => void bridge.handleOpenInTerm(r, wt)}
+                          onCloseSession={(id) => void window.condash.termClose(id)}
+                        />
+                      </Show>
+                    </Suspense>
+                  </section>
+                </Show>
+              </div>
+            </Show>
+          </Show>
+        </div>
+
+        {/* Right strip — Code + Knowledge handles. Mutually exclusive
+            in the working-surface slot; clicking the active one hides
+            the slot, clicking the other swaps. */}
+        <aside class="edge-strip edge-strip-right">
+          <button
+            class="edge-handle edge-handle-vertical"
+            classList={{ active: layout().working === 'code' }}
+            aria-pressed={layout().working === 'code'}
+            onClick={onCodeHandleClick}
+            disabled={!handlesEnabled()}
+            title={layout().working === 'code' ? 'Hide Code' : 'Show Code'}
+          >
+            <span class="edge-handle-label">Code</span>
+          </button>
+          <button
+            class="edge-handle edge-handle-vertical"
+            classList={{ active: layout().working === 'knowledge' }}
+            aria-pressed={layout().working === 'knowledge'}
+            onClick={onKnowledgeHandleClick}
+            disabled={!handlesEnabled()}
+            title={layout().working === 'knowledge' ? 'Hide Knowledge' : 'Show Knowledge'}
+          >
+            <span class="edge-handle-label">Knowledge</span>
+          </button>
+        </aside>
+      </div>
+
+      {/* TerminalPane is always mounted at full window width, below the
+          workspace row. Its own tab strip carries the persistent
+          Terminal handle on the left — clicking the handle toggles
+          the body open/closed. When closed, only the strip remains
+          visible (height collapses to the strip height); when open,
+          the body grows to its persisted height above the strip. The
+          left / right edge strips above end where this pane begins,
+          so the bottom band is genuinely full width. */}
+      <TerminalPane
+        open={layout().terminal}
+        onClose={() => updateLayout({ terminal: false })}
+        onTogglePane={toggleTerminal}
+        launcherCommand={terminalPrefs()?.launcher_command ?? null}
+        cwd={conceptionPath()}
+        xtermPrefs={terminalPrefs()?.xterm}
+        registerHandle={(handle) => {
+          terminalHandle = handle;
+        }}
       />
-
-      <Show
-        when={conceptionPath()}
-        fallback={
-          <div class="empty">
-            <p>Pick a conception directory to list its projects.</p>
-            <button onClick={handlePick}>Choose folder…</button>
-          </div>
-        }
-      >
-        <Show when={tab() === 'projects'}>
-          <Suspense fallback={<div class="empty">Loading…</div>}>
-            <Show
-              when={(projects() ?? []).length > 0}
-              fallback={<div class="empty">No projects found under projects/.</div>}
-            >
-              <ProjectsView
-                buckets={groupByStatus(projects() ?? [])}
-                searchInput={searchInput()}
-                onOpen={handleOpenProject}
-                onToggleStep={handleToggleStep}
-                onDropProject={handleDropOnColumn}
-                onWorkOn={(p) => void bridge.handleWorkOn(p)}
-              />
-            </Show>
-          </Suspense>
-        </Show>
-
-        <Show when={tab() === 'knowledge'}>
-          <Suspense fallback={<div class="empty">Loading…</div>}>
-            <Show
-              when={knowledge()}
-              fallback={
-                <div class="empty">No knowledge/ directory under the selected conception path.</div>
-              }
-            >
-              <KnowledgeView
-                root={knowledge()!}
-                searchInput={searchInput()}
-                onOpen={handleOpenKnowledgeFile}
-              />
-            </Show>
-          </Suspense>
-        </Show>
-
-        <Show when={tab() === 'code'}>
-          <Suspense fallback={<div class="empty">Loading…</div>}>
-            <Show
-              when={(repos() ?? []).length > 0}
-              fallback={
-                <div class="empty">
-                  No repositories listed. Add <code>repositories.primary</code> /{' '}
-                  <code>secondary</code> to <code>configuration.json</code> via the gear.
-                </div>
-              }
-            >
-              <CodeView
-                repos={repos() ?? []}
-                groups={repoGroups()}
-                slots={openWithSlots() ?? {}}
-                liveRepos={liveRepos()}
-                liveSessionCwds={liveSessionCwds()}
-                codeRunSessions={codeRunSessions()}
-                xtermPrefs={terminalPrefs()?.xterm}
-                onOpen={handleOpenInEditor}
-                onLaunch={(slot, path) => void handleLaunch(slot, path)}
-                onForceStop={(r) => void handleForceStop(r)}
-                onStop={handleStopRepo}
-                onRun={(r, wt) => void handleRunRepo(r, wt)}
-                onOpenInTerm={(r, wt) => void bridge.handleOpenInTerm(r, wt)}
-                onCloseSession={(id) => void window.condash.termClose(id)}
-              />
-            </Show>
-          </Suspense>
-        </Show>
-      </Show>
 
       <ProjectPreview
         project={previewProject()}
@@ -688,17 +855,6 @@ function App() {
           onOpenInOs={handleOpenInEditor}
         />
       </Show>
-
-      <TerminalPane
-        open={terminalOpen()}
-        onClose={() => setTerminalOpen(false)}
-        launcherCommand={terminalPrefs()?.launcher_command ?? null}
-        cwd={conceptionPath()}
-        xtermPrefs={terminalPrefs()?.xterm}
-        registerHandle={(handle) => {
-          terminalHandle = handle;
-        }}
-      />
 
       <Show when={searchModalOpen()}>
         <SearchModal

--- a/src/renderer/modals.css
+++ b/src/renderer/modals.css
@@ -38,6 +38,61 @@
   min-height: 0;
 }
 
+/* Source filter — pill-row that lets the user narrow results to
+ * Projects only, Knowledge only, or All. Sits between the search input
+ * and the result list. Counts on each pill always reflect the
+ * unfiltered result set, so the user can see what each option would
+ * yield without committing to it. */
+.search-source-filter {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 14px 8px;
+  flex-wrap: wrap;
+}
+
+.search-source-pill {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 4px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.search-source-pill:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.search-source-pill.active {
+  background: var(--bg-elevated);
+  color: var(--text);
+  border-color: var(--border-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.search-source-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0;
+  color: var(--text-faint);
+  text-transform: none;
+}
+
 .search-modal-body .search-results {
   overflow-y: auto;
   max-height: 64vh;

--- a/src/renderer/search-modal.tsx
+++ b/src/renderer/search-modal.tsx
@@ -27,6 +27,12 @@ const EMPTY_RESULTS: SearchResults = { hits: [], terms: [], totalBeforeCap: 0, t
  * references (declaring them inside SearchModal means each render call
  * re-creates the function identity, which trips Solid's reactive tracking).
  */
+/** Which source bucket(s) to surface in the result list. `all` shows
+ * both — projects (with their notes) and knowledge files. The pill
+ * filter sits on the search modal header. The backend doesn't know
+ * about the filter; we just hide non-matching buckets in the UI. */
+type SourceFilter = 'all' | 'projects' | 'knowledge';
+
 export function SearchModal(props: {
   onClose: () => void;
   onOpenProject: (projectPath: string) => void;
@@ -34,6 +40,7 @@ export function SearchModal(props: {
 }) {
   const [input, setInput] = createSignal('');
   const [query, setQuery] = createSignal('');
+  const [sourceFilter, setSourceFilter] = createSignal<SourceFilter>('all');
   let inputEl: HTMLInputElement | undefined;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -45,6 +52,26 @@ export function SearchModal(props: {
   const grouped = createMemo(() => groupHits(results()?.hits ?? []));
   const truncated = createMemo(() => !!results()?.truncated);
   const totalBeforeCap = createMemo(() => results()?.totalBeforeCap ?? 0);
+
+  // Counts shown on the filter pills — derived from the unfiltered
+  // groups so each pill always reflects "how many hits I'd see if I
+  // picked this filter," even while a different one is selected.
+  const projectCount = createMemo(() =>
+    grouped().projects.reduce((acc, g) => acc + 1 + g.files.length, 0),
+  );
+  const knowledgeCount = createMemo(() => grouped().knowledge.length);
+  const totalCount = createMemo(() => projectCount() + knowledgeCount());
+
+  const showProjects = (): boolean => sourceFilter() === 'all' || sourceFilter() === 'projects';
+  const showKnowledge = (): boolean => sourceFilter() === 'all' || sourceFilter() === 'knowledge';
+
+  // Visible-results count under the active filter — drives the
+  // "no matches in this source" empty state.
+  const visibleCount = createMemo(() => {
+    if (sourceFilter() === 'projects') return projectCount();
+    if (sourceFilter() === 'knowledge') return knowledgeCount();
+    return totalCount();
+  });
 
   const onInput = (value: string): void => {
     setInput(value);
@@ -104,23 +131,67 @@ export function SearchModal(props: {
             ×
           </button>
         </header>
+        <Show when={input().trim().length > 0}>
+          <div class="search-source-filter" role="radiogroup" aria-label="Filter by source">
+            <button
+              class="search-source-pill"
+              classList={{ active: sourceFilter() === 'all' }}
+              role="radio"
+              aria-checked={sourceFilter() === 'all'}
+              onClick={() => setSourceFilter('all')}
+            >
+              All <span class="search-source-count">{totalCount()}</span>
+            </button>
+            <button
+              class="search-source-pill"
+              classList={{ active: sourceFilter() === 'projects' }}
+              role="radio"
+              aria-checked={sourceFilter() === 'projects'}
+              onClick={() => setSourceFilter('projects')}
+            >
+              Projects <span class="search-source-count">{projectCount()}</span>
+            </button>
+            <button
+              class="search-source-pill"
+              classList={{ active: sourceFilter() === 'knowledge' }}
+              role="radio"
+              aria-checked={sourceFilter() === 'knowledge'}
+              onClick={() => setSourceFilter('knowledge')}
+            >
+              Knowledge <span class="search-source-count">{knowledgeCount()}</span>
+            </button>
+          </div>
+        </Show>
         <div class="search-modal-body">
           <Show when={input().trim().length > 0} fallback={<SearchTips />}>
             <Suspense fallback={<div class="empty">Searching…</div>}>
-              <Show when={grouped().total > 0} fallback={<div class="empty">No matches.</div>}>
+              <Show
+                when={visibleCount() > 0}
+                fallback={
+                  <div class="empty">
+                    {grouped().total === 0
+                      ? 'No matches.'
+                      : `No matches in ${sourceFilter() === 'projects' ? 'projects' : 'knowledge'}.`}
+                  </div>
+                }
+              >
                 <ul class="search-results search-results-grouped">
-                  <For each={grouped().projects}>
-                    {(g) => (
-                      <ProjectGroupRow
-                        group={g}
-                        onOpenProject={openProjectAndClose}
-                        onOpenFile={openFileAndClose}
-                      />
-                    )}
-                  </For>
-                  <For each={grouped().knowledge}>
-                    {(hit) => <FileResultRow hit={hit} onOpen={openFileAndClose} />}
-                  </For>
+                  <Show when={showProjects()}>
+                    <For each={grouped().projects}>
+                      {(g) => (
+                        <ProjectGroupRow
+                          group={g}
+                          onOpenProject={openProjectAndClose}
+                          onOpenFile={openFileAndClose}
+                        />
+                      )}
+                    </For>
+                  </Show>
+                  <Show when={showKnowledge()}>
+                    <For each={grouped().knowledge}>
+                      {(hit) => <FileResultRow hit={hit} onOpen={openFileAndClose} />}
+                    </For>
+                  </Show>
                 </ul>
                 <Show when={truncated()}>
                   <div class="search-truncated-hint">

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -251,6 +251,150 @@ button:hover {
   height: 100%;
 }
 
+/* Workspace — flex row holding the left edge strip, the center stack
+ * (top band + TerminalPane + bottom strip), and the right edge strip.
+ * Edge strips host the persistent pane handles; the center hosts the
+ * actual content. */
+.workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  min-height: 0;
+}
+
+.workspace-center {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Edge strip — narrow always-visible bar that hosts one or two pane
+ * handles. The handle is a vertical (or horizontal for the bottom)
+ * button doubling as a label and a toggle. Always present so a hidden
+ * pane can be summoned back. */
+.edge-strip {
+  display: flex;
+  background: var(--bg-elevated);
+  flex-shrink: 0;
+}
+
+.edge-strip-left,
+.edge-strip-right {
+  width: 28px;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 8px 0;
+  gap: 4px;
+}
+
+.edge-strip-left {
+  border-right: 1px solid var(--border);
+}
+
+.edge-strip-right {
+  border-left: 1px solid var(--border);
+}
+
+/* Edge handle — the clickable badge inside an edge strip. Carries the
+ * pane name as vertical text on the side strips; horizontal text on
+ * the bottom strip. Active state mirrors the toolbar's old pill style:
+ * elevated background + strong border. */
+.edge-handle {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  padding: 6px 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
+}
+
+.edge-handle:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.edge-handle.active {
+  background: var(--bg);
+  color: var(--text);
+  border-color: var(--border-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+}
+
+.edge-handle:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Vertical handles (left + right edges) — text reads top-to-bottom.
+ * Sized to fill the strip width minus a few pixels of breathing room. */
+.edge-handle-vertical {
+  width: 100%;
+  flex: 0 0 auto;
+  padding: 8px 0;
+}
+
+.edge-handle-vertical .edge-handle-label {
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+/* Unified-layout top band — Projects + working surface (Code or
+ * Knowledge), side-by-side. The grid template is set inline from the
+ * persisted Projects width when both panes are visible; with one pane
+ * hidden it collapses to a single column. The band itself only renders
+ * when at least one of its panes is on; otherwise TerminalPane below
+ * fills the window. */
+.top-band {
+  flex: 1;
+  display: grid;
+  min-height: 0;
+  /* grid-template-columns set inline — see topBandStyle() in main.tsx. */
+}
+
+/* Vertical handle between Projects and the working surface. The same
+ * pattern as .terminal-splitter (col-resize, accent-on-hover) so the two
+ * resizers feel related. */
+.top-band-splitter {
+  cursor: col-resize;
+  background: var(--border);
+  transition: background 100ms ease;
+}
+
+.top-band-splitter:hover {
+  background: var(--accent);
+}
+
+/* Common pane wrapper. Each pane manages its own internal scroll; the
+ * wrapper just provides a flex column with min-height: 0 so children
+ * can shrink properly inside the grid cell. */
+.pane {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg);
+}
+
+.pane-projects {
+  border-right: 1px solid var(--border);
+}
+
 .toolbar {
   display: flex;
   align-items: center;

--- a/src/renderer/terminal-pane.css
+++ b/src/renderer/terminal-pane.css
@@ -9,14 +9,16 @@
   /* Height controlled inline via the resize handle. */
 }
 
-/* Mounted-but-collapsed state: the pane stays in the DOM (so renderer-level
- * spawn handlers always have a TerminalPaneHandle) but takes no height and
- * is invisible. */
+/* Closed state — the body collapses but the tab strip stays visible
+ * (carrying the persistent Terminal handle, the spawn buttons, and
+ * the live tabs). The whole pane shrinks to the strip's natural
+ * height (~32px), so the strip behaves as a permanent bottom bar
+ * with the same component as when the pane is expanded. */
 .terminal-pane.closed {
-  height: 0 !important;
-  border-top: none;
-  visibility: hidden;
-  pointer-events: none;
+  height: auto !important;
+}
+.terminal-pane.closed .terminal-host {
+  display: none;
 }
 
 .terminal-pane-resize {
@@ -34,29 +36,48 @@
   background: color-mix(in srgb, var(--accent) 30%, transparent);
 }
 
-.terminal-pane-close {
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  z-index: 3;
-  width: 22px;
+/* "Terminal" pill — sits inline at the left of the tab strip, in the
+ * left column only. Acts as the persistent toggle for the pane: when
+ * the pane is closed, the strip is the only thing visible at the
+ * bottom of the window and clicking the pill expands the body; when
+ * open, clicking the pill collapses the body. Active styling marks
+ * the pill while the body is showing. Matches the Projects / Code /
+ * Knowledge edge handles in shape. */
+.terminal-pane-handle {
+  flex-shrink: 0;
   height: 22px;
+  padding: 0 12px;
   border: 1px solid var(--border);
-  border-radius: 4px;
+  border-radius: var(--radius);
   background: var(--bg);
   color: var(--text-muted);
-  font-size: 14px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   line-height: 1;
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  margin-right: 4px;
+  transition:
+    background 120ms ease,
+    color 120ms ease,
+    border-color 120ms ease;
 }
 
-.terminal-pane-close:hover {
+.terminal-pane-handle:hover {
   background: var(--bg-hover);
   color: var(--text);
+}
+
+.terminal-pane-handle.active {
+  background: var(--bg-elevated);
+  color: var(--text);
   border-color: var(--border-strong);
+  box-shadow: inset 0 0 0 1px var(--border-strong);
 }
 
 .terminal-columns {

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -56,6 +56,9 @@ export interface TerminalPaneHandle {
 export function TerminalPane(props: {
   open: boolean;
   onClose: () => void;
+  /** Toggle the pane open / closed. Used by the in-strip Terminal
+   *  handle which is visible whether the body is shown or not. */
+  onTogglePane: () => void;
   registerHandle: (handle: TerminalPaneHandle | null) => void;
   /** Optional launcher command (e.g. `claude`). When set, a second `+` button
    * spawns a shell that runs this command. */
@@ -451,6 +454,7 @@ export function TerminalPane(props: {
       isActiveColumn={activeColumn() === col}
       renamingId={renamingId()}
       launcherCommand={props.launcherCommand}
+      paneOpen={props.open}
       dnd={dnd}
       registerHost={(c, el) => {
         if (c === 'left') leftHost = el;
@@ -478,6 +482,7 @@ export function TerminalPane(props: {
         setActiveColumn(c);
         search.openSearch();
       }}
+      onTogglePane={() => props.onTogglePane()}
     />
   );
 
@@ -489,19 +494,13 @@ export function TerminalPane(props: {
       classList={{ closed: !props.open }}
       style={{ height: `${paneHeight()}px` }}
     >
-      <div
-        class="terminal-pane-resize"
-        onMouseDown={(e) => resize.startHeightDrag(e)}
-        title="Drag to resize"
-      />
-      <button
-        class="terminal-pane-close"
-        onClick={props.onClose}
-        title="Close pane"
-        aria-label="Close pane"
-      >
-        ×
-      </button>
+      <Show when={props.open}>
+        <div
+          class="terminal-pane-resize"
+          onMouseDown={(e) => resize.startHeightDrag(e)}
+          title="Drag to resize"
+        />
+      </Show>
       <div
         class="terminal-columns"
         ref={(el) => (columnsRoot = el)}

--- a/src/renderer/terminal-pane/column.tsx
+++ b/src/renderer/terminal-pane/column.tsx
@@ -11,6 +11,9 @@ export interface TerminalColumnProps {
   /** Optional launcher command (when set, the column gets a second `+`
    *  button labelled with the command name, e.g. `claude`). */
   launcherCommand?: string | null;
+  /** True when the surrounding pane is currently visible. Drives the
+   *  active state of the in-strip Terminal handle. */
+  paneOpen: boolean;
   dnd: DragDropController;
   /** Refs for the xterm host (one per column; the parent stashes them so
    *  it can re-parent xterm elements on column moves). */
@@ -24,6 +27,10 @@ export interface TerminalColumnProps {
   onSpawnShell: (col: Column, launcher: boolean) => void;
   onSaveBuffer: (col: Column) => void;
   onOpenSearch: (col: Column) => void;
+  /** Toggle the pane open/closed. The Terminal handle in the strip
+   *  fires this. Only the left column renders the handle, so the pane
+   *  has exactly one toggle regardless of split state. */
+  onTogglePane: () => void;
 }
 
 /** One column of the bottom terminal pane: tab strip on top + xterm host
@@ -46,6 +53,23 @@ export function TerminalColumn(props: TerminalColumnProps) {
         onDrop={(e) => props.dnd.onDropOnStrip(e, props.col)}
         onClick={() => props.onActivateColumn(props.col)}
       >
+        {/* Terminal handle — only in the left column so the pane has
+         *  one toggle regardless of split state. Doubles as both
+         *  open-pane and hide-pane (active when open). */}
+        <Show when={props.col === 'left'}>
+          <button
+            class="terminal-pane-handle"
+            classList={{ active: props.paneOpen }}
+            aria-pressed={props.paneOpen}
+            onClick={(e) => {
+              e.stopPropagation();
+              props.onTogglePane();
+            }}
+            title={props.paneOpen ? 'Hide Terminal' : 'Show Terminal'}
+          >
+            Terminal
+          </button>
+        </Show>
         <For each={props.tabs}>
           {(tab) => (
             <div

--- a/src/renderer/toolbar.tsx
+++ b/src/renderer/toolbar.tsx
@@ -1,59 +1,33 @@
 import { Show } from 'solid-js';
+import type { LayoutState } from '@shared/types';
 import './toolbar.css';
 
-export type Tab = 'projects' | 'knowledge' | 'code';
-
-/** Top-of-window toolbar — tab buttons + the search input for the active
- * tab (Projects / Knowledge only).
+/** Top-of-window toolbar — only the search input now.
  *
- * Other actions (Show Terminal, Refresh, Settings, Open conception
- * folder, About / Help docs) live in the application menu now. The
- * toolbar's job is workspace navigation + the per-tab search box. */
+ * Pane visibility is toggled from the edge handles around the workspace
+ * (see `.edge-strip-*` in main.tsx). The toolbar's job is the per-pane
+ * search box; placeholder text adapts to whichever searchable panes are
+ * visible (Projects and / or Knowledge). */
 export function Toolbar(props: {
-  tab: Tab;
+  layout: LayoutState;
   conceptionPath: string | null;
   searchValue: string;
   onSearchInput: (value: string) => void;
-  onTabChange: (tab: Tab) => void;
 }) {
-  const placeholder = (): string => {
-    if (props.tab === 'projects')
-      return 'Search projects — multi-word AND, "phrases" stay together';
-    if (props.tab === 'knowledge')
-      return 'Search knowledge — multi-word AND, "phrases" stay together';
-    return '';
-  };
   const showSearch = (): boolean =>
-    !!props.conceptionPath && (props.tab === 'projects' || props.tab === 'knowledge');
+    !!props.conceptionPath && (props.layout.projects || props.layout.working === 'knowledge');
+
+  const placeholder = (): string => {
+    const tokens: string[] = [];
+    if (props.layout.projects) tokens.push('projects');
+    if (props.layout.working === 'knowledge') tokens.push('knowledge');
+    if (tokens.length === 0) return '';
+    return `Search ${tokens.join(' + ')} — multi-word AND, "phrases" stay together`;
+  };
 
   return (
     <header class="toolbar">
-      <nav class="tabs main-tabs">
-        <button
-          class="tab"
-          classList={{ active: props.tab === 'projects' }}
-          onClick={() => props.onTabChange('projects')}
-        >
-          Projects
-        </button>
-        <button
-          class="tab"
-          classList={{ active: props.tab === 'code' }}
-          onClick={() => props.onTabChange('code')}
-          disabled={!props.conceptionPath}
-        >
-          Code
-        </button>
-        <button
-          class="tab"
-          classList={{ active: props.tab === 'knowledge' }}
-          onClick={() => props.onTabChange('knowledge')}
-          disabled={!props.conceptionPath}
-        >
-          Knowledge
-        </button>
-      </nav>
-      <Show when={showSearch()}>
+      <Show when={showSearch()} fallback={<div class="toolbar-spacer" />}>
         <input
           class="toolbar-search"
           type="search"

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2,6 +2,7 @@ import type {
   ConceptionInitState,
   DirtyDetails,
   KnowledgeNode,
+  LayoutState,
   OpenWithSlotKey,
   OpenWithSlots,
   Project,
@@ -44,6 +45,10 @@ export interface CondashApi {
   initConception(path: string): Promise<{ created: string[] }>;
   getTheme(): Promise<Theme>;
   setTheme(theme: Theme): Promise<void>;
+  /** Composite-layout state (which panes are shown + their sizes).
+   * Persisted in the global per-machine settings.json. */
+  getLayout(): Promise<LayoutState>;
+  setLayout(layout: LayoutState): Promise<void>;
   /** Absolute path to `~/.config/condash/settings.json` (or platform equivalent),
    * for the settings modal's "Open externally" button. */
   getSettingsPath(): Promise<string>;
@@ -129,7 +134,11 @@ export type MenuCommand =
   | 'open-conception'
   | 'open-settings'
   | 'request-quit'
+  | 'toggle-projects'
   | 'toggle-terminal'
+  | 'show-code'
+  | 'show-knowledge'
+  | 'hide-working'
   | 'refresh'
   | 'about'
   | 'help-architecture'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -63,12 +63,35 @@ export interface ProjectFileEntry {
 
 export type Theme = 'light' | 'dark' | 'system';
 
+/** Right-slot working surface — picks which of Code / Knowledge is shown
+ * in the top-band right pane, or `null` to leave it hidden. The two are
+ * mutually exclusive: showing one swaps the other out. */
+export type WorkingSurface = 'code' | 'knowledge' | null;
+
+/** Composite-layout state. The unified window has a top band (Projects on
+ * the left, working surface on the right) and a bottom band (Terminal).
+ * Each band can be hidden independently; the working surface is also
+ * tristate. Sizes are persisted alongside visibility so re-showing a pane
+ * restores its previous dimensions. */
+export interface LayoutState {
+  projects: boolean;
+  /** Code / Knowledge / hidden — single right-slot tristate. */
+  working: WorkingSurface;
+  terminal: boolean;
+  /** Width of the Projects pane in CSS pixels when both Projects and the
+   * working surface are visible. The working surface fills the rest. */
+  projectsWidth: number;
+}
+
 export interface Settings {
   conceptionPath: string | null;
   theme: Theme;
   /** Per-machine terminal prefs. Moved here from configuration.json so each
    * laptop carries its own font/screenshot/keybinding choices. */
   terminal?: TerminalPrefs;
+  /** Composite-layout visibility + sizes. Persisted globally (per-machine)
+   * so a fresh launch reopens with the last layout. */
+  layout?: LayoutState;
 }
 
 /** One row of `git status --porcelain=v1` output, normalised for the renderer. */


### PR DESCRIPTION
## Summary

- Replace the Projects / Code / Knowledge / Terminal tab switcher with a composite layout where each pane toggles independently, so multiple contexts can stay visible at once.
- Persist the layout (which panes are shown + their sizes) in the global per-machine settings.json so the app reopens in the last shape.

## Changes

- New `LayoutState` in shared types and per-machine `settings.json`, with `getLayout` / `setLayout` IPC. Older settings files without a `layout` block stay valid — the default is shallow-merged in on read.
- Renderer: collapsed the `tab` + `terminalOpen` state into a single `layout` signal; resource gating (knowledge tree, repo list) now keys off it.
- Toolbar component is gone. Pane toggles moved to vertical edge-handle pills — left edge for Projects, right edge for Code and Knowledge as a mutex pair.
- Terminal pane never fully collapses: its tab strip is now the persistent full-width bottom bar, with the Terminal pill on the left, spawn / save / search controls in the middle, and live tabs visible whether the body is shown or hidden. Clicking the pill toggles the body.
- The Code / Knowledge slot is mutually exclusive — picking one swaps the other out, matching how the tabs already worked.
- View menu rebuilds with checkbox entries for Projects / Terminal and a radio-like trio for Show Code / Show Knowledge / Hide working surface.
- Per-pane search input removed; the global search modal gains an All / Projects / Knowledge filter pill row with live counts.
- New top-band Projects ↔ working-surface CSS grid with a draggable splitter; widths persist.

## Impact

- The old `×` close button on the terminal pane is gone — the Terminal pill in the strip is now the toggle.
- The renderer no longer has a `tab` concept; downstream code keying off the old union is removed.
- A few pre-existing screenshot / modal-back-stack tests reference UI affordances that have moved (toolbar Settings button, etc.) and need a follow-up refresh.

## Watchpoints

- First-launch: confirm pane visibility persists across launches and the View-menu check marks line up with the actual layout.
- Terminal-strip behaviour: in collapsed state, the strip should still expose `+` / `λ` / save / find controls and the live tab list — same component, just no body.