### PR TITLE
Tighten editorial layer in four shipped skill templates

### DIFF
--- a/conception-template/.claude/skills/knowledge/update.md
+++ b/conception-template/.claude/skills/knowledge/update.md
@@ -39,13 +39,13 @@ If the fact is in-flight project work or a point-in-time finding, it goes under 
 
 4. **Cross-link.** Link the body file to the `projects/` item (if any) that produced the knowledge. Update the item's `## Notes` section.
 
-5. **Dirty the knowledge index** when the change is index-relevant:
+5. **Dirty the knowledge index.** Default to running:
 
    ```bash
    condash dirty touch knowledge --json
    ```
 
-   Run when the action **added**, **renamed**, or **substantially rewrote the scope** of a body file. Pure body edits that don't change scope (no new heading, no renamed concept) do **not** stale the index — skip the call. `/knowledge index` clears the marker. Remind the user — the index is not auto-triggered.
+   Skip only on a literal one-line typo or wording fix to existing prose. Anything that adds, renames, restructures, or rewrites a paragraph dirties the index — when in doubt, touch it. Cost of a false-positive is one quick `/knowledge index` run; cost of a false-negative is stale tags / descriptions teammates rely on for triage. `/knowledge index` clears the marker; the index is not auto-triggered, so remind the user to run it.
 
 ## Rules
 

--- a/conception-template/.claude/skills/projects/close.md
+++ b/conception-template/.claude/skills/projects/close.md
@@ -16,19 +16,33 @@ Trigger: `/projects close <slug>`.
 
    **Exception — intentional deferrals.** Treat as silently complete any step whose text carries `(outside this item)`, `(out of scope)`, `(follow-up)`, or `(tracked in <slug>)`.
 
-4. **Knowledge promotion scan.**
+4. **Knowledge promotion review.** Editorial step — Claude does the reading, the CLI is a backstop.
 
-   ```bash
-   condash projects scan-promotions <slug> --json
-   ```
+   a. **Read the README and every `notes/*.md` body** returned by step 2's `read --with-notes`. Do not skim. Durable findings often land outside the heuristic's reach: in `## Description`, `## Steps` prose, `## Timeline` entries, or notes phrased as observations rather than imperatives.
 
-   The CLI grep-walks the item's `notes/*.md` for the durable-finding heuristic and returns `data.candidates[]` with `relPath`, `line`, `match`, and the surrounding `paragraph`. Present each as a numbered candidate. For each, ask: *"Promote to `knowledge/`? (y / n / edit-first)"*.
+   b. **Apply the three-question durability test from `knowledge/conventions.md`** to every candidate paragraph you noticed:
 
-   - **y** → invoke `/knowledge update`, then **automatically** stamp the origin paragraph in the project note: `**Transferred:** YYYY-MM-DD → <knowledge-path>`.
-   - **edit-first** → refine, re-present, re-ask.
+      1. Does it hold beyond this task? (Not specific to the in-flight work.)
+      2. Does it apply to more than one app, or to the ecosystem? (Or: would a teammate touching another app want to find it.)
+      3. Does it stay true regardless of the current PR's outcome? (Survives both merge and abandonment.)
+
+      Three yes → keep as a candidate. Any no → silently drop. Do not present a candidate that fails the test.
+
+   c. **Run the heuristic backstop** to catch anything you missed:
+
+      ```bash
+      condash projects scan-promotions <slug> --json
+      ```
+
+      The CLI grep-walks `notes/*.md` for `always|never|must|convention|rule|pattern|whenever|all (apps|sites|projects)` and returns `data.candidates[]` with `relPath`, `line`, `match`, and the surrounding `paragraph`. For each row, check whether you already have it in your candidate set; if not, re-apply the three-question test before adding it. Skip any paragraph already carrying a `**Transferred:**` stamp.
+
+   d. **Present surviving candidates** (yours + any new from the scan) as a numbered list, each with the origin `<file>:<line>` reference, the exact paragraph, and the proposed `knowledge/` location (use the bucket-picking rubric from `knowledge/SKILL.md`). For each, ask: *"Promote to `knowledge/<path>`? (y / n / edit-first)"*.
+
+   - **y** → invoke `/knowledge update`, then **automatically** stamp the origin paragraph (in the README or the note) with `**Transferred:** YYYY-MM-DD → <knowledge-path>`.
+   - **edit-first** → refine wording or target path, re-present, re-ask.
    - **n** → skip.
 
-   If `data.candidates` is empty: mention it, offer one manual prompt ("Any specific passage to promote?"), move on.
+   If your reading produced zero candidates and the scan also returned empty, say so and move on — don't synthesise a prompt to fish for one.
 
 5. **Flip status + append timeline:**
 

