### PR TITLE
Stop `knowledge index` from polluting parent bullets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
         "vite-plugin-solid": "^2.11.0",
+        "vitest": "^2.1.9",
         "wait-on": "^8.0.1"
       }
     },
@@ -2621,6 +2622,98 @@
         "d3-transition": "^3.0.1"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
       "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
@@ -3110,6 +3203,15 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -3438,6 +3540,15 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/cacache": {
       "version": "16.1.3",
       "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
@@ -3642,6 +3753,22 @@
         }
       ]
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3668,6 +3795,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chevrotain": {
@@ -4603,6 +4739,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -5219,6 +5364,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5314,6 +5465,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/exponential-backoff": {
@@ -6440,6 +6609,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -6458,6 +6633,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-fetch-happen": {
@@ -7192,6 +7376,15 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -7885,6 +8078,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -8067,6 +8266,12 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -8075,6 +8280,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -8276,6 +8487,12 @@
       "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
       "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
     "node_modules/tinyexec": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
@@ -8298,6 +8515,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -8573,6 +8817,499 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
           "optional": true
         }
       }
@@ -9072,6 +9809,574 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/vitest/node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -9161,6 +10466,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html,json}\"",
     "test": "playwright test",
+    "test:unit": "vitest run",
     "postinstall": "electron-rebuild"
   },
   "dependencies": {
@@ -79,6 +80,7 @@
     "typescript": "^5.7.0",
     "vite": "^6.0.0",
     "vite-plugin-solid": "^2.11.0",
+    "vitest": "^2.1.9",
     "wait-on": "^8.0.1"
   }
 }

--- a/src/cli/commands/knowledge.ts
+++ b/src/cli/commands/knowledge.ts
@@ -40,7 +40,11 @@ async function indexCommand(
   conceptionPath: string,
 ): Promise<void> {
   const dryRun = args.flags['dry-run'] === true;
-  const report = await regenerateIndex(conceptionPath, knowledgeStrategy, { dryRun });
+  const rewriteAggregated = args.flags['rewrite-aggregated'] === true;
+  const report = await regenerateIndex(conceptionPath, knowledgeStrategy, {
+    dryRun,
+    rewriteAggregated,
+  });
   emit(ctx, report, formatIndexReport);
 }
 
@@ -70,11 +74,14 @@ function formatIndexReport(report: IndexRegenReport): string {
       lines.push(`  ? ${r.indexPath}  ${r.oldName}  →  ${r.newName}`);
     }
   }
-  if (report.overTagTarget.length > 0) {
-    lines.push(`Over-target tag count (${report.overTagTarget.length}):`);
-    for (const o of report.overTagTarget) {
-      lines.push(`  · ${o.indexPath}  ${o.entry}  ${o.tagCount} tags`);
+  if (report.overTagDropped.length > 0) {
+    lines.push(`Cap reached, dropped surplus tags (${report.overTagDropped.length}):`);
+    for (const o of report.overTagDropped) {
+      lines.push(`  · ${o.indexPath}  ${o.entry}  dropped: ${o.dropped.join(', ')}`);
     }
+  }
+  if (report.rewriteAggregated) {
+    lines.push('Mode: --rewrite-aggregated (subdir bullets re-derived from descendants).');
   }
   if (report.dirtyClear) lines.push('Dirty marker cleared.');
   return lines.join('\n') + '\n';
@@ -488,6 +495,8 @@ function printSubHelp(): void {
       '  retrieve    Match a query against index.md keywords; falls back to grep.',
       '  stamp       Idempotently write a **Verified:** line into a file.',
       '  index       Regenerate every knowledge/**/index.md.',
+      '              Flags: --dry-run, --rewrite-aggregated (one-shot migration:',
+      '              re-derive every subdir bullet from descendants, mark drafted).',
       '',
     ].join('\n'),
   );

--- a/src/cli/commands/projects.ts
+++ b/src/cli/commands/projects.ts
@@ -86,7 +86,11 @@ async function indexCommand(
   conceptionPath: string,
 ): Promise<void> {
   const dryRun = args.flags['dry-run'] === true;
-  const report = await regenerateIndex(conceptionPath, projectsStrategy, { dryRun });
+  const rewriteAggregated = args.flags['rewrite-aggregated'] === true;
+  const report = await regenerateIndex(conceptionPath, projectsStrategy, {
+    dryRun,
+    rewriteAggregated,
+  });
   emit(ctx, report, formatIndexReport);
 }
 
@@ -118,10 +122,10 @@ function formatIndexReport(report: IndexRegenReport): string {
       lines.push(`  ? ${r.indexPath}  ${r.oldName}  →  ${r.newName}`);
     }
   }
