### PR TITLE
Make Knowledge / Resources / Skills panes a collapsible directory tree

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,7 +14,7 @@ condash reads two JSON files. Both are optional in principle — the dashboard r
 | File                 | Path                                                                                                                                                                        | Lifecycle                  | Owns                                                                            |
 | -------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------- |
 | `configuration.json` | `<conception_path>/configuration.json`                                                                                                                                      | Per-tree, versioned in git | `workspace_path`, `worktrees_path`, `resources_path`, `skills_path`, `repositories`, `open_with`, `pdf_viewer`   |
-| `settings.json`      | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux) · `~/Library/Application Support/condash/settings.json` (macOS) · `%APPDATA%\condash\settings.json` (Windows) | Per-user, per-machine      | `conceptionPath`, `theme`, `terminal`, `layout`, `welcome`, `cardMinWidth`      |
+| `settings.json`      | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux) · `~/Library/Application Support/condash/settings.json` (macOS) · `%APPDATA%\condash\settings.json` (Windows) | Per-user, per-machine      | `conceptionPath`, `theme`, `terminal`, `layout`, `welcome`, `cardMinWidth`, `treeExpansion`      |
 
 The split is by **lifecycle**, not by feature. Each key lives in exactly one file:
 
@@ -240,6 +240,11 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
     "projects": 600,
     "code": 600,
     "knowledge": 480
