### PR TITLE
Tighten tree-view ergonomics; surface CLAUDE.md in Skills

### DIFF
--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -7,7 +7,9 @@ The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the
 
 ## What it shows
 
-By default the pane reads from `<conception>/.claude/skills/`. Each directory under the root is treated as a skill — its `SKILL.md` is highlighted as the section index, and its body files (`create.md`, `update.md`, `index.md`, …) render as cards inside that section. The walker recurses to any depth, so nested helper directories render as their own sections.
+By default the pane reads from `<conception>/.claude/skills/`. Each directory under the root is treated as a skill — its `SKILL.md` is rendered as a badged callout at the top of the directory's expanded body (just below the directory header), and its body files (`create.md`, `update.md`, `index.md`, …) render as cards underneath. The walker recurses to any depth, so nested helper directories render as their own sections.
+
+The pane also surfaces the conception's `CLAUDE.md` files — `<conception>/CLAUDE.md` and `<conception>/.claude/CLAUDE.md` — as top-level entries with a `CLAUDE` badge, alongside the regular skill directories. They open in the same note modal as everything else.
 
 Only `.md` files are surfaced — non-markdown files in a skill directory are ignored.
 
@@ -19,8 +21,8 @@ Click any card to open the file in the note modal — the same editor used elsew
 
 Skills installed by `condash skills install` are tracked in `<skills_path>/.condash-skills.json`. The pane uses this manifest to flag two states:
 
-- **shipped** — the on-disk content matches the version condash shipped. Cards display a `shipped` chip; `SKILL.md` carries the same flag on its section badge.
-- **shipped · diverged** — the file is shipped but locally edited. Cards display an amber `shipped · diverged` chip; the section badge for `SKILL.md` switches to amber. Opening the file shows a banner: *"Shipped by condash, but locally edited. Running `condash skills install` will flag this divergence."*
+- **shipped** — the on-disk content matches the version condash shipped. Cards display a `shipped` chip; the `SKILL` callout carries the same flag.
+- **shipped · diverged** — the file is shipped but locally edited. Cards display an amber `shipped · diverged` chip; the `SKILL` callout switches to amber. Opening the file shows a banner: *"Shipped by condash, but locally edited. Running `condash skills install` will flag this divergence."*
 
 The flags are informational only — local edits are never blocked. They exist so a quick scan tells you where your customisations are and warns you before an upstream re-install reverts them.
 

--- a/src/main/skills.test.ts
+++ b/src/main/skills.test.ts
@@ -104,4 +104,25 @@ describe('readSkillsTree', () => {
     const skill = tree.children?.[0]?.children?.find((c) => c.name === 'SKILL.md');
     expect(skill?.shipped).toBeUndefined();
   });
+
+  it('injects synthetic CLAUDE.md entries when present at the conception root', async () => {
+    setupSkills();
+    writeFileSync(join(tmp, 'CLAUDE.md'), '# Project CLAUDE\n\nProject-level rules.\n');
+    writeFileSync(join(tmp, '.claude', 'CLAUDE.md'), '# Inner CLAUDE\n\nClaude-dir rules.\n');
+    const tree = (await readSkillsTree(tmp, '.claude/skills'))!;
+    const claude = (tree.children ?? []).filter((c) => c.name === 'CLAUDE.md');
+    // Both candidates surface, in stable order (root first, then `.claude/`).
+    expect(claude.length).toBe(2);
+    expect(claude[0]?.title).toBe('Project CLAUDE');
+    expect(claude[0]?.path).toContain('CLAUDE.md');
+    expect(claude[0]?.relPath.startsWith('__claude__/')).toBe(true);
+    expect(claude[1]?.title).toBe('Inner CLAUDE');
+  });
+
+  it('skips CLAUDE.md when neither location exists', async () => {
+    setupSkills();
+    const tree = (await readSkillsTree(tmp, '.claude/skills'))!;
+    const claude = (tree.children ?? []).filter((c) => c.name === 'CLAUDE.md');
+    expect(claude.length).toBe(0);
+  });
 });

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -13,6 +13,15 @@ const HIDDEN_PREFIX = /^\./;
  * Knowledge (recursive, only `.md` surfaced) plus an optional `shipped`
  * stamp on files tracked by `.condash-skills.json`. Symlink loops are
  * deduped via realpath.
