### PR TITLE
Documentation overhaul: drift fixes, audience tags, welcome screen

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ macOS and Windows are unaffected.
 - [`docs/reference/config.md`](docs/reference/config.md) — `configuration.json` + `settings.json` schema + per-key reference.
 - [`docs/explanation/non-goals.md`](docs/explanation/non-goals.md) — explicit non-goals; **read before adding "while we're at it" features**.
 
-The in-app Help menu reads files out of the asar via the allowlist in `src/main/help.ts`, which maps the legacy short names (`architecture`, `configuration`, `non-goals`) to the Diátaxis paths above. There is no separate copy at the repo root — the migration shipped in `v2.0.6`.
+The in-app Help menu reads files out of the asar via the allowlist in `src/main/help.ts`. As of the docs-overhaul pass (May 2026) it carries thirteen short names — `welcome`, `getting-started`, `install`, `first-launch`, `shortcuts`, `configuration`, `cli`, `mutations`, `architecture`, `why-markdown`, `values`, `non-goals`, `index` — all mapping to canonical Diátaxis paths under `docs/`. The OS-level Help submenu groups them in three blocks: Welcome / Getting started, Reference (configuration / CLI / mutations), Explanation (architecture / values / non-goals); separate items link out to `condash.vcoeur.com` and the issue tracker via `shell.openExternal`. There is no separate copy at the repo root — the migration shipped in `v2.0.6`.
+
+The first-launch **welcome screen** lives in `src/renderer/welcome-screen.tsx` and renders inside `workspace-center` when the conception path is set, the projects list is empty, and the knowledge tree is empty (and the user hasn't dismissed it). Dismiss state persists at `welcome.dismissed` in `settings.json` via the `getWelcomeDismissed` / `setWelcomeDismissed` IPC verbs.
 
 When changing app behaviour, update the matching `docs/` file in the same commit. The schema in `src/main/config-schema.ts` and the public reference (`docs/reference/config.md`) must agree on every release.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # condash
 
-Markdown project dashboard for the conception convention — every project, incident, and document lives as a plain `.md` file under `projects/YYYY-MM/YYYY-MM-DD-<slug>/README.md`, and condash renders the live dashboard view.
+A desktop dashboard for a directory of Markdown files — projects, incidents, and documents written as plain `.md` under `projects/YYYY-MM/YYYY-MM-DD-<slug>/README.md`. The files are the source of truth; condash is the live view layer.
+
+→ **Documentation: [condash.vcoeur.com](https://condash.vcoeur.com)**
+
+If you're new, start at [Get started](https://condash.vcoeur.com/get-started/) — install, first launch, and a ten-minute first-run tutorial.
+If you want to contribute, read [Values](https://condash.vcoeur.com/explanation/values/), [Non-goals](https://condash.vcoeur.com/explanation/non-goals/), and [Contributing](https://condash.vcoeur.com/explanation/contributing/) before writing code.
 
 This repo is the **Electron build**, canonical as of 2026-04-27. The Tauri lineage lives on at [`vcoeur/condash-tauri`](https://github.com/vcoeur/condash-tauri) (last release: v1.8.8) and remains buildable as long as bug fixes are warranted.
-
-**Status**: parity reached against Tauri v1.8.1 daily-driver surface; packaging + first published release tracked in [`conception/projects/2026-04/2026-04-27-condash-packaging`](https://github.com/vcoeur/conception/tree/main/projects/2026-04/2026-04-27-condash-packaging).
 
 ## Why a rewrite
 
@@ -70,14 +73,16 @@ No HTTP server, no SSE, no fingerprint poll, no Rust. Renderer talks to main via
 
 ## Documentation
 
-The full documentation tree is at [`docs/`](docs/) (Diátaxis layout):
+The published site at [**condash.vcoeur.com**](https://condash.vcoeur.com) is built from [`docs/`](docs/) (Diátaxis layout) by the GitHub Pages workflow on every release.
 
-- [`docs/index.md`](docs/index.md) — landing page with links into every section.
-- [`docs/explanation/internals.md`](docs/explanation/internals.md) — load-bearing invariants (drift-checked mutations, atomic-rename writes, the per-file write queue, the TTL git-status cache, the SIGTERM → force_stop → SIGKILL pty pipeline, the IPC contract).
-- [`docs/reference/config.md`](docs/reference/config.md) — `<conception>/configuration.json` reference: every key, with examples and edit paths.
-- [`docs/explanation/non-goals.md`](docs/explanation/non-goals.md) — what condash will deliberately not do.
+Headline pages:
 
-The same docs are available inside the running app via the `?` button in the toolbar (the in-app loader maps `architecture` / `configuration` / `non-goals` to the Diátaxis paths above — see `src/main/help.ts`).
+- [Get started](https://condash.vcoeur.com/get-started/) — install, first launch, releases.
+- [Tutorials](https://condash.vcoeur.com/tutorials/) — first run, first project, a day with condash.
+- [Reference](https://condash.vcoeur.com/reference/) — every CLI verb, config key, IPC verb, README field, mutation, shortcut, env var.
+- [Explanation](https://condash.vcoeur.com/explanation/) — values, non-goals, internals, contributing, why Markdown-first.
+
+The same docs ship **inside the running app** through the Help menu — Welcome / Install / First launch / Shortcuts / Configuration / CLI / Mutations / Architecture / Why Markdown-first / Values / Non-goals — backed by the allowlist in [`src/main/help.ts`](src/main/help.ts) reading from the asar-bundled `docs/` tree. External links from the in-app pages route to the public site through `openExternal`.
 
 ## License
 

--- a/docs/explanation/contributing.md
+++ b/docs/explanation/contributing.md
@@ -1,0 +1,151 @@
+---
+title: Contributing · condash explanation
+description: How to clone, build, run, test, and submit a change to condash. The on-ramp for first-time contributors.
+---
+
+# Contributing
+
+> **Audience.** Developer — first-time contributor or returning developer who needs a refresher on the workflow.
+
+condash is a single-developer project, but the codebase is designed to welcome outside contributions. This page is the on-ramp: clone, build, run, test, ship a change.
+
+If you want the design rationale rather than the workflow, read [Values](values.md) and [Non-goals](non-goals.md) first.
+
+## Prerequisites
+
+- **Node.js 20+** — exact minor doesn't matter; CI tests against 20.x.
+- **`git`** on `PATH`. condash shells out for status / worktree info; the build also uses it.
+- **A C/C++ toolchain** for native modules (currently `node-pty`):
+  - Linux — `build-essential python3 libxkbfile-dev libsecret-1-dev`.
+  - macOS — Xcode Command Line Tools (`xcode-select --install`).
+  - Windows — Visual Studio Build Tools 2019+ with the C++ workload.
+- **An editor or IDE** of your choice. The repo is plain TypeScript + CSS; any modern editor works. The codebase has no `.vscode/` settings to import.
+
+That's it. No framework boilerplate, no per-developer config.
+
+## Clone, install, run
+
+```bash
+git clone https://github.com/vcoeur/condash.git
+cd condash
+make install      # one-off — npm install + electron-rebuild
+make dev          # watch mode: tsc + vite + electron with --no-sandbox
+```
+
+`make dev` runs three processes concurrently:
+
+- `tsc --watch` typechecks `src/main/` and `src/renderer/` continuously. No emit — esbuild handles bundling.
+- `vite` serves the renderer at `localhost:5600`. Hot module reload works for the renderer.
+- `electron` opens a single `BrowserWindow` against the dev URL. Main / preload changes restart on the next launch (`Ctrl+R` on the dev window).
+
+If port 5600 is in use, `make kill` frees it. Add or change ports? See the dev-port checklist in [`CLAUDE.md`](https://github.com/vcoeur/condash/blob/main/CLAUDE.md).
+
+## Project layout
+
+```
+src/
+├── main/         # Electron main process. fs, IPC handlers, watchers, mutations.
+├── preload/      # contextBridge — exposes window.condash typed as CondashApi.
+├── renderer/     # Solid SPA. Components, signals, Markdown rendering, modals.
+├── shared/       # Types + IPC contract. Imported by all three layers.
+└── cli/          # The condash CLI (since v2.4.0). Same binary, different argv.
+
+scripts/          # Build glue. esbuild entry point, electron-builder helpers.
+docs/             # This documentation site.
+tests/            # Playwright E2E + Vitest unit tests.
+conception-template/  # Skills + sample tree shipped via `condash skills install`.
+```
+
+Three TS configs:
+
+- `tsconfig.main.json` — main + preload + cli.
+- `tsconfig.renderer.json` — renderer.
+- `tsconfig.json` — shared + tooling.
+
+Each config is checked independently. `make typecheck` runs both. esbuild does the actual emission for main + preload + cli; vite handles the renderer.
+
+## How a feature lands
+
+A typical feature touches three layers in sequence:
+
+1. **`src/shared/api.ts`** — add the IPC verb signature to the `CondashApi` interface. Plain serialisable inputs and outputs (no functions, no Date objects, ISO strings).
+2. **`src/main/`** — implement the handler. Register it in `src/main/index.ts:registerIpc` as a single-line `ipcMain.handle('verb', impl)`.
+3. **`src/preload/index.ts`** — add a one-liner: `verb: (...args) => ipcRenderer.invoke('verb', ...args)`.
+4. **`src/renderer/`** — call it through `window.condash.verb(...)`.
+
+Because `CondashApi` is a single typed interface, the compiler will refuse to build until all four layers agree. There is no string-mux'd action layer where a typo silently no-ops.
+
+For renderer-only features (UI states, animations, derived signals), only the renderer changes.
+
+## Testing
+
+```bash
+make typecheck    # tsc --noEmit on both projects
+make test         # vitest unit tests
+make e2e          # Playwright against a real Electron build
+```
+
+- **Vitest** — `tests/unit/`. Fast. Pure-function tests (parsers, path helpers, regexes).
+- **Playwright** — `tests/e2e/`. Drives the real Electron app. Slower, more authoritative. The Playwright fixture launches Electron with `CONDASH_FORCE_PROD=1` so the renderer loads the real `dist/` build, not the Vite dev server.
+
+For a feature that touches the dashboard's behaviour, prefer Playwright. The e2e suite seeds a temporary conception tree, exercises the feature, and asserts on real DOM + real file writes.
+
+## Style and conventions
+
+- **`make format`** runs Prettier across `src/`. Run it before every commit. CI fails on unformatted code.
+- **No comments unless the *why* is non-obvious.** Names already say *what*. See [`CLAUDE.md`](https://github.com/vcoeur/condash/blob/main/CLAUDE.md) for the longer version.
+- **Don't add features beyond what the task requires.** Bug fixes don't need surrounding cleanup. Three similar lines beats a premature abstraction.
+- **Small commits, descriptive subjects.** Imperative mood, ≤72 characters.
+- **One PR per logical change.** A 30-line PR with one review cycle ships faster than a 300-line PR that needs three.
+
+## What the build pipeline produces
+
+```
+make build       # → dist-electron/main/index.js, dist-electron/preload/index.js, dist/
+make package     # → release/{*.AppImage, *.deb, *.dmg, *.exe, latest*.yml}
+```
+
+Native modules (`electron`, `node-pty`) stay external — esbuild leaves them as `require()` calls so they load from `node_modules`. `electron-rebuild` rebuilds them against the bundled Electron's Node ABI; `electron-builder` runs it again at package time.
+
+The release pipeline (`.github/workflows/release.yml`) builds all four installers on tag push, uploads them to the GitHub Release as draft assets, and rebuilds the apt repository at `condash.vcoeur.com/apt/` from every published `.deb`.
+
+## Documentation changes
+
+This documentation site lives at `docs/` in the same repo. The mkdocs nav is at `mkdocs.yml`. To preview locally:
+
+```bash
+pip install mkdocs-material
+mkdocs serve     # → http://localhost:8000
+```
+
+Conventions:
+
+- Every page declares its **Audience** at the top, immediately under the H1.
+- Diátaxis layout: tutorials teach, guides solve, reference looks up, explanation explains.
+- Cross-link to neighbouring pages.
+- Source-of-truth fields (config keys, IPC verbs, exit codes) are tested against the code in CI: if the docs diverge, the test fails.
+
+Every code change that affects user-visible behaviour ships with a docs update in the same commit.
+
+## Issues, PRs, releases
+
+- **Issues** — file at [`github.com/vcoeur/condash/issues`](https://github.com/vcoeur/condash/issues). For bugs, include the OS, the condash version (footer of the dashboard), and a minimal repro tree if you can.
+- **PRs** — branch from `main`, open a PR against `main`. The PR template asks for a Summary, a Changes list, and an optional Impact / Watchpoints section.
+- **Releases** — tagged `vMAJOR.MINOR.PATCH`. PATCH for bug fixes and docs; MINOR for new behaviour; MAJOR for breaking config or Markdown changes. Tag pushes trigger the release workflow automatically.
+
+## What to work on
+
+Three good places to start:
+
+1. **Issues tagged `good first issue`** at the issue tracker.
+2. **Pages tagged "stub" or "TODO"** in this docs tree — search the source for `TODO` and `<!-- stub -->`.
+3. **A feature you want yourself.** condash exists because someone wanted it; the next feature probably will too.
+
+Before starting on anything large, open an issue with the proposed approach and link to the values it serves. A 200-word issue saves a 2000-word PR rewrite.
+
+## See also
+
+- [Values](values.md) — the principles a contribution should serve.
+- [Non-goals](non-goals.md) — things contributions should not try to be.
+- [Internals](internals.md) — load-bearing invariants worth understanding before touching the main process.
+- [`CLAUDE.md`](https://github.com/vcoeur/condash/blob/main/CLAUDE.md) — the developer-instructions file checked into the repo.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -5,8 +5,12 @@ description: Why condash works the way it does — the design commitments, and h
 
 # Explanation
 
-Three pages.
+> **Audience.** New user (curious about why) and Developer (designing or reviewing changes).
+
+Five pages, in roughly the order to read them:
 
 - **[Why Markdown-first](why-markdown.md)** — the pitch. Why files-as-source-of-truth, why no SaaS, why you can put this down as easily as you pick it up.
-- **[Internals](internals.md)** — the three Electron processes, the IPC contract, the chokidar watcher, the per-file write queue, the PTY kill pipeline. How the pieces hang together.
+- **[Values](values.md)** — the design principles every change should serve.
 - **[Non-goals](non-goals.md)** — what condash deliberately doesn't do, and why. Read before opening a "while we're at it" PR.
+- **[Internals](internals.md)** — the three Electron processes, the IPC contract, the chokidar watcher, the per-file write queue, the PTY kill pipeline. How the pieces hang together.
+- **[Contributing](contributing.md)** — clone, build, run, test, ship a change.

--- a/docs/explanation/non-goals.md
+++ b/docs/explanation/non-goals.md
@@ -5,6 +5,8 @@ description: Things condash will deliberately not do. Each entry has a why — r
 
 # Non-goals
 
+> **Audience.** Developer — anyone considering a change to condash.
+
 Things condash will deliberately not do. Each entry has a *why* — read it before opening a "while we're at it" PR.
 
 ## No code editing in condash

--- a/docs/explanation/values.md
+++ b/docs/explanation/values.md
@@ -1,0 +1,118 @@
+---
+title: Values · condash explanation
+description: The design values that drive condash. The positive counterpart to the non-goals page — read this before adding a feature, then check the non-goals before designing it.
+---
+
+# Values
+
+> **Audience.** Developer — anyone designing, reviewing, or contributing changes to condash.
+
+[Non-goals](non-goals.md) is a list of things condash will deliberately not do. This page is the positive counterpart: the principles that explain *why* the non-goals are non-goals, and that should guide any feature decision.
+
+## 1. The Markdown is the source of truth
+
+The conception tree on disk is authoritative. The dashboard is a renderer, not a database front-end. Anything condash knows about your work, it just read from a file. Anything you change in the dashboard, it just wrote to a file.
+
+Practical consequences:
+
+- **No cache except where simplicity demands one.** The git-status TTL cache exists because polling `git status` on every paint is wasteful, but the cache is 3 seconds — short enough to be invisible, short enough to never lie about reality.
+- **No background sync.** The user's editor and the dashboard write to the same files; concurrency is handled by drift checks, not by reconciling a separate database.
+- **No schema migration.** Markdown header fields are parsed lazily. New fields can appear; old fields can disappear; existing trees keep working.
+
+If a feature needs a database, an index, or a sync server, it probably belongs somewhere other than condash.
+
+## 2. Single user, local only
+
+condash binds to nothing public. It speaks IPC to one renderer and `fs` to one tree. There is no auth, no multi-user mode, no remote control surface, no opt-in telemetry.
+
+Practical consequences:
+
+- **No login screen, ever.** No accounts, no API keys, no OAuth flow.
+- **No opt-out telemetry either.** condash collects nothing about you. The only thing it ever fetches is the GitHub Releases feed during the auto-update check.
+- **No feature where "single-user" is in tension with how it's meant to work.** Real-time collaboration, presence indicators, "X is editing this" markers: not even on the long-term roadmap. Use git.
+
+## 3. Simple over clever
+
+Reach for the boring solution first. Re-walk the tree on every search query. Use a 3-second cache instead of a coherent index. Atomic writes via tmp + rename instead of an in-memory journal. Solid signals instead of state-management folklore.
+
+Practical consequences:
+
+- **Three similar lines is fine.** Don't introduce an abstraction the third time the pattern appears — wait until the fifth, when you actually understand the cleavage.
+- **No frameworks for things stdlib does.** The Markdown headers parse with a regex. The README walker is a single recursive `readdir`. There is no DI container, no event bus, no service-locator.
+- **`tsc --noEmit` + esbuild instead of a unified build framework.** The build pipeline fits in `scripts/build-electron.mjs`.
+
+The exception: where simplicity actively hurts the user. The 16 ms paint budget below is non-negotiable, even when "simple" would mean a 60 ms re-render.
+
+## 4. Sub-16-millisecond interaction-to-paint
+
+Any user-initiated action must commit to paint within one display frame at 60 Hz. This is the budget that makes the dashboard feel like a tool and not a webpage.
+
+Practical consequences:
+
+- **Optimistic UI is the default.** A click toggles the step in the renderer immediately; the IPC write follows; on failure, the renderer rolls back and surfaces a toast.
+- **No animations on critical paths.** Status pills don't fade. Cards don't slide. The drag-drop handler does not animate the dropped position into place.
+- **Profiling, not vibes.** When a renderer pause appears, it's measured (with `performance.mark` / Chrome DevTools), not handwaved. The IPC handler that backs each verb has a known latency.
+
+If a feature can't fit in 16 ms, it gets a different surface — a modal, a dialog, an explicit "running…" state. Never a stalled main UI.
+
+## 5. Cross-platform without per-OS branches in the renderer
+
+condash is Electron precisely so the renderer renders identically on Linux, macOS, and Windows. The renderer code is allowed to call native APIs through IPC, but it must never branch on `process.platform`.
+
+Practical consequences:
+
+- **All path normalisation happens at the IPC boundary.** `toPosix` in `src/shared/path.ts` is the only path-format API the renderer touches. The main process keeps native separators internally.
+- **All shell wrapping happens in the main process.** `wrapForShell` in `src/main/terminals.ts` builds platform-specific argv for `bash`, `cmd.exe`, and `pwsh`. The renderer just sends `{shell, command}`.
+- **CSS uses logical properties** (no `marginLeft`-style; use `margin-inline-start`). Flex / grid only — no absolute pixel positioning that depends on a particular OS chrome.
+
+If a feature would require a per-OS branch in the renderer, it needs a different design.
+
+## 6. Open standards over bespoke formats
+
+When a standard exists, use it. When one doesn't, prefer plain text + a regex over a custom binary format.
+
+Practical consequences:
+
+- **GitHub Flavored Markdown for content.** Tasks (`[ ]`/`[x]`) are GFM-task-list. Headers are H1/H2/H3. Tables are pipe tables. Anyone with a Markdown editor can read the same files.
+- **JSON for structured config.** No YAML, no TOML. JSON has stdlib parsers everywhere, strict schema validators, and reliable in-app editing.
+- **OSC 133 for terminal prompt boundaries.** Same protocol as iTerm2, WezTerm, kitty, Warp. Drop-in shell snippets, no custom protocol.
+- **`xterm-256color` for terminal capabilities.** Works with every modern terminal program.
+
+The exception: when a standard doesn't exist (the **Status** field syntax, the directory layout `projects/YYYY-MM/<slug>/`), pick the simplest possible plain-text shape and commit to it.
+
+## 7. The dashboard is a thin write surface
+
+Of every action a user performs, only a small handful translate to file writes from the dashboard. The rest belong to the user's editor or to a Claude Code session via the management skills.
+
+The full list of writes lives in [Mutation model](../reference/mutations.md). It is short on purpose.
+
+Practical consequences:
+
+- **No "rich editing" of READMEs.** The text is a plain Markdown buffer in CodeMirror with task-list and wikilink decoration. No WYSIWYG, no toolbar, no slash-commands.
+- **Mutations are reversible by `sed`.** Anything condash writes, you could write by hand. The renderer is a shortcut, not a magic layer.
+- **Drift is detected, not reconciled.** If the file changed under condash's feet, the next mutation refuses and the user re-reads the file. There is no merge.
+
+When in doubt, do less from the dashboard, more from the editor.
+
+## 8. Skills are first-class
+
+condash ships its own Claude Code skills (`/projects`, `/knowledge`) and is designed to coexist with them. Anything the dashboard does, the user can also do from a Claude Code session via plain file I/O — no IPC bridge, no API surface, no integration layer.
+
+Practical consequences:
+
+- **No feature that requires the dashboard to be running** to make sense. Items can be created, edited, and closed entirely from the shell or from a Claude session — the dashboard catches up via the chokidar watcher.
+- **No feature that requires bespoke "AI integration".** condash doesn't talk to any LLM directly. The skills do, on the user's terms.
+- **The skill content is shipped from condash itself.** `condash skills install` copies the canonical skill files into the user's tree. New skill verbs land in condash, the user re-runs `condash skills install`, and they're available in Claude Code.
+
+## How to use this page
+
+When you open a PR that adds a feature, ask: which value drives this? When you reject a PR, ask: which value did this trample? When a feature looks compelling but doesn't fit any of these eight, that's a signal it might belong in a different tool.
+
+If you think a value needs revisiting, open an issue with a concrete user story, get sign-off, then propose the change here. Like the [non-goals](non-goals.md) page, this is append-only in spirit — softening a value silently is a recipe for scope creep.
+
+## See also
+
+- [Non-goals](non-goals.md) — the negative counterpart to this page.
+- [Internals](internals.md) — the load-bearing invariants that implement these values.
+- [Why Markdown-first](why-markdown.md) — the user-facing pitch built on top of value 1.
+- [Contributing](contributing.md) — how to put these values into practice when working on condash itself.

--- a/docs/explanation/why-markdown.md
+++ b/docs/explanation/why-markdown.md
@@ -5,6 +5,8 @@ description: The case for a project tracker built on plain Markdown files in git
 
 # Why Markdown-first
 
+> **Audience.** New user evaluating condash, plus anyone curious about the design rationale.
+
 Every project tracker answers a few questions for you: what am I working on, what's its status, what did I decide and why, what's still open? There are plenty of good tools for this — Linear, GitHub Projects, Notion, Jira, Obsidian with a kanban plugin. `condash` exists because none of them give you all three of the following at the same time:
 
 1. **The files are yours.** Editable in the editor you already use, diffable in git, grep-able from a shell, readable by every tool that has ever spoken Markdown.

--- a/docs/get-started/first-launch.md
+++ b/docs/get-started/first-launch.md
@@ -5,50 +5,74 @@ description: What happens the first time you open condash, how to pick your conc
 
 # First launch
 
+> **Audience.** New user — never used condash before.
+
 The first time you launch condash, it needs to know which Markdown tree to render. There's no hard-coded default — if it can't find one, a native folder picker opens and asks you to select it.
 
 ## The conception tree
 
 A conception tree is a directory on your disk with at least one of:
 
-- A `configuration.yml` file at the root (optional for a fresh tree, required for the repo strip and "open with" buttons to do anything useful).
+- A `configuration.json` file at the root (optional; needed only for the Code tab and "open with" buttons to do something useful).
 - A `projects/` subdirectory containing your item READMEs.
 
 Optional siblings — `knowledge/`, a `documents/` drop-point, and so on — add features but aren't required to boot condash. See the **[conception convention](../reference/conception-convention.md)** for the full shape.
 
-If you don't already have a tree, a minimal bootstrap is a scratch directory with an empty `projects/` inside:
+If you don't already have a tree, the simplest bootstrap is an empty `projects/` directory:
 
 ```bash
-mkdir -p /tmp/condash-scratch/projects
-CONDASH_CONCEPTION_PATH=/tmp/condash-scratch condash
+mkdir -p ~/src/conception/projects
 ```
 
-That's enough for the dashboard to render — use the **+ Item** button to create your first README.
+Then point condash at `~/src/conception` through the folder picker. The dashboard renders an empty Projects tab and a welcome screen guides you to your first action — see [Welcome screen](#welcome-screen) below.
 
-## The three ways condash finds your tree
+## How condash finds your tree
 
 On startup condash checks, in order:
 
-1. **`CONDASH_CONCEPTION_PATH` environment variable.** Wins over everything. Useful for scripts, demos, and running condash against a scratch tree without touching your saved settings:
+1. **`CONDASH_CONCEPTION_PATH` environment variable.** A one-shot override that wins over everything else, useful for scripted demos and ad-hoc trees:
    ```bash
    CONDASH_CONCEPTION_PATH=/tmp/scratch-tree condash
    ```
-2. **Saved user setting.** If the env var is unset, condash reads `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` (Linux/macOS) or `%APPDATA%\condash\settings.yaml` (Windows). The file has one key:
-   ```yaml
-   conception_path: /home/you/src/conception
+2. **Saved user setting.** `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux), `~/Library/Application Support/condash/settings.json` (macOS), `%APPDATA%\condash\settings.json` (Windows). One key:
+   ```json
+   {
+     "conception_path": "/home/you/src/conception"
+   }
    ```
-   It's written automatically after the folder picker on first launch.
-3. **Folder picker.** If neither the env var nor the settings file supply a path, condash opens a native OS folder picker. Pick the directory that holds your `projects/` + (optional) `configuration.yml`. On **Cancel**, condash exits cleanly.
+   The folder picker writes this on first launch, so you usually don't edit it by hand.
+3. **Folder picker.** If neither the env var nor the settings file supply a path, condash opens a native OS folder picker. Pick the directory that holds your `projects/` (and optionally `configuration.json`). On **Cancel**, condash exits cleanly.
+
+## Welcome screen
+
+If the conception path resolves to a directory that has **no items** in `projects/` and **no entries** in `knowledge/`, condash shows a Welcome screen instead of an empty dashboard. Three actions:
+
+- **Create your first project** — opens the new-item modal with sensible defaults.
+- **Take the tour** — opens the in-app Help with the welcome page.
+- **Open the documentation site** — opens [condash.vcoeur.com](https://condash.vcoeur.com) in your browser.
+
+A small "Don't show this again" checkbox writes `welcome.dismissed = true` to `settings.json`. Once you have content in the tree (one item or one knowledge file is enough), the welcome screen stops appearing on its own.
 
 ## Changing your mind later
 
 To point condash at a different tree:
 
-- **Temporarily**: set `CONDASH_CONCEPTION_PATH` for one run, then relaunch without it to go back to the saved tree.
-- **Permanently**: edit `${XDG_CONFIG_HOME:-~/.config}/condash/settings.yaml` directly, or delete the file to get the folder picker again on the next launch.
+- **Through the CLI**: `condash config conception-path /path/to/other-tree` writes `settings.json` for you. The next launch picks it up.
+- **By hand**: edit `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` directly.
+- **Re-run the picker**: delete the `conception_path` key (or the whole file) and the picker reappears on the next launch.
 
 ## What else you can configure
 
-The conception path is the only thing condash needs to boot. Everything else — the workspace of code repos shown in the Code tab, the "open with" launcher chains, terminal preferences — lives inside the conception tree itself as `configuration.yml`. Edit it by hand or through the gear icon in the dashboard header (which opens a plain YAML editor).
+The conception path is the only thing condash needs to boot. Everything else has sensible defaults.
 
-See **[Config file reference](../reference/config.md)** for the full schema.
+The **per-tree** config (`<conception>/configuration.json`) holds the workspace path, the list of repos in the Code tab, and the launcher chains for "open with" buttons. It's checked into git and shared with teammates.
+
+The **per-machine** config (`settings.json`) holds the conception path, the theme, and any per-machine overrides for terminal / "open with" preferences.
+
+See **[Config files reference](../reference/config.md)** for the full schema.
+
+## See also
+
+- [Install](install.md) — get the binary on your machine.
+- [Configure the conception path](../guides/configure-conception-path.md) — the deeper guide on this exact topic.
+- [First run](../tutorials/first-run.md) — a guided walk through your first session, with a sample tree.

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -5,10 +5,12 @@ description: Install condash, find the right release for your OS, launch it for 
 
 # Get started
 
+> **Audience.** New user.
+
 Three steps to a working condash install. Each takes about a minute if the download is fast.
 
 1. **[Install](install.md)** — download the installer for your OS, bypass the unsigned-binary warning, and launch condash.
-2. **[Find a release](releases.md)** — how to check for updates, what each version tag means, and why there's no auto-updater.
+2. **[Find a release](releases.md)** — how to check for updates, what each version tag means, and how the auto-updater behaves.
 3. **[First launch](first-launch.md)** — pick your conception tree on first open; condash remembers it from then on.
 
 Once condash is running, the **[Tutorials](../tutorials/index.md)** take you through your first project, and the **[Guides](../guides/index.md)** cover task-focused how-tos.

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -5,6 +5,8 @@ description: Download and launch the unsigned Electron build of condash on Linux
 
 # Install
 
+> **Audience.** New user — never used condash before, want it on your machine.
+
 **When to read this.** You downloaded condash from the GitHub Releases page and your OS is asking whether to trust it.
 
 The Electron builds of condash are **unsigned on purpose**. Signing Windows and macOS binaries costs $180–400/year in cert fees, and condash is a single-developer tool. Each OS asks you to confirm the download once on first launch; this page walks through the gesture per platform.

--- a/docs/get-started/releases.md
+++ b/docs/get-started/releases.md
@@ -1,9 +1,11 @@
 ---
 title: Releases · condash
-description: How to find the latest condash release, what the version scheme means, and what "unsigned draft release" looks like in practice.
+description: How to find the latest condash release, what the version scheme means, and how the auto-updater behaves.
 ---
 
 # Releases
+
+> **Audience.** New user and Daily user.
 
 condash is shipped as a pre-built desktop binary on GitHub Releases. This page is about **finding the right version** — one link above all else: **[releases/latest](https://github.com/vcoeur/condash/releases/latest)**.
 
@@ -45,8 +47,8 @@ If the [latest-release](https://github.com/vcoeur/condash/releases/latest) URL 4
 
 If you're waiting on a specific fix, the GitHub **Actions** tab shows the build progress; the release appears under **All releases** the moment the maintainer flips the draft to published.
 
-## No auto-updater, by design
+## Auto-update
 
-The desktop app does not check for or install updates on its own. See **[Install — Why no auto-update?](install.md#auto-update)** for the reasoning.
+condash ships with `electron-updater` wired against its GitHub Releases. On launch the packaged build checks the latest published release, downloads the matching artifact in the background, and prompts to restart when it's ready. See **[Install — Auto-update](install.md#auto-update)** for the per-OS behaviour and the apt-repository carve-out.
 
-Practical consequence: if you run condash daily and want to stay current, subscribe to the repo's **Releases** tab — GitHub will email you when a new version ships.
+If you'd rather track releases manually, subscribe to the repo's **Releases** tab on GitHub — you'll get an email when a new version ships.

--- a/docs/guides/configure-conception-path.md
+++ b/docs/guides/configure-conception-path.md
@@ -5,6 +5,8 @@ description: Point condash at the directory it should render — persistently or
 
 # Configure the conception path
 
+> **Audience.** New user and Daily user.
+
 **When to read this.** You want condash to render a tree other than the one it's using now, or you want to know all the ways that path can be set.
 
 The conception path is the only piece of configuration condash needs before it can start. Everything else has a sensible default.
@@ -31,17 +33,26 @@ Delete the file to force the folder picker on the next launch.
 
 On startup condash checks, in order:
 
-1. `conception_path` in `settings.json`.
-2. First-launch folder picker. Writes the choice back to `settings.json`.
-3. Hard error — condash refuses to start.
+1. `CONDASH_CONCEPTION_PATH` environment variable (one-shot override).
+2. `conception_path` in `settings.json`.
+3. First-launch folder picker. Writes the choice back to `settings.json`.
+4. Hard error — condash refuses to start.
 
-> **Note.** The Electron build does not yet honour an environment-variable override (the Tauri build read `CONDASH_CONCEPTION_PATH`). To switch trees today, edit `settings.json` or relaunch the picker. Drop a request in [issues](https://github.com/vcoeur/condash/issues) if you need an env-var hook for scripted demos.
+### Option 3 — `CONDASH_CONCEPTION_PATH` for a one-off
+
+A session-scoped override:
+
+```bash
+CONDASH_CONCEPTION_PATH=/tmp/scratch-tree condash
+```
+
+The env var wins over `settings.json` for that launch only. It is **not** persisted, so the next plain `condash` falls back to the saved path. Useful for demos and scratch trees.
 
 ## When to use a scratch tree
 
 A scratch tree is any directory with a minimal `projects/YYYY-MM/` layout that you point condash at temporarily. Common reasons:
 
-- **Learning** — the bundled `conception-demo` tree, fetched in [First run](../tutorials/first-run.md).
+- **Learning** — a fresh tree you create yourself, walked through in [First run](../tutorials/first-run.md).
 - **Onboarding a teammate** — fork a small sample tree, have them point condash at it, walk them through creating their first item, then point them at the team tree.
 - **Snapshot of a bug** — reduce a broken tree to a minimal reproducer, commit it, and file the issue with the snapshot path in the repro steps.
 

--- a/docs/guides/deliverables.md
+++ b/docs/guides/deliverables.md
@@ -5,6 +5,8 @@ description: The `## Deliverables` section syntax, filename conventions, PDF gen
 
 # Deliverables and PDFs
 
+> **Audience.** Daily user.
+
 **When to read this.** Your item produces a tangible output — a report, a design doc, an incident post-mortem — and you want it to show up on the card with a download link and an embedded viewer.
 
 Deliverables are a first-class concept: a `## Deliverables` section in a README lists one or more PDF files, and condash renders a download badge on the card plus a viewer in the expanded card.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -5,6 +5,8 @@ description: Task-focused how-tos for the parts of condash you probably won't di
 
 # Guides
 
+> **Audience.** Daily user.
+
 Each guide answers one specific question. They assume you've worked through the [Tutorials](../tutorials/index.md) and know the basic shape of the tool.
 
 **Configuration**
@@ -20,6 +22,7 @@ Each guide answers one specific question. They assume you've worked through the 
 - [The knowledge tree](knowledge-tree.md)
 - [Search your history](search.md)
 - [Deliverables and PDFs](deliverables.md)
+- [Troubleshooting](troubleshooting.md)
 
 **Extending**
 

--- a/docs/guides/knowledge-tree.md
+++ b/docs/guides/knowledge-tree.md
@@ -5,6 +5,8 @@ description: Put durable reference material under `knowledge/` and see it render
 
 # The knowledge tree
 
+> **Audience.** Daily user.
+
 **When to read this.** Your conception tree has grown, you keep writing the same note twice across items, and you want a place for durable reference material that outlives any one project.
 
 `knowledge/` is a sibling of `projects/` under your conception root. condash walks it recursively and renders it as the **Knowledge** tab — a plain file explorer for durable docs that don't belong to any single item.

--- a/docs/guides/multi-machine.md
+++ b/docs/guides/multi-machine.md
@@ -5,6 +5,8 @@ description: Sync a conception tree between machines via git. What goes in versi
 
 # Multi-machine setup
 
+> **Audience.** Daily user.
+
 **When to read this.** You work across two (or more) machines — a desktop and a laptop, your work box and a personal box — and you want the same tree on each, with per-machine tweaks that don't fight each other.
 
 condash was designed for this split from day one. One versioned JSON file at the tree root, one per-machine JSON file in your platform's user-config directory. The two layer at launch with clear precedence.

--- a/docs/guides/repositories-and-open-with.md
+++ b/docs/guides/repositories-and-open-with.md
@@ -5,6 +5,8 @@ description: Point condash at your workspace, group repos into primary / seconda
 
 # Repositories and open-with buttons
 
+> **Audience.** Daily user.
+
 **When to read this.** The **Code** tab shows the wrong repos, or the wrong repos are in the primary card, or the "open in IDE" button launches the wrong thing (or nothing).
 
 Everything on this page lives in `<conception_path>/configuration.json`. This file is versioned with the tree — changes propagate to every teammate who pulls. Per-machine overrides go in `settings.json` (see [Multi-machine setup](multi-machine.md)).

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -5,6 +5,8 @@ description: Use the History tab's full-text search, read the ranking, read the 
 
 # Search your history
 
+> **Audience.** Daily user.
+
 **When to read this.** You remember writing something — a note, a README paragraph, a step description — and you need to find it without grepping the tree by hand.
 
 The **History** tab is a full-text search across every item's README, every note file, and every knowledge file. It re-indexes on every query; there's no background job and no stale cache.

--- a/docs/guides/skill-extensions.md
+++ b/docs/guides/skill-extensions.md
@@ -5,6 +5,8 @@ description: Three realistic extension patterns for the shipped `/conception-ite
 
 # Extend the management skill
 
+> **Audience.** Daily user and Developer.
+
 **When to read this.** You installed the shipped `/conception-items` skill, used it for a week, and hit "I wish this also did X". This page shows three concrete patterns that cover the 90% of what teams actually add on top.
 
 The shipped skill is minimal on purpose. Every extension here is a ten-minute change to a single `SKILL.md` file — there's no plugin API, no hook registration; you're editing a Markdown prompt file and relying on Claude Code to read your updated instructions.

--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -5,6 +5,8 @@ description: Open the PTY pane, manage tabs across two sides, use the launcher b
 
 # Use the embedded terminal
 
+> **Audience.** Daily user.
+
 **When to read this.** You want to stop alt-tabbing out to a separate terminal window while you work — or you tried the `>_` button in the header, opened the pane once, and couldn't find half the features.
 
 The embedded terminal is a real PTY driven by `node-pty` in the main process and rendered by `xterm.js` (locked to xterm 6.x with the recommended addon stack — search, web-links, clipboard, unicode11, webgl, serialize, image, ligatures) in the renderer.
@@ -120,6 +122,11 @@ See the [config reference](../reference/config.md) for the full key table with d
 
 Edit `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` directly — `settings.json` is hand-edited today; the gear modal only edits the tree-level `configuration.json`. Changes land on the next launch. To test a new shortcut quickly, set it, relaunch, and press the combination.
 
-## Platform note
+## Platform notes
 
-The terminal is Linux and macOS only. On Windows the pane opens with a "terminal only supported on Linux/macOS" error message — PTY support through WSL is on the backlog, not shipped.
+The terminal works on Linux, macOS, and Windows. The shell defaults differ by platform:
+
+- **Linux / macOS** — `$SHELL` (or `/bin/bash` if unset).
+- **Windows** — `%ComSpec%` (`cmd.exe` by default). Override with `terminal.shell = "C:\\Program Files\\PowerShell\\7\\pwsh.exe"` if you prefer PowerShell, or any `bash` from Git for Windows / MSYS2.
+
+Per-platform shell wrapping (so `terminal.run` strings reach the right shell) lives in `src/main/terminals.ts:wrapForShell`. Shell-integration snippets under `integrations/` cover bash, zsh, fish, and PowerShell.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -1,0 +1,164 @@
+---
+title: Troubleshooting · condash guide
+description: Common problems, what they look like, and how to fix them — installer refusals, empty dashboards, stuck terminals, missing repos.
+---
+
+# Troubleshooting
+
+> **Audience.** New user and Daily user — anything that surprises someone using condash for real work.
+
+If you hit something not on this page, file an [issue](https://github.com/vcoeur/condash/issues) with the OS, condash version (footer of the dashboard), and a minimal repro.
+
+## Install / first launch
+
+### "App can't be opened — developer cannot be verified" (macOS)
+
+condash is unsigned on purpose. macOS asks you to confirm the download once. The bypass differs between Sonoma and Sequoia — see **[Install — macOS Gatekeeper bypass](../get-started/install.md#macos-gatekeeper-bypass)**.
+
+### "Windows protected your PC" (Windows)
+
+Click **More info → Run anyway**. SmartScreen flags every unsigned binary the first time it sees it. See **[Install — Windows SmartScreen bypass](../get-started/install.md#windows-smartscreen-bypass)**.
+
+### AppImage exits silently with no window (Linux)
+
+Most likely a missing system library. Run the AppImage from a terminal so you can see stderr:
+
+```bash
+./condash-*.AppImage
+```
+
+If the error mentions `libnss`, `libgtk`, or `libatk-bridge`, install Electron's runtime deps:
+
+```bash
+sudo apt install libnss3 libatk-bridge2.0-0 libgtk-3-0 libgbm1   # Debian/Ubuntu
+sudo dnf install nss atk at-spi2-atk gtk3 mesa-libgbm             # Fedora
+```
+
+### Folder picker keeps coming back at every launch
+
+condash should remember the conception path you picked. If the picker reappears every time, check the per-machine settings file:
+
+```bash
+cat ${XDG_CONFIG_HOME:-~/.config}/condash/settings.json
+```
+
+If `conception_path` is not set or points to a directory that no longer exists, condash falls back to the picker. Edit the file by hand to fix it, or pick the right path through the picker once more — condash writes the choice on success.
+
+## Empty dashboard
+
+### "Projects (0)" but my tree has READMEs
+
+Check the conception path is correct (footer of the dashboard, or `cat settings.json`). If the path is right but the count is zero, your items don't match the strict layout. condash only renders items at:
+
+```
+projects/YYYY-MM/YYYY-MM-DD-<slug>/README.md
+```
+
+Items at the wrong nesting depth (e.g. `projects/<slug>/` without a month directory) are skipped. The slug must match `^[a-z0-9-]+$` after the date prefix.
+
+Fix: `git mv` the items into the right shape, or use the [`condash projects`](../reference/cli.md) verbs to validate.
+
+### Code tab is empty / "Code (0)"
+
+The Code tab scans `workspace_path` from `configuration.json` for direct subdirectories containing a `.git/`. Two common reasons it's empty:
+
+- `workspace_path` is unset in `configuration.json`. Set it to the directory containing your repos.
+- `workspace_path` points at a parent directory whose direct children are *not* git repos (e.g. an extra nesting level — `~/src/` when your repos are in `~/src/projects/`). The scan is one level deep.
+
+Fix: open the gear modal and edit `workspace_path` to point at the right directory. The Code tab refreshes within a couple of seconds.
+
+### Knowledge tab is empty
+
+Same shape: condash looks for `<conception_path>/knowledge/`. If the directory is missing, the tab is hidden. Create it with `mkdir knowledge && echo "# Knowledge" > knowledge/index.md` — the tab appears immediately.
+
+## Embedded terminal
+
+### Terminal pane opens, but no shell prompt
+
+The shell process exited immediately. Three common causes:
+
+- The configured `terminal.shell` doesn't exist (`/bin/zsh` on a system without zsh installed). Fall back to `/bin/bash` in `settings.json`.
+- The shell rc-file (`.bashrc`, `.zshrc`) errors out. Open the same shell in a separate terminal to see the error.
+- (Linux only) `node-pty` was built against the wrong Node ABI. This shouldn't happen for the packaged `.AppImage` / `.deb`. If it does, file an issue with the version.
+
+### `Ctrl+C` copies instead of sending SIGINT (or vice versa)
+
+`Ctrl+C` does **double duty**: copy the current selection if there is one, otherwise send SIGINT. So if you've highlighted some output and hit `Ctrl+C`, you'll copy it. Click somewhere else to clear the selection, then `Ctrl+C` interrupts.
+
+### Terminal pane is missing on Windows
+
+The terminal works on all three platforms. If the pane fails to open on Windows, check that PowerShell or `cmd.exe` resolves through `process.env.ComSpec` and that no system-level policy is blocking child-process creation.
+
+## "Open in IDE" buttons do nothing
+
+The buttons spawn the command in `open_with.<slot>.command` from `settings.json` (per-machine) or `configuration.json` (tree-wide). Two failure modes:
+
+- The command isn't on `$PATH` (typical for macOS GUI editors that don't install a shell launcher). Use the `open -na` form on macOS — see [Config files — Per-OS recipes](../reference/config.md#per-os-recipes).
+- The path being passed isn't under `workspace_path` or `worktrees_path`. condash refuses to spawn launchers outside those sandboxes; check the toast message.
+
+## Auto-update
+
+### "An update was downloaded" toast, but condash doesn't restart
+
+`electron-updater` downloads the new build silently and prompts to restart. If the prompt appears but nothing happens after clicking restart:
+
+- **macOS** — re-flagged by Gatekeeper. Drop the quarantine attribute and reopen:
+  ```bash
+  xattr -dr com.apple.quarantine /Applications/condash.app
+  ```
+- **Linux AppImage** — make sure the AppImage lives somewhere writable by your user (not under `/opt/`). `electron-updater` rewrites the file in place.
+- **Linux apt** — apt-installed users are exempt from in-app updates. `sudo apt update && sudo apt upgrade` is the update path.
+
+### Auto-update is checking too often / not at all
+
+The check fires once per launch. If you keep condash open for days, the update toast may never appear — relaunch to trigger a check, or watch the [releases page](https://github.com/vcoeur/condash/releases) directly.
+
+## File-edit conflicts
+
+### "Reload before saving" toast on every save
+
+A drift check failed: the file on disk no longer matches what condash had cached. Two reasons:
+
+- You edited the file in your editor while the dashboard had an older version. **Click the refresh icon** in the dashboard header, then redo the change.
+- A chokidar event was missed (rare; usually a network filesystem). Same fix.
+
+### My step toggles silently undo themselves
+
+Same root cause as above. The renderer flips the marker optimistically, the IPC write fails the drift check, and the renderer rolls back. Refresh the dashboard to pick up the on-disk state.
+
+## Performance
+
+### Refresh button takes longer than a second
+
+The conception tree is too big or sits on a slow filesystem (network mount). condash re-walks the tree on each refresh — there is no index on purpose (see [Why no search index](../explanation/internals.md#why-no-search-index)). At a few hundred items this should be well under 50 ms; if you hit a noticeably slower wall, file an issue with the tree size and FS type.
+
+### Embedded terminal is laggy under load
+
+xterm.js renders a lot of cells on every paint. Two knobs help:
+
+- Lower `terminal.xterm.scrollback` from the default 10 000 to something smaller (1 000).
+- Toggle `terminal.xterm.ligatures` off — the ligatures addon is expensive on long lines.
+
+Both keys live in `configuration.json` under `terminal.xterm`. The Settings → Terminal tab in the gear modal edits them live.
+
+## CLI
+
+### `condash projects list` says "no conception"
+
+The CLI honours the same path-resolution chain as the GUI but does not open the folder picker. Point it explicitly:
+
+```bash
+condash --conception ~/src/conception projects list
+```
+
+Or set the path through `condash config conception-path ~/src/conception` (writes to `settings.json`, picked up by both the GUI and the CLI).
+
+### `condash` opens the GUI when I expected the CLI
+
+The CLI dispatcher only fires for known nouns (`projects`, `knowledge`, `search`, `repos`, `worktrees`, `dirty`, `skills`, `config`, `help`) or top-level `--help` / `--version`. A typo silently drops you into the GUI. See [`condash --help`](../reference/cli.md) for the full list.
+
+## Still stuck?
+
+- Open the [issue tracker](https://github.com/vcoeur/condash/issues) and search for the symptom.
+- If nothing matches, file a new issue. Include OS, condash version, and minimum repro.
+- For design questions, see [Why Markdown-first](../explanation/why-markdown.md), [Values](../explanation/values.md), and [Non-goals](../explanation/non-goals.md).

--- a/docs/guides/wikilinks.md
+++ b/docs/guides/wikilinks.md
@@ -5,6 +5,8 @@ description: Cross-link items with `[[slug]]` syntax, resolve by short name or b
 
 # Link items with wikilinks
 
+> **Audience.** Daily user.
+
 **When to read this.** You want one item's README or note to point at another item, without copy-pasting a path that breaks the moment the item moves.
 
 condash resolves `[[slug]]`-style wikilinks (Obsidian-style) inside README bodies and inside notes. The resolver is deliberately narrow: it works on item slugs, not on arbitrary paths, so the link survives a move between months.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,12 +7,44 @@ description: Live desktop dashboard for a Markdown-first project-tracking conven
 
 <p class="tagline">A dashboard for the Markdown you already write.</p>
 
-`condash` is a single-user desktop app that renders a live dashboard of a directory tree of **projects**, **incidents**, and **documents** written as plain Markdown. No database, no sync server, no account — the Markdown files are the source of truth, and `condash` is the view layer.
+`condash` is a single-user desktop app that renders a live dashboard of a directory of **projects**, **incidents**, and **documents** written as plain Markdown. No database, no sync server, no account — the Markdown files are the source of truth, and `condash` is the view layer.
 
 ![condash dashboard overview](assets/screenshots/dashboard-overview-light.png#only-light)
 ![condash dashboard overview](assets/screenshots/dashboard-overview-dark.png#only-dark)
 
-## Install
+## Where do I go?
+
+Pick the entry point that matches your situation:
+
+<div class="grid cards" markdown>
+
+-   **:material-rocket-launch: I'm new — get me started**
+
+    [Install →](get-started/install.md) · [First launch →](get-started/first-launch.md) · [First-run tutorial →](tutorials/first-run.md)
+
+    Audience: never used condash, may not know what "conception" means yet.
+
+-   **:material-tools: I use condash — I need to do something**
+
+    [Guides →](guides/index.md) · [Troubleshooting →](guides/troubleshooting.md) · [Reference →](reference/index.md)
+
+    Audience: knows the basics, wants a how-to or a lookup.
+
+-   **:material-code-tags: I want to change condash**
+
+    [Values →](explanation/values.md) · [Non-goals →](explanation/non-goals.md) · [Internals →](explanation/internals.md) · [Contributing →](explanation/contributing.md)
+
+    Audience: developer evaluating, designing, or contributing changes.
+
+-   **:material-help-circle-outline: I just want to know why**
+
+    [Why Markdown-first →](explanation/why-markdown.md)
+
+    The pitch. Files in git over a SaaS, the dashboard as a thin view layer, three good-fit scenarios.
+
+</div>
+
+## Install in one minute
 
 **Linux, macOS, Windows** — download the installer for your OS from the latest GitHub Release:
 
@@ -28,9 +60,9 @@ Debian/Ubuntu users can skip the manual download and use the apt repository — 
 
 The builds are **unsigned** — each OS asks you to confirm once on first launch. Full walkthrough: **[Install →](get-started/install.md)**.
 
-> **Runtime requirement.** condash shells out to `git` for status and worktree information, so `git` must be on `PATH`. Linux distributions ship it; on macOS install Xcode Command Line Tools (`xcode-select --install`) or Homebrew git; on Windows install [Git for Windows](https://git-scm.com/download/win).
+> **Runtime requirement.** condash shells out to `git` for status and worktree information, so `git` must be on `PATH`. Linux distros ship it; on macOS install Xcode Command Line Tools (`xcode-select --install`) or Homebrew git; on Windows install [Git for Windows](https://git-scm.com/download/win).
 
-Building from source (need [Node.js 20+](https://nodejs.org) and, on Linux, the libraries Electron's chrome-sandbox links against — `libnss3`, `libatk-bridge2.0-0`, `libgtk-3-0`):
+Building from source (Node.js 20+ and, on Linux, Electron's native deps — `libnss3`, `libatk-bridge2.0-0`, `libgtk-3-0`):
 
 ```bash
 git clone https://github.com/vcoeur/condash.git
@@ -39,31 +71,37 @@ make install    # one-off — npm install
 make dev        # watch mode: tsc + vite + electron
 ```
 
-## Start here
+## What it does, in three bullets
 
-<div class="grid cards" markdown>
+- **Renders your conception tree** — the dashboard reads `<conception>/projects/`, `knowledge/`, and `configuration.json`, then displays Projects (Current / Next / Backlog / Done), Code (your repos), Knowledge (your reference notes), and History (full-text search). Live — chokidar fires on every file change.
+- **Mutates a small set of lines** — toggle a step, change a status, save a note, edit the JSON config. Everything else is yours to write in your editor or via the management skill.
+- **Provides a CLI** — the same `condash` binary serves a CLI surface (`condash projects list`, `condash search "…"`, etc.). Skills and shell scripts use it instead of re-implementing condash's parser. See [CLI reference](reference/cli.md).
 
--   **New? [Tutorials](tutorials/index.md)**
+## What it doesn't do
 
-    Work through the three learning paths: install and first run, your first project, then a full day using condash end-to-end.
+- No multi-user collaboration. condash is single-user, local-only.
+- No web UI, no embedded HTTP server.
+- No code editing. Source files open in your IDE via configurable launcher slots.
+- No telemetry. Nothing is sent anywhere except the GitHub Releases feed for auto-updates.
 
--   **Solve a specific problem? [Guides](guides/index.md)**
+The full list with rationale lives at **[Non-goals →](explanation/non-goals.md)**.
 
-    Task-focused how-tos: the embedded terminal, wikilinks, the knowledge tree, multi-machine setup, and more.
+## Documentation map
 
--   **Looking something up? [Reference](reference/index.md)**
+The docs follow [Diátaxis](https://diataxis.fr/) — four sections, each with a clear job:
 
-    Every CLI flag, every config key, every README field, and every action the dashboard takes on your files.
-
--   **Want the why? [Explanation](explanation/index.md)**
-
-    Why Markdown-first, and how the parser, config, and native-window rendering work under the hood.
-
-</div>
+| Section | When to read | What you'll find |
+|---|---|---|
+| **[Get started](get-started/index.md)** | First time, fresh install | Install bypass, first launch, releases |
+| **[Tutorials](tutorials/index.md)** | Learning by doing | Three linear walks: first run, first project, a day's work |
+| **[Guides](guides/index.md)** | Specific task | Configure paths, terminal, wikilinks, knowledge tree, troubleshooting |
+| **[Reference](reference/index.md)** | Looking it up | Every CLI verb, config key, IPC verb, README field, mutation, shortcut |
+| **[Explanation](explanation/index.md)** | Understanding why | Markdown-first pitch, design values, internals, non-goals, contributing |
 
 ## Links
 
 - [Source on GitHub](https://github.com/vcoeur/condash)
 - [Latest release](https://github.com/vcoeur/condash/releases/latest)
 - [All releases](https://github.com/vcoeur/condash/releases)
+- [Issue tracker](https://github.com/vcoeur/condash/issues)
 - [Author](https://vcoeur.com)

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,63 +1,254 @@
 ---
 title: CLI · condash reference
-description: How to launch condash and where its configuration lives.
+description: The condash command-line surface — list projects, search, manage worktrees, install skills, all from the same binary that runs the GUI.
 ---
 
 # CLI
 
-condash is a single Electron binary. It takes no subcommands and no flags — everything is either an environment variable or a line in `settings.json` / `configuration.json`.
+> **Audience.** Daily user and Developer.
+
+The same `condash` binary that opens the dashboard also serves a command-line interface. When you invoke it with a known noun, condash short-circuits the GUI and runs the CLI dispatcher instead. No Chromium boots, no window opens, output goes to stdout / stderr.
+
+```
+condash <noun> <verb> [args] [--flags]
+```
+
+The CLI exists because skills (`/projects`, `/knowledge`) and shell scripts need a programmatic surface that shares condash's parser, validator, and indexer — without re-implementing them in `bash + grep + sed`.
 
 ## At a glance
 
 | Invocation | What it does |
 |---|---|
-| `condash` (installed) | Launch the packaged Electron app against the saved conception tree |
+| `condash` | Launch the packaged Electron GUI against the saved conception tree |
+| `condash --help` | Print the top-level CLI help |
+| `condash --version` | Print the CLI version |
+| `condash <noun> <verb>` | Run a CLI verb against the resolved conception path |
 | `make dev` (from source) | Watch mode: tsc + vite + Electron with `--no-sandbox` |
-| `make package` (from source) | Produce per-OS installers under `release/` via electron-builder |
+| `make package` (from source) | Per-OS installers under `release/` via electron-builder |
 
-## `condash`
+## How dispatch decides
 
-The packaged Electron app. Installed by the per-OS installer on the [releases page](https://github.com/vcoeur/condash/releases) — `.AppImage`, `.deb`, `.dmg`, `.exe` — or available on PATH after `apt install condash` from the [apt repository](../get-started/install.md#linux-apt-repository-recommended).
+`src/main/index.ts:isCliInvocation` scans `process.argv` for the first non-flag token. If it matches one of the CLI nouns below, condash exec's the CLI bundle. Otherwise it boots the GUI.
 
-```bash
-condash
+CLI nouns:
+
+```
+projects   knowledge   search   repos   worktrees   dirty   skills   config   help
 ```
 
-That's it — no arguments. The binary launches an Electron `BrowserWindow` rendering the Solid SPA from `dist/` (production) or the Vite dev server on `localhost:5600` (dev mode). The same renderer code runs on every platform — no per-OS CSS branches.
+Top-level `--help`, `-h`, `--version`, and `-v` always route to the CLI (they print help/version text instead of opening a window).
 
-Closing the window exits the process. Relaunch whenever you want to come back — state lives in the Markdown files, not in the app.
+A typo (`condash projct list`) silently boots the GUI — the dispatcher only knows about exact noun matches.
+
+## Universal flags
+
+Available on every noun:
+
+| Flag | Meaning |
+|---|---|
+| `--conception <path>` | Override the conception root for this invocation only |
+| `--json` | Emit a single JSON envelope on stdout |
+| `--ndjson` | Emit one JSON object per line (streaming-friendly) |
+| `--quiet`, `-q` | Suppress diagnostics on stderr |
+| `--no-color` | Disable ANSI styling |
+| `--help`, `-h` | Show help for this noun / verb |
+| `--version`, `-v` | Show version |
+
+`--json` and `--ndjson` are mutually exclusive. When neither is set, stdout is human-readable text.
+
+## Exit codes
+
+```
+0  ok
+1  runtime
+2  usage
+3  validation
+4  not-found
+5  no-conception
+6  ambiguous
+```
+
+Code 5 means the CLI could not resolve a conception path — pass `--conception <path>` or set one with `condash config conception-path <path>`.
+
+## Conception-path resolution
+
+The CLI honours the same chain as the GUI, minus the folder picker:
+
+1. `--conception <path>` flag.
+2. `conception_path` in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (or platform equivalent).
+3. Hard error (exit 5).
+
+`condash config conception-path` and `condash config conception-path <path>` read or write the saved value.
+
+## Nouns
+
+### `projects`
+
+Item lifecycle and reads.
+
+| Verb | What it does |
+|---|---|
+| `list` | List items, optionally filtered by `--status`, `--kind`, `--apps`, `--branch`, `--sort` |
+| `read <slug>` | Read one item by slug or path |
+| `resolve <slug>` | Resolve a slug to its absolute path |
+| `search <query>` | Full-text search across items, optional `--status` / `--kind` / `--limit` |
+| `validate [<slug>]` | Validate header fields against the schema; pass `--all` for the whole tree |
+| `status get <slug>` / `status set <slug> <new-status>` | Read or change the `**Status**` field |
+| `close <slug>` | Set status to `done` (or `--status <name>`) and append a `Closed.` timeline entry |
+
+Slug forms accepted:
+
+- Full dated: `2026-04-17-foo` — exact folder name, minus the month dir.
+- Short: `foo` — any part of the slug after the date prefix.
+- Month-qualified: `2026-04/2026-04-17-foo`.
+
+### `knowledge`
+
+Knowledge-tree operations.
+
+| Verb | What it does |
+|---|---|
+| `tree` | Render the knowledge index as a tree, depth-limited via `--depth` |
+| `verify` | Audit verification stamps (`**Verified:** YYYY-MM-DD`) and report stale ones |
+| `retrieve <query>` | Triage walk — find relevant knowledge files for a topic, by `--mode` (`names`, `bodies`, `both`) |
+| `stamp <path>` | Add or refresh a verification stamp on a knowledge file, optionally `--where <field>` and `--date <iso>` |
+
+### `search`
+
+Cross-tree full-text search.
+
+```bash
+condash search "session cookie" --scope all
+```
+
+`--scope` accepts `all`, `projects`, `knowledge`. Defaults to `all`.
+
+### `repos`
+
+List configured repositories from `configuration.json`.
+
+```bash
+condash repos list                       # primary + secondary, no worktrees
+condash repos list --include-worktrees   # add worktrees in <worktrees_path>/
+```
+
+### `worktrees`
+
+Alias for `repos list --include-worktrees`, filtered to worktree entries. Richer surface (per-branch grouping, dirty status) is on the roadmap.
+
+### `dirty`
+
+Read or touch the dirty-index sentinels (`projects/.index-dirty`, `knowledge/.index-dirty`).
+
+| Verb | What it does |
+|---|---|
+| `list` | Show which trees have a dirty marker |
+| `touch <tree>` | Mark a tree dirty — `<tree>` is `projects` or `knowledge` |
+| `clear <tree\|all>` | Clear one tree's marker, or all of them |
+
+The skills (`/projects index`, `/knowledge index`) clear these after they regenerate.
+
+### `skills`
+
+Manage condash-shipped Claude Code skills.
+
+| Verb | What it does |
+|---|---|
+| `list` | Print every skill that ships with this condash version |
+| `install [<name>...]` | Copy shipped skill files into `<conception>/.claude/skills/`. With no args, walks each file with diff + per-file confirmation |
+| `status` | Compare local skills against the shipped versions and the recorded SHA256 manifest |
+
+The manifest at `.claude/skills/.condash-skills.json` tracks the shipped version and SHA256 per file, so updates can detect local edits.
+
+### `config`
+
+Read or change condash configuration.
+
+| Verb | What it does |
+|---|---|
+| `conception-path` | Print the saved conception path |
+| `conception-path <path>` | Save a new conception path to `settings.json` |
+| `list` | Print every key from `configuration.json` and `settings.json` (merged view) |
+| `get <key>` | Print one key's value, dot-separated path (`terminal.shell`) |
+
+`config conception-path` is the only verb that does not need an existing conception path — it sets one.
+
+### `help`
+
+`condash help` prints the top-level help. `condash help <noun>` re-dispatches to the noun's `--help` path so there's only one source of help text per noun.
+
+## Output modes
+
+Default output is human-readable text aligned for a terminal. `--json` emits a single envelope:
+
+```json
+{
+  "ok": true,
+  "data": [/* … */],
+  "warnings": []
+}
+```
+
+`--ndjson` emits one object per line — useful for piping into `jq`:
+
+```bash
+condash projects list --ndjson | jq 'select(.status == "now")'
+```
+
+When neither is set and stdout is a TTY, ANSI styling is on. When stdout is piped, styling is off automatically (or override with `--no-color`).
+
+## Worked examples
+
+```bash
+# What's currently active?
+condash projects list --status now,review
+
+# All items for one app, sorted by date.
+condash projects list --apps notes.vcoeur.com --sort date
+
+# Resolve a slug, then open the README in $EDITOR.
+$EDITOR "$(condash projects resolve fuzzy-search-v2)"/README.md
+
+# Validate every item in the tree.
+condash projects validate --all
+
+# Search across both trees for a phrase.
+condash search "session cookie" --scope all --limit 20
+
+# Update shipped skills after upgrading condash.
+condash skills install
+
+# Pipe to jq.
+condash projects list --json | jq '.data[] | select(.kind == "incident")'
+```
 
 ## Dev launch
 
 From a clone of the repo:
 
 ```bash
-make install      # one-off, npm install
-make dev          # watch: esbuild rebuilds main, vite serves renderer, electron reloads on change
+make install      # one-off — npm install + electron-rebuild
+make dev          # watch: esbuild rebuilds main + cli, vite serves renderer, electron reloads
 ```
 
-`make dev` passes `--no-sandbox` to Electron so you don't have to fix `chrome-sandbox` ownership in every fresh worktree. The dev window only loads `localhost:5600` and local `file://` URLs — the threat surface is local-only. Drop `--no-sandbox` from `dev:electron` in `package.json` if you want the sandbox on; you'll then need:
+`make dev` runs the Electron build with `--no-sandbox` to avoid per-worktree `chrome-sandbox` ownership fixes. The dev window only loads `localhost:5600` and local `file://` URLs — the threat surface is local-only. Drop `--no-sandbox` from `dev:electron` in `package.json` if you want the sandbox on, then once per worktree:
 
 ```bash
 sudo chown root node_modules/electron/dist/chrome-sandbox
 sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
 ```
 
-once per worktree. macOS and Windows are unaffected.
-
-## Configuration
-
-condash reads no command-line flags. Configuration lives in three layers (see [Config files](config.md) for the full schema):
-
-1. **Environment variables** — see [Environment variables](env.md). The current build does not yet honour `CONDASH_CONCEPTION_PATH`; the conception path is set through the first-launch folder picker.
-
-2. **`settings.json`** at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux), `~/Library/Application Support/condash/settings.json` (macOS), `%APPDATA%\condash\settings.json` (Windows) — per-user, per-machine. Owned by Electron's `app.getPath('userData')`. Holds `conception_path` plus the three blocks that naturally differ per machine: `terminal`, `pdf_viewer`, `open_with`.
-
-3. **`configuration.json`** at `<conception_path>/configuration.json` — per-tree, versioned in git. Holds `workspace_path`, `worktrees_path`, `repositories` (incl. `run:` / `force_stop:`). Edit it by hand or through the gear icon in the dashboard header (plain-text JSON editor).
+macOS and Windows are unaffected.
 
 ## What's not in the CLI
 
-- **Headless mode.** The Electron build does not ship a `condash-serve` binary — there is no embedded HTTP server and no browser-friendly URL to point Playwright at. Drive the renderer through Electron itself for end-to-end tests.
-- **Creating items.** The dashboard doesn't create items, and neither does the CLI. Use your editor, or the [management skill](skill.md).
-- **Listing or searching items.** Use the **History** tab in the dashboard, or `grep` over the tree.
-- **A server mode for multiple users.** condash is single-user. If you want multi-user, something else is the right tool.
+- **Headless GUI mode.** The CLI never opens a window. There's no embedded HTTP server and no browser-friendly URL to point Playwright at.
+- **A daemon / background watcher.** The CLI is one-shot per invocation. The chokidar watcher runs only when the GUI is open.
+- **Mutating items beyond `status set` / `status close`.** Step toggles, note edits, and config edits are GUI-only today. Use the [`/projects` skill](skill.md) from a Claude Code session for anything richer.
+- **A multi-user / server mode.** condash is single-user on purpose — see [Non-goals](../explanation/non-goals.md).
+
+## See also
+
+- [Configuration files](config.md) — the JSON schemas the CLI shares with the GUI.
+- [Environment variables](env.md) — what the binary reads from the environment.
+- [Management skill](skill.md) — Claude Code skills that wrap the CLI.

--- a/docs/reference/conception-convention.md
+++ b/docs/reference/conception-convention.md
@@ -5,6 +5,8 @@ description: The content-level syntax condash reads out of each README body — 
 
 # Status, steps, deliverables
 
+> **Audience.** Daily user.
+
 ## At a glance
 
 Every item is a directory under `projects/YYYY-MM/YYYY-MM-DD-slug/` containing a `README.md`. There is no top-level `incidents/` or `documents/` folder — the `**Kind**` field in the header discriminates. Three body sections are parsed: `## Steps`, `## Deliverables`, and anything whose heading is used by the step-add-by-section flow (`## Timeline`, etc., are left alone).

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -5,6 +5,8 @@ description: The two JSON files condash reads (per-tree and per-machine) and wha
 
 # Config files
 
+> **Audience.** Daily user.
+
 condash reads two JSON files. Both are optional in principle — the dashboard runs with sensible defaults — but in practice you set at least the conception path on first launch.
 
 ## At a glance

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -5,10 +5,15 @@ description: The short list of environment variables condash reads.
 
 # Environment variables
 
+> **Audience.** Daily user and Developer.
+
 ## At a glance
 
 | Name | Purpose | Default | Accepted values |
 |---|---|---|---|
+| `CONDASH_CONCEPTION_PATH` | One-shot conception-path override | unset | Any absolute path |
+| `CONDASH_FORCE_DEVICE_SCALE_FACTOR` | Force a fixed integer scale (Wayland fallback) | unset | Positive number |
+| `CONDASH_FORCE_PROD` | Force the renderer to load the packaged build (Playwright fixture) | unset | `1` or unset |
 | `SHELL` | Fallback for `terminal.shell` | `/bin/bash` | Absolute path to an interactive shell |
 | `XDG_CONFIG_HOME` | Linux per-user config root | `~/.config` | Any absolute path |
 | `ELECTRON_DISABLE_SANDBOX` | Disable Chromium's setuid sandbox | unset | `1` or unset |
@@ -31,9 +36,26 @@ Set by Electron itself when launched with `--no-sandbox` (the dev script in `pac
 
 You should not set this manually for the production `.deb` build — it installs `chrome-sandbox` SUID-root at `/opt/condash/`, and disabling the sandbox there is a net regression.
 
+## `CONDASH_CONCEPTION_PATH`
+
+A one-shot override for the conception path. When set, it wins over the `conception_path` value in `settings.json`. Useful for:
+
+- Pointing condash at a scratch tree without editing settings.
+- Demoing against a specific tree from a script.
+- Running multiple condash instances against different trees from different shells.
+
+The override is **session-scoped** — it is not persisted back into `settings.json`, and the next launch without the env var falls back to the saved value.
+
+## `CONDASH_FORCE_DEVICE_SCALE_FACTOR`
+
+Linux + Wayland fallback for fractional-scaling issues on uncommon compositors. When set to a number (e.g. `1.5`), Chromium renders at that fixed integer-divisible scale and the compositor down-scales — useful when the default `WaylandFractionalScaleV1` negotiation produces blurry output on a specific compositor. Leave unset on every other configuration.
+
+## `CONDASH_FORCE_PROD`
+
+Set by the Playwright e2e fixture to force the renderer to load the packaged `dist/` build via `file://`, bypassing the Vite dev URL. Not intended for direct use.
+
 ## Not read from the environment
 
-- `CONDASH_CONCEPTION_PATH` — **not yet wired** in the Electron build. The conception path is set through the first-launch folder picker and persisted to `settings.json:conception_path`. The Tauri build read this var; the Electron build will accept it once an explicit need shows up.
 - `CONDASH_ASSET_DIR` — the Electron build has no equivalent. Use `make dev` for the Vite hot-reload loop instead; the production renderer bundle is served from `dist/` inside the asar at runtime.
 - `CONDASH_PORT` — there is no embedded HTTP server. The Vite dev server listens on `5600` (configured in `vite.config.ts`, `Makefile`, `package.json` together — see the dev-port checklist in `CLAUDE.md`).
 - `CONCEPTION_PATH` — despite the [management skill](skill.md) reading it, condash itself does not.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -5,6 +5,8 @@ description: Exhaustive lookup for every command, config key, README field, muta
 
 # Reference
 
+> **Audience.** Daily user and Developer.
+
 Short pages, one per surface. Look things up here; learn them in the [Tutorials](../tutorials/index.md) and [Guides](../guides/index.md).
 
 - **[CLI](cli.md)** — launching condash, the dev workflow, and where flags don't apply.

--- a/docs/reference/inline-runner.md
+++ b/docs/reference/inline-runner.md
@@ -5,6 +5,8 @@ description: The per-repo Run/Stop button, the `run:` field, and the single-sess
 
 # Inline dev-server runner
 
+> **Audience.** Daily user.
+
 Since v0.13.0, each row in the Code tab — every repo and every declared sub-repo — can carry an inline dev-server runner. Click **Run** and condash spawns the command under a PTY; an xterm mounts right under the row streaming live output. The running server survives tab switches, terminal toggles, and even dashboard reloads (the registry lives server-side).
 
 ## When to reach for it

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -5,6 +5,8 @@ description: The full Electron IPC contract between the renderer and the main pr
 
 # IPC API
 
+> **Audience.** Developer.
+
 condash is a single-process Electron app: there is no embedded HTTP server, no axum, no `127.0.0.1:<port>`. The renderer talks to the main process exclusively through Electron IPC, and the entire surface is the [`CondashApi`](https://github.com/vcoeur/condash/blob/main/src/shared/api.ts) interface in `src/shared/api.ts`.
 
 This page is the public reference for that contract. The preload bridge ([`src/preload/index.ts`](https://github.com/vcoeur/condash/blob/main/src/preload/index.ts)) exposes one method per verb on `window.condash`; the main-process registry ([`src/main/index.ts:registerIpc`](https://github.com/vcoeur/condash/blob/main/src/main/index.ts)) registers exactly one handler per verb. No string-mux'd actions, no implicit channels.

--- a/docs/reference/mutations.md
+++ b/docs/reference/mutations.md
@@ -5,6 +5,8 @@ description: The exhaustive list of every action the dashboard takes on your fil
 
 # Mutation model
 
+> **Audience.** Daily user and Developer.
+
 ## At a glance
 
 The dashboard's **write surface is small**. It touches three places only:

--- a/docs/reference/readme-format.md
+++ b/docs/reference/readme-format.md
@@ -5,6 +5,8 @@ description: The header fields condash reads from each item's README.md — type
 
 # README format
 
+> **Audience.** Daily user.
+
 ## At a glance
 
 Every item lives at `projects/YYYY-MM/YYYY-MM-DD-slug/README.md`. The first line is the title (`# …`); everything from line 2 up to the first `##` heading is the **header**, a sequence of `**Key**: value` lines.

--- a/docs/reference/shortcuts.md
+++ b/docs/reference/shortcuts.md
@@ -5,6 +5,8 @@ description: Every keyboard shortcut the dashboard and embedded terminal recogni
 
 # Keyboard shortcuts
 
+> **Audience.** Daily user.
+
 ## At a glance
 
 | Area | Count | Configurable? |

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -5,6 +5,8 @@ description: Reference for the shipped /conception-items Claude Code skill — a
 
 # Management skill
 
+> **Audience.** Daily user.
+
 ## At a glance
 
 `condash` renders items but does not create them. The shipped **[`/conception-items`](https://github.com/vcoeur/condash/tree/main/examples/skills/conception-items)** Claude Code skill covers the creation + update + close lifecycle by editing files directly. It has **no knowledge of the condash CLI or HTTP server** — the two tools meet at the filesystem and nowhere else.

--- a/docs/tutorials/daily-loop.md
+++ b/docs/tutorials/daily-loop.md
@@ -5,6 +5,8 @@ description: Open an existing item, edit code in the repo strip, run a build in 
 
 # A day with condash
 
+> **Audience.** New user becoming a daily user — you've finished the first two tutorials and want to see the realistic workflow.
+
 **When to read this.** You've done [First run](first-run.md) and [Your first project](first-project.md). You want to see the full workflow: not just "how do I create an item?", but "what does a day of real work look like when this tree is your work tracker?".
 
 By the end, you'll have walked through the loop most people use condash for — open item, open its repo, edit, build, document, push, close — and know which surface each step uses.
@@ -60,7 +62,7 @@ You get a `thread 'main' panicked at 'attempt to subtract with overflow'` — co
 
 The terminal has two useful quality-of-life features:
 
-- **Screenshot paste** — press `Ctrl+Shift+V` anywhere in the dashboard and condash inserts the absolute path of the newest file in your configured screenshot directory into the active terminal prompt. Useful for "take a screenshot of the crash → paste the path into an `ls -la` or a `cat`". Configure `terminal.screenshot_dir` in `settings.yaml` (see [Config reference](../reference/config.md)).
+- **Screenshot paste** — press `Ctrl+Shift+V` anywhere in the dashboard and condash inserts the absolute path of the newest file in your configured screenshot directory into the active terminal prompt. Useful for "take a screenshot of the crash → paste the path into an `ls -la` or a `cat`". Configure `terminal.screenshot_dir` in `settings.json` (see [Config reference](../reference/config.md)).
 - **Multiple tabs** — click the `+` in the terminal pane header to open a second tab; each tab keeps its own bash session and scrollback even when you toggle the pane closed.
 
 See [Use the embedded terminal](../guides/terminal.md) for the full feature set.
@@ -74,7 +76,7 @@ Fix the panic in your IDE (in this tutorial you don't have to — the helio repo
 Incidents ship with a `notes/` folder and often end up with a deliverable PDF in `deliverables/`. In the demo, `search-crash-large-logs/deliverables/incident-report.pdf` is a placeholder. Generate your real report from the README + notes:
 
 ```bash
-cd ~/conception-demo/projects/2026-04/2026-04-08-search-crash-large-logs
+cd ~/src/conception/projects/2026-04/2026-04-08-search-crash-large-logs
 bash ~/.claude/scripts/md_to_pdf.sh notes/investigation.md deliverables/incident-report.pdf
 ```
 

--- a/docs/tutorials/first-project.md
+++ b/docs/tutorials/first-project.md
@@ -5,7 +5,9 @@ description: Create an item, wire its steps, add a note, link to another item �
 
 # Your first project
 
-**When to read this.** You finished [First run](first-run.md) and have condash running against the `conception-demo` tree. Now you want to do actual work in it — create an item, change its status, add and close steps, drop a note, cross-link items.
+> **Audience.** New user — comfortable with the basics, ready to actually use the dashboard.
+
+**When to read this.** You finished [First run](first-run.md) and have condash open against your tree. Now you want to do actual work in it — create an item, change its status, add and close steps, drop a note, cross-link items.
 
 By the end, you'll have added a new project to the tree, walked it from `later` through `now` to `done`, and understood which actions live in the dashboard versus which live in your editor.
 
@@ -19,7 +21,7 @@ See the full list in [Mutation model](../reference/mutations.md).
 
 Projects live at `projects/YYYY-MM/YYYY-MM-DD-slug/README.md`. Pick today's date and a slug.
 
-**From the dashboard**: click the **`+`** button in the header (right of the terminal icon). A modal opens asking for the handful of fields condash's parser actually reads:
+**From the dashboard**: click the **`+`** button in the header (right of the terminal icon), or use the *Create your first project* card on the Welcome screen. A modal opens asking for the handful of fields condash's parser actually reads:
 
 - **Kind** — project, incident, or document.
 - **Status** — `now` / `review` / `later` / `backlog` / `done`.
@@ -33,8 +35,8 @@ Click **Create item**. condash writes `projects/<YYYY-MM>/<YYYY-MM-DD>-<slug>/RE
 **From the shell** (equivalent, useful when condash isn't running):
 
 ```bash
-mkdir -p ~/conception-demo/projects/2026-04/2026-04-18-helio-benchmark-harness/notes
-cat > ~/conception-demo/projects/2026-04/2026-04-18-helio-benchmark-harness/README.md <<'EOF'
+mkdir -p ~/src/conception/projects/2026-04/2026-04-18-helio-benchmark-harness/notes
+cat > ~/src/conception/projects/2026-04/2026-04-18-helio-benchmark-harness/README.md <<'EOF'
 # Helio benchmark harness
 
 **Date**: 2026-04-18
@@ -93,7 +95,7 @@ Click into the project card to expand it. Somewhere in the header you'll see a s
 Check with `git diff` in a second shell:
 
 ```bash
-cd ~/conception-demo
+cd ~/src/conception
 git diff projects/2026-04/2026-04-18-helio-benchmark-harness/README.md
 ```
 

--- a/docs/tutorials/first-run.md
+++ b/docs/tutorials/first-run.md
@@ -1,71 +1,66 @@
 ---
 title: First run · condash
-description: Install condash, point it at the bundled demo tree, and get a rendered dashboard in ten minutes.
+description: Install condash, point it at a fresh conception tree, and get your first item rendered. Ten minutes.
 ---
 
 # First run
 
-**When to read this.** You've never used condash. You want to get to a working dashboard on your machine in one sitting, with a tree of realistic items to poke at before you commit to building your own.
+> **Audience.** New user — never used condash before. You have it installed; you want to see it working with your own tree.
 
-By the end, you'll have condash installed, running against the bundled `conception-demo` tree, and the `Projects`, `Code`, `Knowledge`, and `History` tabs will all render with content.
+By the end of this tutorial you'll have:
+
+- condash installed and launched.
+- A fresh conception tree with one project in it.
+- The dashboard rendering your project, with a Steps section, a Status pill, and a Notes folder you can read in your editor.
+
+Time: ten minutes if the install is already done; twenty if you're installing from scratch.
 
 ## 1. Install condash
 
-The fastest path is a prebuilt installer from the [GitHub Releases page](https://github.com/vcoeur/condash/releases). Each release ships a per-OS bundle:
+If you haven't already, install condash from the [GitHub Releases page](https://github.com/vcoeur/condash/releases) — `.AppImage` / `.deb` for Linux, `.dmg` for macOS, `.exe` for Windows. Each platform asks for a one-time bypass; the [Install](../get-started/install.md) page walks through the gesture per OS.
 
-| Platform | Artifact |
-|---|---|
-| Linux | `condash-<version>.AppImage` or `condash_<version>_amd64.deb` |
-| macOS | `condash-<version>.dmg` |
-| Windows | `condash Setup <version>.exe` |
-
-The builds are unsigned — your OS will ask you to confirm once on first launch. See [Install](../get-started/install.md) for the per-platform bypass.
-
-If you'd rather build from source, clone the repo and run:
+Verify the binary is on your `$PATH`:
 
 ```bash
-make install               # one-off, npm install
-make build                 # compile main + renderer
-make package               # produce the platform installer under release/
+condash --version
 ```
 
-That's the same pipeline CI uses. You'll need Node.js 20+ and, on Linux, the libraries Electron's chrome-sandbox links against (`libnss3`, `libatk-bridge2.0-0`, `libgtk-3-0`, `libgbm1`).
+You should see something like `condash 2.5.0`.
 
-## 2. Fetch the demo tree
+## 2. Create an empty tree
 
-The condash repo ships a realistic demo tree at [`examples/conception-demo/`](https://github.com/vcoeur/condash/tree/main/examples/conception-demo). It has nine items, all six statuses, a knowledge tree, and two deliverable PDFs — enough for every feature in the rest of the tutorials to have something to act on.
-
-Copy it into a working location:
+Pick any directory on your disk. We'll use `~/src/conception` for the rest of this tutorial — substitute your own path if you prefer.
 
 ```bash
-mkdir -p ~/conception-demo
-curl -fsSL https://codeload.github.com/vcoeur/condash/tar.gz/main \
-  | tar -xz --strip-components=2 -C ~/conception-demo \
-      condash-main/examples/conception-demo
+mkdir -p ~/src/conception/projects
 ```
 
-Inspect what you got:
+That's the minimum. condash also looks for an optional `knowledge/` sibling and a `configuration.json` at the root, but neither is required to boot.
 
-```
-~/conception-demo/
-├── README.md
-├── configuration.json
-├── projects/
-│   ├── 2026-03/         # items created last month (2 done)
-│   └── 2026-04/         # 7 items created this month (3 now, 1 review, 2 later, 1 backlog)
-└── knowledge/
-    ├── conventions.md
-    ├── internal/
-    └── topics/
+If you want to start with a more populated tree (a knowledge index, conventions, sample skills), copy the template that ships with condash:
+
+```bash
+# Locate the template inside the install
+condash skills install --help     # the same logic powers `skills install`
 ```
 
-Everything is plain Markdown. Open `projects/2026-04/2026-04-02-fuzzy-search-v2/README.md` in your editor to see the header format.
+The template lives at `<install_dir>/conception-template/`. The exact path depends on your installer — on Linux apt installs it's `/opt/condash/resources/app.asar/conception-template/`. The `condash skills install` verb (covered in [Multi-machine setup](../guides/multi-machine.md)) copies the skill subset into a tree on demand.
 
-## 3. Point condash at the tree
+## 3. Tell condash where the tree lives
 
-On first launch with no tree configured, condash opens a native folder picker and writes your choice to `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json`. Pick `~/conception-demo` the first time and the next launches reuse it automatically.
+Two ways:
 
-To make a different tree the default, re-launch with the picker (delete `settings.json` first) or edit `conception_path` in `settings.json` by hand.
+**With the CLI** (one command, no GUI):
+
+```bash
+condash config conception-path ~/src/conception
+```
+
+This writes `conception_path` into your platform's `settings.json`. The next launch picks it up.
+
+**With the folder picker** (the friendly path):
+
+Just run `condash`. With no `conception_path` saved yet, the app opens a native folder picker. Select `~/src/conception` and click Open. condash writes the choice for you and continues.
 
 ## 4. Launch
 
@@ -73,40 +68,89 @@ To make a different tree the default, re-launch with the picker (delete `setting
 condash
 ```
 
-Electron opens a single `BrowserWindow` rendering the Solid SPA — same renderer everywhere (Chromium). You should see this:
+A single window opens. Because the tree is empty (no items in `projects/`, no entries in `knowledge/`), condash shows the **Welcome screen** instead of an empty dashboard:
 
-![Dashboard rendering the demo tree — Current tab selected](../assets/screenshots/dashboard-overview-light.png#only-light)
-![Dashboard rendering the demo tree — Current tab selected](../assets/screenshots/dashboard-overview-dark.png#only-dark)
+- *Create your first project* — opens the new-item modal.
+- *Take the tour* — opens the in-app Help with a short overview.
+- *Open the documentation* — opens [condash.vcoeur.com](https://condash.vcoeur.com) in your browser.
 
-The header shows four top-level tabs with counts: **Projects (9)**, **Code (3)**, **Knowledge (8)**, **History (9)**. Under **Projects**, the sub-tabs are **Current / Next / Backlog / Done**. The demo tree was built so every bucket has something in it.
+Click **Create your first project**.
 
+## 5. Create your first item
 
+The new-item modal asks for the handful of fields condash's parser actually reads:
 
-## 5. Walk around
+- **Kind** — pick `project`.
+- **Status** — pick `now` so the item lands in the Current sub-tab.
+- **Title** — anything; "Try condash" is fine.
+- **Slug** — auto-derived from the title; leave the default.
+- **Apps** — leave empty for this tutorial.
 
-Take two minutes to click through:
+Click **Create item**. condash:
 
-- **Current** — 3 items with status `now` (one of each kind: document, incident, project) and 1 item with status `review`. Click the fuzzy-search-v2 row; the card expands, showing the README on the left and a step list on the right with all four marker states (`[x]`, `[~]`, `[ ]`, `[-]`).
-- **Next** — the later bucket. Two projects (`json-export` and one more).
-- **Backlog** — one project, parked.
-- **Done** — two archived items from the previous month.
-- **Code** — three repos: condash scanned `workspace_path: /tmp/conception-demo-workspace` from `configuration.json` and found one `.git/` per entry. (If the Code tab shows 0, the workspace path on your machine doesn't exist yet — we'll set that up properly in [Your first project](first-project.md).)
-- **Knowledge** — the `knowledge/` tree rendered as an explorer: `conventions.md` at the root, `Internal` and `Topics` folders with index files.
-- **History** — full-text search across every item + note. Type `fuzzy` to see ranked matches.
+1. Creates `projects/<YYYY-MM>/<YYYY-MM-DD>-try-condash/README.md` with a minimal template.
+2. Creates an empty `notes/` sibling.
+3. Switches to the Current sub-tab and expands the new card.
 
-Click the gear icon in the top right to see the **Configuration** modal — a plain-text JSON editor backed by `conception-demo/configuration.json`. Save is atomic (temp file → rename). Per-machine preferences (`terminal`, `pdf_viewer`, `open_with`) live separately in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` and are hand-edited. You'll use this modal in the next tutorial.
+The Welcome screen disappears — you have content now.
 
-## 6. Close the window
+## 6. Walk around
 
-Closing the native window exits condash. Relaunch with `condash` whenever you want to come back — state lives in the files, not in the app.
+Take a minute to click through:
+
+- **Projects → Current** — your one item with status `now`. Click the row to expand.
+- **Code** — likely empty unless you set `workspace_path` in `configuration.json`. We'll cover that in the [next tutorial](first-project.md).
+- **Knowledge** — empty unless you copied the knowledge template earlier. The tab is hidden when the directory is missing.
+- **History** — full-text search across items + notes. Type the title of your project; it surfaces immediately.
+
+Click the **gear icon** in the header. The **Configuration** modal opens with a plain-text JSON editor backed by `<conception>/configuration.json`. The file doesn't exist yet — type `{}` and Save (atomic temp + rename); a minimal valid config is born. We'll fill it in next.
+
+## 7. Read what got created
+
+Switch to your editor and open the README condash just wrote:
+
+```bash
+$EDITOR ~/src/conception/projects/*/*/README.md
+```
+
+You'll see something like:
+
+```markdown
+# Try condash
+
+**Date**: 2026-05-01
+**Kind**: project
+**Status**: now
+
+## Goal
+
+(your goal here)
+
+## Steps
+
+- [ ] (your first step)
+
+## Timeline
+
+- 2026-05-01 — Project created.
+
+## Notes
+```
+
+That's the whole item. The dashboard reads this exact file; mutations (toggling a step, changing status) rewrite specific lines. The format is documented in [README format](../reference/readme-format.md).
+
+## 8. Close the window
+
+Closing the native window exits condash. State lives in your files; relaunch with `condash` whenever you want to come back.
 
 ## What you just learned
 
 - Installing condash is either a one-click installer from GitHub Releases or three `make` targets from source.
-- The first-launch folder picker is the whole setup flow. The conception-tree path is the only thing you must set.
-- The dashboard renders the files as-is. A chokidar watcher pushes file-change events into the renderer so external edits show up live, but there's no database, no cache, and no schema.
-- Configuration splits in two: tree-level (`<conception>/configuration.json`, team-shared) and per-machine (`${XDG_CONFIG_HOME:-~/.config}/condash/settings.json`). We'll dig into that split in [Configure the conception path](../guides/configure-conception-path.md).
+- The conception path is the only thing condash needs to boot. Set it once with `condash config conception-path` or through the first-launch folder picker.
+- The Welcome screen meets you on an empty tree and offers a path forward — create an item, take the tour, or read the docs.
+- Items are filesystem directories with a `README.md` and optional `notes/`. The dashboard mutates a small set of lines in those files; everything else is yours to edit in your editor.
+- Configuration splits in two: tree-level (`<conception>/configuration.json`, team-shared) and per-machine (`settings.json`, hand-edited or written by the CLI / folder picker).
 
 ## Next
 
-**[Your first project →](first-project.md)** — create a real item, wire its steps, link it to another item, add a note.
+**[Your first project →](first-project.md)** — wire `workspace_path`, get the Code tab populated, edit a step, add a note, link to another item.

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -5,10 +5,12 @@ description: Learn condash by doing. Three linear walkthroughs take you from a f
 
 # Tutorials
 
+> **Audience.** New user.
+
 Three tutorials, meant to be read in order. Each one lands you at a working end state.
 
-1. **[First run](first-run.md)** — install condash, point it at the bundled demo tree, and get to a rendered dashboard. Ten minutes.
+1. **[First run](first-run.md)** — install condash, point it at a fresh tree, and get your first item rendered. Ten to twenty minutes.
 2. **[Your first project](first-project.md)** — create an item, wire up its steps, add notes, link it to another item. Twenty minutes.
 3. **[A day with condash](daily-loop.md)** — the realistic workflow: open an item, edit code in the repo strip, use the embedded terminal, close and archive. Thirty minutes.
 
-If you're looking for a specific task ("how do I configure the PDF viewer?"), skip these and go to the **[Guides](../guides/index.md)**. If you want to look something up ("what does `--no-native` do?"), go to the **[Reference](../reference/index.md)**.
+If you're looking for a specific task ("how do I configure the open-with launchers?"), skip these and go to the **[Guides](../guides/index.md)**. If you want to look something up ("what's the exit code for a CLI usage error?"), go to the **[Reference](../reference/index.md)**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - Search your history: guides/search.md
     - Deliverables and PDFs: guides/deliverables.md
     - Multi-machine setup: guides/multi-machine.md
+    - Troubleshooting: guides/troubleshooting.md
     - Extend the management skill: guides/skill-extensions.md
 
   - Reference:
@@ -111,7 +112,9 @@ nav:
   - Explanation:
     - explanation/index.md
     - Why Markdown-first: explanation/why-markdown.md
-    - Internals: explanation/internals.md
+    - Values: explanation/values.md
     - Non-goals: explanation/non-goals.md
+    - Internals: explanation/internals.md
+    - Contributing: explanation/contributing.md
 
   - Legal: legal.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,9 @@
         "solid-js": "^1.9.3",
         "zod": "^4.3.6"
       },
+      "bin": {
+        "condash": "dist-cli/condash.cjs"
+      },
       "devDependencies": {
         "@electron/rebuild": "^3.7.2",
         "@playwright/test": "^1.59.1",

--- a/src/main/help.ts
+++ b/src/main/help.ts
@@ -7,19 +7,40 @@ import { join } from 'node:path';
  * The whitelist is the only path-traversal defence — the renderer can pass
  * any string, but only these resolve to a file.
  */
-export type HelpDocName = 'architecture' | 'configuration' | 'non-goals' | 'index';
+export type HelpDocName =
+  | 'welcome'
+  | 'getting-started'
+  | 'install'
+  | 'first-launch'
+  | 'shortcuts'
+  | 'configuration'
+  | 'cli'
+  | 'mutations'
+  | 'architecture'
+  | 'why-markdown'
+  | 'values'
+  | 'non-goals'
+  | 'index';
 
 /**
- * Maps the renderer-facing slug to the actual file inside `docs/`. The slugs
- * stay short and stable for IPC; the paths point at the canonical Diátaxis
- * pages (`explanation/internals.md`, `reference/config.md`,
- * `explanation/non-goals.md`) so the in-app Help modal and the public docs
- * site read from the same source.
+ * Maps the renderer-facing slug to the actual file inside `docs/`. Keeping the
+ * slugs short and stable lets the IPC contract stay tiny while the canonical
+ * Diátaxis paths can move freely. The Help modal and the public docs site
+ * read the same files — the asar bundles the entire `docs/` tree.
  */
 const PATHS: Record<HelpDocName, string> = {
+  welcome: 'index.md',
   index: 'index.md',
-  architecture: 'explanation/internals.md',
+  'getting-started': 'get-started/index.md',
+  install: 'get-started/install.md',
+  'first-launch': 'get-started/first-launch.md',
+  shortcuts: 'reference/shortcuts.md',
   configuration: 'reference/config.md',
+  cli: 'reference/cli.md',
+  mutations: 'reference/mutations.md',
+  architecture: 'explanation/internals.md',
+  'why-markdown': 'explanation/why-markdown.md',
+  values: 'explanation/values.md',
   'non-goals': 'explanation/non-goals.md',
 };
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -309,10 +309,33 @@ function buildMenu(layout: LayoutState = DEFAULT_LAYOUT): void {
       click: () => send('about'),
     },
     { type: 'separator' },
-    { label: 'Architecture', click: () => send('help-architecture') },
+    { label: 'Welcome / documentation index', click: () => send('help-welcome') },
+    { label: 'Getting started', click: () => send('help-getting-started') },
+    { label: 'Install', click: () => send('help-install') },
+    { label: 'First launch', click: () => send('help-first-launch') },
+    { label: 'Keyboard shortcuts', click: () => send('help-shortcuts') },
+    { type: 'separator' },
     { label: 'Configuration reference', click: () => send('help-configuration') },
+    { label: 'CLI reference', click: () => send('help-cli') },
+    { label: 'Mutation model', click: () => send('help-mutations') },
+    { type: 'separator' },
+    { label: 'Architecture', click: () => send('help-architecture') },
+    { label: 'Why Markdown-first', click: () => send('help-why-markdown') },
+    { label: 'Values', click: () => send('help-values') },
     { label: 'Non-goals', click: () => send('help-non-goals') },
-    { label: 'Documentation index', click: () => send('help-index') },
+    { type: 'separator' },
+    {
+      label: 'Open documentation site',
+      click: () => {
+        void shell.openExternal('https://condash.vcoeur.com');
+      },
+    },
+    {
+      label: 'Open issue tracker',
+      click: () => {
+        void shell.openExternal('https://github.com/vcoeur/condash/issues');
+      },
+    },
   ];
 
   const template: MenuItemConstructorOptions[] = [
@@ -503,6 +526,17 @@ function registerIpc(): void {
     // Application menu reflects layout state — rebuild so the View
     // submenu's check marks line up with the new state.
     buildMenu(layout);
+  });
+
+  ipcMain.handle('getWelcomeDismissed', async () => {
+    const { welcome } = await readSettings();
+    return welcome?.dismissed === true;
+  });
+
+  ipcMain.handle('setWelcomeDismissed', async (_, value: boolean) => {
+    const next = await readSettings();
+    next.welcome = { ...(next.welcome ?? {}), dismissed: value };
+    await writeSettings(next);
   });
 
   ipcMain.handle(

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -22,6 +22,8 @@ const api: CondashApi = {
   setTheme: (theme) => ipcRenderer.invoke('setTheme', theme),
   getLayout: () => ipcRenderer.invoke('getLayout'),
   setLayout: (layout) => ipcRenderer.invoke('setLayout', layout),
+  getWelcomeDismissed: () => ipcRenderer.invoke('getWelcomeDismissed'),
+  setWelcomeDismissed: (value) => ipcRenderer.invoke('setWelcomeDismissed', value),
   getSettingsPath: () => ipcRenderer.invoke('getSettingsPath'),
   toggleStep: (path, lineIndex, expectedMarker, newMarker) =>
     ipcRenderer.invoke('step.toggle', path, lineIndex, expectedMarker, newMarker),

--- a/src/renderer/help-modal.tsx
+++ b/src/renderer/help-modal.tsx
@@ -3,13 +3,35 @@ import { renderMarkdown, runMermaidIn } from './markdown';
 import { routeMarkdownClick, scrollToAnchor } from './md-link-router';
 import 'highlight.js/styles/github.css';
 
-export type HelpDoc = 'architecture' | 'configuration' | 'non-goals' | 'index';
+export type HelpDoc =
+  | 'welcome'
+  | 'getting-started'
+  | 'install'
+  | 'first-launch'
+  | 'shortcuts'
+  | 'configuration'
+  | 'cli'
+  | 'mutations'
+  | 'architecture'
+  | 'why-markdown'
+  | 'values'
+  | 'non-goals'
+  | 'index';
 
 const TITLE: Record<HelpDoc, string> = {
-  architecture: 'Architecture',
-  configuration: 'Configuration reference',
-  'non-goals': 'Non-goals',
+  welcome: 'Welcome to condash',
   index: 'Documentation index',
+  'getting-started': 'Getting started',
+  install: 'Install',
+  'first-launch': 'First launch',
+  shortcuts: 'Keyboard shortcuts',
+  configuration: 'Configuration reference',
+  cli: 'CLI reference',
+  mutations: 'Mutation model',
+  architecture: 'Architecture',
+  'why-markdown': 'Why Markdown-first',
+  values: 'Values',
+  'non-goals': 'Non-goals',
 };
 
 /**

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -29,6 +29,7 @@ import { TerminalPane, type TerminalPaneHandle } from './terminal-pane';
 import { buildSlugIndex } from './wikilinks';
 import { PdfModal } from './pdf-modal';
 import { HelpModal, type HelpDoc } from './help-modal';
+import { WelcomeScreen } from './welcome-screen';
 import { PromptModal, type PromptModalState } from './prompt-modal';
 import {
   applyStatus,
@@ -51,6 +52,7 @@ import './styles.css';
 import './modals.css';
 import './note-modal.css';
 import './project-preview.css';
+import './welcome-screen.css';
 
 function applyTheme(theme: Theme): void {
   const root = document.documentElement;
@@ -84,6 +86,8 @@ function App() {
   const [aboutOpen, setAboutOpen] = createSignal(false);
   const [quitConfirmOpen, setQuitConfirmOpen] = createSignal(false);
   const [promptState, setPromptState] = createSignal<PromptModalState | null>(null);
+  const [welcomeDismissed, setWelcomeDismissed] = createSignal<boolean>(false);
+  void window.condash.getWelcomeDismissed().then(setWelcomeDismissed);
 
   const flashToast = (msg: string) => {
     setToast(msg);
@@ -355,12 +359,7 @@ function App() {
       setAboutOpen(true);
       return;
     }
-    if (
-      command === 'help-architecture' ||
-      command === 'help-configuration' ||
-      command === 'help-non-goals' ||
-      command === 'help-index'
-    ) {
+    if (command.startsWith('help-')) {
       // Strip the `help-` prefix to get the HelpDoc name.
       const doc = command.slice('help-'.length) as HelpDoc;
       setHelpDoc(doc);
@@ -515,6 +514,44 @@ function App() {
   const handleConfirmQuit = () => {
     setQuitConfirmOpen(false);
     void window.condash.quitApp();
+  };
+
+  const knowledgeIsEmpty = (): boolean => {
+    const k = knowledge();
+    if (k === null || k === undefined) return true;
+    if (Array.isArray((k as { children?: unknown[] }).children)) {
+      return (k as { children: unknown[] }).children.length === 0;
+    }
+    return false;
+  };
+
+  // Welcome screen shows on a tree with no items and no knowledge entries,
+  // unless the user dismissed it. Once content lands, it stops appearing
+  // automatically; the dismiss is for users who never want to see it again.
+  const shouldShowWelcome = (): boolean => {
+    if (welcomeDismissed()) return false;
+    if (!conceptionPath()) return false;
+    if (projects.loading) return false;
+    if ((projects() ?? []).length > 0) return false;
+    if (!knowledgeIsEmpty()) return false;
+    return true;
+  };
+
+  const handleWelcomeOpenTree = () => {
+    void window.condash.openConceptionDirectory();
+  };
+
+  const handleWelcomeTakeTour = () => {
+    setHelpDoc('welcome');
+  };
+
+  const handleWelcomeOpenDocs = () => {
+    void window.condash.openExternal('https://condash.vcoeur.com');
+  };
+
+  const handleWelcomeDismiss = () => {
+    setWelcomeDismissed(true);
+    void window.condash.setWelcomeDismissed(true);
   };
 
   const slugIndex = () => buildSlugIndex(projects() ?? [], knowledge() ?? null);
@@ -674,6 +711,16 @@ function App() {
               </div>
             }
           >
+            <Show when={shouldShowWelcome()}>
+              <WelcomeScreen
+                conceptionPath={conceptionPath()!}
+                onOpenTree={handleWelcomeOpenTree}
+                onTakeTour={handleWelcomeTakeTour}
+                onOpenDocs={handleWelcomeOpenDocs}
+                onOpenSettings={() => setSettingsOpen(true)}
+                onDismiss={handleWelcomeDismiss}
+              />
+            </Show>
             <Show when={topBandVisible()}>
               <div class="top-band" ref={(el) => (topBandRef = el)} style={topBandStyle()}>
                 <Show when={layout().projects}>

--- a/src/renderer/welcome-screen.css
+++ b/src/renderer/welcome-screen.css
@@ -1,0 +1,139 @@
+.welcome-screen {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.welcome-inner {
+  max-width: 720px;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+.welcome-heading {
+  font-size: 1.6rem;
+  font-weight: 600;
+  margin: 0;
+  text-align: center;
+}
+
+.welcome-tagline {
+  text-align: center;
+  margin: 0;
+  color: var(--color-fg-muted, #6c7686);
+}
+
+.welcome-path {
+  text-align: center;
+  margin: 0 0 1.5rem 0;
+  font-size: 0.85rem;
+  color: var(--color-fg-muted, #6c7686);
+}
+
+.welcome-path code {
+  background: var(--color-bg-subtle, rgba(0, 0, 0, 0.04));
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.85em;
+}
+
+.welcome-path-edit {
+  background: none;
+  border: none;
+  color: var(--color-link, #1f6feb);
+  cursor: pointer;
+  padding: 0 0.2rem;
+  font-size: inherit;
+  text-decoration: underline;
+}
+
+.welcome-intro {
+  margin: 0 0 0.5rem 0;
+  color: var(--color-fg, #2a2f37);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.welcome-intro code {
+  background: var(--color-bg-subtle, rgba(0, 0, 0, 0.04));
+  padding: 0.05rem 0.35rem;
+  border-radius: 3px;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.85em;
+}
+
+.welcome-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
+}
+
+.welcome-card {
+  text-align: start;
+  padding: 1rem;
+  background: var(--color-bg-card, #ffffff);
+  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  cursor: pointer;
+  transition:
+    transform 80ms ease,
+    border-color 80ms ease;
+  font: inherit;
+  color: inherit;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.welcome-card:hover {
+  border-color: var(--color-accent, #1f6feb);
+  transform: translateY(-1px);
+}
+
+.welcome-card:focus-visible {
+  outline: 2px solid var(--color-accent, #1f6feb);
+  outline-offset: 2px;
+}
+
+.welcome-card-title {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.welcome-card-body {
+  color: var(--color-fg-muted, #6c7686);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.welcome-card-url {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 0.85em;
+}
+
+.welcome-dismiss {
+  text-align: center;
+  margin: 0.5rem 0 0 0;
+}
+
+.welcome-dismiss-link {
+  background: none;
+  border: none;
+  color: var(--color-fg-muted, #6c7686);
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-decoration: underline;
+  padding: 0.4rem;
+}
+
+.welcome-dismiss-link:hover {
+  color: var(--color-fg, #2a2f37);
+}

--- a/src/renderer/welcome-screen.tsx
+++ b/src/renderer/welcome-screen.tsx
@@ -1,0 +1,83 @@
+import type { JSX } from 'solid-js';
+
+interface WelcomeScreenProps {
+  conceptionPath: string;
+  onOpenTree: () => void;
+  onTakeTour: () => void;
+  onOpenDocs: () => void;
+  onOpenSettings: () => void;
+  onDismiss: () => void;
+}
+
+/**
+ * Empty-state surface shown when the conception tree is reachable but has no
+ * items in `projects/` and no entries in `knowledge/`. Three actions match the
+ * three things a brand-new user typically wants to do next: open the tree in
+ * the OS file manager (so they can drop a README in by hand or via their
+ * editor / a Claude skill), read the bundled welcome doc, or jump out to the
+ * public site.
+ *
+ * The dismiss link writes `welcome.dismissed = true` to settings.json via the
+ * onDismiss callback. Once content lands in the tree the screen stops
+ * appearing on its own — the dismiss is for users who want it gone before
+ * adding their first item (e.g. opening a tree they manage entirely from
+ * their editor).
+ */
+export function WelcomeScreen(props: WelcomeScreenProps): JSX.Element {
+  return (
+    <div class="welcome-screen" role="region" aria-label="Welcome to condash">
+      <div class="welcome-inner">
+        <h1 class="welcome-heading">Welcome to condash</h1>
+        <p class="welcome-tagline">A dashboard for the Markdown you already write.</p>
+        <p class="welcome-path">
+          Tree: <code>{props.conceptionPath}</code>{' '}
+          <button
+            type="button"
+            class="welcome-path-edit"
+            onClick={props.onOpenSettings}
+            title="Open configuration editor"
+          >
+            edit
+          </button>
+        </p>
+
+        <p class="welcome-intro">
+          Your tree is empty. condash renders projects, incidents, and documents stored as plain
+          Markdown under <code>projects/YYYY-MM/&lt;item&gt;/README.md</code>. To get started:
+        </p>
+
+        <div class="welcome-cards">
+          <button type="button" class="welcome-card" onClick={props.onOpenTree}>
+            <div class="welcome-card-title">Open my tree</div>
+            <div class="welcome-card-body">
+              Open the conception directory in your OS file manager so you can drop in your first
+              README, or open it in your editor. condash picks up changes live.
+            </div>
+          </button>
+
+          <button type="button" class="welcome-card" onClick={props.onTakeTour}>
+            <div class="welcome-card-title">Read the welcome doc</div>
+            <div class="welcome-card-body">
+              The bundled docs are available offline through the Help menu. The welcome page walks
+              you through everything condash does.
+            </div>
+          </button>
+
+          <button type="button" class="welcome-card" onClick={props.onOpenDocs}>
+            <div class="welcome-card-title">Open the documentation site</div>
+            <div class="welcome-card-body">
+              Visit <span class="welcome-card-url">condash.vcoeur.com</span> for the full Diátaxis
+              tree: tutorials, guides, reference, and the design rationale.
+            </div>
+          </button>
+        </div>
+
+        <p class="welcome-dismiss">
+          <button type="button" class="welcome-dismiss-link" onClick={props.onDismiss}>
+            Don't show this again
+          </button>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -50,6 +50,10 @@ export interface CondashApi {
    * Persisted in the global per-machine settings.json. */
   getLayout(): Promise<LayoutState>;
   setLayout(layout: LayoutState): Promise<void>;
+  /** Whether the first-launch welcome screen was dismissed by the user.
+   * Stored as `welcome.dismissed` in settings.json. */
+  getWelcomeDismissed(): Promise<boolean>;
+  setWelcomeDismissed(value: boolean): Promise<void>;
   /** Absolute path to `~/.config/condash/settings.json` (or platform equivalent),
    * for the settings modal's "Open externally" button. */
   getSettingsPath(): Promise<string>;
@@ -72,9 +76,9 @@ export interface CondashApi {
   writeNote(path: string, expectedContent: string, newContent: string): Promise<void>;
   /**
    * Read one of the bundled help docs (`docs/<name>.md`). The main process
-   * whitelists the four shipped names; anything else rejects.
+   * whitelists the shipped names; anything else rejects.
    */
-  helpReadDoc(name: 'architecture' | 'configuration' | 'non-goals' | 'index'): Promise<string>;
+  helpReadDoc(name: HelpDocName): Promise<string>;
   /**
    * Subscribe to per-path tree events emitted by the main-process file watcher.
    * Each callback receives a debounced batch. Returns an unsubscribe function.
@@ -149,10 +153,34 @@ export type MenuCommand =
   | 'hide-working'
   | 'refresh'
   | 'about'
-  | 'help-architecture'
+  | 'help-welcome'
+  | 'help-getting-started'
+  | 'help-install'
+  | 'help-first-launch'
+  | 'help-shortcuts'
   | 'help-configuration'
+  | 'help-cli'
+  | 'help-mutations'
+  | 'help-architecture'
+  | 'help-why-markdown'
+  | 'help-values'
   | 'help-non-goals'
   | 'help-index';
+
+export type HelpDocName =
+  | 'welcome'
+  | 'getting-started'
+  | 'install'
+  | 'first-launch'
+  | 'shortcuts'
+  | 'configuration'
+  | 'cli'
+  | 'mutations'
+  | 'architecture'
+  | 'why-markdown'
+  | 'values'
+  | 'non-goals'
+  | 'index';
 
 declare global {
   interface Window {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -91,6 +91,11 @@ export interface Settings {
   /** Composite-layout visibility + sizes. Persisted globally (per-machine)
    * so a fresh launch reopens with the last layout. */
   layout?: LayoutState;
+  /** First-launch welcome screen state. The screen shows automatically when
+   * the conception tree has no items and no knowledge entries; setting
+   * `dismissed` hides it permanently for users who manage trees entirely
+   * outside the dashboard. */
+  welcome?: { dismissed?: boolean };
 }
 
 /** One row of `git status --porcelain=v1` output, normalised for the renderer. */


### PR DESCRIPTION
## Summary

- Fix every hard drift found in the audit: CLI reference (CLI surface added in v2.4.0 was entirely undocumented), releases (auto-updater wired but doc said otherwise), env vars (CONDASH_CONCEPTION_PATH IS honoured by readSettings), terminal (works on Windows too via wrapForShell), and tutorials/first-run (referenced a non-existent examples/conception-demo).
- Add a positive Values page (the counterpart to Non-goals), a Contributing guide for first-time devs, and a Troubleshooting page.
- Tag every page with its target audience (New user / Daily user / Developer) at the top, immediately under the H1.
- Rewrite docs/index.md as an audience picker so a brand-new visitor can find the right doorway in one click.
- Expand the in-app Help menu allowlist from 4 entries to 13. Reshape the OS Help submenu into three blocks (welcome / reference / explanation) and add external links to condash.vcoeur.com and the issue tracker.
- Add a first-launch welcome screen to the renderer, shown on a tree with no items + no knowledge entries. Three actions: open the tree, read the welcome doc, open the documentation site. Dismissable via welcome.dismissed in settings.json (new IPC verbs getWelcomeDismissed / setWelcomeDismissed).
- Update the repo README + CLAUDE.md to point at condash.vcoeur.com first and to describe the new Help allowlist.

## Audit summary

Conception project tracking this work: vcoeur/conception/projects/2026-05/2026-05-01-condash-documentation-overhaul/.

The audit notes (notes/02-audit-and-ia.md) catalogue eight hard-drift items and three structural gaps. Each is addressed in this PR.

## Test plan

- [x] make typecheck — passes
- [x] make format — passes (welcome-screen.tsx + welcome-screen.css formatted)
- [x] mkdocs build --strict — passes
- [ ] Manual: launch on a fresh tree, confirm welcome screen renders, confirm the three buttons work
- [ ] Manual: confirm the Help submenu shows the new entries and renders each