+  },
+  "treeExpansion": {
+    "knowledge": ["topics", "topics/security"],
+    "resources": [],
+    "skills": ["pr"]
   }
 }
 ```
@@ -252,6 +257,7 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
 | `layout`         | Composite-layout state. See [LayoutState](#layoutstate) below.                                                                                  |
 | `welcome`        | First-launch state. `welcome.dismissed: true` hides the Welcome screen even when both Projects and Knowledge are empty.                         |
 | `cardMinWidth`   | Per-pane card grid min-width. See [CardMinWidth](#cardminwidth) below.                                                                          |
+| `treeExpansion`  | Per-pane set of expanded directory `relPath`s for the Knowledge / Resources / Skills tree panes. Empty (or missing) means everything is collapsed — the on-purpose first-load state per #89. |
 
 `open_with`, `pdf_viewer`, and `repositories` are intentionally **not** valid in `settings.json` — they live tree-side in `configuration.json`. Setting them here is silently ignored.
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -18,6 +18,7 @@ import { requirePathUnder, requirePathUnderWorkspace } from './path-bounds';
 import { readKnowledgeTree } from './knowledge';
 import { readResourcesTree } from './resources';
 import { readSkillsTree } from './skills';
+import { treeCreateMd, treeImportFile, treeMkdir } from './tree-mutations';
 import { resolveConceptionPaths } from './conception-paths';
 import { createProjectNote, readNote } from './note';
 import { search } from './search';
@@ -42,6 +43,7 @@ import type {
   ProjectCreateInput,
   ProjectCreateResult,
   StepMarker,
+  TreeRoot,
 } from '../shared/types';
 import { statusOrder } from '../shared/projects';
 
@@ -554,6 +556,18 @@ function registerIpc(): void {
     const { skills } = await resolveConceptionPaths(conceptionPath);
     return readSkillsTree(conceptionPath, skills);
   });
+
+  ipcMain.handle('tree.createMd', (_, root: TreeRoot, dirRelPath: string, filename: string) =>
+    treeCreateMd(root, dirRelPath, filename),
+  );
+
+  ipcMain.handle('tree.mkdir', (_, root: TreeRoot, dirRelPath: string, name: string) =>
+    treeMkdir(root, dirRelPath, name),
+  );
+
+  ipcMain.handle('tree.importFile', (_, root: TreeRoot, dirRelPath: string) =>
+    treeImportFile(root, dirRelPath),
+  );
 
   ipcMain.handle('search', async (_, query: string) => {
     const { conceptionPath } = await readSettings();

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,8 +1,11 @@
 import { ipcMain } from 'electron';
 import { toPosix } from '../../shared/path';
 import { DEFAULT_LAYOUT, readSettings, settingsPath, updateSettings } from '../settings';
-import type { CardMinWidthPrefs, LayoutState, Theme } from '../../shared/types';
+import type { CardMinWidthPrefs, LayoutState, Theme, TreeExpansionPrefs } from '../../shared/types';
 import { DEFAULT_CARD_MIN_WIDTH } from '../../shared/types';
+
+const TREE_EXPANSION_KEYS = ['knowledge', 'resources', 'skills'] as const;
+type TreeExpansionKey = (typeof TREE_EXPANSION_KEYS)[number];
 
 const THEMES: ReadonlySet<Theme> = new Set(['light', 'dark', 'system']);
 
@@ -87,6 +90,56 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
       if (typeof v === 'number' && Number.isFinite(v)) out[key] = v;
     }
     return out;
+  });
+
+  ipcMain.handle('getTreeExpansion', async () => {
+    const { treeExpansion } = await readSettings();
+    const out: Required<TreeExpansionPrefs> = {
+      knowledge: [],
+      resources: [],
+      skills: [],
+    };
+    for (const key of TREE_EXPANSION_KEYS) {
+      const v = treeExpansion?.[key];
+      if (Array.isArray(v)) {
+        // Coerce to string + dedupe; filter anything that isn't a string
+        // so a corrupt settings file can't crash the renderer.
+        const seen = new Set<string>();
+        for (const entry of v) {
+          if (typeof entry === 'string') seen.add(entry);
+        }
+        out[key] = Array.from(seen);
+      }
+    }
+    return out;
+  });
+
+  ipcMain.handle('setTreeExpansion', async (_, raw: unknown) => {
+    const input = (raw ?? {}) as Record<string, unknown>;
+    const allowed = new Set<string>(TREE_EXPANSION_KEYS);
+    for (const key of Object.keys(input)) {
+      if (!allowed.has(key)) {
+        throw new Error(`setTreeExpansion: unknown key ${JSON.stringify(key)}`);
+      }
+    }
+    const sanitised: TreeExpansionPrefs = {};
+    let nonEmpty = false;
+    for (const key of TREE_EXPANSION_KEYS) {
+      const v = input[key as TreeExpansionKey];
+      if (!Array.isArray(v)) continue;
+      const seen = new Set<string>();
+      for (const entry of v) {
+        if (typeof entry === 'string') seen.add(entry);
+      }
+      if (seen.size > 0) {
+        sanitised[key] = Array.from(seen);
+        nonEmpty = true;
+      }
+    }
+    await updateSettings((cur) => ({
+      ...cur,
+      treeExpansion: nonEmpty ? sanitised : undefined,
+    }));
   });
 
   ipcMain.handle('setCardMinWidth', async (_, raw: unknown) => {

--- a/src/main/tree-mutations.ts
+++ b/src/main/tree-mutations.ts
@@ -1,0 +1,148 @@
+import { constants as fsConstants, promises as fs } from 'node:fs';
+import { basename, extname, join, normalize } from 'node:path';
+import { dialog } from 'electron';
+import type { TreeRoot } from '../shared/types';
+import { toPosix } from '../shared/path';
+import { readSettings } from './settings';
+import { resolveConceptionPaths } from './conception-paths';
+import { requirePathUnder } from './path-bounds';
+
+/**
+ * Helpers backing the `tree.*` IPC verbs that mutate the on-disk
+ * Knowledge / Resources / Skills trees. Each verb resolves the pane's
+ * on-disk root, joins the renderer-supplied `dirRelPath` + child name,
+ * normalises, then re-checks the result is still under the pane's root
+ * via `requirePathUnder` so a renderer that hands us `..` / an absolute
+ * path can never escape the bound. The renderer is trusted today, but we
+ * apply the same defence-in-depth as `assertUnderConception` in
+ * `src/main/index.ts`.
+ */
+
+/** Resolve a tree root to its absolute on-disk path. Knowledge is hardcoded
+ * to `<conception>/knowledge/`; resources + skills come from
+ * `configuration.json`. */
+async function resolveRoot(root: TreeRoot): Promise<string> {
+  const { conceptionPath } = await readSettings();
+  if (!conceptionPath) throw new Error('no conception path is set');
+  if (root === 'knowledge') return join(conceptionPath, 'knowledge');
+  const { resources, skills } = await resolveConceptionPaths(conceptionPath);
+  if (root === 'resources') return join(conceptionPath, resources);
+  if (root === 'skills') return join(conceptionPath, skills);
+  throw new Error(`unknown tree root: ${root as string}`);
+}
+
+/** Lowercase, replace runs of non-alphanumerics with `-`, trim leading/
+ *  trailing hyphens. Empty input maps to a single placeholder. */
+function sanitiseSegment(name: string, fallback: string): string {
+  const cleaned = name
+    .toLowerCase()
+    .replace(/[^a-z0-9.]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return cleaned.length > 0 ? cleaned : fallback;
+}
+
+/** Sanitise `filename`, splitting any user-supplied extension off so the
+ *  basename is hyphen-cased without touching `.` characters. For
+ *  knowledge / skills the extension is always `.md`; for resources we keep
+ *  the user's extension and default to `.md` when none was supplied. */
+function buildFilename(root: TreeRoot, raw: string): string {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) throw new Error('filename must be a non-empty string');
+  const ext = extname(trimmed).toLowerCase();
+  const stem = ext ? trimmed.slice(0, trimmed.length - ext.length) : trimmed;
+  const cleanedStem = sanitiseSegment(stem, 'untitled').replace(/\.+/g, '-');
+  if (root === 'resources') {
+    return cleanedStem + (ext || '.md');
+  }
+  // Knowledge + skills: `.md` only.
+  return cleanedStem + '.md';
+}
+
+/** Resolve `<root>/<dirRelPath>/<name>` and prove via realpath that it
+ *  stays under the pane's root. Returns the canonical absolute path. */
+async function resolveChildBounded(
+  root: TreeRoot,
+  dirRelPath: string,
+  childName: string,
+): Promise<{ rootAbs: string; targetAbs: string }> {
+  const rootAbs = await resolveRoot(root);
+  if (typeof dirRelPath !== 'string') {
+    throw new Error('dirRelPath must be a string');
+  }
+  // `''` is allowed (means the root itself).
+  const cleanedDir = normalize(dirRelPath);
+  if (/^(\.\.([\\/]|$))/.test(cleanedDir) || cleanedDir.startsWith('/')) {
+    throw new Error('dirRelPath escapes the pane root');
+  }
+  if (cleanedDir.includes('..')) {
+    // normalize() may leave a literal `..` mid-path if the prefix wasn't
+    // resolvable; reject defensively.
+    const segments = cleanedDir.split(/[\\/]/);
+    if (segments.includes('..')) throw new Error('dirRelPath escapes the pane root');
+  }
+  const dirAbs = cleanedDir === '' || cleanedDir === '.' ? rootAbs : join(rootAbs, cleanedDir);
+  // The directory must already exist on disk and stay under the root.
+  await requirePathUnder(dirAbs, rootAbs);
+  const targetAbs = join(dirAbs, childName);
+  // Sanity check that childName itself doesn't contain a separator that
+  // would let the join slip out of the directory; sanitiseSegment already
+  // strips them, but double-check before any writes.
+  if (basename(targetAbs) !== childName) {
+    throw new Error('invalid child name');
+  }
+  return { rootAbs, targetAbs };
+}
+
+export async function treeCreateMd(
+  root: TreeRoot,
+  dirRelPath: string,
+  filename: string,
+): Promise<string> {
+  const sanitised = buildFilename(root, filename);
+  const { targetAbs } = await resolveChildBounded(root, dirRelPath, sanitised);
+  // `wx` flag refuses to overwrite — surfaces a clear error to the
+  // renderer when the user picks a name that's already taken.
+  await fs.writeFile(targetAbs, '', { encoding: 'utf8', flag: 'wx' });
+  return toPosix(targetAbs);
+}
+
+export async function treeMkdir(root: TreeRoot, dirRelPath: string, name: string): Promise<string> {
+  const sanitised = sanitiseSegment(name, '').replace(/\.+/g, '-');
+  if (sanitised.length === 0) throw new Error('directory name is empty after sanitisation');
+  const { targetAbs } = await resolveChildBounded(root, dirRelPath, sanitised);
+  await fs.mkdir(targetAbs, { recursive: true });
+  return toPosix(targetAbs);
+}
+
+export async function treeImportFile(root: TreeRoot, dirRelPath: string): Promise<string | null> {
+  // Resolve + bounds-check the destination before opening the dialog so
+  // we never copy a file just to throw away on a bad target.
+  const rootAbs = await resolveRoot(root);
+  const cleanedDir = normalize(dirRelPath ?? '');
+  const dirAbs = cleanedDir === '' || cleanedDir === '.' ? rootAbs : join(rootAbs, cleanedDir);
+  await requirePathUnder(dirAbs, rootAbs);
+
+  const result = await dialog.showOpenDialog({
+    title: 'Import file',
+    properties: ['openFile'],
+    buttonLabel: 'Import',
+  });
+  if (result.canceled || result.filePaths.length === 0) return null;
+  const sourceAbs = result.filePaths[0];
+  if (!sourceAbs) return null;
+  const sourceName = basename(sourceAbs);
+  // Sanitise just the basename — keep the extension verbatim so a `.pdf`
+  // import lands as `.pdf`. For knowledge / skills we still want `.md`-
+  // ish material, but enforcing here would block the legitimate "drop a
+  // PDF reference into knowledge/external/" workflow; leave the
+  // categorisation to the user.
+  const ext = extname(sourceName);
+  const stem = ext ? sourceName.slice(0, sourceName.length - ext.length) : sourceName;
+  const cleanedStem = sanitiseSegment(stem, 'imported').replace(/\.+/g, '-');
+  const finalName = cleanedStem + ext;
+  const targetAbs = join(dirAbs, finalName);
+  if (basename(targetAbs) !== finalName) throw new Error('invalid imported filename');
+  // `COPYFILE_EXCL` refuses to overwrite — same behaviour as createMd.
+  await fs.copyFile(sourceAbs, targetAbs, fsConstants.COPYFILE_EXCL);
+  return toPosix(targetAbs);
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -35,6 +35,8 @@ const api: CondashApi = {
   setWelcomeDismissed: (value) => ipcRenderer.invoke('setWelcomeDismissed', value),
   getCardMinWidth: () => ipcRenderer.invoke('getCardMinWidth'),
   setCardMinWidth: (prefs) => ipcRenderer.invoke('setCardMinWidth', prefs),
+  getTreeExpansion: () => ipcRenderer.invoke('getTreeExpansion'),
+  setTreeExpansion: (prefs) => ipcRenderer.invoke('setTreeExpansion', prefs),
   getSettingsPath: () => ipcRenderer.invoke('getSettingsPath'),
   toggleStep: (path, lineIndex, expectedMarker, newMarker) =>
     ipcRenderer.invoke('step.toggle', path, lineIndex, expectedMarker, newMarker),
@@ -92,6 +94,10 @@ const api: CondashApi = {
   openPath: (target: string) => ipcRenderer.invoke('openPath', target),
   createProjectNote: (projectPath: string, slug: string) =>
     ipcRenderer.invoke('project.createNote', projectPath, slug),
+  treeCreateMd: (root, dirRelPath, filename) =>
+    ipcRenderer.invoke('tree.createMd', root, dirRelPath, filename),
+  treeMkdir: (root, dirRelPath, name) => ipcRenderer.invoke('tree.mkdir', root, dirRelPath, name),
+  treeImportFile: (root, dirRelPath) => ipcRenderer.invoke('tree.importFile', root, dirRelPath),
   quitApp: () => ipcRenderer.invoke('quitApp'),
   getAppInfo: () => ipcRenderer.invoke('getAppInfo'),
   pdfToFileUrl: (path: string) => ipcRenderer.invoke('pdf.toFileUrl', path),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -22,10 +22,12 @@ import type {
   TermSession,
   TerminalPrefs,
   Theme,
+  TreeRoot,
   WorkingSurface,
   Worktree,
 } from '@shared/types';
 import { DEFAULT_CARD_MIN_WIDTH } from '@shared/types';
+import type { TreeAffordance, TreeViewMutationApi, TreeViewPromptApi } from './panes/tree-view';
 import { NoteModal, type ModalState } from './note-modal';
 import { ProjectPreview } from './project-preview';
 import { resetMermaidTheme } from './markdown';
@@ -214,6 +216,85 @@ function App() {
       flashToast(`Could not persist card min-width: ${(err as Error).message}`, 'error');
     });
   };
+
+  // Per-pane expansion state for the Knowledge / Resources / Skills tree
+  // panes (issue #89). Each set holds the directory `relPath`s that are
+  // currently expanded; an empty set means the pane is fully collapsed
+  // (the on-purpose first-load state). The hydrate-from-IPC then-callback
+  // overrides the empty defaults when the user has prior state on disk.
+  const [knowledgeExpanded, setKnowledgeExpanded] = createSignal<ReadonlySet<string>>(new Set());
+  const [resourcesExpanded, setResourcesExpanded] = createSignal<ReadonlySet<string>>(new Set());
+  const [skillsExpanded, setSkillsExpanded] = createSignal<ReadonlySet<string>>(new Set());
+  void window.condash.getTreeExpansion().then((prefs) => {
+    setKnowledgeExpanded(new Set(prefs.knowledge));
+    setResourcesExpanded(new Set(prefs.resources));
+    setSkillsExpanded(new Set(prefs.skills));
+  });
+
+  /** Persist the union of the three pane sets to settings.json.
+   *  Fire-and-forget — a write failure surfaces as a toast but the
+   *  in-memory state stays authoritative for the session. */
+  const persistTreeExpansion = (): void => {
+    const prefs = {
+      knowledge: Array.from(knowledgeExpanded()),
+      resources: Array.from(resourcesExpanded()),
+      skills: Array.from(skillsExpanded()),
+    };
+    void window.condash.setTreeExpansion(prefs).catch((err) => {
+      flashToast(`Could not persist tree expansion: ${(err as Error).message}`, 'error');
+    });
+  };
+
+  const toggleTreeExpand = (treeKey: TreeRoot, relPath: string): void => {
+    const setterByKey = {
+      knowledge: setKnowledgeExpanded,
+      resources: setResourcesExpanded,
+      skills: setSkillsExpanded,
+    } as const;
+    const getterByKey = {
+      knowledge: knowledgeExpanded,
+      resources: resourcesExpanded,
+      skills: skillsExpanded,
+    } as const;
+    const next = new Set(getterByKey[treeKey]());
+    if (next.has(relPath)) next.delete(relPath);
+    else next.add(relPath);
+    setterByKey[treeKey](next);
+    persistTreeExpansion();
+  };
+
+  /** Force a directory into the expanded set without toggling — used after
+   *  a successful tree mutation so the user can see the new file. */
+  const expandTreeDir = (treeKey: TreeRoot, relPath: string): void => {
+    if (relPath === '') return; // root is always expanded; no need to track
+    const setterByKey = {
+      knowledge: setKnowledgeExpanded,
+      resources: setResourcesExpanded,
+      skills: setSkillsExpanded,
+    } as const;
+    const getterByKey = {
+      knowledge: knowledgeExpanded,
+      resources: resourcesExpanded,
+      skills: skillsExpanded,
+    } as const;
+    const cur = getterByKey[treeKey]();
+    if (cur.has(relPath)) return;
+    const next = new Set(cur);
+    next.add(relPath);
+    setterByKey[treeKey](next);
+    persistTreeExpansion();
+  };
+
+  const treeMutations: TreeViewMutationApi = {
+    createMd: (root, dirRelPath, filename) =>
+      window.condash.treeCreateMd(root, dirRelPath, filename),
+    mkdir: (root, dirRelPath, name) => window.condash.treeMkdir(root, dirRelPath, name),
+    importFile: (root, dirRelPath) => window.condash.treeImportFile(root, dirRelPath),
+  };
+  const treePrompts: TreeViewPromptApi = {
+    prompt: openPrompt,
+  };
+  const treeError = (msg: string): void => flashToast(msg, 'error');
 
   /** Apply a layout patch and persist it. The persistence is fire-and-
    * forget: any settings.json write failure surfaces as a toast but the
@@ -808,6 +889,43 @@ function App() {
     },
   };
 
+  /** Per-pane post-mutation handler. Bumps the refresh key so the pane
+   *  re-fetches its tree, expands the source directory so the user sees
+   *  the new entry, and (for createMd / importFile) opens the new file
+   *  the way that pane normally opens its file kind. `mkdir` only
+   *  expands so the user can drop notes in. */
+  const handleAfterTreeMutation = (
+    treeKey: TreeRoot,
+    newPath: string,
+    kind: TreeAffordance,
+    sourceDirRelPath: string,
+  ): void => {
+    setRefreshKey((k) => k + 1);
+    expandTreeDir(treeKey, sourceDirRelPath);
+    if (kind === 'mkdir') return;
+    if (treeKey === 'knowledge') {
+      handleOpenKnowledgeFile(newPath);
+      return;
+    }
+    if (treeKey === 'skills') {
+      // Match `handleOpenSkillFile` — title falls back to the basename
+      // because the freshly-created file has no h1 yet.
+      const title = newPath.split('/').pop() ?? newPath;
+      handleOpenSkillFile(newPath, title, null);
+      return;
+    }
+    // Resources: open via the user's main editor for non-viewable kinds,
+    // or the inline viewer for markdown / pdf / text.
+    const lower = newPath.toLowerCase();
+    if (lower.endsWith('.md')) {
+      handleViewResource(newPath, newPath.split('/').pop() ?? newPath);
+    } else if (lower.endsWith('.pdf')) {
+      setPdfPath(newPath);
+    } else {
+      void window.condash.openInEditor(newPath);
+    }
+  };
+
   const handleOpenHelp = (doc: HelpDoc) => {
     setHelpDoc(doc);
   };
@@ -1127,7 +1245,18 @@ function App() {
                           </div>
                         }
                       >
-                        <KnowledgeView root={knowledge()!} onOpen={handleOpenKnowledgeFile} />
+                        <KnowledgeView
+                          root={knowledge()!}
+                          onOpen={handleOpenKnowledgeFile}
+                          expanded={knowledgeExpanded}
+                          onToggleExpand={(rel) => toggleTreeExpand('knowledge', rel)}
+                          mutations={treeMutations}
+                          prompts={treePrompts}
+                          onAfterMutation={(newPath, kind, source) =>
+                            handleAfterTreeMutation('knowledge', newPath, kind, source)
+                          }
+                          onError={treeError}
+                        />
                       </Show>
                     </Suspense>
                   </section>
@@ -1145,6 +1274,14 @@ function App() {
                             flashToast(`Open failed: ${(err as Error).message}`, 'error');
                           });
                         }}
+                        expanded={resourcesExpanded}
+                        onToggleExpand={(rel) => toggleTreeExpand('resources', rel)}
+                        mutations={treeMutations}
+                        prompts={treePrompts}
+                        onAfterMutation={(newPath, kind, source) =>
+                          handleAfterTreeMutation('resources', newPath, kind, source)
+                        }
+                        onError={treeError}
                       />
                     </Suspense>
                   </section>
@@ -1165,6 +1302,14 @@ function App() {
                               flashToast(`Copy failed: ${(err as Error).message}`, 'error'),
                             );
                         }}
+                        expanded={skillsExpanded}
+                        onToggleExpand={(rel) => toggleTreeExpand('skills', rel)}
+                        mutations={treeMutations}
+                        prompts={treePrompts}
+                        onAfterMutation={(newPath, kind, source) =>
+                          handleAfterTreeMutation('skills', newPath, kind, source)
+                        }
+                        onError={treeError}
                       />
                     </Suspense>
                   </section>

--- a/src/renderer/panes/knowledge.tsx
+++ b/src/renderer/panes/knowledge.tsx
@@ -38,29 +38,18 @@ function freshnessOf(verifiedAt: string | undefined, todayISO: string): string {
   return 'old';
 }
 
+function isKnowledgeIndex(node: KnowledgeNode): boolean {
+  return node.kind === 'file' && node.name.toLowerCase() === 'index.md';
+}
+
 /** Return the directory's `index.md` child (case-insensitive on the
  *  filename), if any. Surfaced as the `[INDEX]` badge on the dir header
  *  and dropped from the file list so it doesn't double up as a card. */
 function findIndexChild(node: KnowledgeNode): KnowledgeNode | undefined {
   for (const child of node.children ?? []) {
-    if (child.kind === 'file' && child.name.toLowerCase() === 'index.md') return child;
+    if (isKnowledgeIndex(child)) return child;
   }
   return undefined;
-}
-
-/** Strip every `index.md` from the tree — it's already surfaced as the
- *  per-directory INDEX badge, and we don't want it doubling up as a
- *  card under the directory header. Returns a shallow-cloned tree so
- *  the original `KnowledgeNode` reference (held by the createResource)
- *  stays untouched. */
-function stripIndexes(node: KnowledgeNode): KnowledgeNode {
-  if (node.kind !== 'directory') return node;
-  const filtered: KnowledgeNode[] = [];
-  for (const child of node.children ?? []) {
-    if (child.kind === 'file' && child.name.toLowerCase() === 'index.md') continue;
-    filtered.push(stripIndexes(child));
-  }
-  return { ...node, children: filtered };
 }
 
 export function KnowledgeView(props: {
@@ -80,7 +69,7 @@ export function KnowledgeView(props: {
     <div class="knowledge-pane" ref={scrollRef}>
       <TreeView<KnowledgeNode>
         treeKey="knowledge"
-        root={stripIndexes(props.root)}
+        root={props.root}
         expanded={props.expanded}
         onToggleExpand={props.onToggleExpand}
         affordances={KNOWLEDGE_AFFORDANCES}
@@ -88,6 +77,7 @@ export function KnowledgeView(props: {
         prompts={props.prompts}
         onAfterMutation={props.onAfterMutation}
         onError={props.onError}
+        skipFile={isKnowledgeIndex}
         renderDirSuffix={(dir) => (
           <Show when={findIndexChild(dir)}>
             {(idx) => (

--- a/src/renderer/panes/knowledge.tsx
+++ b/src/renderer/panes/knowledge.tsx
@@ -1,98 +1,30 @@
-import { createMemo, For, Show } from 'solid-js';
+import { Show } from 'solid-js';
 import type { KnowledgeNode } from '@shared/types';
 import { BookIcon } from '../icons';
-import { formatSectionLabel } from './pane-utils';
 import { usePaneScrollMemory } from './pane-scroll-memory';
+import {
+  TreeView,
+  type TreeAffordance,
+  type TreeViewMutationApi,
+  type TreeViewPromptApi,
+} from './tree-view';
 import './knowledge-pane.css';
 
-/* Knowledge pane — flat card list grouped one section per directory. The
- * chrome (section header capsule, card silhouette, hover-brighten) mirrors
- * the Code and Projects panes so the three panes feel like one app. The
- * directory's `index.md` (when present) is surfaced as an [INDEX] badge
- * on the section header — clicking it opens the index file. */
+/* Knowledge pane — collapsible directory tree (issue #89). The pane keeps
+ * its current card silhouette (bucket-coloured stripe, freshness chip,
+ * one-line summary) and surfaces every directory's `index.md` as the
+ * `[INDEX]` badge on that directory's header. The tree itself lives in
+ * the shared `TreeView` component. */
 
 type BucketId = 'general' | 'internal' | 'topics' | 'external';
 
-interface KnowledgeFile {
-  node: KnowledgeNode;
-  bucket: BucketId;
-}
-
-interface KnowledgeSection {
-  id: string;
-  label: string;
-  bucket: BucketId;
-  index?: KnowledgeNode;
-  files: KnowledgeFile[];
-}
-
-const BUCKET_ORDER: readonly BucketId[] = ['general', 'internal', 'topics', 'external'];
+const KNOWLEDGE_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
 
 function bucketOf(relPath: string): BucketId {
   if (relPath.startsWith('internal')) return 'internal';
   if (relPath.startsWith('external')) return 'external';
   if (relPath.startsWith('topics')) return 'topics';
   return 'general';
-}
-
-function buildSections(root: KnowledgeNode | null): KnowledgeSection[] {
-  if (!root) return [];
-
-  const sectionsByDir = new Map<string, KnowledgeSection>();
-  const general: KnowledgeFile[] = [];
-
-  const visit = (node: KnowledgeNode, dirRel: string): void => {
-    if (node.kind === 'file') return;
-    const isRoot = dirRel === '';
-    const childDirs: KnowledgeNode[] = [];
-    const childFiles: KnowledgeNode[] = [];
-    for (const child of node.children ?? []) {
-      if (child.kind === 'directory') childDirs.push(child);
-      else childFiles.push(child);
-    }
-    let indexNode: KnowledgeNode | undefined;
-    const contentNodes: KnowledgeNode[] = [];
-    for (const f of childFiles) {
-      if (f.name.toLowerCase() === 'index.md') indexNode = f;
-      else contentNodes.push(f);
-    }
-
-    if (isRoot) {
-      for (const f of contentNodes) general.push({ node: f, bucket: 'general' });
-    } else if (contentNodes.length > 0 || indexNode) {
-      const bucket = bucketOf(dirRel);
-      const label = formatSectionLabel(dirRel);
-      const files: KnowledgeFile[] = contentNodes
-        .slice()
-        .sort((a, b) => a.title.localeCompare(b.title))
-        .map((n) => ({ node: n, bucket }));
-      sectionsByDir.set(dirRel, { id: dirRel, label, bucket, index: indexNode, files });
-    }
-
-    for (const sub of childDirs) {
-      const childRel = dirRel ? `${dirRel}/${sub.name}` : sub.name;
-      visit(sub, childRel);
-    }
-  };
-  visit(root, '');
-
-  const out: KnowledgeSection[] = [];
-  if (general.length > 0) {
-    out.push({
-      id: 'general',
-      label: 'GENERAL',
-      bucket: 'general',
-      files: general.sort((a, b) => a.node.title.localeCompare(b.node.title)),
-    });
-  }
-  const rest = Array.from(sectionsByDir.values());
-  rest.sort((a, b) => {
-    const ai = BUCKET_ORDER.indexOf(a.bucket);
-    const bi = BUCKET_ORDER.indexOf(b.bucket);
-    if (ai !== bi) return ai - bi;
-    return a.id.localeCompare(b.id);
-  });
-  return out.concat(rest);
 }
 
 function freshnessOf(verifiedAt: string | undefined, todayISO: string): string {
@@ -106,93 +38,113 @@ function freshnessOf(verifiedAt: string | undefined, todayISO: string): string {
   return 'old';
 }
 
+/** Return the directory's `index.md` child (case-insensitive on the
+ *  filename), if any. Surfaced as the `[INDEX]` badge on the dir header
+ *  and dropped from the file list so it doesn't double up as a card. */
+function findIndexChild(node: KnowledgeNode): KnowledgeNode | undefined {
+  for (const child of node.children ?? []) {
+    if (child.kind === 'file' && child.name.toLowerCase() === 'index.md') return child;
+  }
+  return undefined;
+}
+
+/** Strip every `index.md` from the tree — it's already surfaced as the
+ *  per-directory INDEX badge, and we don't want it doubling up as a
+ *  card under the directory header. Returns a shallow-cloned tree so
+ *  the original `KnowledgeNode` reference (held by the createResource)
+ *  stays untouched. */
+function stripIndexes(node: KnowledgeNode): KnowledgeNode {
+  if (node.kind !== 'directory') return node;
+  const filtered: KnowledgeNode[] = [];
+  for (const child of node.children ?? []) {
+    if (child.kind === 'file' && child.name.toLowerCase() === 'index.md') continue;
+    filtered.push(stripIndexes(child));
+  }
+  return { ...node, children: filtered };
+}
+
 export function KnowledgeView(props: {
   root: KnowledgeNode;
   onOpen: (path: string, title?: string) => void;
+  expanded: () => ReadonlySet<string>;
+  onToggleExpand: (relPath: string) => void;
+  mutations: TreeViewMutationApi;
+  prompts: TreeViewPromptApi;
+  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
+  onError: (message: string) => void;
 }) {
   const todayISO = new Date().toISOString().slice(0, 10);
-  const sections = createMemo<KnowledgeSection[]>(() => buildSections(props.root));
   const scrollRef = usePaneScrollMemory('knowledge');
 
   return (
     <div class="knowledge-pane" ref={scrollRef}>
-      <DirectoryView sections={sections()} todayISO={todayISO} onOpen={props.onOpen} />
+      <TreeView<KnowledgeNode>
+        treeKey="knowledge"
+        root={stripIndexes(props.root)}
+        expanded={props.expanded}
+        onToggleExpand={props.onToggleExpand}
+        affordances={KNOWLEDGE_AFFORDANCES}
+        mutations={props.mutations}
+        prompts={props.prompts}
+        onAfterMutation={props.onAfterMutation}
+        onError={props.onError}
+        renderDirSuffix={(dir) => (
+          <Show when={findIndexChild(dir)}>
+            {(idx) => (
+              <button
+                type="button"
+                class="knowledge-section-index"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  props.onOpen(idx().path, idx().title);
+                }}
+                title={`Open ${dir.relPath || 'knowledge'} index`}
+              >
+                INDEX
+              </button>
+            )}
+          </Show>
+        )}
+        renderFile={(file) => (
+          <KnowledgeCard
+            node={file}
+            todayISO={todayISO}
+            onOpen={() => props.onOpen(file.path, file.title)}
+          />
+        )}
+      />
     </div>
   );
 }
 
-function DirectoryView(props: {
-  sections: KnowledgeSection[];
-  todayISO: string;
-  onOpen: (path: string, title?: string) => void;
-}) {
-  return (
-    <For each={props.sections}>
-      {(section) => (
-        <section class="knowledge-group" data-bucket={section.bucket}>
-          <h2 class="knowledge-section-header">
-            <span class="name">{section.label}</span>
-            <Show when={section.files.length > 0}>
-              <span class="count">{section.files.length}</span>
-            </Show>
-            <Show when={section.index}>
-              {(idx) => (
-                <button
-                  type="button"
-                  class="knowledge-section-index"
-                  onClick={() => props.onOpen(idx().path, idx().title)}
-                  title={`Open ${section.label.toLowerCase()} index`}
-                >
-                  INDEX
-                </button>
-              )}
-            </Show>
-            <span class="rule" />
-          </h2>
-          <div class="knowledge-grid">
-            <For each={section.files}>
-              {(file) => (
-                <KnowledgeCard
-                  file={file}
-                  todayISO={props.todayISO}
-                  onOpen={() => props.onOpen(file.node.path, file.node.title)}
-                />
-              )}
-            </For>
-          </div>
-        </section>
-      )}
-    </For>
-  );
-}
-
-function KnowledgeCard(props: { file: KnowledgeFile; todayISO: string; onOpen: () => void }) {
-  const fresh = (): string => freshnessOf(props.file.node.verifiedAt, props.todayISO);
+function KnowledgeCard(props: { node: KnowledgeNode; todayISO: string; onOpen: () => void }) {
+  const fresh = (): string => freshnessOf(props.node.verifiedAt, props.todayISO);
+  const bucket = (): BucketId => bucketOf(props.node.relPath);
   return (
     <article
       class="knowledge-card"
-      data-bucket={props.file.bucket}
-      title={props.file.node.path}
+      data-bucket={bucket()}
+      title={props.node.path}
       onClick={() => props.onOpen()}
     >
       <header class="knowledge-card-head">
         <span class="knowledge-card-glyph" aria-hidden="true">
           <BookIcon />
         </span>
-        <h3 class="knowledge-card-title">{props.file.node.title}</h3>
-        <Show when={props.file.node.verifiedAt}>
+        <h3 class="knowledge-card-title">{props.node.title}</h3>
+        <Show when={props.node.verifiedAt}>
           <span
             class="knowledge-card-verified"
             data-fresh={fresh()}
-            title={`Verified ${props.file.node.verifiedAt}`}
+            title={`Verified ${props.node.verifiedAt}`}
           >
             <span class="knowledge-card-verified-label">Verified</span>{' '}
-            <span class="knowledge-card-verified-date">{props.file.node.verifiedAt}</span>
+            <span class="knowledge-card-verified-date">{props.node.verifiedAt}</span>
           </span>
         </Show>
       </header>
-      <Show when={props.file.node.summary}>
-        <p class="knowledge-card-summary">{props.file.node.summary}</p>
+      <Show when={props.node.summary}>
+        <p class="knowledge-card-summary">{props.node.summary}</p>
       </Show>
     </article>
   );

--- a/src/renderer/panes/resources.tsx
+++ b/src/renderer/panes/resources.tsx
@@ -1,60 +1,15 @@
-import { createMemo, createSignal, For, Show } from 'solid-js';
+import { createSignal, Show } from 'solid-js';
 import type { ResourceCategory, ResourceNode } from '@shared/types';
-import { formatSectionLabel } from './pane-utils';
 import { usePaneScrollMemory } from './pane-scroll-memory';
+import {
+  TreeView,
+  type TreeAffordance,
+  type TreeViewMutationApi,
+  type TreeViewPromptApi,
+} from './tree-view';
 import './resources-pane.css';
 
-interface FlatSection {
-  /** Empty string for the root section. */
-  id: string;
-  label: string;
-  files: ResourceNode[];
-}
-
-/**
- * Walk the resources tree and emit one section per directory (root +
- * every nested directory). Recurses to any depth — sections with no files
- * are dropped so an empty wrapper directory doesn't render an empty
- * section header.
- */
-function buildSections(root: ResourceNode | null): FlatSection[] {
-  if (!root) return [];
-  const sections = new Map<string, ResourceNode[]>();
-
-  const visit = (node: ResourceNode, dirRel: string): void => {
-    if (node.kind !== 'directory') return;
-    const fileChildren: ResourceNode[] = [];
-    const dirChildren: ResourceNode[] = [];
-    for (const child of node.children ?? []) {
-      if (child.kind === 'directory') dirChildren.push(child);
-      else fileChildren.push(child);
-    }
-    if (fileChildren.length > 0) {
-      sections.set(dirRel, fileChildren);
-    }
-    for (const sub of dirChildren) {
-      const childRel = dirRel ? `${dirRel}/${sub.name}` : sub.name;
-      visit(sub, childRel);
-    }
-  };
-  visit(root, '');
-
-  const out: FlatSection[] = [];
-  for (const [id, files] of sections) {
-    const label = formatSectionLabel(id);
-    out.push({
-      id,
-      label,
-      files: files.slice().sort((a, b) => a.name.localeCompare(b.name)),
-    });
-  }
-  out.sort((a, b) => {
-    if (a.id === '') return -1;
-    if (b.id === '') return 1;
-    return a.id.localeCompare(b.id);
-  });
-  return out;
-}
+const RESOURCES_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'importFile', 'mkdir'];
 
 export interface ResourcesViewActions {
   /** Open via the user's main `open_with` slot. */
@@ -78,14 +33,19 @@ export function ResourcesView(props: {
   onOpenSettings?: () => void;
   /** Open the conception folder in the OS file manager. */
   onOpenConceptionDir?: () => void;
+  expanded: () => ReadonlySet<string>;
+  onToggleExpand: (relPath: string) => void;
+  mutations: TreeViewMutationApi;
+  prompts: TreeViewPromptApi;
+  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
+  onError: (message: string) => void;
 }) {
-  const sections = createMemo<FlatSection[]>(() => buildSections(props.root));
   const scrollRef = usePaneScrollMemory('resources');
 
   return (
     <div class="resources-pane" ref={scrollRef}>
       <Show
-        when={sections().length > 0}
+        when={props.root}
         fallback={
           <div class="empty">
             <p>No resources directory yet.</p>
@@ -112,22 +72,20 @@ export function ResourcesView(props: {
           </div>
         }
       >
-        <For each={sections()}>
-          {(section) => (
-            <section class="resources-group">
-              <h2 class="resources-section-header">
-                <span class="name">{section.label}</span>
-                <span class="count">{section.files.length}</span>
-                <span class="rule" />
-              </h2>
-              <div class="resources-grid">
-                <For each={section.files}>
-                  {(file) => <ResourceCard node={file} actions={props.actions} />}
-                </For>
-              </div>
-            </section>
-          )}
-        </For>
+        {(root) => (
+          <TreeView<ResourceNode>
+            treeKey="resources"
+            root={root()}
+            expanded={props.expanded}
+            onToggleExpand={props.onToggleExpand}
+            affordances={RESOURCES_AFFORDANCES}
+            mutations={props.mutations}
+            prompts={props.prompts}
+            onAfterMutation={props.onAfterMutation}
+            onError={props.onError}
+            renderFile={(file) => <ResourceCard node={file} actions={props.actions} />}
+          />
+        )}
       </Show>
     </div>
   );

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -1,68 +1,36 @@
-import { createMemo, For, Show } from 'solid-js';
+import { Show } from 'solid-js';
 import type { SkillNode } from '@shared/types';
-import { formatSectionLabel } from './pane-utils';
 import { usePaneScrollMemory } from './pane-scroll-memory';
+import {
+  TreeView,
+  type TreeAffordance,
+  type TreeViewMutationApi,
+  type TreeViewPromptApi,
+} from './tree-view';
 import './skills-pane.css';
 
-interface SkillSection {
-  /** Path relative to the skills root, e.g. "projects" or "projects/subdir". */
-  id: string;
-  label: string;
-  /** SKILL.md when this directory is a skill — surfaced as the section index. */
-  index?: SkillNode;
-  /** Other `.md` body files in this directory. */
-  files: SkillNode[];
+const SKILLS_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
+
+/** Pull the directory's `SKILL.md` (case-sensitive — that's how the
+ *  manifest stores it) so it can render as a `[SKILL]` badge on the
+ *  directory header instead of as a separate card. */
+function findSkillIndex(node: SkillNode): SkillNode | undefined {
+  for (const child of node.children ?? []) {
+    if (child.kind === 'file' && child.name === 'SKILL.md') return child;
+  }
+  return undefined;
 }
 
-/**
- * Walk the skills tree and emit one section per directory at any depth
- * that contains at least one `.md`. `SKILL.md` (case-sensitive — that is
- * how the manifest stores it) is pulled out of the file list and rendered
- * as a `[SKILL]` index badge on the section header.
- */
-function buildSections(root: SkillNode | null): SkillSection[] {
-  if (!root) return [];
-  const out: SkillSection[] = [];
-
-  const visit = (node: SkillNode, dirRel: string): void => {
-    if (node.kind !== 'directory') return;
-    const fileChildren: SkillNode[] = [];
-    const dirChildren: SkillNode[] = [];
-    for (const child of node.children ?? []) {
-      if (child.kind === 'directory') dirChildren.push(child);
-      else fileChildren.push(child);
-    }
-
-    let index: SkillNode | undefined;
-    const others: SkillNode[] = [];
-    for (const f of fileChildren) {
-      if (f.name === 'SKILL.md') index = f;
-      else others.push(f);
-    }
-
-    if (index || others.length > 0) {
-      const label = formatSectionLabel(dirRel);
-      out.push({
-        id: dirRel,
-        label,
-        index,
-        files: others.sort((a, b) => a.name.localeCompare(b.name)),
-      });
-    }
-
-    for (const sub of dirChildren) {
-      const childRel = dirRel ? `${dirRel}/${sub.name}` : sub.name;
-      visit(sub, childRel);
-    }
-  };
-  visit(root, '');
-
-  out.sort((a, b) => {
-    if (a.id === '') return -1;
-    if (b.id === '') return 1;
-    return a.id.localeCompare(b.id);
-  });
-  return out;
+/** Drop every `SKILL.md` from the tree — handled separately by the
+ *  per-directory `renderDirSuffix` slot. */
+function stripSkillIndexes(node: SkillNode): SkillNode {
+  if (node.kind !== 'directory') return node;
+  const filtered: SkillNode[] = [];
+  for (const child of node.children ?? []) {
+    if (child.kind === 'file' && child.name === 'SKILL.md') continue;
+    filtered.push(stripSkillIndexes(child));
+  }
+  return { ...node, children: filtered };
 }
 
 export function SkillsView(props: {
@@ -73,14 +41,19 @@ export function SkillsView(props: {
   /** Copy the install command to the clipboard so the user can paste into
    *  the embedded terminal. */
   onCopyInstallCommand?: () => void;
+  expanded: () => ReadonlySet<string>;
+  onToggleExpand: (relPath: string) => void;
+  mutations: TreeViewMutationApi;
+  prompts: TreeViewPromptApi;
+  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
+  onError: (message: string) => void;
 }) {
-  const sections = createMemo<SkillSection[]>(() => buildSections(props.root));
   const scrollRef = usePaneScrollMemory('skills');
 
   return (
     <div class="skills-pane" ref={scrollRef}>
       <Show
-        when={sections().length > 0}
+        when={props.root}
         fallback={
           <div class="empty">
             <p>No skills installed.</p>
@@ -107,65 +80,64 @@ export function SkillsView(props: {
           </div>
         }
       >
-        <For each={sections()}>
-          {(section) => (
-            <section class="skills-group">
-              <h2 class="skills-section-header">
-                <span class="name">{section.label}</span>
-                <Show when={section.files.length > 0}>
-                  <span class="count">{section.files.length}</span>
-                </Show>
-                <Show when={section.index}>
-                  {(idx) => (
-                    <button
-                      type="button"
-                      class="skills-section-index"
-                      classList={{
-                        shipped: !!idx().shipped,
-                        diverged: !!idx().shipped?.diverged,
-                      }}
-                      onClick={() => props.onOpen(idx().path, idx().title, idx().shipped)}
-                      aria-label={`Open SKILL.md for ${section.label}${
-                        idx().shipped?.diverged
-                          ? ' (shipped, locally edited)'
-                          : idx().shipped
-                            ? ' (shipped)'
-                            : ''
-                      }`}
-                      title={
-                        idx().shipped?.diverged
-                          ? 'SKILL.md (shipped, locally edited)'
-                          : idx().shipped
-                            ? 'SKILL.md (shipped)'
-                            : 'SKILL.md'
-                      }
-                    >
-                      SKILL
-                      <Show when={idx().shipped}>
-                        <span class="shipped-tag">
-                          {idx().shipped?.diverged ? ' · diverged' : ' · shipped'}
-                        </span>
-                      </Show>
-                    </button>
-                  )}
-                </Show>
-                <span class="rule" />
-              </h2>
-              <Show when={section.files.length > 0}>
-                <div class="skills-grid">
-                  <For each={section.files}>
-                    {(file) => (
-                      <SkillCard
-                        node={file}
-                        onOpen={() => props.onOpen(file.path, file.title, file.shipped)}
-                      />
-                    )}
-                  </For>
-                </div>
+        {(root) => (
+          <TreeView<SkillNode>
+            treeKey="skills"
+            root={stripSkillIndexes(root())}
+            expanded={props.expanded}
+            onToggleExpand={props.onToggleExpand}
+            affordances={SKILLS_AFFORDANCES}
+            mutations={props.mutations}
+            prompts={props.prompts}
+            onAfterMutation={props.onAfterMutation}
+            onError={props.onError}
+            renderDirSuffix={(dir) => (
+              <Show when={findSkillIndex(dir)}>
+                {(idx) => (
+                  <button
+                    type="button"
+                    class="skills-section-index"
+                    classList={{
+                      shipped: !!idx().shipped,
+                      diverged: !!idx().shipped?.diverged,
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      props.onOpen(idx().path, idx().title, idx().shipped);
+                    }}
+                    aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
+                      idx().shipped?.diverged
+                        ? ' (shipped, locally edited)'
+                        : idx().shipped
+                          ? ' (shipped)'
+                          : ''
+                    }`}
+                    title={
+                      idx().shipped?.diverged
+                        ? 'SKILL.md (shipped, locally edited)'
+                        : idx().shipped
+                          ? 'SKILL.md (shipped)'
+                          : 'SKILL.md'
+                    }
+                  >
+                    SKILL
+                    <Show when={idx().shipped}>
+                      <span class="shipped-tag">
+                        {idx().shipped?.diverged ? ' · diverged' : ' · shipped'}
+                      </span>
+                    </Show>
+                  </button>
+                )}
               </Show>