--- a/conception-template/.claude/skills/projects/update.md
+++ b/conception-template/.claude/skills/projects/update.md
@@ -31,4 +31,12 @@ Trigger: `/projects update <slug>` or implicit ("add a note to <slug>", "change 
 
 ## Promoting durable knowledge
 
-Apply the three-question durability test from `knowledge/conventions.md`. Three yes → `/knowledge update`, link under `## Notes`, stamp the origin paragraph `**Transferred:** YYYY-MM-DD → <knowledge-path>`. `/projects close` performs this stamping automatically when a candidate is confirmed during its scan.
+After every notes write — not just at close — re-read the paragraph you just wrote and apply the durability test from `knowledge/conventions.md`:
+
+1. Does it hold beyond this task? (Not specific to the in-flight work.)
+2. Does it apply to more than one app, or to the ecosystem?
+3. Does it stay true regardless of the current PR's outcome?
+
+Three yes → invoke `/knowledge update` now (don't wait for `/projects close`), link the resulting body file under `## Notes` in the project README, and stamp the origin paragraph in the note: `**Transferred:** YYYY-MM-DD → <knowledge-path>`. Any no → leave it in `notes/` only.
+
+Catching durable findings at write-time keeps `knowledge/` fresh while context is loaded; deferring them all to `/projects close` risks losing the fact in heuristic-grep blind spots. `/projects close` still performs a final pass and stamping for anything that slipped through.

--- a/conception-template/.claude/skills/skills/SKILL.md
+++ b/conception-template/.claude/skills/skills/SKILL.md
@@ -75,12 +75,12 @@ For each `edited` row, ask the user one question. Show:
 
 ### 4. Apply `accept shipped` choices
 
-The CLI's `--force` flag operates per skill, not per file. So if the user picked "accept shipped" for some files in `projects/` but "keep local" for others in the same skill, **don't run `--force` on `projects/`** — that would overwrite the keep-local files too.
+The CLI's `--force` flag operates per skill, not per file — using it risks overwriting "keep local" files in the same skill. To keep the decision boundary at the file level, **always use the per-file write path**, even when every `edited` row in a skill was "accept shipped":
 
-Two-tier handling:
+1. For each accept-shipped file: read the shipped content from the path in `condash skills list --json` (`data.skills[].files`-derived; the `sourceDir` is in the JSON), then `Write` it to the on-disk path.
+2. After all per-file writes, run `condash skills install <skill> --json` (no `--force`) once per touched skill so the manifest gets refreshed — the CLI will see local matches shipped and mark each file `Unchanged`.
 
-- **Whole-skill accept** (every `edited` row in the skill is "accept shipped"): run `condash skills install <skill> --force --json` once for the whole skill. Clean.
-- **Mixed within a skill**: for each accept-shipped file, get the shipped content via the path in `condash skills list --json` (`data.skills[].files`-derived; the `sourceDir` is in the JSON), then `Write` it to the on-disk path. Then run `condash skills install <skill> --json` (no `--force`) so the manifest gets refreshed — the CLI will see the local now matches shipped and mark it `Unchanged`.
+This loses the small efficiency of a single `--force` on whole-skill accepts, and gains correctness: the per-file branching state never has to be tracked across the prompt loop, and `--force` cannot leak into a mixed-decision skill.
 
 ### 5. Handle `missing` and `orphan`
 


### PR DESCRIPTION
## Summary

- The `condash projects scan-promotions` heuristic only matches imperative phrasings and only scans `notes/`, missing README-borne findings and observational prose. Several skill templates were over-delegating judgment to that scan and to similar CLI mechanics.
- Four skill templates now keep editorial decisions (durability, dirty-marker, per-file consent) in the skill prose; CLI heuristics become a backstop, not the source of truth.

## Changes

- `conception-template/.claude/skills/projects/close.md`: knowledge-promotion step now reads the README + every note, applies the conventions three-question durability test, then runs `scan-promotions` as a backstop and folds in any new candidates.
- `conception-template/.claude/skills/projects/update.md`: durability test promoted from a closing-only footnote to an explicit post-write checklist; durable findings are caught at write-time.
- `conception-template/.claude/skills/knowledge/update.md`: defaults to dirtying the index; only literal one-line typo edits skip the touch.
- `conception-template/.claude/skills/skills/SKILL.md`: drops the two-tier 'whole-skill accept' branch in step 4. Always per-file write, then a trailing manifest refresh — `--force` can no longer leak into a mixed-decision skill.

## Impact

- Existing conceptions pick up these changes only after the user runs `/skills update` (or `condash skills install`); the v2.6.0 manifest hashes match the previous shipped versions, so the audit will surface them as `outdated`.
- No CLI behaviour change — purely template prose.