+ *
+ * Also injects synthetic root-level entries for the conception's
+ * `CLAUDE.md` (root) and `.claude/CLAUDE.md`, when present. Those files
+ * sit outside the skills directory but are surfaced here because they
+ * carry the same kind of agent-instruction content as `SKILL.md` and
+ * the user expects to reach them from the Skills pane. Each synthetic
+ * entry is a `kind: 'file'` SkillNode with `name === 'CLAUDE.md'`; the
+ * renderer detects that name to render a "CLAUDE" badge instead of the
+ * usual skill-card layout.
  */
 export async function readSkillsTree(
   conceptionPath: string,
@@ -25,7 +34,49 @@ export async function readSkillsTree(
     return null;
   }
   const shipped = await buildShippedLookup(root);
-  return walk(root, '', basename(skillsRelPath) || 'skills', new Set<string>(), shipped, root);
+  const tree = await walk(
+    root,
+    '',
+    basename(skillsRelPath) || 'skills',
+    new Set<string>(),
+    shipped,
+    root,
+  );
+  const claudeEntries = await readConceptionClaudeMd(conceptionPath);
+  if (claudeEntries.length > 0) {
+    tree.children = [...claudeEntries, ...(tree.children ?? [])];
+  }
+  return tree;
+}
+
+/** Probe `<conceptionPath>/CLAUDE.md` and `<conceptionPath>/.claude/CLAUDE.md`
+ *  and return synthetic SkillNode entries for whichever exist. The synthetic
+ *  `relPath` is sentinel-prefixed (`__claude__/...`) so it can't collide with
+ *  any real path inside the skills tree. */
+async function readConceptionClaudeMd(conceptionPath: string): Promise<SkillNode[]> {
+  const candidates: Array<{ rel: string; abs: string }> = [
+    { rel: '__claude__/CLAUDE.md', abs: join(conceptionPath, 'CLAUDE.md') },
+    { rel: '__claude__/.claude/CLAUDE.md', abs: join(conceptionPath, '.claude', 'CLAUDE.md') },
+  ];
+  const found: SkillNode[] = [];
+  for (const { rel, abs } of candidates) {
+    try {
+      const stat = await fs.stat(abs);
+      if (!stat.isFile()) continue;
+    } catch {
+      continue;
+    }
+    const meta = await readMarkdownMeta(abs, 'CLAUDE.md');
+    found.push({
+      relPath: rel,
+      path: toPosix(abs),
+      name: 'CLAUDE.md',
+      title: meta.title,
+      kind: 'file',
+      summary: meta.summary,
+    });
+  }
+  return found;
 }
 
 async function walk(

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -59,12 +59,16 @@ export async function setWatchedConception(conceptionPath: string | null): Promi
   // set. `skills_path` defaults to `.claude/skills`, which would normally
   // be filtered out — bypass the rule for paths under the configured
   // skills/resources roots so a `.claude/skills/foo.md` change still fires.
+  // The same bypass covers `<conception>/.claude/CLAUDE.md`, which is
+  // surfaced in the Skills pane as a synthetic root entry.
+  const claudeDot = toPosix(join(conceptionPath, '.claude', 'CLAUDE.md'));
   const ignored = (path: string): boolean => {
     if (NODE_MODULES_RE.test(path) || DIST_RE.test(path) || TARGET_RE.test(path)) return true;
     if (!DOTFILE_SEGMENT_RE.test(path)) return false;
     const posix = toPosix(path);
     if (posix === roots.resources || posix.startsWith(`${roots.resources}/`)) return false;
     if (posix === roots.skills || posix.startsWith(`${roots.skills}/`)) return false;
+    if (posix === claudeDot) return false;
     return true;
   };
 
@@ -76,6 +80,11 @@ export async function setWatchedConception(conceptionPath: string | null): Promi
       join(conceptionPath, skills),
       join(conceptionPath, 'configuration.json'),
       join(conceptionPath, 'configuration.yml'),
+      // Conception-level CLAUDE.md (root and `.claude/`). Surfaced as
+      // synthetic skill entries so the Skills pane can open them — they
+      // need to repaint the pane on edit, hence the explicit watches.
+      join(conceptionPath, 'CLAUDE.md'),
+      join(conceptionPath, '.claude', 'CLAUDE.md'),
     ],
     {
       ignored,
@@ -155,6 +164,15 @@ function classify(
   const configYml = toPosix(join(conception, 'configuration.yml'));
   if (pathP === configJson || pathP === configYml) {
     return { kind: 'config', path };
+  }
+
+  // Conception-level CLAUDE.md surfaces in the Skills pane as a
+  // synthetic entry — route changes through the `skills` event so
+  // the pane refetches and the synthetic entry repaints.
+  const claudeRoot = toPosix(join(conception, 'CLAUDE.md'));
+  const claudeDot = toPosix(join(conception, '.claude', 'CLAUDE.md'));
+  if (pathP === claudeRoot || pathP === claudeDot) {
+    return { kind: 'skills', op, path };
   }
 
   // Project README: <conception>/projects/<month>/<slug>/README.md

--- a/src/renderer/panes/code-pane.css
+++ b/src/renderer/panes/code-pane.css
@@ -114,7 +114,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 14px 12px 18px;
+  padding: 5px 10px 5px 14px;
   cursor: pointer;
   user-select: none;
   font-family: var(--font-ui);
@@ -143,7 +143,7 @@
 
 .code-run-head .repo {
   font-weight: 600;
-  font-size: 14px;
+  font-size: 13px;
   letter-spacing: -0.005em;
   color: var(--text);
 }

--- a/src/renderer/panes/knowledge-pane.css
+++ b/src/renderer/panes/knowledge-pane.css
@@ -37,29 +37,28 @@
   color: var(--text-faint);
 }
 
-/* INDEX badge — opens the section's directory index.md. Uses the global
- * accent so it pops against the muted section header without competing
- * with the Code-pane pink/orange semantic palette. */
-.knowledge-section-index {
-  font: inherit;
-  font-family: var(--font-ui);
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.18em;
+/* INDEX special-file row — the dir's `index.md` rendered as the first
+ * card inside the dir's expanded body, with a colour-coded badge that
+ * mirrors the per-bucket stripe used on regular knowledge cards. */
+.knowledge-special-file {
   color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
-  padding: 1px 7px;
-  border-radius: 3px;
-  cursor: pointer;
-  transition:
-    background 100ms ease,
-    border-color 100ms ease;
 }
 
-.knowledge-section-index:hover {
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
-  border-color: var(--accent);
+.knowledge-special-file[data-bucket='general'] {
+  color: var(--col-soon);
+}
+.knowledge-special-file[data-bucket='internal'] {
+  color: var(--col-review);
+}
+.knowledge-special-file[data-bucket='topics'] {
+  color: var(--col-later);
+}
+.knowledge-special-file[data-bucket='external'] {
+  color: var(--col-backlog);
+}
+
+.knowledge-special-file .tree-special-meta[data-fresh='old'] {
+  color: var(--warn);
 }
 
 .knowledge-section-header .rule {

--- a/src/renderer/panes/knowledge.tsx
+++ b/src/renderer/panes/knowledge.tsx
@@ -42,16 +42,6 @@ function isKnowledgeIndex(node: KnowledgeNode): boolean {
   return node.kind === 'file' && node.name.toLowerCase() === 'index.md';
 }
 
-/** Return the directory's `index.md` child (case-insensitive on the
- *  filename), if any. Surfaced as the `[INDEX]` badge on the dir header
- *  and dropped from the file list so it doesn't double up as a card. */
-function findIndexChild(node: KnowledgeNode): KnowledgeNode | undefined {
-  for (const child of node.children ?? []) {
-    if (isKnowledgeIndex(child)) return child;
-  }
-  return undefined;
-}
-
 export function KnowledgeView(props: {
   root: KnowledgeNode;
   onOpen: (path: string, title?: string) => void;
@@ -77,23 +67,30 @@ export function KnowledgeView(props: {
         prompts={props.prompts}
         onAfterMutation={props.onAfterMutation}
         onError={props.onError}
-        skipFile={isKnowledgeIndex}
-        renderDirSuffix={(dir) => (
-          <Show when={findIndexChild(dir)}>
-            {(idx) => (
-              <button
-                type="button"
-                class="knowledge-section-index"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  props.onOpen(idx().path, idx().title);
-                }}
-                title={`Open ${dir.relPath || 'knowledge'} index`}
+        specialFile={(file) => isKnowledgeIndex(file)}
+        renderSpecialFile={(file, dir) => (
+          <button
+            type="button"
+            class="tree-special-file knowledge-special-file"
+            data-bucket={bucketOf(dir.relPath)}
+            onClick={(e) => {
+              e.stopPropagation();
+              props.onOpen(file.path, file.title);
+            }}
+            title={`Open ${dir.relPath || 'knowledge'} index`}
+          >
+            <span class="tree-special-badge">INDEX</span>
+            <span class="tree-special-title">{file.title}</span>
+            <Show when={file.verifiedAt}>
+              <span
+                class="tree-special-meta"
+                data-fresh={freshnessOf(file.verifiedAt, todayISO)}
+                title={`Verified ${file.verifiedAt}`}
               >
-                INDEX
-              </button>
-            )}
-          </Show>
+                {file.verifiedAt}
+              </span>
+            </Show>
+          </button>
         )}
         renderFile={(file) => (
           <KnowledgeCard

--- a/src/renderer/panes/skills-pane.css
+++ b/src/renderer/panes/skills-pane.css
@@ -36,43 +36,29 @@
   background: var(--border-subtle);
 }
 
-.skills-section-index {
-  font-size: 9.5px;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  padding: 2px 6px;
-  border-radius: 999px;
-  border: 1px solid var(--accent);
-  color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  cursor: pointer;
-  transition: background 100ms;
-}
-
-.skills-section-index:hover {
-  background: color-mix(in srgb, var(--accent) 22%, transparent);
-}
-
-.skills-section-index:focus-visible,
 .skills-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 1px;
 }
 
-.skills-section-index .shipped-tag {
-  font-weight: 500;
-  opacity: 0.85;
-  margin-left: 4px;
+/* SKILL special-file row — the dir's `SKILL.md` rendered as the first
+ * card inside the dir's expanded body. Inherits the generic
+ * `.tree-special-file` chrome and supplies a SKILL-coloured badge,
+ * with a warn tint when the file diverges from the shipped manifest. */
+.skill-special-file {
+  color: var(--accent);
 }
 
-.skills-section-index.diverged {
-  border-color: var(--warn);
+.skill-special-file.diverged {
   color: var(--warn);
-  background: color-mix(in srgb, var(--warn) 12%, transparent);
 }
 
-.skills-section-index.diverged .shipped-tag {
-  opacity: 1;
+/* Conception-level CLAUDE.md surfaced at the skills root. Uses
+ * `--col-running` (pink) so it reads as "agent instructions, live
+ * context" rather than "shipped skill" — distinct from the SKILL row
+ * just below it. */
+.claude-special-file {
+  color: var(--col-running);
 }
 
 .skills-grid {

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -17,13 +17,11 @@ function isSkillIndex(node: SkillNode): boolean {
   return node.kind === 'file' && node.name === 'SKILL.md';
 }
 
-/** Pull the directory's `SKILL.md` so it can render as a `[SKILL]`
- *  badge on the directory header instead of as a separate card. */
-function findSkillIndex(node: SkillNode): SkillNode | undefined {
-  for (const child of node.children ?? []) {
-    if (isSkillIndex(child)) return child;
-  }
-  return undefined;
+/** Recognise a synthetic CLAUDE.md entry injected by the main-process
+ *  skills walker. Carries `name === 'CLAUDE.md'` and lives only at the
+ *  skills root (`relPath` starts with the `__claude__/` sentinel). */
+function isClaudeMd(node: SkillNode): boolean {
+  return node.kind === 'file' && node.name === 'CLAUDE.md';
 }
 
 export function SkillsView(props: {
@@ -84,46 +82,65 @@ export function SkillsView(props: {
             prompts={props.prompts}
             onAfterMutation={props.onAfterMutation}
             onError={props.onError}
-            skipFile={isSkillIndex}
-            renderDirSuffix={(dir) => (
-              <Show when={findSkillIndex(dir)}>
-                {(idx) => (
+            specialFile={(file, dir) => {
+              // Sub-directories surface their SKILL.md; the synthetic
+              // CLAUDE.md entries surface only at the root level.
+              if (dir.relPath === '') return isClaudeMd(file);
+              return isSkillIndex(file);
+            }}
+            renderSpecialFile={(file, dir) => {
+              if (isClaudeMd(file)) {
+                return (
                   <button
                     type="button"
-                    class="skills-section-index"
-                    classList={{
-                      shipped: !!idx().shipped,
-                      diverged: !!idx().shipped?.diverged,
-                    }}
+                    class="tree-special-file claude-special-file"
                     onClick={(e) => {
                       e.stopPropagation();
-                      props.onOpen(idx().path, idx().title, idx().shipped);
+                      props.onOpen(file.path, file.title, file.shipped);
                     }}
-                    aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
-                      idx().shipped?.diverged
-                        ? ' (shipped, locally edited)'
-                        : idx().shipped
-                          ? ' (shipped)'
-                          : ''
-                    }`}
-                    title={
-                      idx().shipped?.diverged
-                        ? 'SKILL.md (shipped, locally edited)'
-                        : idx().shipped
-                          ? 'SKILL.md (shipped)'
-                          : 'SKILL.md'
-                    }
+                    title={`Open ${file.path}`}
+                    aria-label={`Open ${file.path}`}
                   >
-                    SKILL
-                    <Show when={idx().shipped}>
-                      <span class="shipped-tag">
-                        {idx().shipped?.diverged ? ' · diverged' : ' · shipped'}
-                      </span>
-                    </Show>
+                    <span class="tree-special-badge">CLAUDE</span>
+                    <span class="tree-special-title">{file.title}</span>
+                    <span class="tree-special-meta">{file.relPath}</span>
                   </button>
-                )}
-              </Show>
-            )}
+                );
+              }
+              const shipped = file.shipped;
+              return (
+                <button
+                  type="button"
+                  class="tree-special-file skill-special-file"
+                  classList={{
+                    shipped: !!shipped,
+                    diverged: !!shipped?.diverged,
+                  }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    props.onOpen(file.path, file.title, shipped);
+                  }}
+                  aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
+                    shipped?.diverged ? ' (shipped, locally edited)' : shipped ? ' (shipped)' : ''
+                  }`}
+                  title={
+                    shipped?.diverged
+                      ? 'SKILL.md (shipped, locally edited)'
+                      : shipped
+                        ? 'SKILL.md (shipped)'
+                        : 'SKILL.md'
+                  }
+                >
+                  <span class="tree-special-badge">SKILL</span>
+                  <span class="tree-special-title">{file.title}</span>
+                  <Show when={shipped}>
+                    <span class="tree-special-meta">
+                      {shipped?.diverged ? 'diverged' : 'shipped'}
+                    </span>
+                  </Show>
+                </button>
+              );
+            }}
             renderFile={(file) => (
               <SkillCard
                 node={file}

--- a/src/renderer/panes/tree-view.css
+++ b/src/renderer/panes/tree-view.css
@@ -59,15 +59,24 @@
   text-transform: uppercase;
   color: var(--text-muted);
   cursor: default;
+  /* Pull the row taller so the whole strip is a comfortable hit area
+   * for the disclosure toggle (matches the bumped twisty size). */
+  min-height: 28px;
+  padding: 2px 0;
+  border-radius: 4px;
 }
 
-/* Make the whole header (except the buttons) act like the twisty so
- * users can click anywhere on the row to collapse/expand. The twisty
- * button still gets the keyboard focus. */
+/* The whole header row toggles the directory — match cursor + hover
+ * so the affordance reads as one big disclosure target. The twisty
+ * still gets keyboard focus. */
 .tree-dir-header[data-root='false'] {
   cursor: pointer;
 }
-.tree-dir-header[data-root='false']:hover .tree-dir-name {
+.tree-dir-header[data-root='false']:hover {
+  background: color-mix(in srgb, var(--text) 4%, transparent);
+}
+.tree-dir-header[data-root='false']:hover .tree-dir-name,
+.tree-dir-header[data-root='false']:hover .tree-dir-twisty {
   color: var(--text);
 }
 
@@ -75,15 +84,20 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 18px;
-  height: 18px;
+  /* Bumped from 18px → 24px so the chevron itself is a comfortable
+   * touch / mouse target, not just a fleck of glyph. */
+  width: 24px;
+  height: 24px;
   padding: 0;
   background: transparent;
   border: none;
-  color: var(--text-faint);
+  color: var(--text-muted);
   cursor: pointer;
-  border-radius: 3px;
-  transition: background 100ms ease;
+  border-radius: 4px;
+  transition:
+    background 100ms ease,
+    color 100ms ease;
+  flex-shrink: 0;
 }
 
 .tree-dir-twisty:hover:not(:disabled) {
@@ -98,7 +112,8 @@
 
 .tree-dir-twisty-glyph {
   display: inline-block;
-  font-size: 11px;
+  /* Larger chevron to match the bumped twisty hit area. */
+  font-size: 14px;
   line-height: 1;
   transition: transform 120ms ease;
 }
@@ -175,4 +190,70 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+/* Special-file slot — wraps the per-pane `renderSpecialFile` render
+ * (Knowledge `INDEX`, Skills `SKILL`, top-level `CLAUDE.md`). Sits as
+ * the first child inside the dir's expanded body, ahead of any nested
+ * directories or regular file cards. The pane stylesheets supply the
+ * actual badge look on `.tree-special-file`. */
+.tree-special {
+  display: flex;
+  flex-direction: column;
+}
+
+.tree-special-file {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px;
+  border: 1px solid var(--border-subtle, var(--border));
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  color: var(--text);
+  font-family: var(--font-ui);
+  font-size: 12.5px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 100ms ease;
+}
+
+.tree-special-file:hover {
+  border-color: var(--border-strong);
+}
+
+.tree-special-file:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+
+.tree-special-badge {
+  font-family: var(--font-ui);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  background: color-mix(in srgb, currentColor 12%, transparent);
+  text-transform: uppercase;
+  flex-shrink: 0;
+}
+
+.tree-special-title {
+  flex: 1;
+  font-weight: 600;
+  font-size: 12.5px;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tree-special-meta {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-muted);
+  font-weight: 500;
+  flex-shrink: 0;
 }

--- a/src/renderer/panes/tree-view.tsx
+++ b/src/renderer/panes/tree-view.tsx
@@ -62,14 +62,24 @@ export interface TreeViewProps<TFile extends TreeViewBaseNode> {
   /** Render a single file leaf. The pane keeps full control of card
    *  layout, click handling, and badges. */
   renderFile: (file: TFile) => JSX.Element;
-  /** Optional pane-specific suffix for a directory's header — the
-   *  Knowledge `INDEX` badge or the Skills `SKILL` badge live here. */
+  /** Optional pane-specific suffix for a directory's header — kept for
+   *  decoration that is *not* the special-file callout. The
+   *  index.md / SKILL.md / CLAUDE.md badges no longer live here; they
+   *  render inside the dir's expanded body via `renderSpecialFile`. */
   renderDirSuffix?: (dir: TFile) => JSX.Element;
+  /** Predicate identifying a directory's "special file" — index.md for
+   *  Knowledge, SKILL.md for sub-skill dirs, CLAUDE.md at the skills
+   *  root. The first matched file per directory is pulled out of the
+   *  regular file list and rendered first inside the expanded body via
+   *  `renderSpecialFile`. */
+  specialFile?: (file: TFile, dir: TFile) => boolean;
+  /** Render the special file as a badged callout. Receives the file
+   *  node and the parent directory so the badge can carry e.g.
+   *  `INDEX for topics` context if the pane wants it. */
+  renderSpecialFile?: (file: TFile, dir: TFile) => JSX.Element;
   /** Optional predicate that drops a file from the directory's card
    *  list (and from its file count) without removing it from the
-   *  underlying tree. Used to hide `index.md` / `SKILL.md` so they
-   *  surface only as the per-directory `[INDEX]` / `[SKILL]` badge
-   *  rendered by `renderDirSuffix`. */
+   *  underlying tree. */
   skipFile?: (file: TFile) => boolean;
   /** Which affordance buttons sit on every directory header. */
   affordances: ReadonlyArray<TreeAffordance>;
@@ -99,6 +109,8 @@ export function TreeView<TFile extends TreeViewBaseNode>(props: TreeViewProps<TF
         onToggleExpand={props.onToggleExpand}
         renderFile={props.renderFile}
         renderDirSuffix={props.renderDirSuffix}
+        specialFile={props.specialFile}
+        renderSpecialFile={props.renderSpecialFile}
         skipFile={props.skipFile}
         affordances={props.affordances}
         mutations={props.mutations}
@@ -119,6 +131,8 @@ interface DirectoryBodyProps<TFile extends TreeViewBaseNode> {
   onToggleExpand: (relPath: string) => void;
   renderFile: (file: TFile) => JSX.Element;
   renderDirSuffix?: (dir: TFile) => JSX.Element;
+  specialFile?: (file: TFile, dir: TFile) => boolean;
+  renderSpecialFile?: (file: TFile, dir: TFile) => JSX.Element;
   skipFile?: (file: TFile) => boolean;
   affordances: ReadonlyArray<TreeAffordance>;
   mutations: TreeViewMutationApi;
@@ -140,12 +154,24 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
     }
     return out;
   });
-  const childFiles = createMemo<TFile[]>(() => {
-    const out: TFile[] = [];
-    const skip = props.skipFile;
+  const specialChild = createMemo<TFile | null>(() => {
+    const test = props.specialFile;
+    if (!test) return null;
     for (const child of props.node.children ?? []) {
       if (child.kind !== 'file') continue;
       const file = child as TFile;
+      if (test(file, props.node)) return file;
+    }
+    return null;
+  });
+  const childFiles = createMemo<TFile[]>(() => {
+    const out: TFile[] = [];
+    const skip = props.skipFile;
+    const special = specialChild();
+    for (const child of props.node.children ?? []) {
+      if (child.kind !== 'file') continue;
+      const file = child as TFile;
+      if (special && file === special) continue;
       if (skip?.(file)) continue;
       out.push(file);
     }
@@ -171,10 +197,13 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
         prompts={props.prompts}
         onAfterMutation={props.onAfterMutation}
         onError={props.onError}
-        directFileCount={childFiles().length}
+        directFileCount={childFiles().length + (specialChild() ? 1 : 0)}
       />
       <Show when={isExpanded(props.expanded(), props.node.relPath, props.isRoot)}>
         <div class="tree-children">
+          <Show when={specialChild() && props.renderSpecialFile}>
+            <div class="tree-special">{props.renderSpecialFile!(specialChild()!, props.node)}</div>
+          </Show>
           <For each={childDirs()}>
             {(dir) => (
               <DirectoryBody
@@ -186,6 +215,8 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
                 onToggleExpand={props.onToggleExpand}
                 renderFile={props.renderFile}
                 renderDirSuffix={props.renderDirSuffix}
+                specialFile={props.specialFile}
+                renderSpecialFile={props.renderSpecialFile}
                 skipFile={props.skipFile}
                 affordances={props.affordances}
                 mutations={props.mutations}
@@ -274,11 +305,23 @@ function DirectoryHeader<TFile extends TreeViewBaseNode>(
     }
   };
 
+  /** The whole header row toggles the directory — the disclosure target
+   *  is the row, not just the chevron. Clicks on inner buttons (the
+   *  affordance row, or any `<button>` a `renderDirSuffix` slot might
+   *  add) are excluded so they keep their own behaviour. */
+  const handleHeaderClick = (e: MouseEvent): void => {
+    if (props.isRoot) return;
+    const target = e.target as HTMLElement | null;
+    if (target?.closest('button.tree-dir-action, button.tree-dir-suffix-action')) return;
+    props.onToggleExpand(props.node.relPath);
+  };
+
   return (
     <header
       class="tree-dir-header"
       data-root={props.isRoot ? 'true' : 'false'}
       data-open={open() ? 'true' : 'false'}
+      onClick={handleHeaderClick}
     >
       <button
         type="button"
@@ -286,7 +329,10 @@ function DirectoryHeader<TFile extends TreeViewBaseNode>(
         aria-label={open() ? 'Collapse' : 'Expand'}
         title={open() ? 'Collapse' : 'Expand'}
         disabled={props.isRoot}
-        onClick={() => {
+        onClick={(e) => {
+          // The header row already toggles via handleHeaderClick — stop
+          // here so the row handler doesn't fire a second toggle.
+          e.stopPropagation();
           if (!props.isRoot) props.onToggleExpand(props.node.relPath);
         }}
       >
@@ -300,7 +346,9 @@ function DirectoryHeader<TFile extends TreeViewBaseNode>(
       <Show when={props.directFileCount > 0}>
         <span class="tree-dir-count">{props.directFileCount}</span>
       </Show>
-      <Show when={props.renderDirSuffix}>{props.renderDirSuffix?.(props.node)}</Show>
+      <Show when={props.renderDirSuffix}>
+        <span class="tree-dir-suffix">{props.renderDirSuffix?.(props.node)}</span>
+      </Show>
       <span class="tree-dir-rule" />
       <div class="tree-dir-actions">
         <Show when={props.affordances.includes('createMd')}>


### PR DESCRIPTION
## Summary

- Four small UI tweaks for the tree-view panes (Code, Knowledge, Skills): denser Active Run rows, special-file callout moved inside the directory body, conception-level CLAUDE.md surfaced from Skills, and a bigger disclosure target.
- Generalises the per-directory "special file" slot (`index.md` for Knowledge, `SKILL.md` for Skills, `CLAUDE.md` at the Skills root) into shared tree-view machinery so a future pane can opt in by passing two props.

## Changes

- `src/renderer/panes/code-pane.css`: shrink Active Run head padding (12 14 12 18 → 5 10 5 14) and bump font from 14 to 13 so more rows fit on screen.
- `src/main/skills.ts`: after walking `<conception>/<skills_path>`, probe `<conception>/CLAUDE.md` and `<conception>/.claude/CLAUDE.md` and prepend synthetic SkillNode entries for whichever exist. Synthetic entries carry `name: 'CLAUDE.md'` and a sentinel-prefixed `relPath` (`__claude__/...`) so they cannot collide with a real path inside the skills tree.
- `src/main/watcher.ts`: add explicit watches for `<conception>/CLAUDE.md` and `<conception>/.claude/CLAUDE.md`; bypass the dotfile-segment ignore for the `.claude/CLAUDE.md` case; classify changes to either as a `skills` event so the Skills pane refetches.
- `src/main/skills.test.ts`: two cases covering synthetic CLAUDE.md injection (root + `.claude/`) and the both-absent path.
- `src/renderer/panes/tree-view.tsx` + `tree-view.css`: new `specialFile`/`renderSpecialFile` props. The first matched file per directory is pulled out of the regular file list and rendered inside the expanded body via the supplied renderer. Generic `.tree-special-file` / `.tree-special-badge` / `.tree-special-title` / `.tree-special-meta` chrome supplied; pane stylesheets colour the badge.
- `src/renderer/panes/knowledge.tsx` + `knowledge-pane.css`: switch from `renderDirSuffix={INDEX badge}` + `skipFile` to the new `specialFile`/`renderSpecialFile` slot. INDEX badge now renders as the first row inside the dir body, with bucket-coloured tinting (`general` / `internal` / `topics` / `external`) and an optional verified-at meta with stale tinting.
- `src/renderer/panes/skills.tsx` + `skills-pane.css`: same migration for `SKILL.md`. CLAUDE.md synthetic entries surface only at the root via the `dir.relPath === ''` branch and render with `--col-running` to read distinctly from the skill cards. Old `.skills-section-index` chip CSS retired.
- `src/renderer/panes/tree-view.css` (cont.): disclosure twisty 18→24 px (glyph 11→14 px); header row gains `min-height: 28px` and a full-row hover background so the whole strip reads as one disclosure target. Inner buttons stop propagation so the row handler does not fire a second toggle.
- `docs/guides/skills-pane.md`: rewrite the "What it shows" section to describe SKILL.md as a callout at the top of the expanded body, document the surfaced `CLAUDE.md` entries, and update the shipped/diverged paragraph to talk about the callout rather than the section badge.

## Impact

- Skills pane now triggers a refetch on `<conception>/CLAUDE.md` and `<conception>/.claude/CLAUDE.md` edits — extra paths added to the chokidar watchers, but they only fire on writes the user makes inside the Skills pane (or via an editor) so the cost is negligible.
- Synthetic relPaths (`__claude__/CLAUDE.md`, `__claude__/.claude/CLAUDE.md`) are stable across sessions but are not real paths — anything that round-trips a SkillNode through the filesystem must use `path`, not `relPath`. Existing call sites already do.