### PR TITLE
Fix Ctrl+Shift+V screenshot-paste regression inside xterm

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -584,6 +584,21 @@ function App() {
       return;
     }
 
+    // Screenshot-paste shortcut wins inside the xterm too — that's the very
+    // surface users want to paste a screenshot path into. The listener runs
+    // in capture phase (see addEventListener below), so stopPropagation here
+    // keeps xterm.js from firing its built-in Ctrl+Shift+V → clipboard text
+    // paste, which would otherwise win and overwrite the screenshot path.
+    if (layout().terminal && terminalHandle) {
+      const screenshotPaste = parseShortcut(prefs.screenshot_paste_shortcut ?? 'Ctrl+Shift+V');
+      if (matchesShortcut(event, screenshotPaste)) {
+        event.preventDefault();
+        event.stopPropagation();
+        void bridge.handleScreenshotPaste();
+        return;
+      }
+    }
+
     // Every other shortcut yields to text inputs / xterm so we don't steal
     // arrow keys, paste, etc. from someone who's typing.
     if (insideEditable) return;
@@ -621,18 +636,17 @@ function App() {
       terminalHandle.moveActiveTab(1);
       return;
     }
-    const paste = parseShortcut(prefs.screenshot_paste_shortcut);
-    if (matchesShortcut(event, paste)) {
-      event.preventDefault();
-      void bridge.handleScreenshotPaste();
-    }
   };
 
+  // Capture phase: the screenshot-paste branch above needs to run before
+  // xterm.js's textarea keydown listener so stopPropagation can suppress
+  // its built-in Ctrl+Shift+V paste. Other branches don't stopPropagation,
+  // so events still bubble normally to descendants when no shortcut matches.
   onMount(() => {
-    document.addEventListener('keydown', handleGlobalKeyDown);
+    document.addEventListener('keydown', handleGlobalKeyDown, true);
   });
   onCleanup(() => {
-    document.removeEventListener('keydown', handleGlobalKeyDown);
+    document.removeEventListener('keydown', handleGlobalKeyDown, true);
   });
 
   // Application menu → renderer plumbing.


### PR DESCRIPTION
## Summary

- Restore the Ctrl+Shift+V → paste-newest-screenshot shortcut inside the xterm pane: it had silently regressed to plain clipboard text paste.
- Root cause: a recent input/xterm guard left the screenshot-paste branch unreachable from inside `.xterm-host`, so xterm.js's built-in Ctrl+Shift+V handler won.

## Changes

- `src/renderer/main.tsx`: hoist the screenshot-paste shortcut check above the `insideEditable` early-return so it fires from inside the terminal too.
- Default `terminal.screenshot_paste_shortcut` to `Ctrl+Shift+V` when unset (previously only the placeholder hint defaulted; the runtime did nothing).
- Switch the document `keydown` listener to capture phase, and call `event.stopPropagation()` on a screenshot-paste match so xterm.js's textarea handler never sees the event.

## Impact

- Capture-phase document listener: other branches do not call `stopPropagation`, so non-matching keystrokes still propagate to descendants normally — typing, search, and existing shortcut behaviour are unchanged.