-  if (report.overTagTarget.length > 0) {
-    lines.push(`Over-target tag count (${report.overTagTarget.length}):`);
-    for (const o of report.overTagTarget) {
-      lines.push(`  · ${o.indexPath}  ${o.entry}  ${o.tagCount} tags`);
+  if (report.overTagDropped.length > 0) {
+    lines.push(`Cap reached, dropped surplus tags (${report.overTagDropped.length}):`);
+    for (const o of report.overTagDropped) {
+      lines.push(`  · ${o.indexPath}  ${o.entry}  dropped: ${o.dropped.join(', ')}`);
     }
   }
   if (report.validationWarnings.length > 0) {

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -25,6 +25,7 @@ const BOOL_FLAGS = new Set([
   'version',
   'with-notes',
   'dry-run',
+  'rewrite-aggregated',
   'all',
   'include-worktrees',
   'header',

--- a/src/main/index-knowledge.ts
+++ b/src/main/index-knowledge.ts
@@ -13,6 +13,7 @@
 
 import { promises as fs } from 'node:fs';
 import { basename, join } from 'node:path';
+import { filterTags } from './index-tag-filter';
 import type { DraftResult, IndexStrategy } from './index-tree';
 
 export const knowledgeStrategy: IndexStrategy = {
@@ -155,21 +156,17 @@ function deriveFileKeywords(filename: string, head: string): string[] {
       }
     }
   }
-  // Dedupe preserving order, cap at 8.
-  const seen = new Set<string>();
-  const out: string[] = [];
-  for (const c of candidates) {
-    if (seen.has(c)) continue;
-    if (c.length < 3) continue;
-    seen.add(c);
-    out.push(c);
-    if (out.length >= 8) break;
+  // Apply the shared tag-quality filter (drops stop-words, dates, UUIDs, etc.)
+  // and dedupe; then cap at 8.
+  const cleaned = filterTags(candidates).slice(0, 8);
+  if (cleaned.length === 0) {
+    // Backstop: include the filename itself so the bullet has at least one
+    // tag. We still pass it through the filter so junk filenames don't sneak
+    // back in.
+    const fallback = filename.replace(/\.md$/, '').toLowerCase();
+    return filterTags([fallback]);
   }
-  if (out.length < 3) {
-    // Backstop: include the filename itself so the bullet has at least one tag.
-    out.push(filename.replace(/\.md$/, '').toLowerCase());
-  }
-  return out;
+  return cleaned;
 }
 
 function deriveSubdirKeywords(head: string): string[] {

--- a/src/main/index-tag-filter.test.ts
+++ b/src/main/index-tag-filter.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { isLowQualityTag, filterTags } from './index-tag-filter';
+
+describe('isLowQualityTag', () => {
+  it('rejects tags shorter than 3 characters', () => {
+    expect(isLowQualityTag('a')).toBe(true);
+    expect(isLowQualityTag('ab')).toBe(true);
+    expect(isLowQualityTag('ci')).toBe(true);
+    expect(isLowQualityTag('abc')).toBe(false);
+  });
+
+  it('rejects tags longer than 40 characters', () => {
+    expect(isLowQualityTag('a'.repeat(40))).toBe(false);
+    expect(isLowQualityTag('a'.repeat(41))).toBe(true);
+  });
+
+  it('rejects pure-numeric tags', () => {
+    expect(isLowQualityTag('42')).toBe(true);
+    expect(isLowQualityTag('2026')).toBe(true);
+    expect(isLowQualityTag('v2')).toBe(true); // length 2 → also rejected by length rule
+    expect(isLowQualityTag('2026q1')).toBe(false); // mixed alphanumeric is fine
+  });
+
+  it('rejects ISO-date-shaped tags', () => {
+    expect(isLowQualityTag('2026-04')).toBe(true);
+    expect(isLowQualityTag('2026-04-17')).toBe(true);
+    expect(isLowQualityTag('2026-4-17')).toBe(false); // not ISO; treat as content
+    expect(isLowQualityTag('q1-2026')).toBe(false);
+  });
+
+  it('rejects UUID-shaped tags (with and without dashes)', () => {
+    expect(isLowQualityTag('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')).toBe(true);
+    expect(isLowQualityTag('AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE')).toBe(true);
+    expect(isLowQualityTag('aaaaaaaabbbbccccddddeeeeeeeeeeee')).toBe(true);
+    expect(isLowQualityTag('not-a-uuid-just-words')).toBe(false);
+  });
+
+  it('rejects English stop-words and common content-free verbs', () => {
+    for (const w of [
+      'the',
+      'and',
+      'for',
+      'with',
+      'this',
+      'that',
+      'observation',
+      'develop',
+      'configure',
+      'summary',
+      'overview',
+    ]) {
+      expect(isLowQualityTag(w)).toBe(true);
+    }
+  });
+
+  it('passes through legit hyphenated content tags', () => {
+    for (const w of [
+      'sandbox-testing',
+      'caddy-access-log',
+      'port-range-11111',
+      'condash',
+      'playwright',
+      'electron-builder',
+      'pii-stripping',
+    ]) {
+      expect(isLowQualityTag(w)).toBe(false);
+    }
+  });
+
+  it('is case-insensitive on stop-words but tag identity is preserved by callers', () => {
+    expect(isLowQualityTag('THE')).toBe(true);
+    expect(isLowQualityTag('The')).toBe(true);
+  });
+});
+
+describe('filterTags', () => {
+  it('removes low-quality tags and preserves order + dedupes by exact-match', () => {
+    const input = [
+      'sandbox-testing',
+      'the',
+      'sandbox-testing', // dup
+      '2026-04',
+      'condash',
+      'a',
+      'caddy-access-log',
+    ];
+    expect(filterTags(input)).toEqual(['sandbox-testing', 'condash', 'caddy-access-log']);
+  });
+
+  it('returns an empty list when every tag is junk', () => {
+    expect(filterTags(['the', 'and', '42', '2026-04'])).toEqual([]);
+  });
+});

--- a/src/main/index-tag-filter.ts
+++ b/src/main/index-tag-filter.ts
@@ -1,0 +1,157 @@
+/**
+ * Tag-quality filter for the knowledge / projects index regenerator.
+ *
+ * Applied at three points (see issue #79):
+ *  - End of `deriveFileKeywords` — replaces the bare `length < 3` check.
+ *  - Beginning of subdir-bullet aggregation — before merging additions into a parent.
+ *  - End of `aggregatedKeywords` build — before the parent's pass sees descendant tags.
+ *
+ * The filter is deliberately conservative: we only reject mechanically detectable
+ * junk (length, pure numeric, date-shaped, UUID-shaped, English stop-words). We do
+ * NOT try to detect semantically weak tags. Borderline-but-real tags survive and
+ * surface via the over-target report.
+ */
+
+const MIN_LENGTH = 3;
+const MAX_LENGTH = 40;
+
+const PURE_NUMERIC_RE = /^\d+$/;
+// ISO date: YYYY-MM or YYYY-MM-DD, zero-padded.
+const ISO_DATE_RE = /^\d{4}-\d{2}(-\d{2})?$/;
+// UUID v1-5 with or without dashes.
+const UUID_RE = /^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$/i;
+
+const STOP_WORDS = new Set<string>([
+  // Pronouns / determiners / common English particles likely to appear as
+  // single-token tags via H2/H3 slugify.
+  'the',
+  'and',
+  'for',
+  'with',
+  'this',
+  'that',
+  'these',
+  'those',
+  'from',
+  'into',
+  'onto',
+  'over',
+  'under',
+  'about',
+  'are',
+  'was',
+  'were',
+  'has',
+  'had',
+  'have',
+  'will',
+  'would',
+  'should',
+  'could',
+  'when',
+  'where',
+  'what',
+  'why',
+  'how',
+  'who',
+  'whom',
+  'whose',
+  'all',
+  'any',
+  'each',
+  'every',
+  'some',
+  'most',
+  'more',
+  'less',
+  'few',
+  'not',
+  'yes',
+  'one',
+  'two',
+  'three',
+  // Content-free verbs / nouns that frequently appear as standalone H2 headings
+  // ("## Develop", "## Summary", "## Notes") and slugify to a single junk token.
+  'develop',
+  'developed',
+  'developing',
+  'observe',
+  'observed',
+  'observation',
+  'observations',
+  'configure',
+  'configured',
+  'configuration',
+  'implement',
+  'implemented',
+  'implementation',
+  'summary',
+  'summaries',
+  'overview',
+  'overviews',
+  'note',
+  'notes',
+  'todo',
+  'todos',
+  'update',
+  'updates',
+  'updated',
+  'change',
+  'changes',
+  'changed',
+  'fix',
+  'fixes',
+  'fixed',
+  'add',
+  'adds',
+  'added',
+  'remove',
+  'removes',
+  'removed',
+  'use',
+  'uses',
+  'used',
+  'using',
+  'run',
+  'runs',
+  'running',
+  'context',
+  'goal',
+  'goals',
+  'scope',
+  'steps',
+  'step',
+  'description',
+  'details',
+  'rationale',
+]);
+
+/**
+ * Returns true if the tag should be rejected as low-quality.
+ * Tag comparison is case-insensitive for stop-words; everything else matches the raw form.
+ */
+export function isLowQualityTag(tag: string): boolean {
+  if (tag.length < MIN_LENGTH) return true;
+  if (tag.length > MAX_LENGTH) return true;
+  if (PURE_NUMERIC_RE.test(tag)) return true;
+  if (ISO_DATE_RE.test(tag)) return true;
+  if (UUID_RE.test(tag)) return true;
+  if (STOP_WORDS.has(tag.toLowerCase())) return true;
+  return false;
+}
+
+/**
+ * Applies `isLowQualityTag` to a tag list, preserving first-seen order and deduplicating
+ * by exact match. Used by callers that own a candidate list and want clean output.
+ */
+export function filterTags(tags: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const tag of tags) {
+    if (isLowQualityTag(tag)) continue;
+    if (seen.has(tag)) continue;
+    seen.add(tag);
+    out.push(tag);
+  }
+  return out;
+}

--- a/src/main/index-tree.test.ts
+++ b/src/main/index-tree.test.ts
@@ -1,0 +1,235 @@
+import { promises as fs } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { knowledgeStrategy } from './index-knowledge';
+import { regenerateIndex } from './index-tree';
+
+let conceptionDir: string;
+let knowledgeDir: string;
+
+beforeEach(async () => {
+  conceptionDir = await mkdtemp(join(tmpdir(), 'condash-index-test-'));
+  knowledgeDir = join(conceptionDir, 'knowledge');
+  await fs.mkdir(knowledgeDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(conceptionDir, { recursive: true, force: true });
+});
+
+async function writeFile(relPath: string, content: string): Promise<void> {
+  const abs = join(conceptionDir, relPath);
+  await fs.mkdir(join(abs, '..'), { recursive: true });
+  await fs.writeFile(abs, content, 'utf8');
+}
+
+async function readFile(relPath: string): Promise<string> {
+  return fs.readFile(join(conceptionDir, relPath), 'utf8');
+}
+
+describe('regenerateIndex (knowledge strategy)', () => {
+  describe('drafted-leaf marker', () => {
+    it('emits the <!-- draft --> marker on every newly-drafted leaf bullet', async () => {
+      await writeFile(
+        'knowledge/topics/index.md',
+        '# Topics\n\nCross-cutting subjects.\n\n## Current files\n',
+      );
+      await writeFile(
+        'knowledge/topics/sandbox-testing.md',
+        '# Sandbox testing\n\nHow to drive vcoeur apps from the sandbox.\n\n## Recipe\n\nCall `condash run`.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+
+      const index = await readFile('knowledge/topics/index.md');
+      expect(index).toMatch(
+        /- \[`sandbox-testing\.md`\]\(sandbox-testing\.md\) — \*[^*]+\*\s+`\[[^\]]+\]` <!-- draft -->/,
+      );
+    });
+
+    it('idempotent: running twice produces zero diff', async () => {
+      await writeFile(
+        'knowledge/topics/index.md',
+        '# Topics\n\nCross-cutting subjects.\n\n## Current files\n',
+      );
+      await writeFile(
+        'knowledge/topics/sandbox-testing.md',
+        '# Sandbox testing\n\nHow to drive vcoeur apps.\n\n## Recipe\n\nCall the binary.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const after1 = await readFile('knowledge/topics/index.md');
+      const report = await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const after2 = await readFile('knowledge/topics/index.md');
+
+      expect(after1).toBe(after2);
+      expect(report.updated).toEqual([]);
+      expect(report.created).toEqual([]);
+    });
+  });
+
+  describe('tag-quality filter on initial draft', () => {
+    it('strips stop-words and content-free verbs from H2-derived tags', async () => {
+      await writeFile(
+        'knowledge/topics/index.md',
+        '# Topics\n\nCross-cutting subjects.\n\n## Current files\n',
+      );
+      await writeFile(
+        'knowledge/topics/legal-privacy.md',
+        // Headings that would slugify to junk: `the`, `summary`, `develop`,
+        // `notes`, `2026-04`. Plus one good heading.
+        '# Legal and privacy\n\nLegal pages and CNIL rules.\n\n## The summary\n\n## Develop\n\n## Notes\n\n## 2026-04\n\n## Caddy access log retention\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const index = await readFile('knowledge/topics/index.md');
+
+      expect(index).not.toMatch(/\bthe\b/i);
+      expect(index).not.toMatch(/\bsummary\b/i);
+      expect(index).not.toMatch(/\bdevelop\b/i);
+      expect(index).not.toMatch(/\b2026-04\b/);
+      // Good heading survives, slug form is hyphenated.
+      expect(index).toContain('caddy');
+    });
+  });
+
+  describe('aggregation cap + curated/drafted distinction', () => {
+    it('caps drafted subdir-bullet aggregation at 8 and surfaces the surplus', async () => {
+      // Build a subtree under topics/ with 12 distinct legit tags spread
+      // across 12 leaves (one tag each). When regenerating the root, the
+      // drafted topics/ bullet must be capped at 8 with the rest in
+      // overTagDropped.
+      const tags = [
+        'sandbox-testing',
+        'caddy-access-log',
+        'port-range-11111',
+        'electron-builder',
+        'pii-stripping',
+        'condash',
+        'playwright',
+        'postgres-ports',
+        'vite-config',
+        'drizzle-kit',
+        'github-pages',
+        'tauri-action',
+      ];
+      await writeFile('knowledge/index.md', '# Knowledge\n\nRoot.\n\n## Structure\n');
+      await writeFile('knowledge/topics/index.md', '# Topics\n\nIntro.\n\n## Current files\n');
+      for (const tag of tags) {
+        // Each leaf has a single H2 heading whose slug = the tag (single
+        // token), forcing exactly one mined keyword per file.
+        const h2 = tag.replace(/-/g, ' ');
+        await writeFile(
+          `knowledge/topics/${tag}.md`,
+          `# ${h2}\n\nIntro for ${tag}.\n\n## ${h2}\n\nBody.\n`,
+        );
+      }
+
+      const report = await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const rootIndex = await readFile('knowledge/index.md');
+
+      // The topics/ bullet should be present and capped.
+      const bulletMatch = rootIndex.match(/- \[`topics\/`\][^\n]+/);
+      expect(bulletMatch).not.toBeNull();
+      const bullet = bulletMatch![0];
+      const tagBlock = bullet.match(/`\[([^\]]+)\]`/);
+      expect(tagBlock).not.toBeNull();
+      const written = tagBlock![1].split(',').map((s) => s.trim());
+      expect(written.length).toBe(8);
+
+      // Report surfaces the dropped surplus on the topics/ bullet.
+      const drop = report.overTagDropped.find((o) => o.entry === 'topics/');
+      expect(drop).toBeDefined();
+      expect(drop!.dropped.length).toBe(tags.length - 8);
+    });
+
+    it('leaves curated subdir bullets (no marker) untouched even when descendants change', async () => {
+      // Hand-curated bullet: no marker, exactly two tags.
+      await writeFile(
+        'knowledge/index.md',
+        '# Knowledge\n\nRoot.\n\n## Structure\n\n- [`topics/`](topics/index.md) — *cross-cutting topics.* `[curated-tag-one, curated-tag-two]`\n',
+      );
+      await writeFile('knowledge/topics/index.md', '# Topics\n\nIntro.\n\n## Current files\n');
+      await writeFile(
+        'knowledge/topics/sandbox-testing.md',
+        '# Sandbox testing\n\nDrive apps from the sandbox.\n\n## Recipe\n\nDoes things.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const rootIndex = await readFile('knowledge/index.md');
+      // Curated bullet preserved verbatim — no marker introduced, no descendant tags merged.
+      expect(rootIndex).toContain(
+        '- [`topics/`](topics/index.md) — *cross-cutting topics.* `[curated-tag-one, curated-tag-two]`',
+      );
+      expect(rootIndex).not.toContain('sandbox-testing');
+      expect(rootIndex).not.toContain('<!-- draft -->');
+    });
+
+    it('--rewrite-aggregated promotes curated bullets to drafted and re-derives tags', async () => {
+      await writeFile(
+        'knowledge/index.md',
+        '# Knowledge\n\nRoot.\n\n## Structure\n\n- [`topics/`](topics/index.md) — *cross-cutting topics.* `[stale-tag]`\n',
+      );
+      await writeFile('knowledge/topics/index.md', '# Topics\n\nIntro.\n\n## Current files\n');
+      await writeFile(
+        'knowledge/topics/sandbox-testing.md',
+        '# Sandbox testing\n\nDrive apps from the sandbox.\n\n## Caddy access log\n\nSomething.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy, { rewriteAggregated: true });
+      const rootIndex = await readFile('knowledge/index.md');
+
+      // Marker added, stale-tag removed, descendant tags surfaced.
+      expect(rootIndex).toContain('<!-- draft -->');
+      expect(rootIndex).not.toContain('stale-tag');
+      expect(rootIndex).toMatch(/topics\/.*caddy/);
+    });
+
+    it('drafted subdir bullet tracked across runs gets re-derived (junk leaks are healed)', async () => {
+      // Initial run drafts the topics/ bullet (no on-disk bullet → engine
+      // creates one with the marker).
+      await writeFile('knowledge/index.md', '# Knowledge\n\nRoot.\n\n## Structure\n');
+      await writeFile('knowledge/topics/index.md', '# Topics\n\nIntro.\n\n## Current files\n');
+      await writeFile(
+        'knowledge/topics/sandbox-testing.md',
+        '# Sandbox testing\n\nFirst.\n\n## Caddy access log\n\nBody.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const after1 = await readFile('knowledge/index.md');
+      expect(after1).toContain('<!-- draft -->');
+
+      // Add a second leaf with a junk tag at the source. Re-run: the junk
+      // doesn't make it into the parent because the filter rejects it.
+      await writeFile(
+        'knowledge/topics/observability.md',
+        '# Observability\n\nMetrics.\n\n## The summary\n\n## Caddy access log\n\nMore.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const after2 = await readFile('knowledge/index.md');
+      expect(after2).not.toMatch(/\b(?:the|summary)\b/i);
+    });
+  });
+
+  describe('curated leaf bullet preserved', () => {
+    it('does not touch curated leaf bullet (no marker) when re-running', async () => {
+      await writeFile(
+        'knowledge/topics/index.md',
+        '# Topics\n\nIntro.\n\n## Current files\n\n- [`sandbox-testing.md`](sandbox-testing.md) — *Curated description.* `[curated-a, curated-b]`\n',
+      );
+      await writeFile(
+        'knowledge/topics/sandbox-testing.md',
+        '# Sandbox testing\n\nNew body.\n\n## Some heading\n\nText.\n',
+      );
+
+      await regenerateIndex(conceptionDir, knowledgeStrategy);
+      const index = await readFile('knowledge/topics/index.md');
+      expect(index).toContain(
+        '- [`sandbox-testing.md`](sandbox-testing.md) — *Curated description.* `[curated-a, curated-b]`',
+      );
+    });
+  });
+});

--- a/src/main/index-tree.ts
+++ b/src/main/index-tree.ts
@@ -15,12 +15,20 @@
  *
  * Idempotence guarantees:
  *  - Same tree contents → zero diff. Every existing entry whose target still
- *    exists is kept verbatim (description and tags untouched).
+ *    exists is kept verbatim (description and tags untouched) when curated.
  *  - Curated description / keyword edits survive across runs. To change them,
  *    edit the index entry directly; the engine never overwrites.
- *  - Subdir bullets get keyword-aggregation: tags surfaced by descendants
- *    are appended to the subdir bullet's tag list (set union, no drops).
- *    Curated tags are floors, not ceilings.
+ *  - Drafted-vs-curated distinction: every bullet the engine writes carries
+ *    a trailing `<!-- draft -->` HTML-comment marker. Removing the marker
+ *    promotes the bullet to "curated" — the engine stops touching it. Adding
+ *    or keeping the marker keeps the bullet under engine ownership: tags are
+ *    re-derived from the current source on every run, junk is filtered out,
+ *    and the aggregated tag list is capped at 8 (`TARGET_MAX`). Surplus
+ *    candidates are reported via `overTagDropped`.
+ *  - `--rewrite-aggregated` mode (one-shot migration): treats every existing
+ *    subdir bullet as drafted for the duration of the run, then re-derives
+ *    its tags from current source and adds the marker. Used to clean a tree
+ *    that was polluted by the legacy "set union, no drops" aggregator.
  *
  * Strategy interface plugs in the per-tree drafting heuristic (how to read a
  * new file's body and propose a description + keywords) and the optional
@@ -29,6 +37,14 @@
 
 import { promises as fs } from 'node:fs';
 import { basename, dirname, join, relative } from 'node:path';
+import { isLowQualityTag } from './index-tag-filter';
+
+/** Per-bullet aggregated-tag cap. Surplus is dropped and surfaced in overTagDropped. */
+const TARGET_MAX = 8;
+
+/** HTML-comment marker rendered on every engine-drafted bullet. */
+const DRAFT_MARKER = '<!-- draft -->';
+const DRAFT_MARKER_RE = /\s+<!--\s*draft\s*-->\s*$/;
 
 // ---------------------------------------------------------------------------
 // Public report shape.
@@ -48,12 +64,15 @@ export interface IndexRegenReport {
   flaggedRenames: RenameFlag[];
   /** Per-tree validation warnings (currently: project header drift). */
   validationWarnings: ValidationWarning[];
-  /** Subdir bullets with > 8 tags after aggregation — for hand-pruning. */
-  overTagTarget: { indexPath: string; entry: string; tagCount: number }[];
+  /** Subdir bullets that hit the `TARGET_MAX` aggregation cap; lists the
+   * tags that didn't make the cut so a human can promote one to curated. */
+  overTagDropped: { indexPath: string; entry: string; dropped: string[] }[];
   /** Whether the tree's `.index-dirty` marker was cleared. */
   dirtyClear: boolean;
   /** True when called with --dry-run; nothing was written. */
   dryRun: boolean;
+  /** True when called with --rewrite-aggregated; surfaces in CLI output. */
+  rewriteAggregated: boolean;
 }
 
 export interface UpdateRow {
@@ -147,6 +166,9 @@ interface BulletEntry {
   tags: string[];
   /** Section heading the bullet currently lives under. */
   sectionHeading: string;
+  /** True when the bullet carries a trailing `<!-- draft -->` marker — the
+   * engine owns it and may rewrite tags on subsequent runs. False = curated. */
+  draft: boolean;
 }
 
 interface IndexFileShape {
@@ -189,22 +211,29 @@ const HEADING2_RE = /^##\s+(.+?)\s*$/;
 
 function matchBullet(
   line: string,
-): { name: string; link: string; desc: string; tags: string } | null {
-  const a = line.match(BULLET_WITH_TAGS_RE);
+): { name: string; link: string; desc: string; tags: string; draft: boolean } | null {
+  // Detect (and strip) a trailing `<!-- draft -->` marker before running the
+  // existing bullet regexes — keeps the regexes blissfully unaware of the
+  // marker.
+  const draft = DRAFT_MARKER_RE.test(line);
+  const stripped = draft ? line.replace(DRAFT_MARKER_RE, '') : line;
+  const a = stripped.match(BULLET_WITH_TAGS_RE);
   if (a)
     return {
       name: (a.groups as { name: string }).name,
       link: (a.groups as { link: string }).link,
       desc: (a.groups as { desc: string }).desc,
       tags: (a.groups as { tags: string }).tags,
+      draft,
     };
-  const b = line.match(BULLET_NO_TAGS_RE);
+  const b = stripped.match(BULLET_NO_TAGS_RE);
   if (b)
     return {
       name: (b.groups as { name: string }).name,
       link: (b.groups as { link: string }).link,
       desc: (b.groups as { desc: string }).desc,
       tags: '',
+      draft,
     };
   return null;
 }
@@ -218,9 +247,10 @@ function matchBullet(
 export async function regenerateIndex(
   conceptionPath: string,
   strategy: IndexStrategy,
-  options: { dryRun?: boolean } = {},
+  options: { dryRun?: boolean; rewriteAggregated?: boolean } = {},
 ): Promise<IndexRegenReport> {
   const dryRun = options.dryRun === true;
+  const rewriteAggregated = options.rewriteAggregated === true;
   const rootPath = join(conceptionPath, strategy.rootDirName);
 
   const report: IndexRegenReport = {
@@ -231,9 +261,10 @@ export async function regenerateIndex(
     unchanged: [],
     flaggedRenames: [],
     validationWarnings: [],
-    overTagTarget: [],
+    overTagDropped: [],
     dirtyClear: false,
     dryRun,
+    rewriteAggregated,
   };
 
   try {
@@ -251,8 +282,10 @@ export async function regenerateIndex(
   const allDirs = await listAllDirectories(rootPath);
   allDirs.sort((a, b) => b.length - a.length); // deepest first
 
-  // Per-subtree aggregated keyword set, populated bottom-up.
-  const aggregatedKeywords = new Map<string, Set<string>>();
+  // Per-subtree aggregated keyword frequency map, populated bottom-up. The
+  // count tracks how many descendant bullets surfaced the tag — used to rank
+  // candidates when the cap forces us to drop some.
+  const aggregatedKeywords = new Map<string, Map<string, number>>();
 
   for (const dir of allDirs) {
     const result = await processDirectory(
@@ -261,6 +294,7 @@ export async function regenerateIndex(
       strategy,
       aggregatedKeywords,
       dryRun,
+      rewriteAggregated,
     );
 
     if (result.created) report.created.push(result.indexPath);
@@ -275,7 +309,7 @@ export async function regenerateIndex(
       report.unchanged.push(result.indexPath);
     }
     report.flaggedRenames.push(...result.renames);
-    report.overTagTarget.push(...result.overTags);
+    report.overTagDropped.push(...result.overTagDropped);
   }
 
   // Clear dirty marker on success.
@@ -304,15 +338,16 @@ interface DirResult {
   dropped: string[];
   tagsAdded: { entry: string; tags: string[] }[];
   renames: RenameFlag[];
-  overTags: { indexPath: string; entry: string; tagCount: number }[];
+  overTagDropped: { indexPath: string; entry: string; dropped: string[] }[];
 }
 
 async function processDirectory(
   dirAbsPath: string,
   conceptionPath: string,
   strategy: IndexStrategy,
-  aggregatedKeywords: Map<string, Set<string>>,
+  aggregatedKeywords: Map<string, Map<string, number>>,
   dryRun: boolean,
+  rewriteAggregated: boolean,
 ): Promise<DirResult> {
   const indexPath = join(dirAbsPath, 'index.md');
   const indexRel = relative(conceptionPath, indexPath);
@@ -325,7 +360,7 @@ async function processDirectory(
     dropped: [],
     tagsAdded: [],
     renames: [],
-    overTags: [],
+    overTagDropped: [],
   };
 
   // Enumerate immediate children, classified.
@@ -370,70 +405,105 @@ async function processDirectory(
     shape.bullets.delete(dropped.name);
   }
 
-  // Draft new entries for on-disk children that have no bullet yet.
+  // Draft new entries for on-disk children that have no bullet yet. New
+  // entries are always emitted with the `<!-- draft -->` marker so the human
+  // can spot them and curate before they ossify into "permanent" bullets.
   const newEntries: BulletEntry[] = [];
   for (const child of children) {
     const canonical = canonicalName(child);
     if (shape.bullets.has(canonical)) continue;
     if (result.renames.some((r) => r.newName === canonical)) continue;
 
-    const draft =
-      child.kind === 'file'
-        ? await strategy.draftFileEntry(dirAbsPath, child)
-        : await strategy.draftSubdirEntry(dirAbsPath, child, [
-            ...(aggregatedKeywords.get(child.absPath) ?? new Set<string>()),
-          ]);
+    let draft: DraftResult;
+    if (child.kind === 'file') {
+      draft = await strategy.draftFileEntry(dirAbsPath, child);
+    } else {
+      const ranked = rankAggregatedTags(aggregatedKeywords.get(child.absPath) ?? new Map());
+      draft = await strategy.draftSubdirEntry(dirAbsPath, child, ranked.kept);
+      if (ranked.dropped.length > 0) {
+        result.overTagDropped.push({
+          indexPath: indexRel,
+          entry: canonical,
+          dropped: ranked.dropped,
+        });
+      }
+    }
 
     const sectionHeading = pickBucketHeading(shape, child);
     const link = strategy.formatChildLink(dirAbsPath, child);
     const linkName = child.kind === 'directory' ? `${child.name}/` : child.name;
-    const bullet = formatBullet(linkName, link, draft);
+    const bullet = formatBullet(linkName, link, draft, /* isDraft */ true);
     newEntries.push({
       name: canonical,
       raw: bullet,
       tags: draft.keywords,
       sectionHeading,
+      draft: true,
     });
     result.added.push(canonical);
   }
 
-  // Aggregate this directory's keyword footprint upward (used by the parent
-  // pass for subdir-bullet keyword unions). Includes tags from kept bullets,
-  // dropped bullets are excluded.
-  const myAggregate = new Set<string>();
+  // Aggregate this directory's keyword footprint upward — frequency-counted
+  // so the parent pass can rank candidates when the cap forces drops. Tags
+  // from kept (curated *and* drafted) bullets here count as 1 each; descendant
+  // contributions add their own counts.
+  const myAggregate = new Map<string, number>();
+  const bumpTag = (tag: string, by = 1): void => {
+    myAggregate.set(tag, (myAggregate.get(tag) ?? 0) + by);
+  };
   for (const bullet of shape.bullets.values()) {
-    for (const t of bullet.tags) myAggregate.add(t);
+    for (const t of bullet.tags) bumpTag(t);
   }
   for (const bullet of newEntries) {
-    for (const t of bullet.tags) myAggregate.add(t);
+    for (const t of bullet.tags) bumpTag(t);
   }
   // Also fold descendants (already populated since we go deepest-first).
-  for (const [path, set] of aggregatedKeywords) {
+  for (const [path, freq] of aggregatedKeywords) {
     if (path.startsWith(dirAbsPath + '/')) {
-      for (const t of set) myAggregate.add(t);
+      for (const [t, n] of freq) bumpTag(t, n);
     }
   }
   aggregatedKeywords.set(dirAbsPath, myAggregate);
 
-  // For *existing* subdir bullets, append any newly-surfaced tags from
-  // descendant aggregations. Curated tags stay; we only ever append.
+  // For *existing* subdir bullets, re-derive tags from the descendant
+  // aggregate when (a) the bullet is drafted (engine-owned), or (b) we're in
+  // --rewrite-aggregated migration mode. Curated bullets are left alone.
   for (const child of children) {
     if (child.kind !== 'directory') continue;
     const canonical = canonicalName(child);
     const bullet = shape.bullets.get(canonical);
     if (!bullet) continue;
-    const childAggregate = aggregatedKeywords.get(child.absPath) ?? new Set();
-    const additions = [...childAggregate].filter((t) => !bullet.tags.includes(t));
-    if (additions.length === 0) continue;
-    const newTags = [...bullet.tags, ...additions];
-    const newRaw = replaceTagsInBullet(bullet.raw, newTags);
+    const isEngineOwned = bullet.draft || rewriteAggregated;
+    if (!isEngineOwned) continue;
+
+    const childFreq = aggregatedKeywords.get(child.absPath) ?? new Map();
+    const ranked = rankAggregatedTags(childFreq);
+    const newTags = ranked.kept;
+
+    // Compute the diff for the change report.
+    const additions = newTags.filter((t) => !bullet.tags.includes(t));
+    const removals = bullet.tags.filter((t) => !newTags.includes(t));
+
+    // Promote a curated-but-rewritten bullet to drafted: --rewrite-aggregated
+    // is the explicit "I want the engine to own this from now on" signal.
+    const becameDraft = !bullet.draft;
+    const willBeDraft = bullet.draft || rewriteAggregated;
+    const newRaw = replaceTagsInBullet(bullet.raw, newTags, willBeDraft);
+
     if (newRaw !== bullet.raw) {
       bullet.tags = newTags;
       bullet.raw = newRaw;
-      result.tagsAdded.push({ entry: canonical, tags: additions });
+      bullet.draft = willBeDraft;
+      if (additions.length > 0 || removals.length > 0 || becameDraft) {
+        result.tagsAdded.push({ entry: canonical, tags: additions });
+      }
     }
-    if (newTags.length > 8) {
-      result.overTags.push({ indexPath: indexRel, entry: canonical, tagCount: newTags.length });
+    if (ranked.dropped.length > 0) {
+      result.overTagDropped.push({
+        indexPath: indexRel,
+        entry: canonical,
+        dropped: ranked.dropped,
+      });
     }
   }
 
@@ -555,6 +625,7 @@ function parseIndex(raw: string): IndexFileShape {
         raw: line,
         tags,
         sectionHeading: section.heading,
+        draft: m.draft,
       });
     }
     if (dirCount === 0 && fileCount === 0) section.kind = 'empty';
@@ -776,19 +847,49 @@ function parseTagList(raw: string): string[] {
     .filter(Boolean);
 }
 
-function formatBullet(linkName: string, link: string, draft: DraftResult): string {
-  const desc = draft.description.replace(/\.$/, '');
-  const tags = draft.keywords.length > 0 ? ` \`[${draft.keywords.join(', ')}]\`` : '';
-  return `- [\`${linkName}\`](${link}) — *${desc}.*${tags}`;
+/**
+ * Rank aggregated tag candidates from a frequency map. Drops low-quality
+ * entries (stop-words, dates, UUIDs, etc.), then sorts by descending frequency
+ * with a name tiebreaker for stable output, then caps at `TARGET_MAX`. Returns
+ * the kept set plus any candidates that couldn't fit the cap (so the CLI can
+ * surface them via `overTagDropped`).
+ */
+function rankAggregatedTags(freq: Map<string, number>): { kept: string[]; dropped: string[] } {
+  const candidates: { tag: string; count: number }[] = [];
+  for (const [tag, count] of freq) {
+    if (isLowQualityTag(tag)) continue;
+    candidates.push({ tag, count });
+  }
+  candidates.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag));
+  const kept = candidates.slice(0, TARGET_MAX).map((c) => c.tag);
+  const dropped = candidates.slice(TARGET_MAX).map((c) => c.tag);
+  return { kept, dropped };
 }
 
-function replaceTagsInBullet(raw: string, tags: string[]): string {
-  // The bullet ends with ` `[t1, t2, …]` `. If absent, append.
+function formatBullet(
+  linkName: string,
+  link: string,
+  draft: DraftResult,
+  isDraft: boolean,
+): string {
+  const desc = draft.description.replace(/\.$/, '');
+  const tags = draft.keywords.length > 0 ? ` \`[${draft.keywords.join(', ')}]\`` : '';
+  const marker = isDraft ? ` ${DRAFT_MARKER}` : '';
+  return `- [\`${linkName}\`](${link}) — *${desc}.*${tags}${marker}`;
+}
+
+function replaceTagsInBullet(raw: string, tags: string[], isDraft: boolean): string {
+  // Strip any trailing draft marker first so the tag-block regex sees clean
+  // input; we re-append the marker (if requested) at the end.
+  const stripped = raw.replace(DRAFT_MARKER_RE, '');
   const tagBlock = ` \`[${tags.join(', ')}]\``;
-  if (/\s*`?\[[^\]]*\]`?\s*$/.test(raw)) {
-    return raw.replace(/\s*`?\[[^\]]*\]`?\s*$/, '') + tagBlock;
+  let body: string;
+  if (/\s*`?\[[^\]]*\]`?\s*$/.test(stripped)) {
+    body = stripped.replace(/\s*`?\[[^\]]*\]`?\s*$/, '') + tagBlock;
+  } else {
+    body = stripped + tagBlock;
   }
-  return raw + tagBlock;
+  return isDraft ? `${body} ${DRAFT_MARKER}` : body;
 }
 
 async function atomicWrite(path: string, content: string): Promise<void> {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.ts'],
+    environment: 'node',
+    reporters: ['default'],
+  },
+  resolve: {
+    alias: {
+      '@shared': resolve(__dirname, 'src/shared'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- Closes #79. Subdir-bullet tag lists in `condash knowledge index` were the unfiltered, never-pruned union of every descendant's tags — a curated 6-tag list grew to 70+ on a real tree; junk like stop-words, dates, and UUIDs leaked in; and there was no marker to tell engine-drafted bullets from human-curated ones.
- The engine now treats every bullet it writes as engine-owned (tagged with a trailing `<!-- draft -->` HTML-comment marker) and re-derives those tags from current source on each run, while leaving curated bullets (no marker) alone.
- A new `--rewrite-aggregated` migration flag promotes existing curated subdir bullets to drafted for one-shot cleanup of trees that were polluted by the old aggregator.

## Changes

- **`src/main/index-tag-filter.ts`** (new) — `isLowQualityTag(t)` / `filterTags(tags)`. Rejects length out of [3, 40], pure-numeric, ISO-date-shaped (`2026-04`), UUID-shaped, and a small set of English stop-words / content-free verbs (`the`, `develop`, `summary`, `notes`, …).
- **`src/main/index-tree.ts`** — adds `<!-- draft -->` marker plumbing (`matchBullet`, `parseIndex`, `formatBullet`, `replaceTagsInBullet`); switches `aggregatedKeywords` from `Set<string>` to `Map<string, number>` for frequency-ranked aggregation; replaces the post-hoc `overTagTarget` warning with a hard `TARGET_MAX = 8` cap that surfaces dropped surplus via `report.overTagDropped`; gates aggregation on `bullet.draft || rewriteAggregated` so curated bullets are immutable.
- **`src/main/index-knowledge.ts`** — `deriveFileKeywords` now runs candidates through `filterTags` instead of a bare `length < 3` check.
- **`src/cli/commands/knowledge.ts`** + **`src/cli/commands/projects.ts`** — pick up the new `--rewrite-aggregated` flag, render the new `overTagDropped` report block, mention the migration mode in `--help`.
- **`src/cli/parser.ts`** — adds `rewrite-aggregated` to `BOOL_FLAGS`.
- **`vitest.config.ts`** (new) + **`package.json`** — vitest dev dep, `npm run test:unit` script. `npm test` still runs Playwright e2e.
- **`src/main/index-tag-filter.test.ts`** + **`src/main/index-tree.test.ts`** (new) — 18 unit + golden-file tests covering each filter rule, marker plumbing, idempotence, the hard cap with `overTagDropped`, and `--rewrite-aggregated` migration semantics.

## Impact

- The engine now distinguishes engine-drafted from human-curated bullets via the marker. Existing trees with bullets that lack the marker are treated as fully curated — `condash knowledge index` (without flags) is a no-op against them, so this PR is backwards-compatible by default.
- To clean a tree polluted by the old aggregator, run `condash knowledge index --rewrite-aggregated` once; it re-derives subdir tags from current descendants, applies the filter and the cap, and adds the marker so the engine takes ownership going forward. Reviewers should diff the result, accept it (or re-curate inline by removing `<!-- draft -->`), and commit.
- The `IndexRegenReport.overTagTarget` field is renamed `overTagDropped` (now lists the dropped tag names rather than just a count). Anyone consuming `--json` from `condash knowledge index` / `condash projects index` programmatically should update their reader.
- New dev dependency: `vitest@^2.1.9`. Playwright tests are unaffected.