### PR TITLE
Bump 2.12.0: flatten repositories, dock ACTIVE RUNS at bottom

### DIFF
--- a/docs/guides/repositories-and-open-with.md
+++ b/docs/guides/repositories-and-open-with.md
@@ -1,13 +1,13 @@
 ---
 title: Repositories and open-with buttons · condash guide
-description: Point condash at your workspace, group repos into primary / secondary / others, and wire the three launcher slots to your own editor and terminal.
+description: Point condash at your workspace, list the repos surfaced on the Code pane, and wire the three launcher slots to your own editor and terminal.
 ---
 
 # Repositories and open-with buttons
 
 > **Audience.** Daily user.
 
-**When to read this.** The **Code** pane shows the wrong repos, or the wrong repos are in the primary card, or the "open in IDE" button launches the wrong thing (or nothing).
+**When to read this.** The **Code** pane shows the wrong repos, the order isn't what you want, or the "open in IDE" button launches the wrong thing (or nothing).
 
 Everything on this page lives in `<conception_path>/configuration.json`. Per-machine overrides go in `settings.json` and win on overlap.
 
@@ -25,25 +25,24 @@ Everything on this page lives in `<conception_path>/configuration.json`. Per-mac
 
 If `workspace_path` is unset, the Code pane disappears.
 
-## Grouping: primary, secondary, others
+## The repository list
 
 ```json
 {
-  "repositories": {
-    "primary": ["helio", "helio-web"],
-    "secondary": ["helio-docs"]
-  }
+  "repositories": [
+    "helio",
+    "helio-web",
+    "helio-docs"
+  ]
 }
 ```
 
-Names are bare directory names (not paths) matched against whatever was found under `workspace_path`. Every repo not listed in either group lands in an auto-generated **OTHERS** card. The three cards render as a single strip, in the order primary → secondary → others:
+Names are bare directory names (not paths) matched against whatever was found under `workspace_path`. The Code pane renders one card per entry in declaration order — keep the repos you touch most often at the top.
 
