### PR TITLE
Make condash runnable on macOS and Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ macOS and Windows are unaffected.
 
 - Run `make format` after every code change.
 - All UI must work without per-OS CSS branches (Electron + Chromium = same renderer everywhere).
-- File-path conventions stay POSIX-shaped in main-process code; convert at the boundary with `path.join`.
+- File-path conventions: every path crossing the IPC boundary is normalised to forward-slash form via `toPosix(p)` from `src/shared/path.ts`. Internal `fs` calls keep the native separator (use `path.join`); the renderer can then split on `/` without per-OS branches. Cross-OS shell wrapping (`bash -lc` / `cmd.exe /d /s /c` / `pwsh -Command`) lives in `src/main/terminals.ts`'s `wrapForShell`.
 - IPC contract is the single typed `CondashApi` interface in `src/shared/api.ts`. Functions, not URLs. Promises for request/response; events only for chokidar push (when wired).
 - Hard interaction-to-paint budget: **≤ 16 ms** for any user-initiated action. Optimistic UI is the default; rollback on IPC failure.
 

--- a/conception-template/configuration.json.example
+++ b/conception-template/configuration.json.example
@@ -1,5 +1,5 @@
 {
-  "$schema_doc": "Source of truth for condash. See docs/configuration.md for the full schema.",
+  "$schema_doc": "Source of truth for condash. See docs/reference/config.md for the full schema and per-OS recipes.",
   "workspace_path": "/path/to/workspace",
   "worktrees_path": "/path/to/workspace/../worktrees",
   "repositories": {
@@ -9,30 +9,15 @@
   "open_with": {
     "main_ide": {
       "label": "Open in main IDE",
-      "commands": ["code {path}"]
+      "command": "code {path}"
     },
     "secondary_ide": {
       "label": "Open in secondary IDE",
-      "commands": ["codium {path}"]
+      "command": "codium {path}"
     },
     "terminal": {
       "label": "Open terminal here",
-      "commands": [
-        "gnome-terminal --working-directory {path}",
-        "konsole --workdir {path}",
-        "x-terminal-emulator --working-directory {path}",
-        "xterm -e bash -c 'cd \"{path}\" && exec bash'"
-      ]
+      "command": "x-terminal-emulator --working-directory {path}"
     }
-  },
-  "pdf_viewer": [],
-  "terminal": {
-    "shell": "",
-    "shortcut": "Ctrl+T",
-    "screenshot_dir": "",
-    "screenshot_paste_shortcut": "Ctrl+Shift+V",
-    "launcher_command": "",
-    "move_tab_left_shortcut": "Ctrl+Left",
-    "move_tab_right_shortcut": "Ctrl+Right"
   }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,8 @@ Debian/Ubuntu users can skip the manual download and use the apt repository — 
 
 The builds are **unsigned** — each OS asks you to confirm once on first launch. Full walkthrough: **[Install →](get-started/install.md)**.
 
+> **Runtime requirement.** condash shells out to `git` for status and worktree information, so `git` must be on `PATH`. Linux distributions ship it; on macOS install Xcode Command Line Tools (`xcode-select --install`) or Homebrew git; on Windows install [Git for Windows](https://git-scm.com/download/win).
+
 Building from source (need [Node.js 20+](https://nodejs.org) and, on Linux, the libraries Electron's chrome-sandbox links against — `libnss3`, `libatk-bridge2.0-0`, `libgtk-3-0`):
 
 ```bash

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -12,15 +12,16 @@ condash reads two JSON files. Both are optional in principle — the dashboard r
 | File | Path | Lifecycle | Owns |
 |------|------|-----------|------|
 | `configuration.json` | `<conception_path>/configuration.json` | Per-tree, versioned in git | `workspace_path`, `worktrees_path`, `repositories` (incl. `run` / `force_stop`) |
-| `settings.json` | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux) · `~/Library/Application Support/condash/settings.json` (macOS) · `%APPDATA%\condash\settings.json` (Windows) | Per-user, per-machine | `conception_path`, `terminal`, `pdf_viewer`, `open_with`, `theme` |
+| `settings.json` | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux) · `~/Library/Application Support/condash/settings.json` (macOS) · `%APPDATA%\condash\settings.json` (Windows) | Per-user, per-machine | `conception_path`, `terminal`, `open_with`, `theme` |
 
 The split is by **lifecycle**, not by feature: anything you'd commit so teammates pick it up automatically goes in `configuration.json`; anything that depends on this machine (your editor binary, your terminal emulator, your Pictures folder) goes in `settings.json`.
 
-`terminal`, `pdf_viewer`, and `open_with` are valid in **either** file — set them in `configuration.json` for tree-wide defaults teammates pick up automatically, or in `settings.json` for per-machine overrides. When the same key appears in both files, **`settings.json` wins**, merged field by field:
+`terminal` and `open_with` are valid in **either** file — set them in `configuration.json` for tree-wide defaults teammates pick up automatically, or in `settings.json` for per-machine overrides. When the same key appears in both files, **`settings.json` wins**, merged field by field:
 
 - `terminal.<field>` — each field set in `settings.json` replaces the tree's value; missing fields fall through.
-- `pdf_viewer` — a non-empty array in `settings.json` replaces the tree's; empty / missing falls through.
 - `open_with.<slot>` — merged per slot; the user's `command` and `label` replace the tree's; tree-only slots survive untouched.
+
+> PDF preview is in-renderer (Chromium `<webview>`) — there is **no** `pdf_viewer` config; the modal's "↗ Open in OS default viewer" button uses `shell.openPath`.
 
 Concretely: move any machine-specific preference from `configuration.json` into `settings.json` on each machine; leave tree-wide preferences in `configuration.json` and every teammate gets them automatically.
 
@@ -55,7 +56,6 @@ Lives at `<conception_path>/configuration.json`. Commit it. Every key is optiona
     "secondary_ide": { "label": "Open in secondary IDE", "command": "code {path}" },
     "terminal":      { "label": "Open terminal here",    "command": "ghostty --working-directory={path}" }
   },
-  "pdf_viewer": ["xdg-open {path}", "evince {path}"],
   "terminal": {
     "shell": "/bin/zsh",
     "shortcut": "Ctrl+T",
@@ -100,7 +100,7 @@ Two buckets, `primary` and `secondary`, each an array of repo entries. Entries t
 | `{"name": "repo"}` | Same as bare — the inline-object form coexists because a repo may want sibling keys. |
 | `{"name": "repo", "submodules": ["sub/a", "sub/b"]}` | Renders the repo as an expandable row. Each submodule gets its own dirty count and "open with" buttons. Useful for monorepos where subtrees are edited independently. Submodule entries follow the same shape as parent entries (string or object). |
 | `{"name": "repo", "run": "<cmd>"}` | Wires an [inline dev-server runner](inline-runner.md) into that row. `run` is independent of `submodules` — a parent's `run` is **not** inherited by its submodules; add `run` per submodule if they each have their own dev server. |
-| `{"name": "repo", "run": "<cmd>", "force_stop": "<cmd>"}` | Same as above plus a repo-level **force-stop** button. The button runs `force_stop` as a shell command, without going through condash's own process tracking — use it to free a port held by a server condash didn't start (stale process from a previous run, a server launched from another terminal, etc.). Typical values: `fuser -k 8300/tcp`, `pkill -f 'manage.py runserver'`, `lsof -ti :8300 \| xargs -r kill -9`. Same shell trust level as `run` — you're running these commands on your own machine, so a malicious tree is a malicious shell. |
+| `{"name": "repo", "run": "<cmd>", "force_stop": "<cmd>"}` | Same as above plus a repo-level **force-stop** button. The button runs `force_stop` as a shell command (`/bin/sh -c` on POSIX, `cmd.exe /d /s /c` on Windows), without going through condash's own process tracking — use it to free a port held by a server condash didn't start. **Per-OS recipes for "kill whatever is holding port 8300":** Linux `fuser -k 8300/tcp` or `pkill -f 'manage.py runserver'`; macOS `lsof -ti tcp:8300 \| xargs kill -9`; Windows `for /f "tokens=5" %a in ('netstat -ano ^| findstr :8300') do taskkill /F /PID %a`. Same shell trust level as `run` — you're running these commands on your own machine, so a malicious tree is a malicious shell. |
 | `{"name": "repo", "label": "<text>"}` | Optional human-friendly label. When set, the **label takes the card title slot** on the Code tab and the directory name moves to a small monospace pill alongside it (suppressed when `label === name`). Useful when the directory name is a slug (`alicepeintures.com`) and a friendlier descriptor (`Alice's site`) gives quicker context, while keeping the on-disk name visible. Works on both top-level entries and submodules; combinable with `run` / `force_stop` / `submodules`. |
 
 Anything under `workspace_path` not named in either bucket lands in a third `OTHERS` card.
@@ -134,15 +134,15 @@ Each slot takes a `label` (tooltip text) and a single `command` string.
 
 Built-in defaults reproduce common IntelliJ / VS Code / terminal behaviour, so a `configuration.json` with no `open_with` block still gives functional buttons. Override only the slots you want to customise.
 
-### `pdf_viewer`
+#### Per-OS recipes
 
-Bare array of shell-style commands for opening PDFs from deliverable links. `{path}` is replaced with the absolute path of the PDF. Tried in order.
+The `command` is invoked directly (not through a shell) — `~/` and `$VARS` are not expanded except for a leading `~/` which condash rewrites to the user's home. Pick a recipe matching your OS:
 
-```json
-{ "pdf_viewer": ["xdg-open {path}", "evince {path}"] }
-```
-
-Empty array or missing key → falls back to the OS default (`xdg-open` on Linux, `open` on macOS).
+| Slot | Linux | macOS | Windows |
+|------|-------|-------|---------|
+| `main_ide` | `idea {path}` · `code {path}` | `open -na "IntelliJ IDEA" --args {path}` · `open -na "Visual Studio Code" --args {path}` | `idea64.exe {path}` · `code {path}` (after VS Code's "Add to PATH" installer step) |
+| `secondary_ide` | `codium {path}` · `zed {path}` | `open -na "VSCodium" --args {path}` · `zed {path}` | `code {path}` · `zed {path}` |
+| `terminal` | `gnome-terminal --working-directory {path}` · `konsole --workdir {path}` · `x-terminal-emulator --working-directory {path}` | `open -a Terminal {path}` · `open -a iTerm {path}` · `open -a Ghostty {path}` | `wt.exe -d "{path}"` (Windows Terminal) · `cmd.exe /K "cd /d {path}"` |
 
 ### `terminal`
 
@@ -223,7 +223,6 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
     "launcher_command": "claude",
     "screenshot_dir": "/home/you/Pictures/Screenshots"
   },
-  "pdf_viewer": ["xdg-open {path}", "evince {path}"],
   "open_with": {
     "main_ide":      { "label": "Open in main IDE",      "command": "idea {path}" },
     "secondary_ide": { "label": "Open in secondary IDE", "command": "code {path}" }
@@ -236,7 +235,6 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
 | `conception_path` | Absolute path to the conception tree condash should render. |
 | `theme` | `light`, `dark`, or `auto`. Persisted by `setTheme`. |
 | `terminal.*` | Same keys as the tree-level `terminal` block above; any field set here overrides the tree value. Missing fields fall through. |
-| `pdf_viewer` | Fallback chain for opening PDFs. Non-empty array here replaces the tree's chain; empty or missing falls through. |
 | `open_with.<slot>.label`, `.command` | Merged per slot. The user's `command` replaces the tree's; the user's `label` replaces the tree's. Tree-only slots survive untouched. |
 
 Resolution order for the conception path, checked in sequence:
@@ -260,7 +258,7 @@ Changes that **do** need a restart:
 
 Changes that reload live without a restart:
 
-- Everything under `open_with`, `pdf_viewer`, `terminal`.
+- Everything under `open_with`, `terminal`.
 - `run` / `force_stop` on an existing repo entry.
 
 ## See also

--- a/src/main/files.ts
+++ b/src/main/files.ts
@@ -1,6 +1,7 @@
 import { promises as fs, type Dirent } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { ProjectFileEntry } from '../shared/types';
+import { toPosix } from '../shared/path';
 
 /**
  * List files inside a project directory (the directory containing `readmePath`).
@@ -23,7 +24,7 @@ export async function listProjectFiles(readmePath: string): Promise<ProjectFileE
     if (entry.name.startsWith('.')) continue;
     const absolute = join(root, entry.name);
     if (entry.isFile()) {
-      out.push({ path: absolute, relPath: entry.name, name: entry.name });
+      out.push({ path: toPosix(absolute), relPath: entry.name, name: entry.name });
       continue;
     }
     if (!entry.isDirectory()) continue;
@@ -37,7 +38,7 @@ export async function listProjectFiles(readmePath: string): Promise<ProjectFileE
       if (child.name.startsWith('.')) continue;
       if (!child.isFile()) continue;
       out.push({
-        path: join(absolute, child.name),
+        path: toPosix(join(absolute, child.name)),
         relPath: `${entry.name}/${child.name}`,
         name: child.name,
       });

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,7 +1,10 @@
 import { app, BrowserWindow, dialog, ipcMain, Menu, shell } from 'electron';
 import type { MenuItemConstructorOptions } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { toPosix } from '../shared/path';
 
 import { detectConceptionState, initConception } from './conception-init';
 import { DEFAULT_LAYOUT, readSettings, settingsPath, writeSettings } from './settings';
@@ -407,7 +410,17 @@ function registerIpc(): void {
 
   ipcMain.handle('getConceptionPath', async () => {
     const { conceptionPath } = await readSettings();
-    return conceptionPath;
+    return conceptionPath ? toPosix(conceptionPath) : null;
+  });
+
+  ipcMain.handle('pdf.toFileUrl', (_, path: string) => {
+    if (typeof path !== 'string' || path.length === 0) {
+      throw new Error('pdf.toFileUrl: path must be a non-empty string');
+    }
+    return {
+      url: pathToFileURL(path).href,
+      filename: basename(path),
+    };
   });
 
   ipcMain.handle('getTheme', async () => {
@@ -415,7 +428,7 @@ function registerIpc(): void {
     return theme;
   });
 
-  ipcMain.handle('getSettingsPath', () => settingsPath());
+  ipcMain.handle('getSettingsPath', () => toPosix(settingsPath()));
 
   ipcMain.handle('setTheme', async (_, theme: Theme) => {
     if (!THEMES.has(theme)) throw new Error(`Unknown theme: ${theme}`);
@@ -476,7 +489,7 @@ function registerIpc(): void {
     });
     if (result.canceled || result.filePaths.length === 0) return null;
 
-    const picked = result.filePaths[0];
+    const picked = toPosix(result.filePaths[0]);
     const next = await readSettings();
     next.conceptionPath = picked;
     await writeSettings(next);
@@ -515,6 +528,7 @@ function registerIpc(): void {
     electron: process.versions.electron,
     chrome: process.versions.chrome,
     node: process.versions.node,
+    platform: process.platform,
   }));
 }
 

--- a/src/main/knowledge.ts
+++ b/src/main/knowledge.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { basename, join } from 'node:path';
 import type { KnowledgeNode } from '../shared/types';
+import { toPosix } from '../shared/path';
 
 const HIDDEN_PREFIX = /^\./;
 
@@ -20,7 +21,7 @@ async function walk(absPath: string, relPath: string, name: string): Promise<Kno
     const meta = await readFileMeta(absPath, name);
     return {
       relPath,
-      path: absPath,
+      path: toPosix(absPath),
       name,
       title: meta.title,
       kind: 'file',
@@ -51,7 +52,7 @@ async function walk(absPath: string, relPath: string, name: string): Promise<Kno
 
   return {
     relPath,
-    path: absPath,
+    path: toPosix(absPath),
     name,
     title: relPath ? basename(absPath) : 'knowledge',
     kind: 'directory',

--- a/src/main/launchers.ts
+++ b/src/main/launchers.ts
@@ -1,5 +1,6 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { OpenWithSlots, OpenWithSlotKey } from '../shared/types';
 import { findRepoEntry, type ConfigShape } from './config-walk';
@@ -40,7 +41,10 @@ export async function listOpenWith(conceptionPath: string): Promise<OpenWithSlot
 /**
  * Tokenise a command template into argv, substituting `{path}` at the arg
  * level (no shell parsing). Quotes are honoured for tokens that contain
- * literal whitespace (e.g. `idea "{path}"`).
+ * literal whitespace (e.g. `idea "{path}"`). A leading `~/` in any token
+ * is expanded to the user's home directory — without this, configs that
+ * reference `~/bin/foo` silently fail to spawn (the literal `~` doesn't
+ * resolve outside a shell).
  */
 function tokenise(command: string, path: string): string[] {
   const tokens: string[] = [];
@@ -68,7 +72,15 @@ function tokenise(command: string, path: string): string[] {
   }
   if (buf.length > 0) tokens.push(buf);
 
-  return tokens.map((tok) => tok.split('{path}').join(path));
+  return tokens.map((tok) => expandTilde(tok.split('{path}').join(path)));
+}
+
+function expandTilde(token: string): string {
+  if (token === '~') return homedir();
+  if (token.startsWith('~/') || token.startsWith('~\\')) {
+    return join(homedir(), token.slice(2));
+  }
+  return token;
 }
 
 export async function launchOpenWith(

--- a/src/main/note.ts
+++ b/src/main/note.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
-import { basename, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
+import { toPosix } from '../shared/path';
 
 export async function readNote(path: string): Promise<string> {
   try {
@@ -49,9 +50,11 @@ async function nextNotePrefix(notesDir: string): Promise<string> {
  * project README path may also be passed; we coerce to its parent folder.
  * Returns the absolute path written. */
 export async function createProjectNote(projectPath: string, slug: string): Promise<string> {
-  const projectDir = projectPath.endsWith('README.md')
-    ? projectPath.slice(0, -'/README.md'.length)
-    : projectPath;
+  // Accepts either the project directory or the README inside it. Use
+  // `path.dirname` rather than slicing a fixed `'/README.md'.length` so
+  // Windows separators (`\README.md`) don't throw off the slice.
+  const projectDir =
+    basename(projectPath).toLowerCase() === 'readme.md' ? dirname(projectPath) : projectPath;
   const notesDir = join(projectDir, 'notes');
   await fs.mkdir(notesDir, { recursive: true });
   const cleaned = sanitiseSlug(slug);
@@ -67,5 +70,5 @@ export async function createProjectNote(projectPath: string, slug: string): Prom
   const projectName = basename(projectDir);
   const body = `# ${prefix} — ${title}\n\n> Created in ${projectName}.\n\n`;
   await fs.writeFile(path, body, { encoding: 'utf8', flag: 'wx' });
-  return path;
+  return toPosix(path);
 }

--- a/src/main/parse.ts
+++ b/src/main/parse.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve } from 'node:path';
 import type { Deliverable, ItemKind, Project, Step, StepCounts, StepMarker } from '../shared/types';
+import { toPosix } from '../shared/path';
 
 const META_LINE = /^\*\*([A-Za-z][\w -]*)\*\*\s*:\s*(.+?)\s*$/;
 const HEADING2 = /^##\s+(.+)$/;
@@ -23,7 +24,7 @@ export async function parseReadme(path: string): Promise<Project> {
 
   return {
     slug,
-    path,
+    path: toPosix(path),
     title: title ?? slug,
     kind: normaliseKind(meta.get('kind')),
     status: (meta.get('status') ?? 'backlog').toLowerCase(),
@@ -152,7 +153,7 @@ function extractDeliverables(lines: readonly string[], itemDir: string): Deliver
     const absolute = isAbsolute(rawPath) ? rawPath : resolve(itemDir, rawPath);
     out.push({
       label: label.trim(),
-      path: absolute,
+      path: toPosix(absolute),
       description: description?.trim() || undefined,
     });
   }

--- a/src/main/repos.ts
+++ b/src/main/repos.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { RepoEntry, Worktree } from '../shared/types';
+import { toPosix } from '../shared/path';
 import { getDirtyCount } from './git-status-cache';
 import { getCurrentBranch, listWorktrees } from './worktrees';
 import { walkRepos, type ConfigShape, type RepoLookup } from './config-walk';
@@ -66,7 +67,7 @@ export async function listRepos(conceptionPath: string): Promise<RepoEntry[]> {
         return {
           name: entry.display,
           label: entry.label,
-          path: entry.cwd,
+          path: toPosix(entry.cwd),
           kind: entry.kind,
           parent: entry.parent,
           dirty: null,
@@ -86,7 +87,7 @@ export async function listRepos(conceptionPath: string): Promise<RepoEntry[]> {
       return {
         name: entry.display,
         label: entry.label,
-        path: entry.cwd,
+        path: toPosix(entry.cwd),
         kind: entry.kind,
         parent: entry.parent,
         dirty,
@@ -119,11 +120,15 @@ async function deriveSubWorktrees(
   const parentList = entry.parent ? (parentWorktrees.get(entry.parent) ?? []) : [];
   if (!parent || parentList.length === 0) {
     const branch = await getCurrentBranch(entry.cwd).catch(() => null);
-    return [{ path: entry.cwd, branch, primary: true }];
+    return [{ path: toPosix(entry.cwd), branch, primary: true }];
   }
-  const subRelative = relative(parent.cwd, entry.cwd);
+  // `wt.path` already comes from `listWorktrees` in POSIX form (see
+  // worktrees.ts), and `entry.cwd` was resolved via `path.join` so on
+  // Windows it would carry `\` separators. Normalise the relative
+  // computation in POSIX-space to avoid mixing separators.
+  const subRelative = toPosix(relative(parent.cwd, entry.cwd));
   const rerooted: Worktree[] = parentList.map((wt) => ({
-    path: subRelative ? join(wt.path, subRelative) : wt.path,
+    path: subRelative ? `${wt.path}/${subRelative}` : wt.path,
     branch: wt.branch,
     primary: wt.primary,
   }));

--- a/src/main/screenshot.ts
+++ b/src/main/screenshot.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
+import { toPosix } from '../shared/path';
 
 /**
  * Find the most recently modified file under `dir` (top-level only). Returns
@@ -28,5 +29,5 @@ export async function latestScreenshot(dir: string): Promise<string | null> {
       best = { path, mtime: stat.mtimeMs };
     }
   }
-  return best?.path ?? null;
+  return best ? toPosix(best.path) : null;
 }

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -1,5 +1,6 @@
 import { join, relative } from 'node:path';
 import type { SearchResults } from '../../shared/types';
+import { toPosix } from '../../shared/path';
 import { collectKnowledgeFiles, collectProjectFiles } from './walk';
 import { matchFile, type MatchOutput } from './match';
 import { parseQuery } from './query';
@@ -34,10 +35,10 @@ export async function search(conceptionPath: string, query: string): Promise<Sea
   for (const file of projectFiles) {
     matchPromises.push(
       matchFile({
-        path: file.path,
-        relPath: relative(conceptionPath, file.path),
+        path: toPosix(file.path),
+        relPath: toPosix(relative(conceptionPath, file.path)),
         source: 'project',
-        projectPath: file.projectPath,
+        projectPath: toPosix(file.projectPath),
         terms,
       }),
     );
@@ -46,8 +47,8 @@ export async function search(conceptionPath: string, query: string): Promise<Sea
   for (const path of knowledgeFiles) {
     matchPromises.push(
       matchFile({
-        path,
-        relPath: relative(conceptionPath, path),
+        path: toPosix(path),
+        relPath: toPosix(relative(conceptionPath, path)),
         source: 'knowledge',
         terms,
       }),

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process';
 import { promises as fs } from 'node:fs';
-import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { basename, join } from 'node:path';
 import { BrowserWindow, type WebContents } from 'electron';
 import * as pty from 'node-pty';
 import type { TermSession, TermSide, TermSpawnRequest, TerminalPrefs } from '../shared/types';
@@ -90,9 +91,36 @@ async function readRawConfig(conceptionPath: string): Promise<ConfigShape> {
 
 function defaultShell(configured?: string): string {
   if (configured && configured.trim()) return configured;
-  if (process.env.SHELL) return process.env.SHELL;
-  if (process.platform === 'win32') return 'cmd.exe';
+  // SHELL is reliably set on POSIX. On Windows it is usually unset; fall
+  // through to ComSpec, then cmd.exe.
+  if (process.platform !== 'win32' && process.env.SHELL) return process.env.SHELL;
+  if (process.platform === 'win32') return process.env.ComSpec || 'cmd.exe';
   return '/bin/bash';
+}
+
+/** Build the argv for running `command` through `shell`. POSIX shells take
+ *  `-l -c <cmd>`; cmd.exe needs `/d /s /c <cmd>`; PowerShell needs
+ *  `-NoLogo -NonInteractive -Command <cmd>`. We detect by the basename of
+ *  the shell binary so a user-configured `pwsh.exe` or `git-bash.exe` is
+ *  routed correctly. */
+function wrapForShell(shell: string, command: string): string[] {
+  const name = basename(shell).toLowerCase();
+  if (process.platform === 'win32') {
+    if (name === 'cmd.exe' || name === 'cmd') {
+      return ['/d', '/s', '/c', command];
+    }
+    if (
+      name === 'powershell.exe' ||
+      name === 'powershell' ||
+      name === 'pwsh.exe' ||
+      name === 'pwsh'
+    ) {
+      return ['-NoLogo', '-NonInteractive', '-Command', command];
+    }
+    // Fall through for bash on Git-for-Windows et al.
+    return ['-c', command];
+  }
+  return ['-l', '-c', command];
 }
 
 export async function spawnTerminal(
@@ -104,7 +132,7 @@ export async function spawnTerminal(
   const settings = await readSettings();
   const shell = defaultShell(settings.terminal?.shell);
 
-  let cwd = request.cwd ?? process.env.HOME ?? '/';
+  let cwd = request.cwd ?? homedir();
   let argv: string[] = [];
   let program = shell;
   let forceStop: string | undefined;
@@ -117,16 +145,17 @@ export async function spawnTerminal(
     // checkout. Without this, every Run lands on the primary checkout
     // regardless of which branch row the user clicked.
     if (!request.cwd && entry.cwd) cwd = entry.cwd;
-    // Wrap the configured run: command in `bash -lc` so user-supplied shells
-    // like `make dev && tail -f log` keep their pipes/&&/operators.
+    // Wrap the configured run: command for the active shell so user-supplied
+    // shells like `make dev && tail -f log` keep their pipes / && / operators
+    // on every OS (POSIX -lc / cmd.exe /d /s /c / pwsh -Command).
     if (entry.run) {
       program = shell;
-      argv = ['-l', '-c', entry.run];
+      argv = wrapForShell(shell, entry.run);
     }
     forceStop = entry.forceStop;
   } else if (request.command) {
     program = shell;
-    argv = ['-l', '-c', request.command];
+    argv = wrapForShell(shell, request.command);
   }
 
   // One run per repo: kill any prior code-side session for the same repo

--- a/src/main/worktrees.ts
+++ b/src/main/worktrees.ts
@@ -1,6 +1,8 @@
 import { execFile } from 'node:child_process';
+import { normalize } from 'node:path';
 import { promisify } from 'node:util';
 import { getDirtyCount } from './git-status-cache';
+import { toPosix } from '../shared/path';
 import type { Worktree } from '../shared/types';
 
 const exec = promisify(execFile);
@@ -64,7 +66,11 @@ export async function listWorktrees(repoPath: string): Promise<Worktree[]> {
       continue;
     }
     if (line.startsWith('worktree ')) {
-      current.path = line.slice('worktree '.length);
+      // git porcelain always reports POSIX `/` separators, even on Windows.
+      // Normalise to the native form first (so internal `path.join` /
+      // `path.relative` against this string don't mix separators), then
+      // re-normalise to POSIX at the IPC boundary below.
+      current.path = normalize(line.slice('worktree '.length));
     } else if (line.startsWith('branch refs/heads/')) {
       current.branch = line.slice('branch refs/heads/'.length);
     } else if (line === 'detached') {
@@ -87,5 +93,7 @@ export async function listWorktrees(repoPath: string): Promise<Worktree[]> {
       wt.dirty = await getDirtyCount(wt.path);
     }),
   );
+  // POSIX-shape every path before it crosses the IPC boundary.
+  for (const wt of out) wt.path = toPosix(wt.path);
   return out;
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -72,6 +72,7 @@ const api: CondashApi = {
     ipcRenderer.invoke('project.createNote', projectPath, slug),
   quitApp: () => ipcRenderer.invoke('quitApp'),
   getAppInfo: () => ipcRenderer.invoke('getAppInfo'),
+  pdfToFileUrl: (path: string) => ipcRenderer.invoke('pdf.toFileUrl', path),
   onMenuCommand: (callback) => {
     const handler = (_: unknown, command: MenuCommand): void => callback(command);
     ipcRenderer.on('menu-command', handler);

--- a/src/renderer/pdf-modal.tsx
+++ b/src/renderer/pdf-modal.tsx
@@ -1,4 +1,4 @@
-import { onCleanup, onMount } from 'solid-js';
+import { createResource, onCleanup, onMount, Show } from 'solid-js';
 
 export function PdfModal(props: {
   path: string;
@@ -19,15 +19,15 @@ export function PdfModal(props: {
     document.removeEventListener('keydown', handleKey, true);
   });
 
-  const fileUrl = (): string => {
-    const encoded = props.path
-      .split('/')
-      .map((seg) => encodeURIComponent(seg))
-      .join('/');
-    return `file://${encoded}`;
-  };
-
-  const fileName = (): string => props.path.split('/').pop() ?? props.path;
+  // Build the `file://` URL in main via `pathToFileURL`. That's the only
+  // path-to-URL conversion that handles Windows drive letters and percent-
+  // encoding correctly across all three OSes — doing it in the renderer
+  // would either require a Node module (not available in the sandbox) or
+  // re-implementing the rules by hand.
+  const [resolved] = createResource(
+    () => props.path,
+    (path) => window.condash.pdfToFileUrl(path),
+  );
 
   return (
     <div class="modal-backdrop" onClick={props.onClose}>
@@ -38,7 +38,7 @@ export function PdfModal(props: {
         onClick={(e) => e.stopPropagation()}
       >
         <header class="modal-head">
-          <span class="modal-title">{fileName()}</span>
+          <span class="modal-title">{resolved()?.filename ?? ''}</span>
           <span class="modal-path">{props.path}</span>
           <button
             class="modal-button"
@@ -52,7 +52,9 @@ export function PdfModal(props: {
           </button>
         </header>
         <div class="pdf-body">
-          <webview src={fileUrl()} partition="persist:pdf" class="pdf-webview" />
+          <Show when={resolved()?.url}>
+            {(url) => <webview src={url()} partition="persist:pdf" class="pdf-webview" />}
+          </Show>
         </div>
       </div>
     </div>

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -1,6 +1,6 @@
 import { createMemo, createResource, createSignal, For, Show } from 'solid-js';
 import { onMount, onCleanup } from 'solid-js';
-import type { TerminalPrefs, TerminalXtermPrefs, Theme } from '@shared/types';
+import type { Platform, TerminalPrefs, TerminalXtermPrefs, Theme } from '@shared/types';
 import type { RawRepo } from '../main/config-schema';
 
 /**
@@ -101,40 +101,80 @@ const OPEN_WITH_SLOTS: { key: 'main_ide' | 'secondary_ide' | 'terminal'; label: 
   { key: 'terminal', label: 'Terminal' },
 ];
 
-const TERMINAL_STRING_FIELDS: {
-  key:
-    | 'shell'
-    | 'shortcut'
-    | 'screenshot_dir'
-    | 'screenshot_paste_shortcut'
-    | 'launcher_command'
-    | 'move_tab_left_shortcut'
-    | 'move_tab_right_shortcut';
+type TerminalStringFieldKey =
+  | 'shell'
+  | 'shortcut'
+  | 'screenshot_dir'
+  | 'screenshot_paste_shortcut'
+  | 'launcher_command'
+  | 'move_tab_left_shortcut'
+  | 'move_tab_right_shortcut';
+
+interface TerminalStringField {
+  key: TerminalStringFieldKey;
   label: string;
-  placeholder: string;
+  /** Per-OS placeholder. `default` is used when the platform is unknown. */
+  placeholder: Partial<Record<Platform | 'default', string>>;
   hint?: string;
-}[] = [
-  { key: 'shell', label: 'Shell', placeholder: '/bin/bash' },
+}
+
+const TERMINAL_STRING_FIELDS: TerminalStringField[] = [
+  {
+    key: 'shell',
+    label: 'Shell',
+    placeholder: { linux: '/bin/bash', darwin: '/bin/zsh', win32: 'cmd.exe', default: '/bin/bash' },
+  },
   {
     key: 'launcher_command',
     label: 'Launcher command',
-    placeholder: 'claude',
+    placeholder: { default: 'claude' },
     hint: 'Run on terminal-tab open before any user input.',
   },
   {
     key: 'screenshot_dir',
     label: 'Screenshot directory',
-    placeholder: '/home/alice/Pictures/Screenshots',
+    placeholder: {
+      linux: '/home/you/Pictures/Screenshots',
+      darwin: '~/Pictures/Screenshots',
+      win32: 'C:\\Users\\you\\Pictures\\Screenshots',
+      default: '~/Pictures/Screenshots',
+    },
   },
-  { key: 'shortcut', label: 'Toggle terminal pane', placeholder: 'Ctrl+`' },
+  { key: 'shortcut', label: 'Toggle terminal pane', placeholder: { default: 'Ctrl+`' } },
   {
     key: 'screenshot_paste_shortcut',
     label: 'Paste latest screenshot path',
-    placeholder: 'Ctrl+Shift+V',
+    placeholder: { default: 'Ctrl+Shift+V' },
   },
-  { key: 'move_tab_left_shortcut', label: 'Move tab left', placeholder: 'Ctrl+Left' },
-  { key: 'move_tab_right_shortcut', label: 'Move tab right', placeholder: 'Ctrl+Right' },
+  { key: 'move_tab_left_shortcut', label: 'Move tab left', placeholder: { default: 'Ctrl+Left' } },
+  {
+    key: 'move_tab_right_shortcut',
+    label: 'Move tab right',
+    placeholder: { default: 'Ctrl+Right' },
+  },
 ];
+
+const WORKSPACE_PLACEHOLDER: Partial<Record<Platform | 'default', string>> = {
+  linux: '/home/you/src/vcoeur',
+  darwin: '~/src/vcoeur',
+  win32: 'C:\\Users\\you\\src\\vcoeur',
+  default: '~/src/vcoeur',
+};
+
+const WORKTREES_PLACEHOLDER: Partial<Record<Platform | 'default', string>> = {
+  linux: '/home/you/src/worktrees',
+  darwin: '~/src/worktrees',
+  win32: 'C:\\Users\\you\\src\\worktrees',
+  default: '~/src/worktrees',
+};
+
+function pick(
+  table: Partial<Record<Platform | 'default', string>>,
+  platform: Platform | undefined,
+): string {
+  if (platform && table[platform]) return table[platform] as string;
+  return table.default ?? '';
+}
 
 interface RawConfig {
   $schema_doc?: string;
@@ -210,6 +250,14 @@ export function SettingsModal(props: {
     () => props.configurationPath,
     (path) => window.condash.readNote(path),
   );
+
+  // Used to pick OS-appropriate placeholder text for path / shell fields.
+  // Falls back to "default" entries until the IPC resolves.
+  const [appInfo] = createResource(
+    () => true,
+    () => window.condash.getAppInfo(),
+  );
+  const platform = (): Platform | undefined => appInfo()?.platform;
 
   const attemptClose = (): void => {
     if (isDirty()) {
@@ -646,7 +694,7 @@ export function SettingsModal(props: {
                       <span>{field.label}</span>
                       <input
                         type="text"
-                        placeholder={field.placeholder}
+                        placeholder={pick(field.placeholder, platform())}
                         {...bindText(
                           `terminal.${field.key}`,
                           () =>
@@ -875,7 +923,7 @@ export function SettingsModal(props: {
                   <span>Workspace path</span>
                   <input
                     type="text"
-                    placeholder="/home/you/src/vcoeur"
+                    placeholder={pick(WORKSPACE_PLACEHOLDER, platform())}
                     {...bindText('workspace_path', () => parsed().workspace_path, setWorkspacePath)}
                   />
                 </label>
@@ -883,7 +931,7 @@ export function SettingsModal(props: {
                   <span>Worktrees path</span>
                   <input
                     type="text"
-                    placeholder="/home/you/src/worktrees"
+                    placeholder={pick(WORKTREES_PLACEHOLDER, platform())}
                     {...bindText('worktrees_path', () => parsed().worktrees_path, setWorktreesPath)}
                   />
                 </label>

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -5,6 +5,7 @@ import type {
   LayoutState,
   OpenWithSlotKey,
   OpenWithSlots,
+  Platform,
   Project,
   ProjectFileEntry,
   RepoEntry,
@@ -113,14 +114,21 @@ export interface CondashApi {
   createProjectNote(projectPath: string, slug: string): Promise<string>;
   /** Trigger app quit. Renderer is responsible for any user confirmation. */
   quitApp(): Promise<void>;
-  /** App version + bundled release metadata used by the About modal. */
+  /** App version + bundled release metadata used by the About modal.
+   *  `platform` is the Node platform string (`linux`/`darwin`/`win32`) used
+   *  by the renderer to pick OS-appropriate placeholders. */
   getAppInfo(): Promise<{
     name: string;
     version: string;
     electron: string;
     chrome: string;
     node: string;
+    platform: Platform;
   }>;
+  /** Build a `file://` URL for a local path (handles Windows drive letters
+   *  and percent-encoding). Returns the URL plus the basename so the
+   *  renderer can render it without doing its own POSIX-only path split. */
+  pdfToFileUrl(path: string): Promise<{ url: string; filename: string }>;
   /**
    * Subscribe to commands sent by the application menu (File → Search,
    * File → Open conception directory, File → Quit). Returns an unsubscribe.

--- a/src/shared/path.ts
+++ b/src/shared/path.ts
@@ -1,0 +1,18 @@
+/** Normalise a filesystem path to forward-slash form, suitable for
+ *  shipping over IPC and for the renderer to split on `/`. Identity on
+ *  POSIX (no `\` ever appears in paths there); converts `\` → `/` on
+ *  Windows. Drive letters (`C:`) pass through unchanged.
+ *
+ *  Per CLAUDE.md, every path that crosses the IPC boundary is shaped
+ *  this way so the renderer never has to think about per-OS separators. */
+export function toPosix(path: string): string {
+  return path.includes('\\') ? path.replace(/\\/g, '/') : path;
+}
+
+/** Last segment of a forward-slash path. Convenience for renderer code
+ *  that previously did `p.split('/').pop()` — keeps the same behaviour
+ *  but spells the intent. */
+export function posixBasename(path: string): string {
+  const i = path.lastIndexOf('/');
+  return i === -1 ? path : path.slice(i + 1);
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,3 +1,9 @@
+/** Subset of `NodeJS.Platform` we actually care about. The renderer doesn't
+ *  link `@types/node` so it can't reach the full union — we mirror the three
+ *  values that influence per-OS behaviour and leave a string fallback for
+ *  the rare exotic (`freebsd`, `aix`, ...). */
+export type Platform = 'linux' | 'darwin' | 'win32' | (string & {});
+
 export type ItemKind = 'project' | 'incident' | 'document' | 'unknown';
 
 export type KnownStatus = 'now' | 'review' | 'later' | 'backlog' | 'done';


### PR DESCRIPTION
## Summary

- A static cross-platform audit of condash found no library-level Linux dependency, but ~10 small sites in path handling and shell invocation quietly assumed POSIX — the Run button and PDF preview were both broken on Windows. This PR fixes them in one go and leaves macOS in a fully working state.
- Adds a single `toPosix(p)` helper at `src/shared/path.ts` and applies it at every IPC return that emits a path, so renderer code can keep splitting on `/` without per-OS branches.
- Refreshes the conception template, the docs, and the project's CLAUDE.md so a fresh user on any OS gets a working first-run.

## Changes

- **`src/shared/path.ts`** — new `toPosix(p)` + `posixBasename(p)`. Identity on POSIX; `\\` → `/` on Windows.
- **`src/shared/types.ts`** — new `Platform` type (renderer-safe subset of `NodeJS.Platform`).
- **IPC normalisation** — apply `toPosix` at every main → renderer return site that emits a path: `repos.ts`, `worktrees.ts`, `files.ts`, `knowledge.ts`, `parse.ts`, `note.ts`, `screenshot.ts`, `search/index.ts`, plus `getSettingsPath`, `pickConceptionPath`, `getConceptionPath` in `main/index.ts`.
- **`src/main/terminals.ts`** — `wrapForShell()` picks argv per shell binary: `bash -lc` on POSIX; `cmd.exe /d /s /c` / `pwsh -NoLogo -NonInteractive -Command` / `bash -c` (Git-for-Windows) on Windows. Replace `process.env.HOME ?? '/'` with `os.homedir()`. Fall through to `ComSpec` on Windows when no `SHELL` is set.
- **`src/main/worktrees.ts`** — `path.normalize` the `worktree <path>` line from `git worktree list --porcelain` (porcelain always reports POSIX) so subsequent `path.relative` / `path.join` doesn't mix separators on Windows. Re-emit POSIX at the IPC boundary.
- **`src/main/note.ts`** — `createProjectNote` uses `path.dirname` instead of slicing `'/README.md'.length`.
- **`src/main/launchers.ts`** — tokeniser expands a leading `~/` or `~\\` to `os.homedir()`, so user configs that reference the home dir actually launch on every OS.
- **`src/renderer/pdf-modal.tsx`** — drop the local `split('/')` URL builder; resolve via a new `pdf.toFileUrl` IPC that calls `pathToFileURL` in main and returns `{url, filename}`. Fixes Windows PDF preview.
- **`src/renderer/settings-modal.tsx`** — per-OS placeholders for `shell`, `screenshot_dir`, `workspace_path`, `worktrees_path`, driven by a new `platform` field on the `getAppInfo` IPC.
- **`conception-template/configuration.json.example`** — rewrite `open_with.{slot}.commands: [...]` arrays to a single `command:` string (matches the strict schema condash has used since v2.x); drop the dead `pdf_viewer` field that the strict schema would reject. Also drops the `terminal` block that already migrated to `settings.json`.
- **`docs/reference/config.md`** — add per-OS recipe tables for `open_with` (Linux / macOS / Windows IDE + terminal launchers) and for `force_stop` (port-kill recipes per OS). Drop the dead `pdf_viewer` section and its mentions elsewhere in the file.
- **`docs/index.md`** — note the runtime requirement that `git` be on `PATH`, with per-OS install pointers (Xcode CLT, Git for Windows).
- **`CLAUDE.md`** — replace the old "POSIX-shaped in main, convert at the boundary" rule with the stronger "every path crossing IPC is normalised via `toPosix`"; point at `wrapForShell` for the shell-wrapping convention.

## Impact

- **macOS** is in a fully working state after this PR. **Windows** should now boot, render the dashboard, run the Run button, preview PDFs, and accept paths through the settings modal — but it has not been exercised on a real Windows machine; treat as best-effort until a Windows test environment exists.
- **No behaviour change on Linux.** `toPosix` is a no-op on strings without `\\`; `wrapForShell` returns the existing `['-l', '-c', cmd]` shape on POSIX. The existing Playwright suite is unchanged.
- New IPC: `pdf.toFileUrl(path) → { url, filename }`. New `platform` field on `getAppInfo` return. Both are additive — no existing call site changes shape.
- The conception template now writes a config that validates against the strict schema. Users who initialised before this change keep their existing file untouched.

## Watchpoints

- Old saved configs that still carry `open_with.{slot}.commands: [...]` (array) or top-level `pdf_viewer: [...]` will fail strict-schema validation on first save through the settings modal. The fix is to edit the file by hand to use the singular `command:` and to drop `pdf_viewer`.
- The renderer now expects `appInfo().platform` to resolve before it can show OS-correct placeholders; until the IPC resolves, the `default` placeholder is used. No functional impact.
- Out-of-scope (left as-is): `scripts/perf-baseline.mjs` and `scripts/snap.mjs` are still Linux-only dev tooling; replacing the `git`-on-PATH dependency with `isomorphic-git` was deliberately deferred (perf + complexity hit not justified). Both are documented.