-            </section>
-          )}
-        </For>
+            )}
+            renderFile={(file) => (
+              <SkillCard
+                node={file}
+                onOpen={() => props.onOpen(file.path, file.title, file.shipped)}
+              />
+            )}
+          />
+        )}
       </Show>
     </div>
   );

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -11,26 +11,19 @@ import './skills-pane.css';
 
 const SKILLS_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
 
-/** Pull the directory's `SKILL.md` (case-sensitive — that's how the
- *  manifest stores it) so it can render as a `[SKILL]` badge on the
- *  directory header instead of as a separate card. */
-function findSkillIndex(node: SkillNode): SkillNode | undefined {
-  for (const child of node.children ?? []) {
-    if (child.kind === 'file' && child.name === 'SKILL.md') return child;
-  }
-  return undefined;
+function isSkillIndex(node: SkillNode): boolean {
+  // Case-sensitive — that's how the manifest stores it and how
+  // `condash skills install` reasons about file identity.
+  return node.kind === 'file' && node.name === 'SKILL.md';
 }
 
-/** Drop every `SKILL.md` from the tree — handled separately by the
- *  per-directory `renderDirSuffix` slot. */
-function stripSkillIndexes(node: SkillNode): SkillNode {
-  if (node.kind !== 'directory') return node;
-  const filtered: SkillNode[] = [];
+/** Pull the directory's `SKILL.md` so it can render as a `[SKILL]`
+ *  badge on the directory header instead of as a separate card. */
+function findSkillIndex(node: SkillNode): SkillNode | undefined {
   for (const child of node.children ?? []) {
-    if (child.kind === 'file' && child.name === 'SKILL.md') continue;
-    filtered.push(stripSkillIndexes(child));
+    if (isSkillIndex(child)) return child;
   }
-  return { ...node, children: filtered };
+  return undefined;
 }
 
 export function SkillsView(props: {
@@ -83,7 +76,7 @@ export function SkillsView(props: {
         {(root) => (
           <TreeView<SkillNode>
             treeKey="skills"
-            root={stripSkillIndexes(root())}
+            root={root()}
             expanded={props.expanded}
             onToggleExpand={props.onToggleExpand}
             affordances={SKILLS_AFFORDANCES}
@@ -91,6 +84,7 @@ export function SkillsView(props: {
             prompts={props.prompts}
             onAfterMutation={props.onAfterMutation}
             onError={props.onError}
+            skipFile={isSkillIndex}
             renderDirSuffix={(dir) => (
               <Show when={findSkillIndex(dir)}>
                 {(idx) => (

--- a/src/renderer/panes/tree-view.css
+++ b/src/renderer/panes/tree-view.css
@@ -1,0 +1,178 @@
+/* Shared styles for the collapsible directory tree used by the
+ * Knowledge / Resources / Skills panes (issue #89). The pane wrapper
+ * still owns padding, scrolling, and per-pane card grids; this file
+ * styles only the tree chrome itself (directory header, twisty,
+ * affordance buttons, indentation rail). */
+
+.tree-view {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tree-directory {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+/* Indent every nested directory off the depth attribute. The root
+ * directory (`data-depth="0"`) hugs the pane's edge; children indent
+ * by 16 px per level so a deeply nested tree stays compact. */
+.tree-directory[data-depth='1'] > .tree-children {
+  padding-left: 16px;
+}
+.tree-directory[data-depth='2'] > .tree-children {
+  padding-left: 16px;
+}
+.tree-directory[data-depth='3'] > .tree-children {
+  padding-left: 16px;
+}
+.tree-directory[data-depth='4'] > .tree-children {
+  padding-left: 16px;
+}
+
+.tree-children {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border-left: 1px dashed var(--border);
+  padding-left: 14px;
+}
+
+/* The root node's children sit flush — no rail, no indent. The pane
+ * chrome handles its own padding so the tree behaves like a list at the
+ * top level. */
+.tree-directory[data-root='true'] > .tree-children {
+  border-left: none;
+  padding-left: 0;
+}
+
+.tree-dir-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  cursor: default;
+}
+
+/* Make the whole header (except the buttons) act like the twisty so
+ * users can click anywhere on the row to collapse/expand. The twisty
+ * button still gets the keyboard focus. */
+.tree-dir-header[data-root='false'] {
+  cursor: pointer;
+}
+.tree-dir-header[data-root='false']:hover .tree-dir-name {
+  color: var(--text);
+}
+
+.tree-dir-twisty {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-faint);
+  cursor: pointer;
+  border-radius: 3px;
+  transition: background 100ms ease;
+}
+
+.tree-dir-twisty:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.tree-dir-twisty:disabled {
+  cursor: default;
+  visibility: hidden;
+}
+
+.tree-dir-twisty-glyph {
+  display: inline-block;
+  font-size: 11px;
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+
+.tree-dir-twisty-glyph[data-open='true'] {
+  transform: rotate(90deg);
+}
+
+.tree-dir-name {
+  color: var(--text);
+}
+
+/* The root header gets a slightly more prominent label so the pane
+ * still has a clear "title" line under the tab bar. */
+.tree-dir-header[data-root='true'] .tree-dir-name {
+  letter-spacing: 0.2em;
+  color: var(--text-muted);
+}
+
+.tree-dir-count {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  color: var(--text-faint);
+}
+
+.tree-dir-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+
+.tree-dir-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+/* Reveal the action buttons on hover or when the directory has focus.
+ * Keep them mounted so a tab through the header doesn't skip them
+ * outright — visibility-toggling would do that. */
+.tree-dir-header:hover .tree-dir-actions,
+.tree-dir-header:focus-within .tree-dir-actions {
+  opacity: 1;
+}
+
+.tree-dir-action {
+  font: inherit;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: lowercase;
+  color: var(--text-muted);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: 1px 7px;
+  border-radius: 3px;
+  cursor: pointer;
+  transition:
+    background 100ms ease,
+    border-color 100ms ease,
+    color 100ms ease;
+}
+
+.tree-dir-action:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.tree-files {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/renderer/panes/tree-view.tsx
+++ b/src/renderer/panes/tree-view.tsx
@@ -1,0 +1,334 @@
+import { createMemo, For, Show, type JSX } from 'solid-js';
+import type { TreeRoot } from '@shared/types';
+import { formatSectionLabel } from './pane-utils';
+import './tree-view.css';
+
+/**
+ * Generic collapsible directory tree shared by the Knowledge, Resources,
+ * and Skills panes (issue #89). Each pane normalises its own node shape
+ * down to the `TreeViewBaseNode` shape below — the recursion only needs
+ * `relPath`, `name`, `kind`, and `children` to walk the tree. The
+ * pane-specific bits (file card, INDEX/SKILL header badge, bucket
+ * coloring) come back through the `renderFile` and `renderDirSuffix` slots.
+ *
+ * State conventions:
+ * - The expansion `Set<string>` carries directory `relPath`s. The root's
+ *   `relPath` is the empty string and is always treated as expanded;
+ *   every other directory starts collapsed (#89 req 3).
+ * - `onAfterMutation` fires after a successful create / import / mkdir,
+ *   carrying the absolute path that was just written so the caller can
+ *   bump its refresh key and (optionally) open the new file.
+ */
+
+export interface TreeViewBaseNode {
+  /** Path relative to the pane's on-disk root. Empty string for the root. */
+  relPath: string;
+  /** Last segment of relPath, or the pane's name for the root. */
+  name: string;
+  kind: 'directory' | 'file';
+  children?: ReadonlyArray<TreeViewBaseNode>;
+}
+
+export type TreeAffordance = 'createMd' | 'mkdir' | 'importFile';
+
+export interface TreeViewMutationApi {
+  createMd: (root: TreeRoot, dirRelPath: string, filename: string) => Promise<string>;
+  mkdir: (root: TreeRoot, dirRelPath: string, name: string) => Promise<string>;
+  importFile: (root: TreeRoot, dirRelPath: string) => Promise<string | null>;
+}
+
+export interface TreeViewPromptApi {
+  prompt: (init: {
+    title: string;
+    message?: string;
+    placeholder?: string;
+    confirmLabel?: string;
+  }) => Promise<string | null>;
+}
+
+export interface TreeViewProps<TFile extends TreeViewBaseNode> {
+  treeKey: TreeRoot;
+  /** The pane's root node. The root header is never rendered — its
+   *  children render directly so the pane keeps its current top-level
+   *  silhouette and the affordance buttons sit on every nested directory
+   *  (and on a synthetic ROOT chip when the root needs them). */
+  root: TFile;
+  /** Read-only accessor for the set of currently-expanded directory
+   *  relPaths. Solid signal so the tree re-renders on toggle. */
+  expanded: () => ReadonlySet<string>;
+  /** Toggle a single directory's expanded state. The component never
+   *  writes the set itself — the parent owns persistence. */
+  onToggleExpand: (relPath: string) => void;
+  /** Render a single file leaf. The pane keeps full control of card
+   *  layout, click handling, and badges. */
+  renderFile: (file: TFile) => JSX.Element;
+  /** Optional pane-specific suffix for a directory's header — the
+   *  Knowledge `INDEX` badge or the Skills `SKILL` badge live here. */
+  renderDirSuffix?: (dir: TFile) => JSX.Element;
+  /** Which affordance buttons sit on every directory header. */
+  affordances: ReadonlyArray<TreeAffordance>;
+  /** Bridge to `window.condash.tree*` — passed in so the component is
+   *  trivially testable without an IPC stub. */
+  mutations: TreeViewMutationApi;
+  prompts: TreeViewPromptApi;
+  /** Fires after a successful mutation with the new file/dir absolute
+   *  path, the kind of mutation, and the `relPath` of the directory
+   *  where the action originated (so the pane can auto-expand it so the
+   *  newly-created child is visible). The pane uses this to refetch its
+   *  tree and (for createMd / importFile) open the result. */
+  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
+  /** Fires when an IPC verb rejects so the pane can surface a toast. */
+  onError: (message: string) => void;
+}
+
+export function TreeView<TFile extends TreeViewBaseNode>(props: TreeViewProps<TFile>): JSX.Element {
+  return (
+    <div class="tree-view">
+      <DirectoryBody
+        node={props.root}
+        depth={0}
+        isRoot={true}
+        treeKey={props.treeKey}
+        expanded={props.expanded}
+        onToggleExpand={props.onToggleExpand}
+        renderFile={props.renderFile}
+        renderDirSuffix={props.renderDirSuffix}
+        affordances={props.affordances}
+        mutations={props.mutations}
+        prompts={props.prompts}
+        onAfterMutation={props.onAfterMutation}
+        onError={props.onError}
+      />
+    </div>
+  );
+}
+
+interface DirectoryBodyProps<TFile extends TreeViewBaseNode> {
+  node: TFile;
+  depth: number;
+  isRoot: boolean;
+  treeKey: TreeRoot;
+  expanded: () => ReadonlySet<string>;
+  onToggleExpand: (relPath: string) => void;
+  renderFile: (file: TFile) => JSX.Element;
+  renderDirSuffix?: (dir: TFile) => JSX.Element;
+  affordances: ReadonlyArray<TreeAffordance>;
+  mutations: TreeViewMutationApi;
+  prompts: TreeViewPromptApi;
+  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
+  onError: (message: string) => void;
+}
+
+/** Render one directory: header (always visible) plus children when
+ *  expanded. Root is always rendered expanded so an all-collapsed pane
+ *  still shows its top-level entries. */
+function DirectoryBody<TFile extends TreeViewBaseNode>(
+  props: DirectoryBodyProps<TFile>,
+): JSX.Element {
+  const childDirs = createMemo<TFile[]>(() => {
+    const out: TFile[] = [];
+    for (const child of props.node.children ?? []) {
+      if (child.kind === 'directory') out.push(child as TFile);
+    }
+    return out;
+  });
+  const childFiles = createMemo<TFile[]>(() => {
+    const out: TFile[] = [];
+    for (const child of props.node.children ?? []) {
+      if (child.kind === 'file') out.push(child as TFile);
+    }
+    return out;
+  });
+
+  return (
+    <section
+      class="tree-directory"
+      data-depth={props.depth}
+      data-root={props.isRoot ? 'true' : 'false'}
+    >
+      <DirectoryHeader
+        node={props.node}
+        depth={props.depth}
+        isRoot={props.isRoot}
+        treeKey={props.treeKey}
+        expanded={props.expanded}
+        onToggleExpand={props.onToggleExpand}
+        renderDirSuffix={props.renderDirSuffix}
+        affordances={props.affordances}
+        mutations={props.mutations}
+        prompts={props.prompts}
+        onAfterMutation={props.onAfterMutation}
+        onError={props.onError}
+        directFileCount={childFiles().length}
+      />
+      <Show when={isExpanded(props.expanded(), props.node.relPath, props.isRoot)}>
+        <div class="tree-children">
+          <For each={childDirs()}>
+            {(dir) => (
+              <DirectoryBody
+                node={dir}
+                depth={props.depth + 1}
+                isRoot={false}
+                treeKey={props.treeKey}
+                expanded={props.expanded}
+                onToggleExpand={props.onToggleExpand}
+                renderFile={props.renderFile}
+                renderDirSuffix={props.renderDirSuffix}
+                affordances={props.affordances}
+                mutations={props.mutations}
+                prompts={props.prompts}
+                onAfterMutation={props.onAfterMutation}
+                onError={props.onError}
+              />
+            )}
+          </For>
+          <Show when={childFiles().length > 0}>
+            <div class="tree-files">
+              <For each={childFiles()}>{(file) => props.renderFile(file)}</For>
+            </div>
+          </Show>
+        </div>
+      </Show>
+    </section>
+  );
+}
+
+interface DirectoryHeaderProps<TFile extends TreeViewBaseNode> {
+  node: TFile;
+  depth: number;
+  isRoot: boolean;
+  treeKey: TreeRoot;
+  expanded: () => ReadonlySet<string>;
+  onToggleExpand: (relPath: string) => void;
+  renderDirSuffix?: (dir: TFile) => JSX.Element;
+  affordances: ReadonlyArray<TreeAffordance>;
+  mutations: TreeViewMutationApi;
+  prompts: TreeViewPromptApi;
+  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
+  onError: (message: string) => void;
+  directFileCount: number;
+}
+
+function DirectoryHeader<TFile extends TreeViewBaseNode>(
+  props: DirectoryHeaderProps<TFile>,
+): JSX.Element {
+  const open = (): boolean => isExpanded(props.expanded(), props.node.relPath, props.isRoot);
+  const label = (): string =>
+    props.isRoot ? props.treeKey.toUpperCase() : formatSectionLabel(props.node.relPath);
+
+  const handleCreateMd = async (): Promise<void> => {
+    const filename = await props.prompts.prompt({
+      title: `New markdown in ${label()}`,
+      message: 'Filename (extension optional). Lowercase, hyphens.',
+      placeholder: 'my-new-note',
+      confirmLabel: 'Create',
+    });
+    if (filename === null || filename.trim().length === 0) return;
+    try {
+      const newPath = await props.mutations.createMd(
+        props.treeKey,
+        props.node.relPath,
+        filename.trim(),
+      );
+      props.onAfterMutation(newPath, 'createMd', props.node.relPath);
+    } catch (err) {
+      props.onError((err as Error).message ?? 'Could not create markdown file.');
+    }
+  };
+
+  const handleMkdir = async (): Promise<void> => {
+    const name = await props.prompts.prompt({
+      title: `New directory in ${label()}`,
+      message: 'Directory name. Lowercase, hyphens.',
+      placeholder: 'subdir',
+      confirmLabel: 'Create',
+    });
+    if (name === null || name.trim().length === 0) return;
+    try {
+      const newPath = await props.mutations.mkdir(props.treeKey, props.node.relPath, name.trim());
+      props.onAfterMutation(newPath, 'mkdir', props.node.relPath);
+    } catch (err) {
+      props.onError((err as Error).message ?? 'Could not create directory.');
+    }
+  };
+
+  const handleImport = async (): Promise<void> => {
+    try {
+      const newPath = await props.mutations.importFile(props.treeKey, props.node.relPath);
+      if (newPath !== null) props.onAfterMutation(newPath, 'importFile', props.node.relPath);
+    } catch (err) {
+      props.onError((err as Error).message ?? 'Could not import file.');
+    }
+  };
+
+  return (
+    <header
+      class="tree-dir-header"
+      data-root={props.isRoot ? 'true' : 'false'}
+      data-open={open() ? 'true' : 'false'}
+    >
+      <button
+        type="button"
+        class="tree-dir-twisty"
+        aria-label={open() ? 'Collapse' : 'Expand'}
+        title={open() ? 'Collapse' : 'Expand'}
+        disabled={props.isRoot}
+        onClick={() => {
+          if (!props.isRoot) props.onToggleExpand(props.node.relPath);
+        }}
+      >
+        <span class="tree-dir-twisty-glyph" data-open={open() ? 'true' : 'false'}>
+          {/* Visible chevron — rotated via CSS rather than swapped out so the
+           * collapse/expand transition can animate.*/}
+          ▸
+        </span>
+      </button>
+      <span class="tree-dir-name">{label()}</span>
+      <Show when={props.directFileCount > 0}>
+        <span class="tree-dir-count">{props.directFileCount}</span>
+      </Show>
+      <Show when={props.renderDirSuffix}>{props.renderDirSuffix?.(props.node)}</Show>
+      <span class="tree-dir-rule" />
+      <div class="tree-dir-actions">
+        <Show when={props.affordances.includes('createMd')}>
+          <button
+            type="button"
+            class="tree-dir-action"
+            title="Create new markdown file in this directory"
+            aria-label="Create new markdown file"
+            onClick={() => void handleCreateMd()}
+          >
+            + md
+          </button>
+        </Show>
+        <Show when={props.affordances.includes('importFile')}>
+          <button
+            type="button"
+            class="tree-dir-action"
+            title="Import an existing file into this directory"
+            aria-label="Import file"
+            onClick={() => void handleImport()}
+          >
+            + file
+          </button>
+        </Show>
+        <Show when={props.affordances.includes('mkdir')}>
+          <button
+            type="button"
+            class="tree-dir-action"
+            title="Create new subdirectory"
+            aria-label="Create new subdirectory"
+            onClick={() => void handleMkdir()}
+          >
+            + dir
+          </button>
+        </Show>
+      </div>
+    </header>
+  );
+}
+
+function isExpanded(set: ReadonlySet<string>, relPath: string, isRoot: boolean): boolean {
+  if (isRoot) return true;
+  return set.has(relPath);
+}

--- a/src/renderer/panes/tree-view.tsx
+++ b/src/renderer/panes/tree-view.tsx
@@ -65,6 +65,12 @@ export interface TreeViewProps<TFile extends TreeViewBaseNode> {
   /** Optional pane-specific suffix for a directory's header — the
    *  Knowledge `INDEX` badge or the Skills `SKILL` badge live here. */
   renderDirSuffix?: (dir: TFile) => JSX.Element;
+  /** Optional predicate that drops a file from the directory's card
+   *  list (and from its file count) without removing it from the
+   *  underlying tree. Used to hide `index.md` / `SKILL.md` so they
+   *  surface only as the per-directory `[INDEX]` / `[SKILL]` badge
+   *  rendered by `renderDirSuffix`. */
+  skipFile?: (file: TFile) => boolean;
   /** Which affordance buttons sit on every directory header. */
   affordances: ReadonlyArray<TreeAffordance>;
   /** Bridge to `window.condash.tree*` — passed in so the component is
@@ -93,6 +99,7 @@ export function TreeView<TFile extends TreeViewBaseNode>(props: TreeViewProps<TF
         onToggleExpand={props.onToggleExpand}
         renderFile={props.renderFile}
         renderDirSuffix={props.renderDirSuffix}
+        skipFile={props.skipFile}
         affordances={props.affordances}
         mutations={props.mutations}
         prompts={props.prompts}
@@ -112,6 +119,7 @@ interface DirectoryBodyProps<TFile extends TreeViewBaseNode> {
   onToggleExpand: (relPath: string) => void;
   renderFile: (file: TFile) => JSX.Element;
   renderDirSuffix?: (dir: TFile) => JSX.Element;
+  skipFile?: (file: TFile) => boolean;
   affordances: ReadonlyArray<TreeAffordance>;
   mutations: TreeViewMutationApi;
   prompts: TreeViewPromptApi;
@@ -134,8 +142,12 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
   });
   const childFiles = createMemo<TFile[]>(() => {
     const out: TFile[] = [];
+    const skip = props.skipFile;
     for (const child of props.node.children ?? []) {
-      if (child.kind === 'file') out.push(child as TFile);
+      if (child.kind !== 'file') continue;
+      const file = child as TFile;
+      if (skip?.(file)) continue;
+      out.push(file);
     }
     return out;
   });
@@ -174,6 +186,7 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
                 onToggleExpand={props.onToggleExpand}
                 renderFile={props.renderFile}
                 renderDirSuffix={props.renderDirSuffix}
+                skipFile={props.skipFile}
                 affordances={props.affordances}
                 mutations={props.mutations}
                 prompts={props.prompts}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -25,6 +25,8 @@ import type {
   Theme,
   TransitionResult,
   TreeEvent,
+  TreeExpansionPrefs,
+  TreeRoot,
 } from './types';
 
 export interface CondashApi {
@@ -83,6 +85,14 @@ export interface CondashApi {
    *  small and re-defaulting works automatically when the bundled
    *  defaults change in a future release. */
   setCardMinWidth(prefs: CardMinWidthPrefs): Promise<void>;
+  /** Per-pane set of expanded directory `relPath`s for the three tree
+   *  panes. The empty-string entry stands in for the pane root. Returns a
+   *  fully-resolved object — every key has at least an empty array so the
+   *  renderer never has to deal with `undefined`. */
+  getTreeExpansion(): Promise<Required<TreeExpansionPrefs>>;
+  /** Persist the per-pane expanded-directory sets. The patch is a full
+   *  replacement; pass `{}` to clear back to the all-collapsed default. */
+  setTreeExpansion(prefs: TreeExpansionPrefs): Promise<void>;
   /** Absolute path to `~/.config/condash/settings.json` (or platform equivalent),
    * for the settings modal's "Open externally" button. */
   getSettingsPath(): Promise<string>;
@@ -187,6 +197,23 @@ export interface CondashApi {
    *  and prefixed with the next zero-padded NN- counter. Returns the absolute
    *  path of the new file (always created — caller can then open it). */
   createProjectNote(projectPath: string, slug: string): Promise<string>;
+  /** Create a new markdown file under one of the three tree panes'
+   *  directories. `dirRelPath` is relative to the pane's on-disk root (`''`
+   *  for the root). `filename` is sanitised to lowercase-hyphen and an
+   *  `.md` extension is appended when missing. Resources accept any
+   *  extension; knowledge / skills always force `.md`. Refuses to overwrite
+   *  an existing file. Returns the new file's absolute path so the caller
+   *  can re-fetch the tree and open the file in the editor. */
+  treeCreateMd(root: TreeRoot, dirRelPath: string, filename: string): Promise<string>;
+  /** Create a new subdirectory under one of the three tree panes'
+   *  directories. Same `dirRelPath` semantics as `treeCreateMd`. `name` is
+   *  sanitised to lowercase-hyphen. Idempotent: a no-op if the directory
+   *  already exists, but always returns its absolute path. */
+  treeMkdir(root: TreeRoot, dirRelPath: string, name: string): Promise<string>;
+  /** Pop an OS file picker, then copy the chosen file into the target tree
+   *  directory. Resolves to the destination's absolute path, or `null` when
+   *  the user cancels. Refuses to overwrite an existing file. */
+  treeImportFile(root: TreeRoot, dirRelPath: string): Promise<string | null>;
   /** Trigger app quit. Renderer is responsible for any user confirmation. */
   quitApp(): Promise<void>;
   /** App version + bundled release metadata used by the About modal.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,7 +131,28 @@ export interface Settings {
    * values keep cards roomy. Per-machine because what feels right depends
    * on the monitor, not the team. */
   cardMinWidth?: CardMinWidthPrefs;
+  /** Per-pane set of expanded directory `relPath`s in the Knowledge,
+   * Resources, and Skills panes. Empty (or missing) means every directory
+   * is collapsed — that is the on-purpose first-load state per the issue
+   * #89 spec. The empty-string entry stands in for the pane's root
+   * directory; everything else matches a `relPath` returned by the tree
+   * reader. Per-machine because the answer is "what was I last looking
+   * at on this laptop", not a team convention. */
+  treeExpansion?: TreeExpansionPrefs;
 }
+
+/** Sets of expanded directory `relPath`s for the three tree panes. The
+ * empty-string entry is the root of that pane. */
+export interface TreeExpansionPrefs {
+  knowledge?: string[];
+  resources?: string[];
+  skills?: string[];
+}
+
+/** Discriminator for the three tree panes. Used by the `tree.*` IPC verbs
+ * to pick the correct on-disk root (knowledge is hardcoded to `knowledge/`;
+ * resources and skills come from `configuration.json`). */
+export type TreeRoot = 'knowledge' | 'resources' | 'skills';
 
 /** Per-pane card min-width in CSS pixels. Used in the grid template
  * `minmax(min(<min>, 100%), 1fr)`. Each field is optional — a missing


### PR DESCRIPTION
Closes #89.

## Summary

- Replaces the flat-section render in the Knowledge, Resources, and Skills panes with a real collapsible directory tree. Every nested directory starts collapsed on first load and the per-pane expanded set persists in `settings.json` so the layout survives reloads and tab switches.
- Adds inline `+ md`, `+ file` (resources only), and `+ dir` affordances on every directory header so authoring a new note, importing an existing file, or creating a subdirectory no longer needs a round-trip to the shell.
- All filesystem writes go through new bounds-checked main-process verbs that resolve the per-pane root, sanitise the user-supplied name, and refuse to overwrite.

## Changes

- New shared component `src/renderer/panes/tree-view.tsx` (+ `tree-view.css`): generic recursive directory tree, root always expanded, nested dirs respect a `Set<string>` of expanded `relPath`s passed in by the parent, hover-revealed action buttons.
- `knowledge.tsx`, `resources.tsx`, `skills.tsx` each rebuilt around the shared tree. Knowledge and Skills strip `index.md` / `SKILL.md` from the file list and continue to surface them as the existing `INDEX` / `SKILL` directory-header badge.
- New main-process module `src/main/tree-mutations.ts` exposing `treeCreateMd` / `treeMkdir` / `treeImportFile`. Each verb resolves the pane's on-disk root (knowledge is hardcoded; resources and skills come from `configuration.json`), sanitises the basename, joins, and bounds-checks via `requirePathUnder`. `wx` / `COPYFILE_EXCL` refuse overwrites.
- `Settings.treeExpansion` plus `getTreeExpansion` / `setTreeExpansion` IPC verbs (registered in `ipc/settings.ts`); empty / missing means everything collapsed, matching the on-purpose first-load state.
- After a successful mutation the source dir is auto-expanded, the affected tree is refetched (`refreshKey` bump), and `createMd` / `importFile` open the new file via the pane's normal open path.
- `docs/reference/config.md` documents the new `treeExpansion` block.

## Impact

- `settings.json` schema gains a new optional top-level `treeExpansion` key. Older settings files keep working unchanged — the field defaults to all-collapsed.
- The Resources `+ file` action opens an Electron file picker in the main process and copies the selection in. New surface for the renderer; bounded to the resolved resources root.
- All three panes now mount the same `TreeView` component, so future tree-pane changes (rename, delete, drag-and-drop) only need to land in one place.

## Watchpoints

- Bounds check — manually exercise `dir = "../../../etc"` in the prompt to confirm the renderer cannot escape the pane root.
- Manual UI smoke is still pending: collapse / expand persistence across tab switches and full app restarts; the three affordances on knowledge / resources / skills; the `INDEX` / `SKILL` badges still wire through correctly on directories that have them.