-![Code pane — three repos organised into primary, secondary, others](../assets/screenshots/code-pane-light.png#only-light)
-![Code pane — three repos organised into primary, secondary, others](../assets/screenshots/code-pane-dark.png#only-dark)
+![Code pane — flat list of repo cards](../assets/screenshots/code-pane-light.png#only-light)
+![Code pane — flat list of repo cards](../assets/screenshots/code-pane-dark.png#only-dark)
 
-Inside a card, each repo renders as a top-level row. Any sub-repos declared for that repo (see [Submodules in a monorepo](#submodules-in-a-monorepo) below) sit on the same row level, visually grouped with the parent by a blue left-border accent. Worktrees for a given repo or sub-repo nest directly under it.
-
-The grouping is a UX signal, nothing more — every group behaves the same (same dirty counts, same launcher buttons). Use it to keep the repos you actually touch today at eye level.
+Each repo renders as a top-level row. Any sub-repos declared for that repo (see [Submodules in a monorepo](#submodules-in-a-monorepo) below) sit on the same row level, visually grouped with the parent by a blue left-border accent. Worktrees for a given repo or sub-repo nest directly under it.
 
 ## Submodules in a monorepo
 
@@ -51,14 +50,12 @@ If you work in a monorepo where different subdirectories are edited independentl
 
 ```json
 {
-  "repositories": {
-    "primary": [
-      {
-        "name": "helio",
-        "submodules": ["apps/web", "apps/api", "crates/parser"]
-      }
-    ]
-  }
+  "repositories": [
+    {
+      "name": "helio",
+      "submodules": ["apps/web", "apps/api", "crates/parser"]
+    }
+  ]
 }
 ```
 
@@ -95,7 +92,7 @@ Built-in defaults for the three slots reproduce the previous IntelliJ / VS Code 
 
 ## Editing via the Settings modal
 
-Open **File → Settings…** (`Ctrl+,`) and pick the **Workspace**, **Repositories**, or **Open with** tab — each has form fields backed by `configuration.json`. There is no in-modal JSON editor; for keys outside the modal (e.g. nested `repositories.primary[].submodules` shapes, `pdf_viewer`), use the **Open configuration.json externally** button in the header to edit the raw JSON in your `$EDITOR`. Either path runs through the same atomic save + strict zod schema.
+Open **File → Settings…** (`Ctrl+,`) and pick the **Workspace**, **Repositories**, or **Open with** tab — each has form fields backed by `configuration.json`. There is no in-modal JSON editor; for keys outside the modal (e.g. nested `repositories[].submodules` shapes, `pdf_viewer`), use the **Open configuration.json externally** button in the header to edit the raw JSON in your `$EDITOR`. Either path runs through the same atomic save + strict zod schema.
 
 Changes to `open_with` and `terminal` reload the dashboard live; `workspace_path`, `worktrees_path`, and the `repositories` list need a restart.
 
@@ -107,17 +104,15 @@ Distinct from `open_with` (which launches **external** tools like your IDE), the
 
 ```json
 {
-  "repositories": {
-    "primary": [
-      { "name": "notes.vcoeur.com", "run": "make dev" },
-      {
-        "name": "helio",
-        "submodules": [
-          { "name": "apps/web", "run": "npm --prefix apps/web run dev" }
-        ]
-      }
-    ]
-  }
+  "repositories": [
+    { "name": "notes.vcoeur.com", "run": "make dev" },
+    {
+      "name": "helio",
+      "submodules": [
+        { "name": "apps/web", "run": "npm --prefix apps/web run dev" }
+      ]
+    }
+  ]
 }
 ```
 

--- a/docs/help/configuration.md
+++ b/docs/help/configuration.md
@@ -18,13 +18,11 @@ for the split.
 {
   "workspace_path": "/home/you/src",
   "worktrees_path": "/home/you/src/worktrees",
-  "repositories": {
-    "primary": [
-      "condash",
-      { "name": "myapp", "run": "make dev" }
-    ],
-    "secondary": ["conception"]
-  },
+  "repositories": [
+    "condash",
+    { "name": "myapp", "run": "make dev" },
+    "conception"
+  ],
   "open_with": {
     "main_ide": { "label": "Open in IDE", "command": "code {path}" }
   }
@@ -37,7 +35,7 @@ for the split.
 | `worktrees_path` | Sandbox for the "Open in IDE" buttons. |
 | `resources_path` | Folder backing the Resources pane. Default `resources`. |
 | `skills_path` | Folder backing the Skills pane. Default `.claude/skills`. |
-| `repositories.primary` / `.secondary` | Repos to surface on the Code pane. Each entry is a string or an object with `name`, optional `submodules`, `run`, `force_stop`, `label`. |
+| `repositories` | Flat ordered list of repos to surface on the Code pane. Each entry is a string or an object with `name`, optional `submodules`, `run`, `force_stop`, `label`. |
 | `open_with` | Three launcher slots (`main_ide`, `secondary_ide`, `terminal`) — tree-side so teammates pick them up automatically. `{path}` is replaced with the absolute target path. |
 
 A repo entry's `run` wires up an inline dev-server runner; `force_stop`
@@ -88,8 +86,7 @@ grouped by which file it writes to.
 
 - **Workspace** — `workspace_path`, `worktrees_path`, `resources_path`,
   `skills_path`.
-- **Repositories** — primary / secondary list, per-repo `run` /
-  `force_stop`.
+- **Repositories** — ordered repo list, per-repo `run` / `force_stop`.
 - **Open with** — slot labels and commands.
 
 Power users can hit **Open configuration.json externally** in the

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -32,24 +32,22 @@ Lives at `<conception_path>/configuration.json`. Commit it. Every key is optiona
   "worktrees_path": "/home/you/src/worktrees",
   "resources_path": "resources",
   "skills_path": ".claude/skills",
-  "repositories": {
-    "primary": [
-      "condash",
-      {
-        "name": "helio",
-        "submodules": [
-          { "name": "apps/web", "run": "make dev" },
-          { "name": "apps/api", "run": "make dev" }
-        ]
-      },
-      {
-        "name": "notes.vcoeur.com",
-        "run": "make dev",
-        "force_stop": "fuser -k 8200/tcp 5200/tcp"
-      }
-    ],
-    "secondary": ["conception"]
-  },
+  "repositories": [
+    "condash",
+    {
+      "name": "helio",
+      "submodules": [
+        { "name": "apps/web", "run": "make dev" },
+        { "name": "apps/api", "run": "make dev" }
+      ]
+    },
+    {
+      "name": "notes.vcoeur.com",
+      "run": "make dev",
+      "force_stop": "fuser -k 8200/tcp 5200/tcp"
+    },
+    "conception"
+  ],
   "open_with": {
     "main_ide": { "label": "Open in main IDE", "command": "idea {path}" },
     "secondary_ide": { "label": "Open in secondary IDE", "command": "code {path}" },
@@ -74,18 +72,16 @@ A `terminal` block at this level still validates for backward-compat, but it is 
 
 ### `repositories`
 
-Two buckets, `primary` and `secondary`, each an array of repo entries. Entries take one of the following shapes:
+A single ordered array of repo entries — the Code pane renders cards in the order declared here. Entries take one of the following shapes:
 
 ```json
 {
-  "repositories": {
-    "primary": [
-      "condash",
-      { "name": "helio" },
-      { "name": "helio", "submodules": ["apps/web", "apps/api"] },
-      { "name": "notes.vcoeur.com", "run": "make dev", "force_stop": "fuser -k 8200/tcp" }
-    ]
-  }
+  "repositories": [
+    "condash",
+    { "name": "helio" },
+    { "name": "helio", "submodules": ["apps/web", "apps/api"] },
+    { "name": "notes.vcoeur.com", "run": "make dev", "force_stop": "fuser -k 8200/tcp" }
+  ]
 }
 ```
 
@@ -101,7 +97,7 @@ Two buckets, `primary` and `secondary`, each an array of repo entries. Entries t
 | `{"name": "repo", "env": [".env", ".env.local"]}`         | Files copied from the primary checkout into a new worktree on `condash worktrees setup` — applied **unconditionally** when present (no flag needed). Closes the silent-undefined-`VITE_*` footgun where forgetting `--copy-env` leaves a Vite SPA reading `import.meta.env.VITE_*` as `undefined`. Default empty → no copy. Path traversal is rejected (no `..`, no absolute paths).                                                                                                                       |
 | `{"name": "repo", "pinned_branch": "<branch>"}`           | Pin the repo to a fixed branch. `condash worktrees setup` skips it instead of creating a worktree on the requested branch. Use for shared / vendored repos that should never track the project branch axis.                                                                                                                                                                                                                                                                                                  |
 
-Anything under `workspace_path` not named in either bucket lands in a third `OTHERS` card.
+Anything under `workspace_path` not named in `repositories` is ignored — only listed entries appear on the Code pane.
 
 ### `open_with`
 
@@ -310,7 +306,7 @@ The file is created on demand: the first-launch folder picker writes it; you can
 **Conception Configuration** (write to `configuration.json`):
 
 - **Workspace** — `workspace_path`, `worktrees_path`, `resources_path`, `skills_path`.
-- **Repositories** — primary / secondary list, per-repo `run` / `force_stop`.
+- **Repositories** — ordered repo list, per-repo `run` / `force_stop`.
 - **Open with** — slot labels and commands.
 
 A header button — **Open configuration.json externally** — shells out via `window.condash.openPath` so power users can edit the raw JSON in their `$EDITOR` instead. Writes that go through the modal are funnelled through `patchConfig`, which parses the live file, applies a mutator, drops empty leaves, and round-trips through the `note.write` IPC's atomic CAS — same path as the in-modal forms — so the [strict zod schema](https://github.com/vcoeur/condash/blob/main/src/main/config-schema.ts) is enforced both ways.

--- a/docs/reference/inline-runner.md
+++ b/docs/reference/inline-runner.md
@@ -23,20 +23,18 @@ The runner is opt-in per repo and per sub-repo. Declare it in [`configuration.js
 
 ```json
 {
-  "repositories": {
-    "primary": [
-      "conception",
-      { "name": "notes.vcoeur.com", "run": "make dev" },
-      {
-        "name": "helio",
-        "run": "cargo watch -x run",
-        "submodules": [
-          { "name": "apps/web", "run": "npm --prefix apps/web run dev" },
-          "apps/api"
-        ]
-      }
-    ]
-  }
+  "repositories": [
+    "conception",
+    { "name": "notes.vcoeur.com", "run": "make dev" },
+    {
+      "name": "helio",
+      "run": "cargo watch -x run",
+      "submodules": [
+        { "name": "apps/web", "run": "npm --prefix apps/web run dev" },
+        "apps/api"
+      ]
+    }
+  ]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.11.4",
+  "version": "2.12.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/misc.ts
+++ b/src/cli/commands/misc.ts
@@ -343,11 +343,8 @@ export async function runRepos(
       const data = d as typeof repos;
       if (data.length === 0) return '(no repos configured)\n';
       return (
-        data
-          .map(
-            (r) => `${r.kind.padEnd(9)}  ${r.name.padEnd(24)}  ${r.missing ? '(missing)' : r.path}`,
-          )
-          .join('\n') + '\n'
+        data.map((r) => `${r.name.padEnd(24)}  ${r.missing ? '(missing)' : r.path}`).join('\n') +
+        '\n'
       );
     });
     return;

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -4,20 +4,18 @@ import { configSchema } from './config-schema';
 describe('configSchema repoEntry', () => {
   it('accepts the new env / install / pinned_branch fields', () => {
     const result = configSchema.safeParse({
-      repositories: {
-        primary: [
-          {
-            name: 'frontend',
-            install: 'npm install',
-            pinned_branch: 'main',
-            env: ['.env', '.env.local'],
-          },
-        ],
-      },
+      repositories: [
+        {
+          name: 'frontend',
+          install: 'npm install',
+          pinned_branch: 'main',
+          env: ['.env', '.env.local'],
+        },
+      ],
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      const repo = result.data.repositories?.primary?.[0];
+      const repo = result.data.repositories?.[0];
       expect(typeof repo).toBe('object');
       if (repo && typeof repo !== 'string') {
         expect(repo.env).toEqual(['.env', '.env.local']);
@@ -29,27 +27,30 @@ describe('configSchema repoEntry', () => {
 
   it('rejects an env array containing an empty string', () => {
     const result = configSchema.safeParse({
-      repositories: {
-        primary: [{ name: 'frontend', env: ['.env', ''] }],
-      },
+      repositories: [{ name: 'frontend', env: ['.env', ''] }],
     });
     expect(result.success).toBe(false);
   });
 
   it('still rejects unknown fields under a repo entry', () => {
     const result = configSchema.safeParse({
-      repositories: {
-        primary: [{ name: 'frontend', not_a_field: 'x' }],
-      },
+      repositories: [{ name: 'frontend', not_a_field: 'x' }],
     });
     expect(result.success).toBe(false);
   });
 
   it('still accepts the bare-string repo shape', () => {
     const result = configSchema.safeParse({
-      repositories: { primary: ['standalone-repo'] },
+      repositories: ['standalone-repo'],
     });
     expect(result.success).toBe(true);
+  });
+
+  it('rejects the legacy primary/secondary bucket shape', () => {
+    const result = configSchema.safeParse({
+      repositories: { primary: ['legacy-repo'] },
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -134,13 +134,7 @@ export const configSchema = z
     resources_path: conceptionRelativePath.optional(),
     /** Directory browsed by the Skills pane (default `.claude/skills`). */
     skills_path: conceptionRelativePath.optional(),
-    repositories: z
-      .object({
-        primary: z.array(repoEntry).optional(),
-        secondary: z.array(repoEntry).optional(),
-      })
-      .strict()
-      .optional(),
+    repositories: z.array(repoEntry).optional(),
     open_with: z
       .object({
         main_ide: openWithSlot.optional(),

--- a/src/main/config-walk.ts
+++ b/src/main/config-walk.ts
@@ -20,10 +20,7 @@ export type RawRepo =
 
 export interface ConfigShape {
   workspace_path?: string;
-  repositories?: {
-    primary?: RawRepo[];
-    secondary?: RawRepo[];
-  };
+  repositories?: RawRepo[];
 }
 
 export interface RepoLookup {
@@ -58,37 +55,23 @@ export function resolveCwd(
 }
 
 /**
- * Walk every repo entry in `config.repositories` (primary + secondary,
- * recursing into `submodules`). The visitor receives a fully-resolved
- * `RepoLookup` and a `kind` discriminator. Visitors that want to short-circuit
- * the walk return `false`; returning `true` (or `void`) keeps the walk going.
+ * Walk every repo entry in `config.repositories` (recursing into `submodules`)
+ * in declaration order. Visitors that want to short-circuit the walk return
+ * `false`; returning `true` (or `void`) keeps the walk going.
  */
-export function walkRepos(
-  config: ConfigShape,
-  visit: (entry: RepoLookup, kind: 'primary' | 'secondary') => boolean | void,
-): void {
+export function walkRepos(config: ConfigShape, visit: (entry: RepoLookup) => boolean | void): void {
   const workspace = config.workspace_path;
-  const visitList = (entries: RawRepo[], kind: 'primary' | 'secondary'): boolean => {
-    for (const entry of entries) {
-      const stop = visitOne(entry, kind, undefined, workspace, visit);
-      if (stop) return true;
-    }
-    return false;
-  };
-  if (config.repositories?.primary) {
-    if (visitList(config.repositories.primary, 'primary')) return;
-  }
-  if (config.repositories?.secondary) {
-    visitList(config.repositories.secondary, 'secondary');
+  if (!config.repositories) return;
+  for (const entry of config.repositories) {
+    if (visitOne(entry, undefined, workspace, visit)) return;
   }
 }
 
 function visitOne(
   entry: RawRepo,
-  kind: 'primary' | 'secondary',
   parent: string | undefined,
   workspace: string | undefined,
-  visit: (entry: RepoLookup, kind: 'primary' | 'secondary') => boolean | void,
+  visit: (entry: RepoLookup) => boolean | void,
 ): boolean {
   if (typeof entry === 'string') {
     const lookup: RepoLookup = {
@@ -97,7 +80,7 @@ function visitOne(
       parent,
       cwd: resolveCwd(workspace, parent, entry),
     };
-    return visit(lookup, kind) === false;
+    return visit(lookup) === false;
   }
   const lookup: RepoLookup = {
     display: parent ? `${parent}/${entry.name}` : entry.name,
@@ -108,10 +91,10 @@ function visitOne(
     run: entry.run,
     forceStop: entry.force_stop,
   };
-  if (visit(lookup, kind) === false) return true;
+  if (visit(lookup) === false) return true;
   if (entry.submodules?.length) {
     for (const sub of entry.submodules) {
-      if (visitOne(sub, kind, entry.name, workspace, visit)) return true;
+      if (visitOne(sub, entry.name, workspace, visit)) return true;
     }
   }
   return false;

--- a/src/main/repos.ts
+++ b/src/main/repos.ts
@@ -7,9 +7,7 @@ import { getCurrentBranch, listWorktrees } from './worktrees';
 import { walkRepos, type ConfigShape, type RepoLookup } from './config-walk';
 import { pathExists } from './fs-helpers';
 
-interface FlatRepo extends RepoLookup {
-  kind: 'primary' | 'secondary';
-}
+type FlatRepo = RepoLookup;
 
 async function readConfig(conceptionPath: string): Promise<ConfigShape> {
   const path = join(conceptionPath, 'configuration.json');
@@ -24,8 +22,8 @@ async function readConfig(conceptionPath: string): Promise<ConfigShape> {
 
 function flatRepos(config: ConfigShape): FlatRepo[] {
   const flat: FlatRepo[] = [];
-  walkRepos(config, (entry, kind) => {
-    flat.push({ ...entry, kind });
+  walkRepos(config, (entry) => {
+    flat.push(entry);
   });
   return flat;
 }
@@ -73,7 +71,6 @@ async function buildEntry(
       name: entry.display,
       label: entry.label,
       path: toPosix(entry.cwd),
-      kind: entry.kind,
       parent: entry.parent,
       dirty: null,
       missing: true,
@@ -93,7 +90,6 @@ async function buildEntry(
     name: entry.display,
     label: entry.label,
     path: toPosix(entry.cwd),
-    kind: entry.kind,
     parent: entry.parent,
     dirty,
     missing: false,

--- a/src/main/worktree-ops.ts
+++ b/src/main/worktree-ops.ts
@@ -445,9 +445,7 @@ function repoLookupMap(config: ConfigWithPaths): Map<string, RepoLookupExtended>
   });
   // Re-walk the raw config to pick up `pinned_branch`, `install`, and `env`
   // (those aren't currently in the RepoLookup shape).
-  const primary = config.repositories?.primary ?? [];
-  const secondary = config.repositories?.secondary ?? [];
-  for (const raw of [...primary, ...secondary]) {
+  for (const raw of config.repositories ?? []) {
     if (typeof raw === 'string') continue;
     const lookup = map.get(raw.name);
     if (!lookup) continue;

--- a/src/main/worktrees.ts
+++ b/src/main/worktrees.ts
@@ -5,8 +5,8 @@ import type { Worktree } from '../shared/types';
 
 /**
  * Current branch for a checkout, or null when HEAD is genuinely detached
- * (or the path is not inside a git repo). Used for sub-repos and secondary
- * repos that aren't queried via `git worktree list`.
+ * (or the path is not inside a git repo). Used for sub-repos and other
+ * checkouts that aren't queried via `git worktree list`.
  */
 export async function getCurrentBranch(repoPath: string): Promise<string | null> {
   try {

--- a/src/renderer/code-runs.tsx
+++ b/src/renderer/code-runs.tsx
@@ -19,10 +19,9 @@ export function CodeRunRows(props: CodeRunRowsProps) {
   return (
     <Show when={props.sessions.length > 0}>
       <section class="code-runs">
-        <h2 class="repos-group-header">
+        <h2 class="code-runs-header">
           <span class="name">ACTIVE RUNS</span>
           <span class="count">{props.sessions.length}</span>
-          <span class="rule" />
         </h2>
         <div class="code-runs-list">
           <For each={props.sessions}>

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -46,7 +46,7 @@ import {
   ProjectsView,
 } from './panes/projects';
 import { KnowledgeView } from './panes/knowledge';
-import { CodeView, groupRepos } from './panes/code';
+import { CodeView } from './panes/code';
 import { ResourcesView, type ResourcesViewActions } from './panes/resources';
 import { SkillsView } from './panes/skills';
 import { SearchModal } from './search-modal';
@@ -416,8 +416,8 @@ function App() {
   //   1. **Scalar** (dirty, upstream) — push events from
   //      `repo-watchers.ts` flow through `repo-events.ts` into path-
   //      shaped `setRepos(...)` writes. Only the cells that actually
-  //      read each value re-evaluate — `repoGroups` and other whole-
-  //      list readers stay quiet on a single dirty tick.
+  //      read each value re-evaluate — whole-list memos like the
+  //      Code-pane `orderedRepos` stay quiet on a single dirty tick.
   //   2. **Set membership** (worktree add/remove, primary checkout
   //      branch switch, configuration.json edit) — `reloadRepos` (full
   //      list) or `reloadPrimaryByPath` (per-primary subset) replaces
@@ -519,8 +519,6 @@ function App() {
     });
   });
   onCleanup(offRepoEvents);
-
-  const repoGroups = createMemo(() => groupRepos(repos));
 
   const [openWithSlots] = createResource(
     () => [conceptionPath(), refreshKey()] as const,
@@ -1361,8 +1359,7 @@ function App() {
                             <div class="empty">
                               <p>No repositories configured.</p>
                               <p>
-                                Add entries under <code>repositories.primary</code> or{' '}
-                                <code>repositories.secondary</code> in{' '}
+                                Add entries to <code>repositories</code> in{' '}
                                 <code>configuration.json</code>.
                               </p>
                               <button
@@ -1378,7 +1375,6 @@ function App() {
                       >
                         <CodeView
                           repos={repos}
-                          groups={repoGroups()}
                           slots={openWithSlots() ?? {}}
                           liveRepos={liveRepos()}
                           liveSessionCwds={liveSessionCwds()}

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -143,9 +143,9 @@ const CONFIG_SUMMARY: { key: string; purpose: string }[] = [
   { key: 'workspace_path', purpose: 'Base directory for non-absolute repo entries.' },
   { key: 'worktrees_path', purpose: 'Where new git worktrees are created (informational).' },
   {
-    key: 'repositories.primary / .secondary',
+    key: 'repositories',
     purpose:
-      'Repos shown on the Code pane. Each entry: name, optional run / force_stop / submodules.',
+      'Flat ordered list of repos shown on the Code pane. Each entry: name, optional run / force_stop / submodules.',
   },
   {
     key: 'open_with',

--- a/src/renderer/panes/code-pane.css
+++ b/src/renderer/panes/code-pane.css
@@ -1,46 +1,21 @@
 .repos-pane {
   flex: 1;
-  overflow-y: auto;
-  padding: 14px 18px 22px;
+  /* The pane itself does not scroll — it splits into a scrollable top
+   * region (.repos-pane-scroll) and a non-scrolling bottom dock
+   * (.code-runs-dock). Without this the inner scroller never clips. */
+  min-height: 0;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 18px;
 }
 
-.repos-group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.repos-group-header {
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  font-family: var(--font-ui);
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-
-.repos-group-header .name {
-  color: var(--text);
-}
-
-.repos-group-header .count {
-  font-family: var(--font-mono);
-  font-variant-numeric: tabular-nums;
-  letter-spacing: 0.04em;
-  color: var(--text-faint);
-}
-
-.repos-group-header .rule {
+.repos-pane-scroll {
   flex: 1;
-  height: 1px;
-  background: var(--border);
+  /* Required for the flex parent to clip — otherwise the grid's
+   * intrinsic content size pushes overflow outside the pane. */
+  min-height: 0;
+  overflow-y: auto;
+  padding: 14px 18px 18px;
 }
 
 .repos-grid {
@@ -55,12 +30,49 @@
   gap: 12px;
 }
 
+.code-runs-dock {
+  flex: 0 0 auto;
+  /* Cap the dock so an expanded xterm can't starve the repo list. The
+   * inner scroller takes over once content exceeds the cap. */
+  max-height: 50%;
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
+  padding: 10px 18px 14px;
+}
+
+/* Empty when no sessions — keeps zero footprint via the inner <Show>. */
+.code-runs-dock:empty {
+  display: none;
+}
+
 .code-runs {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding-bottom: 6px;
-  border-bottom: 1px solid var(--border);
+}
+
+.code-runs-header {
+  margin: 0 0 6px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--font-ui);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.code-runs-header .name {
+  color: var(--text);
+}
+
+.code-runs-header .count {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
+  color: var(--text-faint);
 }
 
 .code-runs-list {

--- a/src/renderer/panes/code.tsx
+++ b/src/renderer/panes/code.tsx
@@ -19,8 +19,6 @@ import { usePaneScrollMemory } from './pane-scroll-memory';
 
 type RepoStatus = 'missing' | 'unknown' | 'clean' | 'dirty';
 
-export type RepoGroup = { id: string; label: string; entries: RepoEntry[] };
-
 const LAUNCHER_SLOTS: readonly OpenWithSlotKey[] = ['main_ide', 'secondary_ide', 'terminal'];
 const LAUNCHER_GLYPH: Record<OpenWithSlotKey, string> = {
   main_ide: '⌘',
@@ -28,7 +26,10 @@ const LAUNCHER_GLYPH: Record<OpenWithSlotKey, string> = {
   terminal: '▶',
 };
 
-export function groupRepos(repos: readonly RepoEntry[]): RepoGroup[] {
+/** Flatten the configured repo list into one ordered card sequence, with each
+ *  submodule parent immediately followed by its children. Top-level entries
+ *  with no children pass through in declaration order. */
+export function orderedRepos(repos: readonly RepoEntry[]): RepoEntry[] {
   const childrenByParent = new Map<string, RepoEntry[]>();
   for (const r of repos) {
     if (!r.parent) continue;
@@ -36,32 +37,14 @@ export function groupRepos(repos: readonly RepoEntry[]): RepoGroup[] {
     arr.push(r);
     childrenByParent.set(r.parent, arr);
   }
-  const primary: RepoEntry[] = [];
-  const secondary: RepoEntry[] = [];
-  const submoduleParents: { parent: RepoEntry; children: RepoEntry[] }[] = [];
+  const out: RepoEntry[] = [];
   for (const r of repos) {
     if (r.parent) continue;
+    out.push(r);
     const kids = childrenByParent.get(r.name);
-    if (kids && kids.length > 0) {
-      submoduleParents.push({ parent: r, children: kids });
-    } else if (r.kind === 'primary') {
-      primary.push(r);
-    } else {
-      secondary.push(r);
-    }
+    if (kids) out.push(...kids);
   }
-  const groups: RepoGroup[] = [];
-  if (primary.length > 0) groups.push({ id: 'primary', label: 'PRIMARY', entries: primary });
-  for (const { parent, children } of submoduleParents) {
-    groups.push({
-      id: parent.name,
-      label: parent.name.toUpperCase(),
-      entries: [parent, ...children],
-    });
-  }
-  if (secondary.length > 0)
-    groups.push({ id: 'secondary', label: 'SECONDARY', entries: secondary });
-  return groups;
+  return out;
 }
 
 /** Synthesise the primary checkout as a Worktree-shaped row when the data
@@ -166,10 +149,7 @@ export function RepoRow(props: {
         </Show>
         <span class="spacer" />
         <Show when={props.repo.parent}>
-          <span
-            class="repo-kind-tag"
-            title={`Submodule, configured under repositories.${props.repo.kind}`}
-          >
+          <span class="repo-kind-tag" title="Submodule, configured under repositories">
             submodule
           </span>
         </Show>
@@ -670,12 +650,11 @@ function BranchInfoBadges(props: { worktree: Worktree; subtreeScoped: boolean })
   );
 }
 
-/** Top-level Code-pane view. Renders one section per group (PRIMARY,
- *  per-submodule parents, SECONDARY) with the repo cards and any inline
- *  CodeRunRow sessions slotted under their owning group. */
+/** Top-level Code-pane view. Renders one flat grid of repo cards in a
+ *  scrollable top region, with ACTIVE RUNS pinned at the bottom so the
+ *  live-process list never scrolls out of view. */
 export function CodeView(props: {
   repos: readonly RepoEntry[];
-  groups: readonly RepoGroup[];
   slots: OpenWithSlots;
   liveRepos: ReadonlySet<string>;
   liveSessionCwds: ReadonlyMap<string, string>;
@@ -689,73 +668,65 @@ export function CodeView(props: {
   onOpenInTerm: (repo: RepoEntry, worktree: Worktree) => void;
   onCloseSession: (id: string) => void;
 }) {
+  // Pane scroll memory binds to the inner scroller so position survives
+  // pane switches; the outer .repos-pane is no longer the scrolling box.
   const scrollRef = usePaneScrollMemory('code');
+  const ordered = createMemo<readonly RepoEntry[]>(() => orderedRepos(props.repos));
+  // Sort active runs to mirror the on-screen repo card order — sessions for
+  // the topmost card come first, regardless of when they were spawned.
+  // Memoised so a parent re-render doesn't re-allocate the array on every
+  // pass and force every <CodeRunRow> to remount.
+  const dockSessions = createMemo<readonly TermSession[]>(() => {
+    const order = new Map(ordered().map((r, i) => [r.name, i]));
+    return props.codeRunSessions.slice().sort((a, b) => {
+      const ai = a.repo ? (order.get(a.repo) ?? Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER;
+      const bi = b.repo ? (order.get(b.repo) ?? Number.MAX_SAFE_INTEGER) : Number.MAX_SAFE_INTEGER;
+      return ai - bi;
+    });
+  });
   return (
-    <div class="repos-pane" ref={scrollRef}>
-      <For each={props.groups}>
-        {(group) => {
-          // Active runs for this group only, sorted to mirror the section's
-          // repo order so what's running for "condash" appears below the
-          // "condash" card and so on. Memoised so a parent re-render (e.g.
-          // a layout signal change) doesn't re-allocate the filtered+sorted
-          // array on every pass — without the memo, <For> below remounts
-          // every CodeRunRow on every render.
-          const groupSessions = createMemo<readonly TermSession[]>(() => {
-            const order = new Map(group.entries.map((e, i) => [e.name, i]));
-            return props.codeRunSessions
-              .filter((s) => s.repo && order.has(s.repo))
-              .slice()
-              .sort((a, b) => (order.get(a.repo!) ?? 0) - (order.get(b.repo!) ?? 0));
-          });
-          return (
-            <section class="repos-group" data-group={group.id}>
-              <h2 class="repos-group-header">
-                <span class="name">{group.label}</span>
-                <span class="count">{group.entries.length}</span>
-                <span class="rule" />
-              </h2>
-              <div class="repos-grid">
-                <For each={group.entries}>
-                  {(repo) => {
-                    const liveBranch = (): string | null => {
-                      const cwd = props.liveSessionCwds.get(repo.name);
-                      if (!cwd) return null;
-                      const wt = (repo.worktrees ?? []).find((w) => w.path === cwd);
-                      if (wt) return wt.branch ?? '(no branch)';
-                      // Fallback: cwd matches the repo's primary path.
-                      if (cwd === repo.path) {
-                        const primary = (repo.worktrees ?? []).find((w) => w.primary);
-                        return primary?.branch ?? null;
-                      }
-                      return null;
-                    };
-                    return (
-                      <RepoRow
-                        repo={repo}
-                        slots={props.slots}
-                        live={props.liveRepos.has(repo.name)}
-                        liveBranch={liveBranch()}
-                        onOpen={props.onOpen}
-                        onLaunch={props.onLaunch}
-                        onForceStop={props.onForceStop}
-                        onStop={props.onStop}
-                        onRun={props.onRun}
-                        onOpenInTerm={props.onOpenInTerm}
-                      />
-                    );
-                  }}
-                </For>
-              </div>
-              <CodeRunRows
-                sessions={groupSessions()}
-                repos={props.repos}
-                xtermPrefs={props.xtermPrefs}
-                onClose={props.onCloseSession}
-              />
-            </section>
-          );
-        }}
-      </For>
+    <div class="repos-pane">
+      <div class="repos-pane-scroll" ref={scrollRef}>
+        <div class="repos-grid">
+          <For each={ordered()}>
+            {(repo) => {
+              const liveBranch = (): string | null => {
+                const cwd = props.liveSessionCwds.get(repo.name);
+                if (!cwd) return null;
+                const wt = (repo.worktrees ?? []).find((w) => w.path === cwd);
+                if (wt) return wt.branch ?? '(no branch)';
+                if (cwd === repo.path) {
+                  const primary = (repo.worktrees ?? []).find((w) => w.primary);
+                  return primary?.branch ?? null;
+                }
+                return null;
+              };
+              return (
+                <RepoRow
+                  repo={repo}
+                  slots={props.slots}
+                  live={props.liveRepos.has(repo.name)}
+                  liveBranch={liveBranch()}
+                  onOpen={props.onOpen}
+                  onLaunch={props.onLaunch}
+                  onForceStop={props.onForceStop}
+                  onStop={props.onStop}
+                  onRun={props.onRun}
+                  onOpenInTerm={props.onOpenInTerm}
+                />
+              );
+            }}
+          </For>
+        </div>
+      </div>
+      <div class="code-runs-dock">
+        <CodeRunRows
+          sessions={dockSessions()}
+          repos={props.repos}
+          xtermPrefs={props.xtermPrefs}
+          onClose={props.onCloseSession}
+        />
+      </div>
     </div>
   );
 }

--- a/src/renderer/panes/knowledge-pane.css
+++ b/src/renderer/panes/knowledge-pane.css
@@ -9,7 +9,7 @@
 }
 
 /* Section header — same capsule + count + rule treatment used by the
- * Code-pane `.repos-group-header` so the three panes share one chrome
+ * Code-pane `.code-runs-header` so the three panes share one chrome
  * vocabulary. Defined locally here (rather than promoted to a shared
  * class) to keep pane-CSS changes scoped. The optional [INDEX] button
  * sits between the count and the rule. */

--- a/src/renderer/repo-events.ts
+++ b/src/renderer/repo-events.ts
@@ -7,8 +7,8 @@
  *   - **Scalar** (`repo-dirty`, `repo-upstream`): path-shaped `setRepos`
  *     writes. Only the cells actually read by a component re-evaluate —
  *     the top-level array reference and unaffected rows stay stable, so
- *     whole-list readers (e.g. `repoGroups`) don't re-run on a single
- *     dirty tick.
+ *     whole-list readers (e.g. the Code-pane `orderedRepos` memo) don't
+ *     re-run on a single dirty tick.
  *
  *   - **Set membership** (`repo-worktrees-changed`): the worktree list
  *     for a primary changed (worktree add/remove) or its checkout

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -170,7 +170,7 @@ export interface RawConfig {
   worktrees_path?: string;
   resources_path?: string;
   skills_path?: string;
-  repositories?: { primary?: RawRepo[]; secondary?: RawRepo[] };
+  repositories?: RawRepo[];
   open_with?: Record<string, { label?: string; command?: string }>;
 }
 

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -170,11 +170,8 @@ export function SettingsModal(props: {
     }
     mutator(parsedConfig);
     const pruned = pruneEmpty(parsedConfig) as RawConfig;
-    if (pruned.repositories?.primary) {
-      pruned.repositories.primary = compactRepos(pruned.repositories.primary);
-    }
-    if (pruned.repositories?.secondary) {
-      pruned.repositories.secondary = compactRepos(pruned.repositories.secondary);
+    if (pruned.repositories) {
+      pruned.repositories = compactRepos(pruned.repositories);
     }
     const next = JSON.stringify(pruned, null, 2) + '\n';
     if (next === text) return;
@@ -296,32 +293,21 @@ export function SettingsModal(props: {
 
   // --- Repositories ----------------------------------------------------
 
-  type RepoBucket = 'primary' | 'secondary';
+  const repos = (): RawRepo[] => parsed().repositories ?? [];
 
-  const repos = (bucket: RepoBucket): RawRepo[] => parsed().repositories?.[bucket] ?? [];
-
-  const updateRepos = (
-    bucket: RepoBucket,
-    mutate: (entries: RawRepo[]) => RawRepo[],
-  ): Promise<void> =>
+  const updateRepos = (mutate: (entries: RawRepo[]) => RawRepo[]): Promise<void> =>
     patchConfig((c) => {
-      const repositories = (c.repositories ?? {}) as {
-        primary?: RawRepo[];
-        secondary?: RawRepo[];
-      };
-      const current = (repositories[bucket] ?? []).slice();
-      repositories[bucket] = mutate(current);
-      c.repositories = repositories;
+      const current = (c.repositories ?? []).slice();
+      c.repositories = mutate(current);
     });
 
-  const addRepo = (bucket: RepoBucket): Promise<void> =>
-    updateRepos(bucket, (entries) => [...entries, { name: '' }]);
+  const addRepo = (): Promise<void> => updateRepos((entries) => [...entries, { name: '' }]);
 
-  const removeRepo = (bucket: RepoBucket, index: number): Promise<void> =>
-    updateRepos(bucket, (entries) => entries.filter((_, i) => i !== index));
+  const removeRepo = (index: number): Promise<void> =>
+    updateRepos((entries) => entries.filter((_, i) => i !== index));
 
-  const moveRepo = (bucket: RepoBucket, index: number, delta: -1 | 1): Promise<void> =>
-    updateRepos(bucket, (entries) => {
+  const moveRepo = (index: number, delta: -1 | 1): Promise<void> =>
+    updateRepos((entries) => {
       const target = index + delta;
       if (target < 0 || target >= entries.length) return entries;
       const next = entries.slice();
@@ -330,12 +316,8 @@ export function SettingsModal(props: {
       return next;
     });
 
-  const updateRepoEntry = (
-    bucket: RepoBucket,
-    index: number,
-    patch: (entry: RawRepo) => RawRepo,
-  ): Promise<void> =>
-    updateRepos(bucket, (entries) => entries.map((e, i) => (i === index ? patch(e) : e)));
+  const updateRepoEntry = (index: number, patch: (entry: RawRepo) => RawRepo): Promise<void> =>
+    updateRepos((entries) => entries.map((e, i) => (i === index ? patch(e) : e)));
 
   // --- Open with -------------------------------------------------------
 
@@ -919,32 +901,27 @@ export function SettingsModal(props: {
                 <code>submodules</code>. <code>env</code> lists files copied from the primary into a
                 new worktree on <code>condash worktrees setup</code>.
               </p>
-              <For each={['primary', 'secondary'] as const}>
-                {(bucket) => (
-                  <div class="settings-bucket">
-                    <h3>{bucket === 'primary' ? 'Primary' : 'Secondary'}</h3>
-                    <For each={repos(bucket)}>
-                      {(entry, index) => (
-                        <RepoRow
-                          entry={entry}
-                          idPrefix={`repo.${bucket}[${index()}]`}
-                          index={index()}
-                          total={repos(bucket).length}
-                          bindText={bindText}
-                          onMove={(delta) => void moveRepo(bucket, index(), delta)}
-                          onRemove={() => void removeRepo(bucket, index())}
-                          onPatch={(next) => updateRepoEntry(bucket, index(), () => next)}
-                        />
-                      )}
-                    </For>
-                    <div class="settings-list-actions">
-                      <button class="modal-button" onClick={() => void addRepo(bucket)}>
-                        + Add repo
-                      </button>
-                    </div>
-                  </div>
-                )}
-              </For>
+              <div class="settings-bucket">
+                <For each={repos()}>
+                  {(entry, index) => (
+                    <RepoRow
+                      entry={entry}
+                      idPrefix={`repo[${index()}]`}
+                      index={index()}
+                      total={repos().length}
+                      bindText={bindText}
+                      onMove={(delta) => void moveRepo(index(), delta)}
+                      onRemove={() => void removeRepo(index())}
+                      onPatch={(next) => updateRepoEntry(index(), () => next)}
+                    />
+                  )}
+                </For>
+                <div class="settings-list-actions">
+                  <button class="modal-button" onClick={() => void addRepo()}>
+                    + Add repo
+                  </button>
+                </div>
+              </div>
             </section>
 
             {/* Open with ----------------------------------------------- */}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -266,8 +266,6 @@ export interface RepoEntry {
   label?: string;
   /** Absolute path on disk. */
   path: string;
-  /** primary | secondary — matches the configuration.json layout. */
-  kind: 'primary' | 'secondary';
   /** When set, this entry is a submodule of the named parent repo. */
   parent?: string;
   /** Count of modified+staged+untracked files; null if git status couldn't run. */

--- a/tests/fixtures/conception-demo/configuration.json
+++ b/tests/fixtures/conception-demo/configuration.json
@@ -2,21 +2,18 @@
   "$schema_doc": "Demo conception fixture for the screenshot harness. Values are plausible but pointed at /tmp so nothing here touches real repos.",
   "workspace_path": "/tmp/conception-demo-workspace",
   "worktrees_path": "/tmp/conception-demo-worktrees",
-  "repositories": {
-    "primary": [
-      {
-        "name": "helio",
-        "run": "cargo watch -x 'run -- serve'",
-        "submodules": [
-          { "name": "crates/parser" },
-          { "name": "crates/search", "run": "cargo watch -p search -x test" }
-        ]
-      },
-      { "name": "helio-web", "run": "npm run dev" },
-      "helio-docs"
-    ],
-    "secondary": []
-  },
+  "repositories": [
+    {
+      "name": "helio",
+      "run": "cargo watch -x 'run -- serve'",
+      "submodules": [
+        { "name": "crates/parser" },
+        { "name": "crates/search", "run": "cargo watch -p search -x test" }
+      ]
+    },
+    { "name": "helio-web", "run": "npm run dev" },
+    "helio-docs"
+  ],
   "open_with": {
     "main_ide": { "label": "Open in main IDE", "command": "idea {path}" },
     "secondary_ide": { "label": "Open in secondary IDE", "command": "code {path}" },

--- a/tests/runner-fire.spec.ts
+++ b/tests/runner-fire.spec.ts
@@ -5,13 +5,11 @@ test('Run on a configured repo spawns the run: command and emits its output', as
   const booted = await bootApp({
     extraConfig: {
       workspace_path: '/tmp',
-      repositories: {
-        // `echo` exits immediately; once the renderer's TerminalPane sees
-        // term.exit it auto-closes the tab via termClose, and termAttach
-        // then returns null because the session is gone. Trail with
-        // `sleep 5` so the pty is alive while the test polls for output.
-        primary: [{ name: '.', run: 'echo hi-from-runner; sleep 5' }],
-      },
+      // `echo` exits immediately; once the renderer's TerminalPane sees
+      // term.exit it auto-closes the tab via termClose, and termAttach
+      // then returns null because the session is gone. Trail with
+      // `sleep 5` so the pty is alive while the test polls for output.
+      repositories: [{ name: '.', run: 'echo hi-from-runner; sleep 5' }],
     },
   });
   try {
@@ -68,12 +66,10 @@ test('termClose tears down the process tree (parity-batch-7 Stop pipeline)', asy
   const booted = await bootApp({
     extraConfig: {
       workspace_path: '/tmp',
-      repositories: {
-        // `exec sleep 30` makes the pid we print *become* the sleep process —
-        // so if the kill only reaches the wrapping bash and not its child,
-        // the test harness will still see this pid alive after termClose.
-        primary: [{ name: '.', run: 'echo PID:$$; exec sleep 30' }],
-      },
+      // `exec sleep 30` makes the pid we print *become* the sleep process —
+      // so if the kill only reaches the wrapping bash and not its child,
+      // the test harness will still see this pid alive after termClose.
+      repositories: [{ name: '.', run: 'echo PID:$$; exec sleep 30' }],
     },
   });
   try {
@@ -105,9 +101,7 @@ test('spawning a second run for the same repo replaces the first', async () => {
   const booted = await bootApp({
     extraConfig: {
       workspace_path: '/tmp',
-      repositories: {
-        primary: [{ name: '.', run: 'echo PID:$$; exec sleep 30' }],
-      },
+      repositories: [{ name: '.', run: 'echo PID:$$; exec sleep 30' }],
     },
   });
   try {

--- a/tests/worktree-reload.spec.ts
+++ b/tests/worktree-reload.spec.ts
@@ -39,9 +39,7 @@ test('Code panel reflects git worktree add/remove without manual refresh', async
     extraConfig: {
       workspace_path: workspaceDir,
       worktrees_path: worktreeRoot,
-      repositories: {
-        primary: ['demo-repo'],
-      },
+      repositories: ['demo-repo'],
     },
   });
 


### PR DESCRIPTION
## Summary

- Flatten `repositories` in `configuration.json` to a single ordered array. The `primary` / `secondary` buckets and `RepoEntry.kind` are gone; cards render in declaration order with submodule parents immediately followed by their children.
- Split the Code pane into a scrollable repo grid on top and a pinned ACTIVE RUNS dock at the bottom. The dock is capped at 50% of pane height with internal scroll, so an expanded xterm can't starve the repo list. Sessions in the dock are sorted to mirror the repo card order.
- Drop the per-group `<CodeRunRows>`. There is now one global ACTIVE RUNS section, fed by the full `codeRunSessions` collection. The repo card's existing live-branch indicator continues to signal "running" in-context.

## Why

Active runs were sandwiched between repo groups. As more groups (PAINTINGMANAGER, etc.) were added, the running session could scroll out of view — defeating the live-status indicator. The PRIMARY / SECONDARY headers themselves added visual weight without the user gaining anything (every card is self-labelled).

Conception side: `configuration.json`, `configuration.yml`, and `CLAUDE.md` migrated in [conception@be590f8](https://github.com/vcoeur/conception/commit/be590f8); committed before this branch ships so condash boots cleanly post-upgrade.

## Schema migration

```diff
- "repositories": {
-   "primary": ["foo", { "name": "bar", "run": "make dev" }],
-   "secondary": ["baz"]
- }
+ "repositories": [
+   "foo",
+   { "name": "bar", "run": "make dev" },
+   "baz"
+ ]
```

The schema is strict — old-shape configs are rejected at validation. Bump `configuration.json` in any conception tree before installing v2.12.0.

## Test plan

- [x] `make typecheck` — clean
- [x] `make format` — clean
- [x] Vitest schema tests — 11/11 pass, including a new test that rejects the legacy bucket shape
- [x] Playwright tests for `worktree-reload` + `runner-fire` (the only Playwright tests touching `repositories` config) — 4/4 pass
- [x] CLI smoke: `condash repos list` reads the flat conception config and emits all 11 repos in declaration order with submodules adjacent to their parents
- [ ] Manual UI smoke (open the dashboard, scroll the Code pane with at least one active run) — not run from the CI sandbox; left for the user to verify on local launch

## Notes

- `condash-tauri` (parallel Rust build) reads `configuration.yml` against its own Rust schema — that twin will need a follow-up to accept the new shape.
- 7 unrelated test failures on `dirty-badge`, `help-loader`, and `resources-skills` predate this branch (sandbox path validator, stale help-doc whitelist, skills shipped-chip) — none touch the `repositories` config.

## Design

Full rationale, alternatives considered, and answered design questions in [`projects/2026-05/2026-05-08-condash-dock-active-runs/notes/01-design.md`](https://github.com/vcoeur/conception/blob/main/projects/2026-05/2026-05-08-condash-dock-active-runs/notes/01-design.md).