### PR TITLE
Bump 2.15.2: ship Settings modal tabs + inheritance badges

### DIFF
--- a/docs/help/configuration.md
+++ b/docs/help/configuration.md
@@ -83,28 +83,45 @@ them per-tree.
 
 ## Editing in the app
 
-**File → Settings…** (`Ctrl+,`) opens a full-viewport modal split into
-two file targets. There is no in-modal JSON editor — each preference
-has its own form control.
+**File → Settings…** (`Ctrl+,`) opens a full-viewport modal with a
+two-tab layout. There is no in-modal JSON editor — each preference has
+its own form control.
 
-**Global** (writes to `settings.json`):
+**Global** tab (writes to `settings.json`):
 
-- **Appearance** — theme; per-pane card-grid min-widths.
-- **Terminal** — embedded terminal preferences.
 - **Recent conception paths** — manage the recents list backing
   **File → Open Recent**.
+- **Appearance** — theme; per-pane card-grid min-widths.
+- **Terminal** — embedded terminal preferences.
 
-**This conception** (writes to `condash.json`; the legacy
+**This conception** tab (writes to `condash.json`; the legacy
 `configuration.json` is read but never written to):
 
 - **Workspace** — `workspace_path`, `worktrees_path`, `resources_path`,
   `skills_path`.
 - **Repositories** — ordered repo list, per-repo `run` / `force_stop`.
 - **Open with** — slot labels and commands.
+- **Appearance** — theme + card-grid min-widths overridden for this
+  conception only.
+- **Terminal** — `terminal` block overridden for this conception only.
 
-Each header carries an **Open externally** button — power users can
-edit the raw JSON in their `$EDITOR`. Modal writes round-trip through
-the same atomic save + schema validation path either way.
+Inheritance badges on the **This conception** tab call out where each
+top-level key sits relative to the global value:
+
+- **Inherits** — no override in `condash.json`. The effective value is
+  whatever `settings.json` (or the bundled default) provides. Editing
+  the field on this tab writes the override.
+- **Overridden** — `condash.json` sets the key to a value that differs
+  from `settings.json`. A **Reset to global** button drops the
+  override and falls back to inheritance.
+- **Matches global** — `condash.json` carries the key but the value
+  matches `settings.json` exactly. The override is redundant; a
+  **Remove override** button clears the line so the key inherits.
+
+The rail at the left of the modal carries **Save** (flush focused-but-
+unblurred edits) and **Open externally** (open the active tab's file
+in your `$EDITOR`). Modal writes round-trip through the same atomic
+save + schema-validation path the CLI uses, either way.
 
 ## File → Open Recent
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -307,21 +307,25 @@ The file is created on demand: the first-launch folder picker writes it; you can
 
 ## Editing from the dashboard
 
-**File → Settings…** (`Ctrl+,`) opens a full-viewport modal split into two file targets. There is no in-modal JSON editor: each persisted preference has its own form control.
+**File → Settings…** (`Ctrl+,`) opens a full-viewport modal with a two-tab layout (added in v2.15.2). There is no in-modal JSON editor: each persisted preference has its own form control.
 
-**Global** (writes to `settings.json`):
+**Global** tab (writes to `settings.json`):
 
+- **Recent conception paths** — manage the recents list backing **File → Open Recent**.
 - **Appearance** — theme; per-pane card-grid min-widths.
 - **Terminal** — embedded terminal preferences.
-- **Recent conception paths** — manage the recents list backing **File → Open Recent**.
 
-**This conception** (writes to `condash.json`; the legacy `configuration.json` is read but never written to):
+**This conception** tab (writes to `condash.json`; the legacy `configuration.json` is read but never written to):
 
 - **Workspace** — `workspace_path`, `worktrees_path`, `resources_path`, `skills_path`.
 - **Repositories** — ordered repo list, per-repo `run` / `force_stop`.
 - **Open with** — slot labels and commands.
+- **Appearance** — theme + card-grid min-widths overridden for this conception only.
+- **Terminal** — `terminal` block overridden for this conception only.
 
-Each header carries an **Open externally** button that shells out via `window.condash.openPath` so power users can edit the raw JSON in their `$EDITOR`. Writes go through `patchConfig`, which parses the live file, applies a mutator, drops empty leaves, and round-trips through `note.write`'s atomic CAS — schema-validated by the [strict zod schema](https://github.com/vcoeur/condash/blob/main/src/main/config-schema.ts) before the bytes hit disk.
+Each top-level key on the **This conception** tab carries an inheritance badge that calls out the override state — **Inherits**, **Overridden**, or **Matches global** — plus a **Reset to global** / **Remove override** button when the conception writes anything for that key. Removing an override drops the key from `condash.json` and falls back to inheritance. Writes go through `patchConfig` (condash.json) and `patchSettings` (settings.json), each of which parses the live file, applies a mutator, drops empty leaves, and round-trips through atomic CAS — schema-validated by the [strict zod schemas](https://github.com/vcoeur/condash/blob/main/src/main/config-schema.ts) (`globalSettingsSchema` for settings.json, `conceptionConfigSchema` for condash.json) before the bytes hit disk.
+
+The rail at the left of the modal carries **Save** (flush focused-but-unblurred edits) and **Open externally** (open the active tab's file in the OS default editor). The active tab is remembered between modal opens via `localStorage`.
 
 Keys not surfaced in the modal — `pdf_viewer`, the `welcome.dismissed` flag — still need a hand-edit. See [`settings.json` (per-user, per-machine)](#settingsjson-per-user-per-machine) above for paths.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.15.1",
+      "version": "2.15.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -266,3 +266,24 @@ export function validateAndCanonicaliseConceptionConfig(json: string): string {
 
 /** Backwards-compat alias for the renamed canonicaliser. */
 export const validateAndCanonicaliseConfig = validateAndCanonicaliseConceptionConfig;
+
+/**
+ * Parse → validate → re-serialise the per-machine `settings.json` body. Used
+ * by the Settings modal's Global-tab save path so the bytes that hit disk
+ * are always schema-canonical and the path-tracking fields stay welcomed.
+ */
+export function validateAndCanonicaliseGlobalSettings(json: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (err) {
+    throw new Error(`Invalid JSON: ${(err as Error).message}`);
+  }
+  const result = globalSettingsSchema.safeParse(parsed);
+  if (!result.success) {
+    const issue = result.error.issues[0];
+    const where = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    throw new Error(`settings.json: ${where} — ${issue.message}`);
+  }
+  return JSON.stringify(result.data, null, 2) + '\n';
+}

--- a/src/main/effective-config.ts
+++ b/src/main/effective-config.ts
@@ -1,7 +1,13 @@
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import type { ConfigShape } from './config-walk';
-import type { TerminalPrefs } from '../shared/types';
+import type {
+  CardMinWidthPrefs,
+  LayoutState,
+  TerminalPrefs,
+  Theme,
+  TreeExpansionPrefs,
+} from '../shared/types';
 import { settingsPath } from './settings';
 
 /**
@@ -27,6 +33,10 @@ export interface EffectiveConfig extends ConfigShape {
   open_with?: Record<string, { label: string; command: string }>;
   pdf_viewer?: string[];
   terminal?: TerminalPrefs;
+  theme?: Theme;
+  cardMinWidth?: CardMinWidthPrefs;
+  layout?: LayoutState;
+  treeExpansion?: TreeExpansionPrefs;
 }
 
 /** Filename condash now writes to. */

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseHeader } from '../shared/header';
 
-import { DEFAULT_LAYOUT, readSettings } from './settings';
+import { DEFAULT_LAYOUT, readSettings, settingsPath } from './settings';
 import { findProjectReadmes } from './walk';
 import { parseReadme } from './parse';
 import { setWatchedConception } from './watcher';
@@ -833,6 +833,22 @@ function registerIpc(): void {
       await assertUnderConception(path);
       return writeNote(path, expectedContent, newContent);
     },
+  );
+
+  // Raw read of the per-machine `settings.json`. Used by the Settings modal
+  // to compute inheritance badges (compare global vs. condash.json values)
+  // and to drive the Global-tab editor through the same patchConfig flow it
+  // uses for condash.json. Returns `''` when the file doesn't exist yet —
+  // the modal treats that as "fresh defaults" and creates the file on first
+  // save.
+  ipcMain.handle('settings.readRaw', async () => readNote(settingsPath()));
+
+  // Atomic CAS write to settings.json. Canonicalises through
+  // `globalSettingsSchema` (handled by `writeNote`'s basename dispatch).
+  // Returns the bytes actually written so the caller can keep its CAS
+  // baseline aligned with disk after Zod re-orders keys.
+  ipcMain.handle('settings.writeRaw', async (_, expectedContent: string, newContent: string) =>
+    writeNote(settingsPath(), expectedContent, newContent),
   );
 
   ipcMain.handle('project.createNote', async (_, projectPath: string, slug: string) => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,5 +1,6 @@
 import { ipcMain } from 'electron';
 import { toPosix } from '../../shared/path';
+import { getEffectiveConceptionConfig } from '../effective-config';
 import { DEFAULT_LAYOUT, readSettings, settingsPath, updateSettings } from '../settings';
 import type { CardMinWidthPrefs, LayoutState, Theme, TreeExpansionPrefs } from '../../shared/types';
 import { DEFAULT_CARD_MIN_WIDTH } from '../../shared/types';
@@ -49,8 +50,16 @@ function pruneDefaults(prefs: CardMinWidthPrefs): CardMinWidthPrefs | undefined 
  */
 export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState) => void }): void {
   ipcMain.handle('getTheme', async () => {
-    const { theme } = await readSettings();
-    return theme;
+    // Effective theme: condash.json's override beats settings.json's
+    // global value. Falls back to 'system' when neither side has set a
+    // theme. Re-routed through the effective resolver in v2.15.1 so
+    // per-conception overrides take effect app-wide.
+    const settings = await readSettings();
+    if (settings.lastConceptionPath) {
+      const effective = await getEffectiveConceptionConfig(settings.lastConceptionPath);
+      if (effective.theme) return effective.theme as Theme;
+    }
+    return settings.theme;
   });
 
   ipcMain.handle('getSettingsPath', () => toPosix(settingsPath()));
@@ -83,10 +92,22 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
   });
 
   ipcMain.handle('getCardMinWidth', async () => {
-    const { cardMinWidth } = await readSettings();
+    // Effective per-pane min-width: condash.json's override (whole
+    // object replaces global) beats settings.json. Re-routed through
+    // the effective resolver in v2.15.1 so per-conception overrides
+    // take effect app-wide. The shape is built from the bundled
+    // defaults so missing keys never reach the renderer as undefined.
+    const settings = await readSettings();
+    let raw: Partial<CardMinWidthPrefs> | undefined = settings.cardMinWidth;
+    if (settings.lastConceptionPath) {
+      const effective = await getEffectiveConceptionConfig(settings.lastConceptionPath);
+      if (effective.cardMinWidth) {
+        raw = effective.cardMinWidth as Partial<CardMinWidthPrefs>;
+      }
+    }
     const out: Required<CardMinWidthPrefs> = { ...DEFAULT_CARD_MIN_WIDTH };
     for (const key of CARD_MIN_KEYS) {
-      const v = cardMinWidth?.[key];
+      const v = raw?.[key];
       if (typeof v === 'number' && Number.isFinite(v)) out[key] = v;
     }
     return out;

--- a/src/main/mutate.ts
+++ b/src/main/mutate.ts
@@ -4,7 +4,10 @@ import type { StepMarker, TransitionResult } from '../shared/types';
 import { KNOWN_STATUSES, STEP_MARKERS } from '../shared/types';
 import { isoToday } from '../shared/iso-today';
 import { atomicWrite } from './atomic-write';
-import { validateAndCanonicaliseConfig } from './config-schema';
+import {
+  validateAndCanonicaliseConfig,
+  validateAndCanonicaliseGlobalSettings,
+} from './config-schema';
 
 // One regex for both shapes: capture the step text in group 4 so callers
 // that need the body text use it; callers that only need the marker can
@@ -243,9 +246,15 @@ export async function writeNote(
 
     const baseName = basename(path);
     const isConceptionConfig = baseName === 'condash.json' || baseName === 'configuration.json';
-    const finalContent = isConceptionConfig
-      ? validateAndCanonicaliseConfig(newContent)
-      : newContent;
+    const isGlobalSettings = baseName === 'settings.json';
+    let finalContent: string;
+    if (isConceptionConfig) {
+      finalContent = validateAndCanonicaliseConfig(newContent);
+    } else if (isGlobalSettings) {
+      finalContent = validateAndCanonicaliseGlobalSettings(newContent);
+    } else {
+      finalContent = newContent;
+    }
     await atomicWrite(path, finalContent);
     return finalContent;
   });

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -7,8 +7,8 @@ import * as pty from 'node-pty';
 import type { TermSession, TermSide, TermSpawnRequest, TerminalPrefs } from '../shared/types';
 import { atomicWrite } from './atomic-write';
 import { findRepoEntry, type ConfigShape } from './config-walk';
-import { readSettings, updateSettings } from './settings';
 import { getEffectiveConceptionConfig } from './effective-config';
+import { readSettings, updateSettings } from './settings';
 import { tokenise } from './launchers';
 
 interface Session {
@@ -394,16 +394,25 @@ export function closeSession(id: string): Promise<void> {
   return stopSession(id);
 }
 
-/** Read terminal prefs from settings.json. As of 2026-05-01 these live
- * per-machine, not in the conception's configuration.json — the boot-time
- * migration in main/index.ts copies any pre-existing block. */
+/** Read effective terminal prefs. The active conception's `condash.json`
+ * may override the entire `terminal` block (top-level replace); when no
+ * override is set, the per-machine `settings.json` value applies. The
+ * one-shot migration that promoted terminal from configuration.json into
+ * settings.json (2026-05-01) still runs at boot — the overridable layer
+ * sits on top of that. */
 export async function getTerminalPrefs(): Promise<TerminalPrefs> {
   const settings = await readSettings();
+  if (settings.lastConceptionPath) {
+    const effective = await getEffectiveConceptionConfig(settings.lastConceptionPath);
+    if (effective.terminal) return effective.terminal;
+  }
   return settings.terminal ?? {};
 }
 
 /** Replace the persisted terminal prefs in settings.json. The patch is a
- * full replacement; pass `{}` to clear back to defaults. */
+ * full replacement; pass `{}` to clear back to defaults. Always writes to
+ * the per-machine settings.json — per-conception overrides are written
+ * via the Settings modal's `patchConfig` flow. */
 export async function setTerminalPrefs(patch: TerminalPrefs): Promise<void> {
   await updateSettings((cur) => ({ ...cur, terminal: patch }));
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -43,6 +43,9 @@ const api: CondashApi = {
   getTreeExpansion: () => ipcRenderer.invoke('getTreeExpansion'),
   setTreeExpansion: (prefs) => ipcRenderer.invoke('setTreeExpansion', prefs),
   getSettingsPath: () => ipcRenderer.invoke('getSettingsPath'),
+  getGlobalSettingsRaw: () => ipcRenderer.invoke('settings.readRaw'),
+  writeGlobalSettings: (expectedContent, newContent) =>
+    ipcRenderer.invoke('settings.writeRaw', expectedContent, newContent),
   toggleStep: (path, lineIndex, expectedMarker, newMarker) =>
     ipcRenderer.invoke('step.toggle', path, lineIndex, expectedMarker, newMarker),
   editStepText: (path, lineIndex, expectedText, newText) =>

--- a/src/renderer/modals.css
+++ b/src/renderer/modals.css
@@ -343,6 +343,71 @@
   font-size: 13px;
 }
 
+/* Tab strip — switches between the Global panel and the This-conception
+ * panel. Lives between the modal header and the settings-shell rail/scroll
+ * row. ARIA tablist semantics; arrow-key nav handled in JS. */
+.settings-tablist {
+  flex-shrink: 0;
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-elevated);
+  padding: 0 16px;
+}
+
+.settings-tab {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  border-radius: 0;
+  padding: 10px 16px 8px;
+  margin: 0;
+  color: var(--text-muted);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition:
+    color 0.08s ease,
+    border-color 0.08s ease;
+}
+
+.settings-tab:hover {
+  color: var(--text);
+}
+
+.settings-tab.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+
+.settings-tab-label {
+  font-family: var(--font-display);
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+}
+
+.settings-tab-file {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-faint);
+}
+
+.settings-tab.active .settings-tab-file {
+  color: var(--text-muted);
+}
+
+.settings-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: 4px;
+}
+
 .settings-shell {
   flex: 1;
   min-height: 0;
@@ -395,6 +460,27 @@
   color: var(--text-muted);
   letter-spacing: 0;
   text-transform: none;
+}
+
+/* Brief context paragraph rendered above the rail's section list — tells
+ * the user which file the active tab edits. Replaces the per-group heading
+ * row that lived inside the scroll viewport in v2.15.0. */
+.settings-rail-hint {
+  margin: 0 14px 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+.settings-rail-actions {
+  margin: 14px 14px 0;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
 }
 
 .settings-rail-list {
@@ -520,10 +606,55 @@
   align-items: center;
 }
 
+/* Tabpanel — wraps every section in one tab. Both stay mounted (so
+ * drafts and scroll position survive a tab switch); the inactive panel
+ * is `display: none`-hidden via the modifier class. */
+.settings-tabpanel {
+  display: block;
+}
+
+.settings-tabpanel--hidden {
+  display: none;
+}
+
 .settings-section {
   padding: 8px 0 32px;
   border-bottom: 1px solid var(--border);
   scroll-margin-top: 16px;
+}
+
+/* Section heading row that hosts h2 + badge group on the same line. Used
+ * on the conception tab where each top-level key carries a visible
+ * inheritance badge. */
+.settings-section-head {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+
+.settings-section-head h2 {
+  margin: 0;
+}
+
+.settings-section-subhead {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin: 18px 0 8px;
+}
+
+.settings-section-subhead h3 {
+  margin: 0;
+}
+
+.settings-section-hint {
+  margin: -6px 0 14px;
+  color: var(--text-faint);
+  font-size: 12px;
+  line-height: 1.5;
 }
 
 .settings-section:last-child {
@@ -734,8 +865,12 @@
  * head action), which clips multi-word labels like "+ with run / label". */
 .settings-modal--full .settings-list-actions .modal-button,
 .settings-modal--full .settings-group-divider-actions .modal-button,
+.settings-modal--full .settings-rail-actions .modal-button,
+.settings-modal--full .settings-recents-row .modal-button,
+.settings-modal--full .settings-recents-actions .modal-button,
 .settings-modal--full .settings-confirm-actions .modal-button,
-.settings-modal--full .settings-conception-path .modal-button {
+.settings-modal--full .settings-conception-path .modal-button,
+.settings-modal--full .settings-field-badges .modal-button {
   width: auto;
   height: auto;
   padding: 5px 12px;
@@ -745,6 +880,15 @@
   font-weight: 500;
   white-space: nowrap;
   line-height: 1.2;
+}
+
+/* Compact override for the per-field "Reset to global" / "Remove
+ * override" button — sits next to a small badge and shouldn't dwarf it. */
+.settings-modal--full .settings-field-badges .settings-remove-override {
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
 }
 
 /* Open-with rows: label + command stacked */
@@ -1177,4 +1321,93 @@
   margin-top: 8px;
   display: flex;
   justify-content: flex-end;
+}
+
+/* ---- Inheritance badges (conception tab) ------------------------------- */
+
+/* Pill rendered next to a top-level key's editor on the conception tab.
+ * Three variants — neutral / accent / warning — driven by classList from
+ * the `inheritanceState` helper. */
+.settings-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border: 1px solid transparent;
+  border-radius: 999px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+
+.settings-badge--inherits {
+  color: var(--text-muted);
+  border-color: var(--border);
+  background: var(--bg-subtle);
+}
+
+.settings-badge--overridden {
+  color: #044a26;
+  background: #d1f5dd;
+  border-color: #6dcf94;
+}
+
+.settings-badge--matches {
+  color: #6a4a06;
+  background: #fff1c8;
+  border-color: #e6c66a;
+}
+
+[data-theme='dark'] .settings-badge--overridden {
+  color: #c2efd2;
+  background: rgba(34, 102, 64, 0.4);
+  border-color: rgba(120, 200, 150, 0.55);
+}
+
+[data-theme='dark'] .settings-badge--matches {
+  color: #f0d9a8;
+  background: rgba(120, 92, 28, 0.45);
+  border-color: rgba(220, 180, 90, 0.55);
+}
+
+/* Container for the badge plus the optional Remove-override button. Used
+ * inside section-head rows AND inside FieldWithBadge. */
+.settings-field-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-left: auto;
+}
+
+.settings-remove-override {
+  font-size: 11px;
+  padding: 2px 8px;
+}
+
+/* Field row holding label + badges on one line above the input. Used for
+ * per-field badges on the conception tab (workspace paths, etc.). */
+.settings-field-with-badge {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.settings-field-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.settings-field-with-badge > input,
+.settings-field-with-badge > select,
+.settings-field-with-badge > textarea {
+  /* Inputs inside the labelled-with-badge wrapper inherit the modal-wide
+   * input styles set on bare `label > input` selectors elsewhere; the
+   * extra wrapping div would otherwise lose those rules. */
+  margin-top: 2px;
 }

--- a/src/renderer/settings-modal-parts/badges.tsx
+++ b/src/renderer/settings-modal-parts/badges.tsx
@@ -1,0 +1,157 @@
+import { Show, type JSX } from 'solid-js';
+import type { RawConfig } from './data';
+
+export type InheritanceState = 'inherits' | 'overridden' | 'matches';
+
+/**
+ * Compute the inheritance state of a top-level conception key relative to
+ * the global settings.json value. Three states drive the badge label and
+ * the Remove-override button visibility on the conception tab:
+ *
+ *   - `inherits`  — key is absent from `condash.json`. The effective value
+ *     comes straight from `settings.json`.
+ *   - `overridden` — key is present and the value differs from the global
+ *     one. The override is doing real work.
+ *   - `matches` — key is present but the value is identical to the global
+ *     one. The override is redundant; surface a "Remove override" button.
+ *
+ * Comparison uses `JSON.stringify` over a key-sorted object — sufficient
+ * for the conception-overridable shapes (strings, numbers, arrays of
+ * strings, repository entries, simple objects). For deep-nested
+ * `terminal.xterm.colors` we still compare the whole `terminal` object as
+ * one unit, which matches the schema's "objects replace whole" rule.
+ */
+export function inheritanceState<K extends keyof RawConfig>(
+  key: K,
+  global: RawConfig,
+  conception: RawConfig,
+): InheritanceState {
+  const conceptionHas = Object.prototype.hasOwnProperty.call(conception, key);
+  if (!conceptionHas) return 'inherits';
+  const globalValue = global[key];
+  const conceptionValue = conception[key];
+  return stableEqual(globalValue, conceptionValue) ? 'matches' : 'overridden';
+}
+
+/** Stable JSON-based deep equality. Object keys are sorted recursively so
+ *  the same logical shape always serialises identically. */
+export function stableEqual(a: unknown, b: unknown): boolean {
+  return canonicalise(a) === canonicalise(b);
+}
+
+function canonicalise(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalise).join(',')}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${canonicalise(v)}`).join(',')}}`;
+}
+
+/**
+ * Pill rendered next to a conception-tab field showing whether the
+ * conception is inheriting, overriding, or redundantly matching the global
+ * value. Three CSS variants — see `modals.css` `.settings-badge--*`.
+ */
+export function InheritanceBadge(props: { state: InheritanceState }): JSX.Element {
+  return (
+    <span
+      class="settings-badge"
+      classList={{
+        'settings-badge--inherits': props.state === 'inherits',
+        'settings-badge--overridden': props.state === 'overridden',
+        'settings-badge--matches': props.state === 'matches',
+      }}
+      aria-label={badgeAriaLabel(props.state)}
+      title={badgeTitle(props.state)}
+    >
+      {badgeLabel(props.state)}
+    </span>
+  );
+}
+
+function badgeLabel(state: InheritanceState): string {
+  switch (state) {
+    case 'inherits':
+      return 'Inherits';
+    case 'overridden':
+      return 'Overridden';
+    case 'matches':
+      return 'Matches global';
+  }
+}
+
+function badgeAriaLabel(state: InheritanceState): string {
+  switch (state) {
+    case 'inherits':
+      return 'Inheriting the global value from settings.json';
+    case 'overridden':
+      return 'Overriding the global value';
+    case 'matches':
+      return 'Override matches the global value — redundant';
+  }
+}
+
+function badgeTitle(state: InheritanceState): string {
+  switch (state) {
+    case 'inherits':
+      return 'No override in condash.json — value comes from settings.json.';
+    case 'overridden':
+      return 'condash.json overrides settings.json for this key.';
+    case 'matches':
+      return 'condash.json sets this key to the same value as settings.json — the override is redundant. Remove it to fall back to inheritance.';
+  }
+}
+
+/**
+ * Inline button surfaced on the conception tab when a field is in the
+ * `overridden` or `matches` state. Clicking it deletes the key from
+ * `condash.json`, dropping back to inheritance.
+ */
+export function RemoveOverrideButton(props: {
+  state: InheritanceState;
+  onRemove: () => void;
+  /** Optional one-line override of the default tooltip. */
+  title?: string;
+}): JSX.Element {
+  return (
+    <Show when={props.state !== 'inherits'}>
+      <button
+        type="button"
+        class="modal-button settings-remove-override"
+        onClick={props.onRemove}
+        title={props.title ?? defaultRemoveTitle(props.state)}
+      >
+        {props.state === 'matches' ? 'Remove override' : 'Reset to global'}
+      </button>
+    </Show>
+  );
+}
+
+function defaultRemoveTitle(state: InheritanceState): string {
+  return state === 'matches'
+    ? 'Remove the redundant override from condash.json'
+    : 'Drop this override and inherit the global value';
+}
+
+/**
+ * Composite header used at the top of every conception-tab field group:
+ * label + badge + (optional) Remove-override button laid out on one row.
+ */
+export function FieldBadgeRow(props: {
+  state: InheritanceState;
+  onRemove: () => void;
+  /** Set to true on the global tab where badges are not rendered. */
+  hide?: boolean;
+}): JSX.Element {
+  return (
+    <Show when={!props.hide}>
+      <span class="settings-field-badges">
+        <InheritanceBadge state={props.state} />
+        <RemoveOverrideButton state={props.state} onRemove={props.onRemove} />
+      </span>
+    </Show>
+  );
+}

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -1,43 +1,77 @@
-import type { Platform, TerminalXtermPrefs, Theme } from '@shared/types';
+import type {
+  CardMinWidthPrefs,
+  Platform,
+  TerminalPrefs,
+  TerminalXtermPrefs,
+  Theme,
+} from '@shared/types';
 import type { RawRepo } from '../../main/config-schema';
 
-export type Section = 'workspace' | 'repositories' | 'open-with' | 'terminal' | 'appearance';
+export type SettingsTab = 'global' | 'conception';
 
-export type SectionGroup = 'config' | 'machine';
+/**
+ * Sections rendered on each tab. Theme + cardMinWidth + terminal appear on
+ * BOTH tabs because they are inheritable: the global control writes to
+ * `settings.json` and the conception control writes to `condash.json`. The
+ * id is suffixed with `:global` / `:conception` so scroll-spy can tell them
+ * apart.
+ */
+export type Section =
+  | 'recents:global'
+  | 'appearance:global'
+  | 'terminal:global'
+  | 'workspace:conception'
+  | 'repositories:conception'
+  | 'open-with:conception'
+  | 'appearance:conception'
+  | 'terminal:conception';
 
 export interface SectionMeta {
   id: Section;
   label: string;
-  group: SectionGroup;
+  tab: SettingsTab;
 }
 
+/**
+ * Order matters — drives both the left-rail section list and the scroll-
+ * spy that flips `section` as the user scrolls through the active tab's
+ * panel. Workspace / Repositories / Open with live on the conception tab
+ * only because that's where overriding them makes sense; the Global tab
+ * hosts per-machine defaults (theme + cardMinWidth + terminal) that every
+ * conception inherits unless overridden.
+ */
 export const SECTIONS: SectionMeta[] = [
-  { id: 'appearance', label: 'Appearance', group: 'machine' },
-  { id: 'terminal', label: 'Terminal', group: 'machine' },
-  { id: 'workspace', label: 'Workspace', group: 'config' },
-  { id: 'repositories', label: 'Repositories', group: 'config' },
-  { id: 'open-with', label: 'Open with', group: 'config' },
+  // Global tab.
+  { id: 'recents:global', label: 'Recent conceptions', tab: 'global' },
+  { id: 'appearance:global', label: 'Appearance', tab: 'global' },
+  { id: 'terminal:global', label: 'Terminal', tab: 'global' },
+  // Conception tab.
+  { id: 'workspace:conception', label: 'Workspace', tab: 'conception' },
+  { id: 'repositories:conception', label: 'Repositories', tab: 'conception' },
+  { id: 'open-with:conception', label: 'Open with', tab: 'conception' },
+  { id: 'appearance:conception', label: 'Appearance', tab: 'conception' },
+  { id: 'terminal:conception', label: 'Terminal', tab: 'conception' },
 ];
 
-export interface GroupMeta {
-  id: SectionGroup;
+export interface TabMeta {
+  id: SettingsTab;
   label: string;
   file: string;
   hint: string;
 }
 
-export const GROUPS: GroupMeta[] = [
+export const TABS: TabMeta[] = [
   {
-    id: 'machine',
+    id: 'global',
     label: 'Global',
     file: 'settings.json',
-    hint: 'Per-machine defaults stored in the OS user-data directory. Carries the active conception path and the recents list — cannot be overridden per-conception.',
+    hint: 'Per-machine defaults stored in the OS user-data directory. Owns the active conception path and the recents list. Inherited by every conception unless that conception overrides the key in its `condash.json`.',
   },
   {
-    id: 'config',
+    id: 'conception',
     label: 'This conception',
     file: 'condash.json',
-    hint: 'Per-conception overrides stored in the tree itself. Top-level keys here replace the matching keys in settings.json. Reads fall back to legacy configuration.json when condash.json is absent; writes always target condash.json.',
+    hint: 'Top-level keys here override the matching keys in settings.json. Reads fall back to legacy `configuration.json` when `condash.json` is absent; writes always target `condash.json`.',
   },
 ];
 
@@ -164,6 +198,12 @@ export function pick(
   return table.default ?? '';
 }
 
+/**
+ * Subset of the unified config schema that the Settings modal reads + writes.
+ * Mirrors `globalSettingsSchema` / `conceptionConfigSchema` from
+ * `src/main/config-schema.ts` — every overridable key is present here so
+ * the same RawConfig shape can describe either file.
+ */
 export interface RawConfig {
   $schema_doc?: string;
   workspace_path?: string;
@@ -172,6 +212,15 @@ export interface RawConfig {
   skills_path?: string;
   repositories?: RawRepo[];
   open_with?: Record<string, { label?: string; command?: string }>;
+  pdf_viewer?: string[];
+  theme?: Theme;
+  cardMinWidth?: CardMinWidthPrefs;
+  terminal?: TerminalPrefs;
+  /** Conception-only fields — never set on the conception side. */
+  lastConceptionPath?: string | null;
+  recentConceptionPaths?: string[];
+  /** Modal UI state — last-active tab. Persists per-machine. */
+  lastSettingsTab?: SettingsTab;
 }
 
 /**

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -12,13 +12,14 @@ import type { RawRepo } from '../main/config-schema';
 import {
   type ColorEntry,
   CURSOR_STYLES,
-  GROUPS,
   OPEN_WITH_SLOTS,
   pick,
   pruneEmpty,
   type RawConfig,
   type Section,
   SECTIONS,
+  type SettingsTab,
+  TABS,
   TERMINAL_COLORS,
   TERMINAL_STRING_FIELDS,
   THEME_OPTIONS,
@@ -26,8 +27,36 @@ import {
   WORKTREES_PLACEHOLDER,
   compactRepos,
 } from './settings-modal-parts/data';
+import {
+  FieldBadgeRow,
+  type InheritanceState,
+  inheritanceState,
+} from './settings-modal-parts/badges';
 import { RepoRow } from './settings-modal-parts/repo-row';
 import type { JSX } from 'solid-js';
+
+/** Persisted last-active settings tab. Stored in localStorage so opening
+ *  the modal a second time lands on whichever tab the user was on. Per-
+ *  machine UI state — not a vault-wide preference. */
+const LAST_TAB_STORAGE_KEY = 'condash:settings-modal:last-tab';
+
+function loadLastTab(): SettingsTab {
+  try {
+    const raw = window.localStorage.getItem(LAST_TAB_STORAGE_KEY);
+    return raw === 'conception' ? 'conception' : 'global';
+  } catch {
+    return 'global';
+  }
+}
+
+function persistLastTab(tab: SettingsTab): void {
+  try {
+    window.localStorage.setItem(LAST_TAB_STORAGE_KEY, tab);
+  } catch {
+    // localStorage may throw in private-mode tests; the active-tab default
+    // gracefully degrades to "global" on next open.
+  }
+}
 
 /**
  * Per-machine list of recently-opened conception paths, displayed on the
@@ -52,7 +81,7 @@ function RecentConceptionsSection(): JSX.Element {
   };
 
   return (
-    <section class="settings-section">
+    <section id="settings-section-recents:global" class="settings-section">
       <h2>Recent conception paths</h2>
       <p class="settings-section-hint">
         Newest first. Drives the File → Open Recent submenu. Removing a path here also removes it
@@ -90,19 +119,21 @@ function RecentConceptionsSection(): JSX.Element {
 }
 
 /**
- * Full-viewport Settings modal. Every persisted preference has its own
- * editable control — there is no in-modal JSON editor. Power users get a
- * single "Open configuration.json externally" button in the header that
- * shells out via `window.condash.openPath`.
+ * Full-viewport Settings modal. Two-tab layout: Global (writes to per-
+ * machine `settings.json`) and This conception (writes to
+ * `<conception>/condash.json`). Inheritable keys (theme, cardMinWidth,
+ * terminal) appear on both tabs; the conception tab carries inheritance
+ * badges per top-level key.
  *
- * Writes are funnelled through `patchConfig`, which parses the live file,
+ * Writes are funnelled through `patchConfig` (condash.json) and
+ * `patchSettings` (settings.json), each of which parses the live file,
  * applies a mutator, drops empty leaves, and round-trips through the
- * `note.write` IPC's atomic CAS so the schema-validation path stays the
- * same.
+ * `note.write` / `settings.writeRaw` IPC's atomic CAS so the schema-
+ * validation path stays consistent across the two files.
  *
  * Module shape: types, constants, helpers, and the recursive `RepoRow`
  * row component live in ./settings-modal-parts/. This file owns the
- * SettingsModal shell — every persisted-state closure (drafts, patchConfig,
+ * SettingsModal shell — every persisted-state closure (drafts, patches,
  * bindText, scrollToSection, flushDrafts) lives here so the inline section
  * markup can call them without prop-drilling.
  */
@@ -115,7 +146,7 @@ export function SettingsModal(props: {
    *  values shown in the Appearance subsection. */
   cardMinWidth: Required<CardMinWidthPrefs>;
   /** Commit a partial card-min-width patch. The renderer applies the new
-   *  CSS variables and persists to settings.json. */
+   *  CSS variables and persists. */
   onChangeCardMinWidth: (patch: CardMinWidthPrefs) => void;
   onClose: () => void;
 }) {
@@ -131,7 +162,21 @@ export function SettingsModal(props: {
     () => window.condash.getConceptionConfigPath(),
   );
   const configurationPath = (): string => readPath() ?? writePath;
-  const [section, setSection] = createSignal<Section>('appearance');
+
+  const [tab, setTab] = createSignal<SettingsTab>(loadLastTab());
+  const switchTab = (next: SettingsTab): void => {
+    if (next === tab()) return;
+    setTab(next);
+    persistLastTab(next);
+    // Pin the section signal to whichever section heads the new tab so
+    // the rail's "active" highlight points at the visible panel before
+    // the user has scrolled.
+    const first = SECTIONS.find((s) => s.tab === next);
+    if (first) setSection(first.id);
+  };
+  const [section, setSection] = createSignal<Section>(
+    (SECTIONS.find((s) => s.tab === loadLastTab()) ?? SECTIONS[0]).id,
+  );
   const [error, setError] = createSignal<string | null>(null);
   const [savedAt, setSavedAt] = createSignal<number | null>(null);
   const [pending, setPending] = createSignal(false);
@@ -148,6 +193,14 @@ export function SettingsModal(props: {
   const [content, { mutate: mutateContent }] = createResource(
     () => configurationPath(),
     (path) => window.condash.readNote(path),
+  );
+
+  // Raw text contents of `settings.json`. Used for the Global-tab editor +
+  // for the conception tab's badge comparisons. Empty string means the
+  // file doesn't exist yet on this machine — the modal still renders, the
+  // first save creates it.
+  const [globalContent, { mutate: mutateGlobalContent }] = createResource(() =>
+    window.condash.getGlobalSettingsRaw(),
   );
 
   // Used to pick OS-appropriate placeholder text for path / shell fields.
@@ -190,7 +243,7 @@ export function SettingsModal(props: {
   });
   onCleanup(() => document.removeEventListener('keydown', handleKeydown, true));
 
-  // Saved-at indicator timer — shared by patchConfig + patchTerminal so we
+  // Saved-at indicator timer — shared by patchConfig + patchSettings so we
   // only ever have one pending clear in-flight, and so closing the modal
   // mid-grace doesn't fire setSavedAt on a disposed scope.
   let savedAtTimer: ReturnType<typeof setTimeout> | null = null;
@@ -205,36 +258,25 @@ export function SettingsModal(props: {
     if (savedAtTimer !== null) clearTimeout(savedAtTimer);
   });
 
-  const parsed = createMemo<RawConfig>(() => {
-    const text = content();
-    if (!text) return {};
-    try {
-      return JSON.parse(text) as RawConfig;
-    } catch {
-      return {};
-    }
-  });
+  // --- Parsed memos ---------------------------------------------------
 
-  const parseError = createMemo<string | null>(() => {
-    const text = content();
-    if (!text) return null;
-    try {
-      JSON.parse(text);
-      return null;
-    } catch (err) {
-      return (err as Error).message;
-    }
-  });
+  const parsed = createMemo<RawConfig>(() => parseRawConfig(content() ?? ''));
+  const globalParsed = createMemo<RawConfig>(() => parseRawConfig(globalContent() ?? ''));
+
+  const parseError = createMemo<string | null>(() => parseErrorOf(content() ?? ''));
+  const globalParseError = createMemo<string | null>(() => parseErrorOf(globalContent() ?? ''));
+
+  // --- patchConfig (condash.json) -------------------------------------
 
   /**
-   * Apply `mutator` to the parsed configuration, drop empty leaves, and
-   * persist via the same atomic CAS path the JSON-editor tab used.
+   * Apply `mutator` to the parsed condash.json, drop empty leaves, and
+   * persist via the same atomic CAS path used by every other note write.
    */
   const patchConfig = async (mutator: (config: RawConfig) => void): Promise<void> => {
     const text = content() ?? '';
     let parsedConfig: RawConfig;
     try {
-      parsedConfig = (text ? JSON.parse(text) : {}) as RawConfig;
+      parsedConfig = (text ? (JSON.parse(text) as RawConfig) : {}) as RawConfig;
     } catch (err) {
       setError(`condash.json is invalid: ${(err as Error).message}. Open it externally to repair.`);
       return;
@@ -249,18 +291,18 @@ export function SettingsModal(props: {
     setError(null);
     setPending(true);
     try {
-      // The conception config is canonicalised through the Zod schema on the
-      // main side, so the bytes that reach disk can differ from `next`
-      // (e.g. Zod reorders new keys into schema order). Cache the actual
-      // written content so the next save's CAS baseline matches disk.
+      // The conception config is canonicalised through the Zod schema on
+      // the main side, so the bytes that reach disk can differ from
+      // `next` (e.g. Zod reorders new keys into schema order). Cache the
+      // actual written content so the next save's CAS baseline matches
+      // disk.
       //
-      // Path swap: read from configurationPath() (which may be the legacy
-      // configuration.json) and always write to writePath (canonical
-      // condash.json). The CAS expected-content is the legacy file's
-      // content; on the first write to a fresh condash.json that file
-      // doesn't yet exist, so note.write's drift check sees `''` on disk
-      // — we handle that by passing `''` as the expected baseline when
-      // writing to a new path.
+      // Path swap: read from configurationPath() (which may be the
+      // legacy configuration.json) and always write to writePath
+      // (canonical condash.json). On the first write to a fresh
+      // condash.json the file doesn't yet exist, so note.write's drift
+      // check sees `''` on disk — pass `''` as the expected baseline
+      // when writing to a new path.
       const readFrom = configurationPath();
       const expected = readFrom === writePath ? text : '';
       const written = await window.condash.writeNote(writePath, expected, next);
@@ -280,14 +322,77 @@ export function SettingsModal(props: {
     }
   };
 
+  // --- patchSettings (settings.json) ---------------------------------
+
+  /**
+   * Apply `mutator` to the parsed settings.json, drop empty leaves, and
+   * persist via the new `settings.writeRaw` IPC's atomic CAS. Mirrors
+   * `patchConfig` but writes to the per-machine file. Every Global-tab
+   * editor goes through this; the long-standing `setTheme` / `setLayout`
+   * / `termSetPrefs` IPC verbs continue to write here too for the rest of
+   * the app.
+   */
+  const patchSettings = async (mutator: (settings: RawConfig) => void): Promise<void> => {
+    const text = globalContent() ?? '';
+    let parsedSettings: RawConfig;
+    try {
+      parsedSettings = (text ? (JSON.parse(text) as RawConfig) : {}) as RawConfig;
+    } catch (err) {
+      setError(
+        `settings.json is invalid: ${(err as Error).message}. Open it externally to repair.`,
+      );
+      return;
+    }
+    mutator(parsedSettings);
+    const pruned = pruneEmpty(parsedSettings) as RawConfig;
+    if (pruned.repositories) {
+      pruned.repositories = compactRepos(pruned.repositories);
+    }
+    const next = JSON.stringify(pruned, null, 2) + '\n';
+    if (next === text) return;
+    setError(null);
+    setPending(true);
+    try {
+      const written = await window.condash.writeGlobalSettings(text, next);
+      mutateGlobalContent(written);
+      setSavedAt(Date.now());
+      scheduleSavedAtClear();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  /** Patch the right file based on `target`. */
+  const patchFor = (target: SettingsTab) => (target === 'global' ? patchSettings : patchConfig);
+
+  /** Read the parsed source-of-truth for the given target. */
+  const parsedFor = (target: SettingsTab): RawConfig =>
+    target === 'global' ? globalParsed() : parsed();
+
+  // --- Inheritance state helpers --------------------------------------
+
+  const stateOf = <K extends keyof RawConfig>(key: K): InheritanceState =>
+    inheritanceState(key, globalParsed(), parsed());
+
+  /** Drop a top-level key from condash.json. Used by the "Remove
+   *  override" / "Reset to global" buttons. */
+  const removeOverride = <K extends keyof RawConfig>(key: K): Promise<void> =>
+    patchConfig((c) => {
+      delete (c as Record<string, unknown>)[key as string];
+    });
+
+  // --- External openers ----------------------------------------------
+
   const openConfigExternally = (): void => {
     void window.condash.openPath(configurationPath());
   };
 
-  const [settingsPath] = createResource(() => window.condash.getSettingsPath());
+  const [settingsPathRes] = createResource(() => window.condash.getSettingsPath());
 
   const openSettingsExternally = (): void => {
-    const path = settingsPath();
+    const path = settingsPathRes();
     if (path) void window.condash.openPath(path);
   };
 
@@ -356,7 +461,13 @@ export function SettingsModal(props: {
     props.onClose();
   };
 
-  // --- Workspace -------------------------------------------------------
+  // --- Per-target setters --------------------------------------------
+  //
+  // Workspace + Repositories + Open-with currently live on the conception
+  // tab only — the Global tab keeps its today-shape (Recents + Appearance
+  // + Terminal). Theme / cardMinWidth / terminal are inheritable: each
+  // ships a Global-side setter (writes to settings.json) and a
+  // Conception-side setter (writes to condash.json).
 
   const setWorkspacePath = (value: string): Promise<void> =>
     patchConfig((c) => {
@@ -377,8 +488,6 @@ export function SettingsModal(props: {
     patchConfig((c) => {
       c.skills_path = value || undefined;
     });
-
-  // --- Repositories ----------------------------------------------------
 
   const repos = (): RawRepo[] => parsed().repositories ?? [];
 
@@ -406,8 +515,6 @@ export function SettingsModal(props: {
   const updateRepoEntry = (index: number, patch: (entry: RawRepo) => RawRepo): Promise<void> =>
     updateRepos((entries) => entries.map((e, i) => (i === index ? patch(e) : e)));
 
-  // --- Open with -------------------------------------------------------
-
   const updateOpenWithSlot = (
     key: 'main_ide' | 'secondary_ide' | 'terminal',
     patch: { label?: string; command?: string },
@@ -424,49 +531,110 @@ export function SettingsModal(props: {
       c.open_with = openWith;
     });
 
-  // --- Terminal (settings.json — per-machine) -------------------------
+  // --- Card min width (inheritable) ----------------------------------
+  //
+  // The Global-tab control writes to settings.json AND fires the existing
+  // `setCardMinWidth` IPC so the live CSS variables in the rest of the app
+  // pick up the change immediately. The Conception-tab control writes to
+  // condash.json only; the rest of the app (re-routed in this PR to read
+  // through the effective resolver) picks up the conception override on
+  // its next refresh.
 
-  const [terminalRes, { mutate: mutateTerminal }] = createResource<TerminalPrefs>(() =>
-    window.condash.termGetPrefs(),
-  );
-
-  const terminalPrefs = (): TerminalPrefs => terminalRes() ?? {};
-
-  /**
-   * Apply `mutator` to the persisted terminal prefs in settings.json,
-   * drop empty leaves, and round-trip through `term.setPrefs`.
-   */
-  const patchTerminal = async (mutator: (prefs: TerminalPrefs) => TerminalPrefs): Promise<void> => {
-    const next = mutator({ ...terminalPrefs() });
-    const pruned = (pruneEmpty(next) as TerminalPrefs) ?? {};
-    setError(null);
-    setPending(true);
-    try {
-      await window.condash.termSetPrefs(pruned);
-      mutateTerminal(pruned);
-      setSavedAt(Date.now());
-      scheduleSavedAtClear();
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setPending(false);
-    }
+  const setGlobalCardMinWidth = async (patch: CardMinWidthPrefs): Promise<void> => {
+    await patchSettings((c) => {
+      const merged: CardMinWidthPrefs = { ...(c.cardMinWidth ?? {}), ...patch };
+      // Drop the entry when the user types an empty string — the prop
+      // change comes through as the bundled default, which the prune
+      // step handles.
+      for (const k of Object.keys(merged) as (keyof CardMinWidthPrefs)[]) {
+        if (merged[k] === undefined) delete merged[k];
+      }
+      c.cardMinWidth = Object.keys(merged).length > 0 ? merged : undefined;
+    });
+    // Notify the rest of the app via the existing prop callback so the
+    // CSS variables update without a re-mount.
+    props.onChangeCardMinWidth(patch);
   };
 
+  const setConceptionCardMinWidth = (patch: CardMinWidthPrefs): Promise<void> =>
+    patchConfig((c) => {
+      const merged: CardMinWidthPrefs = { ...(c.cardMinWidth ?? {}), ...patch };
+      for (const k of Object.keys(merged) as (keyof CardMinWidthPrefs)[]) {
+        if (merged[k] === undefined) delete merged[k];
+      }
+      c.cardMinWidth = Object.keys(merged).length > 0 ? merged : undefined;
+    });
+
+  /** Effective per-tab card-min-width snapshot. The Global tab shows
+   *  whatever settings.json carries (or the bundled default); the
+   *  Conception tab shows condash.json's own value when overridden,
+   *  otherwise the global one. */
+  const cardMinWidthFor =
+    (target: SettingsTab) =>
+    (key: keyof CardMinWidthPrefs): number => {
+      if (target === 'global') {
+        return globalParsed().cardMinWidth?.[key] ?? DEFAULT_CARD_MIN_WIDTH[key];
+      }
+      return (
+        parsed().cardMinWidth?.[key] ??
+        globalParsed().cardMinWidth?.[key] ??
+        DEFAULT_CARD_MIN_WIDTH[key]
+      );
+    };
+
+  // --- Theme (inheritable) -------------------------------------------
+
+  const setGlobalTheme = async (next: Theme): Promise<void> => {
+    await patchSettings((c) => {
+      c.theme = next;
+    });
+    // Keep the live theme prop in lock-step with settings.json.
+    props.onChangeTheme(next);
+  };
+
+  const setConceptionTheme = (next: Theme): Promise<void> =>
+    patchConfig((c) => {
+      c.theme = next;
+    });
+
+  /** Effective theme for the given tab. */
+  const themeFor = (target: SettingsTab): Theme => {
+    if (target === 'global') return globalParsed().theme ?? props.theme ?? 'system';
+    return parsed().theme ?? globalParsed().theme ?? props.theme ?? 'system';
+  };
+
+  // --- Terminal prefs (inheritable) ----------------------------------
+
+  const terminalPrefsFor = (target: SettingsTab): TerminalPrefs =>
+    (parsedFor(target).terminal as TerminalPrefs | undefined) ?? {};
+
+  /** Mutate the `terminal` block on the given file via its patch fn. */
+  const patchTerminal = (
+    target: SettingsTab,
+    mutator: (prefs: TerminalPrefs) => TerminalPrefs,
+  ): Promise<void> =>
+    patchFor(target)((c) => {
+      const next = mutator({ ...((c.terminal as TerminalPrefs | undefined) ?? {}) });
+      const cleaned = (pruneEmpty(next) as TerminalPrefs) ?? {};
+      c.terminal = Object.keys(cleaned).length > 0 ? cleaned : undefined;
+    });
+
   const setTerminalString = (
+    target: SettingsTab,
     key: (typeof TERMINAL_STRING_FIELDS)[number]['key'],
     value: string,
   ): Promise<void> =>
-    patchTerminal((p) => {
+    patchTerminal(target, (p) => {
       const next = { ...p } as Record<string, unknown>;
       next[key] = value || undefined;
       return next as TerminalPrefs;
     });
 
-  const xtermPrefs = createMemo<TerminalXtermPrefs>(() => terminalPrefs().xterm ?? {});
+  const xtermPrefsFor = (target: SettingsTab): TerminalXtermPrefs =>
+    terminalPrefsFor(target).xterm ?? {};
 
-  const updateXterm = (patch: Partial<TerminalXtermPrefs>): Promise<void> =>
-    patchTerminal((p) => {
+  const updateXterm = (target: SettingsTab, patch: Partial<TerminalXtermPrefs>): Promise<void> =>
+    patchTerminal(target, (p) => {
       const xterm = (p.xterm ?? {}) as TerminalXtermPrefs;
       const merged: TerminalXtermPrefs = { ...xterm, ...patch };
       if (patch.colors) {
@@ -475,14 +643,38 @@ export function SettingsModal(props: {
       return { ...p, xterm: merged };
     });
 
-  const updateColor = (key: ColorEntry['key'], value: string): void =>
-    void updateXterm({ colors: { [key]: value || undefined } as never });
+  const updateColor = (target: SettingsTab, key: ColorEntry['key'], value: string): void =>
+    void updateXterm(target, { colors: { [key]: value || undefined } as never });
+
+  // --- Scroll-to-section ---------------------------------------------
 
   const scrollToSection = (id: Section): void => {
     setSection(id);
     const el = document.getElementById(`settings-section-${id}`);
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
+
+  // --- Keyboard nav for the tablist ----------------------------------
+
+  const handleTabKey = (e: KeyboardEvent): void => {
+    if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return;
+    e.preventDefault();
+    const order: SettingsTab[] = ['global', 'conception'];
+    const idx = order.indexOf(tab());
+    const next =
+      e.key === 'ArrowLeft'
+        ? order[(idx + order.length - 1) % order.length]
+        : order[(idx + 1) % order.length];
+    switchTab(next);
+    // Move focus to the newly active tab button so screen readers
+    // announce the active state.
+    queueMicrotask(() => {
+      const el = document.querySelector<HTMLButtonElement>(`[data-tab="${next}"]`);
+      el?.focus();
+    });
+  };
+
+  // --- Render --------------------------------------------------------
 
   return (
     <div class="modal-backdrop settings-modal-backdrop" onClick={attemptClose}>
@@ -532,49 +724,84 @@ export function SettingsModal(props: {
             ×
           </button>
         </header>
+
+        {/* Tablist — switches between the Global and This-conception panels. */}
+        <div class="settings-tablist" role="tablist" aria-label="Settings scope">
+          <For each={TABS}>
+            {(meta) => (
+              <button
+                type="button"
+                role="tab"
+                data-tab={meta.id}
+                class="settings-tab"
+                classList={{ active: tab() === meta.id }}
+                aria-selected={tab() === meta.id}
+                aria-controls={`settings-panel-${meta.id}`}
+                tabIndex={tab() === meta.id ? 0 : -1}
+                onClick={() => switchTab(meta.id)}
+                onKeyDown={handleTabKey}
+              >
+                <span class="settings-tab-label">{meta.label}</span>
+                <code class="settings-tab-file">{meta.file}</code>
+              </button>
+            )}
+          </For>
+        </div>
+
         <Show when={parseError()}>
           <div class="modal-error">
             condash.json failed to parse — {parseError()}. Edit it externally to repair.
           </div>
         </Show>
+        <Show when={globalParseError()}>
+          <div class="modal-error">
+            settings.json failed to parse — {globalParseError()}. Edit it externally to repair.
+          </div>
+        </Show>
         <Show when={error()}>
           <div class="modal-error">{error()}</div>
         </Show>
+
         <div class="settings-shell">
           <nav class="settings-rail" aria-label="Settings sections">
-            <For each={GROUPS}>
-              {(g) => (
-                <div class="settings-rail-group">
-                  <div class="settings-rail-group-heading">
-                    <span class="settings-rail-group-label">{g.label}</span>
-                    <code>{g.file}</code>
-                  </div>
-                  <ul class="settings-rail-list">
-                    <For each={SECTIONS.filter((s) => s.group === g.id)}>
-                      {(s) => (
-                        <li>
-                          <button
-                            class="settings-rail-item"
-                            classList={{ active: section() === s.id }}
-                            onClick={() => scrollToSection(s.id)}
-                          >
-                            {s.label}
-                          </button>
-                        </li>
-                      )}
-                    </For>
-                  </ul>
-                </div>
-              )}
-            </For>
+            <p class="settings-rail-hint">{TABS.find((t) => t.id === tab())?.hint}</p>
+            <ul class="settings-rail-list">
+              <For each={SECTIONS.filter((s) => s.tab === tab())}>
+                {(s) => (
+                  <li>
+                    <button
+                      class="settings-rail-item"
+                      classList={{ active: section() === s.id }}
+                      onClick={() => scrollToSection(s.id)}
+                    >
+                      {s.label}
+                    </button>
+                  </li>
+                )}
+              </For>
+            </ul>
+            <div class="settings-rail-actions">
+              <button
+                class="modal-button"
+                onClick={() => void flushDrafts()}
+                disabled={!isDirty()}
+                title="Flush any focused-but-unblurred edits to disk"
+              >
+                Save
+              </button>
+              <button
+                class="modal-button"
+                onClick={tab() === 'global' ? openSettingsExternally : openConfigExternally}
+                title={`Open ${TABS.find((t) => t.id === tab())?.file} with the OS default editor`}
+              >
+                Open externally
+              </button>
+            </div>
           </nav>
+
           <div
             class="settings-scroll"
             onScroll={(e) => {
-              // Throttle the offsetTop layout reads to one per animation
-              // frame. Prior version forced a layout flush on every scroll
-              // event (one offsetTop read per SECTIONS entry), pinning the
-              // main thread on heavy scroll-wheel input.
               if (rafScheduled) return;
               rafScheduled = true;
               const scroller = e.currentTarget;
@@ -582,8 +809,10 @@ export function SettingsModal(props: {
                 rafScheduled = false;
                 const scrollerOffsetTop = scroller.offsetTop;
                 const top = scroller.scrollTop + 8;
-                let active: Section = 'appearance';
-                for (const s of SECTIONS) {
+                const sectionsForTab = SECTIONS.filter((s) => s.tab === tab());
+                if (sectionsForTab.length === 0) return;
+                let active: Section = sectionsForTab[0].id;
+                for (const s of sectionsForTab) {
                   const el = document.getElementById(`settings-section-${s.id}`);
                   if (el && el.offsetTop - scrollerOffsetTop <= top) {
                     active = s.id;
@@ -593,477 +822,278 @@ export function SettingsModal(props: {
               });
             }}
           >
-            {/* Group: settings.json (per-machine global) ----------------- */}
-            <header class="settings-group-divider">
-              <h2>Global</h2>
-              <code>settings.json</code>
-              <span class="settings-group-divider-actions">
-                <button
-                  class="modal-button"
-                  onClick={() => void flushDrafts()}
-                  disabled={!isDirty()}
-                  title="Flush any focused-but-unblurred edits to disk"
-                >
-                  Save
-                </button>
-                <button
-                  class="modal-button"
-                  onClick={openSettingsExternally}
-                  title="Open settings.json with the OS default editor"
-                >
-                  Open externally
-                </button>
-              </span>
-              <span class="settings-group-divider-hint">
-                Per-machine defaults stored in the OS user-data directory. Carries the active
-                conception path and the recents list. Workspace and presentational keys here are
-                inherited by every conception unless that conception's <code>condash.json</code>{' '}
-                overrides them.
-              </span>
-            </header>
+            {/* Global tabpanel ----------------------------------------- */}
+            <div
+              role="tabpanel"
+              id="settings-panel-global"
+              aria-labelledby="settings-tab-global"
+              class="settings-tabpanel"
+              classList={{ 'settings-tabpanel--hidden': tab() !== 'global' }}
+            >
+              <RecentConceptionsSection />
 
-            <RecentConceptionsSection />
+              {/* Appearance — global ---------------------------------- */}
+              <section id="settings-section-appearance:global" class="settings-section">
+                <h2>Appearance</h2>
+                <p class="settings-section-hint">
+                  Per-machine defaults. Each conception can override these in its own{' '}
+                  <code>condash.json</code>.
+                </p>
+                <ThemePicker
+                  current={themeFor('global')}
+                  onChange={(t) => void setGlobalTheme(t)}
+                />
+                <CardDensityFields
+                  resolve={cardMinWidthFor('global')}
+                  onChange={(patch) => void setGlobalCardMinWidth(patch)}
+                />
+              </section>
 
-            {/* Appearance ----------------------------------------------- */}
-            <section id="settings-section-appearance" class="settings-section">
-              <h2>Appearance</h2>
-              <div class="settings-field">
-                <span class="settings-field-label">Theme</span>
-                <div class="settings-radio-group" role="radiogroup">
-                  <For each={THEME_OPTIONS}>
-                    {(opt) => (
-                      <label class="settings-radio">
-                        <input
-                          type="radio"
-                          name="theme"
-                          checked={props.theme === opt.value}
-                          onChange={() => props.onChangeTheme(opt.value)}
-                        />
-                        <span>{opt.label}</span>
-                      </label>
+              {/* Terminal — global ----------------------------------- */}
+              <section id="settings-section-terminal:global" class="settings-section">
+                <h2>Terminal</h2>
+                <p class="settings-section-hint">
+                  Per-machine defaults. Each conception can override the entire{' '}
+                  <code>terminal</code> block in its <code>condash.json</code>.
+                </p>
+                <TerminalFields
+                  target="global"
+                  bindText={bindText}
+                  prefs={() => terminalPrefsFor('global')}
+                  xterm={() => xtermPrefsFor('global')}
+                  setString={(k, v) => setTerminalString('global', k, v)}
+                  updateXterm={(p) => updateXterm('global', p)}
+                  updateColor={(k, v) => updateColor('global', k, v)}
+                  platform={platform}
+                />
+              </section>
+            </div>
+
+            {/* Conception tabpanel ----------------------------------- */}
+            <div
+              role="tabpanel"
+              id="settings-panel-conception"
+              aria-labelledby="settings-tab-conception"
+              class="settings-tabpanel"
+              classList={{ 'settings-tabpanel--hidden': tab() !== 'conception' }}
+            >
+              {/* Workspace ----------------------------------------- */}
+              <section id="settings-section-workspace:conception" class="settings-section">
+                <div class="settings-section-head">
+                  <h2>Workspace</h2>
+                </div>
+                <div class="settings-grid settings-grid--wide">
+                  <FieldWithBadge
+                    label="Workspace path"
+                    state={stateOf('workspace_path')}
+                    onRemove={() => void removeOverride('workspace_path')}
+                  >
+                    <input
+                      type="text"
+                      placeholder={pick(WORKSPACE_PLACEHOLDER, platform())}
+                      {...bindText(
+                        'conception.workspace_path',
+                        () => parsed().workspace_path,
+                        setWorkspacePath,
+                      )}
+                    />
+                  </FieldWithBadge>
+                  <FieldWithBadge
+                    label="Worktrees path"
+                    state={stateOf('worktrees_path')}
+                    onRemove={() => void removeOverride('worktrees_path')}
+                  >
+                    <input
+                      type="text"
+                      placeholder={pick(WORKTREES_PLACEHOLDER, platform())}
+                      {...bindText(
+                        'conception.worktrees_path',
+                        () => parsed().worktrees_path,
+                        setWorktreesPath,
+                      )}
+                    />
+                  </FieldWithBadge>
+                  <FieldWithBadge
+                    label="Resources directory"
+                    hint="Relative to the conception root. Browsed by the Resources pane."
+                    state={stateOf('resources_path')}
+                    onRemove={() => void removeOverride('resources_path')}
+                  >
+                    <input
+                      type="text"
+                      placeholder="resources"
+                      {...bindText(
+                        'conception.resources_path',
+                        () => parsed().resources_path,
+                        setResourcesPath,
+                      )}
+                    />
+                  </FieldWithBadge>
+                  <FieldWithBadge
+                    label="Skills directory"
+                    hint="Relative to the conception root. Markdown files here are editable from the Skills pane."
+                    state={stateOf('skills_path')}
+                    onRemove={() => void removeOverride('skills_path')}
+                  >
+                    <input
+                      type="text"
+                      placeholder=".claude/skills"
+                      {...bindText(
+                        'conception.skills_path',
+                        () => parsed().skills_path,
+                        setSkillsPath,
+                      )}
+                    />
+                  </FieldWithBadge>
+                </div>
+              </section>
+
+              {/* Repositories ----------------------------------------- */}
+              <section id="settings-section-repositories:conception" class="settings-section">
+                <div class="settings-section-head">
+                  <h2>Repositories</h2>
+                  <FieldBadgeRow
+                    state={stateOf('repositories')}
+                    onRemove={() => void removeOverride('repositories')}
+                  />
+                </div>
+                <p class="settings-hint">
+                  Each entry is either just a name (resolved against <code>workspace_path</code>) or
+                  an object with optional <code>label</code>, <code>run</code>,{' '}
+                  <code>force_stop</code>, <code>install</code>, <code>env</code>, and{' '}
+                  <code>submodules</code>.
+                </p>
+                <div class="settings-bucket">
+                  <For each={repos()}>
+                    {(entry, index) => (
+                      <RepoRow
+                        entry={entry}
+                        idPrefix={`repo[${index()}]`}
+                        index={index()}
+                        total={repos().length}
+                        bindText={bindText}
+                        onMove={(delta) => void moveRepo(index(), delta)}
+                        onRemove={() => void removeRepo(index())}
+                        onPatch={(next) => updateRepoEntry(index(), () => next)}
+                      />
                     )}
                   </For>
+                  <div class="settings-list-actions">
+                    <button class="modal-button" onClick={() => void addRepo()}>
+                      + Add repo
+                    </button>
+                  </div>
                 </div>
-              </div>
+              </section>
 
-              <h3>Card density</h3>
-              <p class="settings-hint">
-                Each grid keeps a row of <em>n</em> cards until the pane is wide enough to fit{' '}
-                <em>n+1</em> cards each at this width — at which point the row reflows. Lower
-                numbers pack more cards per row at the same window size.
-              </p>
-              <div class="settings-grid">
-                <For
-                  each={
-                    [
-                      {
-                        key: 'projects',
-                        label: 'Project cards (Projects pane)',
-                      },
-                      {
-                        key: 'code',
-                        label: 'Code cards (Code pane)',
-                      },
-                      {
-                        key: 'knowledge',
-                        label: 'Knowledge cards (Knowledge pane)',
-                      },
-                      {
-                        key: 'resources',
-                        label: 'Resource cards (Resources pane)',
-                      },
-                      {
-                        key: 'skills',
-                        label: 'Skill cards (Skills pane)',
-                      },
-                    ] as const
-                  }
-                >
-                  {(field) => (
-                    <label>
-                      <span>{field.label}</span>
-                      <input
-                        type="number"
-                        min="120"
-                        max="2400"
-                        step="10"
-                        value={props.cardMinWidth[field.key]}
-                        onChange={(e) => {
-                          const raw = e.currentTarget.value;
-                          const parsed =
-                            raw === '' ? DEFAULT_CARD_MIN_WIDTH[field.key] : Number(raw);
-                          if (!Number.isFinite(parsed)) return;
-                          props.onChangeCardMinWidth({ [field.key]: parsed });
-                        }}
-                      />
-                      <small class="settings-field-hint">
-                        Min width in CSS pixels. Default {DEFAULT_CARD_MIN_WIDTH[field.key]}.
-                      </small>
-                    </label>
-                  )}
-                </For>
-              </div>
-            </section>
-
-            {/* Terminal (settings.json — per-machine) ------------------ */}
-            <section id="settings-section-terminal" class="settings-section">
-              <h2>Terminal</h2>
-              <h3>Behaviour &amp; shortcuts</h3>
-              <div class="settings-grid">
-                <For each={TERMINAL_STRING_FIELDS}>
-                  {(field) => (
-                    <label>
-                      <span>{field.label}</span>
-                      <input
-                        type="text"
-                        placeholder={pick(field.placeholder, platform())}
-                        {...bindText(
-                          `terminal.${field.key}`,
-                          () =>
-                            (terminalPrefs() as Record<string, unknown>)[field.key] as
-                              | string
-                              | undefined,
-                          (v) => setTerminalString(field.key, v),
-                        )}
-                      />
-                      <Show when={field.hint}>
-                        <small class="settings-field-hint">{field.hint}</small>
-                      </Show>
-                    </label>
-                  )}
-                </For>
-              </div>
-
-              <h3>Font</h3>
-              <div class="settings-grid">
-                <label>
-                  <span>Font family</span>
-                  <input
-                    type="text"
-                    placeholder="ui-monospace, Menlo, Consolas, monospace"
-                    {...bindText(
-                      'xterm.font_family',
-                      () => xtermPrefs().font_family,
-                      (v) => updateXterm({ font_family: v || undefined }),
-                    )}
+              {/* Open with ----------------------------------------- */}
+              <section id="settings-section-open-with:conception" class="settings-section">
+                <div class="settings-section-head">
+                  <h2>Open with</h2>
+                  <FieldBadgeRow
+                    state={stateOf('open_with')}
+                    onRemove={() => void removeOverride('open_with')}
                   />
-                </label>
-                <label>
-                  <span>Font size (px)</span>
-                  <input
-                    type="number"
-                    min="6"
-                    max="48"
-                    value={xtermPrefs().font_size ?? ''}
-                    placeholder="12"
-                    onChange={(e) =>
-                      void updateXterm({
-                        font_size: e.currentTarget.value
-                          ? Number(e.currentTarget.value)
-                          : undefined,
-                      })
-                    }
-                  />
-                </label>
-                <label>
-                  <span>Line height</span>
-                  <input
-                    type="number"
-                    step="0.05"
-                    min="0.8"
-                    max="2"
-                    value={xtermPrefs().line_height ?? ''}
-                    placeholder="1.0"
-                    onChange={(e) =>
-                      void updateXterm({
-                        line_height: e.currentTarget.value
-                          ? Number(e.currentTarget.value)
-                          : undefined,
-                      })
-                    }
-                  />
-                </label>
-                <label>
-                  <span>Letter spacing (px)</span>
-                  <input
-                    type="number"
-                    step="0.5"
-                    value={xtermPrefs().letter_spacing ?? ''}
-                    placeholder="0"
-                    onChange={(e) =>
-                      void updateXterm({
-                        letter_spacing: e.currentTarget.value
-                          ? Number(e.currentTarget.value)
-                          : undefined,
-                      })
-                    }
-                  />
-                </label>
-                <label>
-                  <span>Font weight</span>
-                  <input
-                    type="text"
-                    placeholder="normal | 400 | 500"
-                    {...bindText(
-                      'xterm.font_weight',
-                      () =>
-                        xtermPrefs().font_weight !== undefined
-                          ? String(xtermPrefs().font_weight)
-                          : undefined,
-                      (v) => updateXterm({ font_weight: v || undefined }),
-                    )}
-                  />
-                </label>
-                <label>
-                  <span>Bold weight</span>
-                  <input
-                    type="text"
-                    placeholder="bold | 600 | 700"
-                    {...bindText(
-                      'xterm.font_weight_bold',
-                      () =>
-                        xtermPrefs().font_weight_bold !== undefined
-                          ? String(xtermPrefs().font_weight_bold)
-                          : undefined,
-                      (v) => updateXterm({ font_weight_bold: v || undefined }),
-                    )}
-                  />
-                </label>
-              </div>
-              <h3>Cursor &amp; buffer</h3>
-              <div class="settings-grid">
-                <label>
-                  <span>Cursor style</span>
-                  <select
-                    value={xtermPrefs().cursor_style ?? 'block'}
-                    onChange={(e) =>
-                      void updateXterm({
-                        cursor_style: e.currentTarget.value as 'block' | 'underline' | 'bar',
-                      })
-                    }
-                  >
-                    <For each={CURSOR_STYLES}>
-                      {(opt) => <option value={opt.value}>{opt.label}</option>}
-                    </For>
-                  </select>
-                </label>
-                <label class="settings-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={xtermPrefs().cursor_blink !== false}
-                    onChange={(e) => void updateXterm({ cursor_blink: e.currentTarget.checked })}
-                  />
-                  <span>Cursor blink</span>
-                </label>
-                <label>
-                  <span>Scrollback (lines)</span>
-                  <input
-                    type="number"
-                    min="0"
-                    max="100000"
-                    value={xtermPrefs().scrollback ?? ''}
-                    placeholder="10000"
-                    onChange={(e) =>
-                      void updateXterm({
-                        scrollback: e.currentTarget.value
-                          ? Number(e.currentTarget.value)
-                          : undefined,
-                      })
-                    }
-                  />
-                </label>
-                <label class="settings-checkbox">
-                  <input
-                    type="checkbox"
-                    checked={xtermPrefs().ligatures === true}
-                    onChange={(e) =>
-                      void updateXterm({ ligatures: e.currentTarget.checked || undefined })
-                    }
-                  />
-                  <span>Programming-font ligatures</span>
-                </label>
-              </div>
-              <h3>Colours</h3>
-              <p class="settings-hint">
-                Leave a field blank to inherit the active theme. Values are CSS colours (hex, named,{' '}
-                <code>color-mix(...)</code>).
-              </p>
-              <div class="settings-color-grid">
-                <For each={TERMINAL_COLORS}>
-                  {(entry) => (
-                    <label class="settings-color">
-                      <span>{entry.label}</span>
-                      <input
-                        type="text"
-                        placeholder="—"
-                        {...bindText(
-                          `xterm.colors.${entry.key}`,
-                          () => xtermPrefs().colors?.[entry.key],
-                          (v) => {
-                            updateColor(entry.key, v);
-                            return Promise.resolve();
-                          },
-                        )}
-                      />
-                    </label>
-                  )}
-                </For>
-              </div>
-            </section>
-
-            {/* Group: condash.json (per-conception override) -------------- */}
-            <header class="settings-group-divider">
-              <h2>This conception</h2>
-              <code>
-                {configurationPath().endsWith('configuration.json')
-                  ? 'configuration.json (legacy)'
-                  : 'condash.json'}
-              </code>
-              <span class="settings-group-divider-actions">
-                <button
-                  class="modal-button"
-                  onClick={() => void flushDrafts()}
-                  disabled={!isDirty()}
-                  title="Flush any focused-but-unblurred edits to disk"
-                >
-                  Save
-                </button>
-                <button
-                  class="modal-button"
-                  onClick={openConfigExternally}
-                  title="Open the conception config file with the OS default editor"
-                >
-                  Open externally
-                </button>
-              </span>
-              <span class="settings-group-divider-hint">
-                Top-level keys here override the matching keys in settings.json. Reads fall back to
-                legacy configuration.json when condash.json is absent; writes always target
-                condash.json.
-              </span>
-            </header>
-
-            {/* Workspace ------------------------------------------------ */}
-            <section id="settings-section-workspace" class="settings-section">
-              <h2>Workspace</h2>
-              <div class="settings-grid settings-grid--wide">
-                <label>
-                  <span>Workspace path</span>
-                  <input
-                    type="text"
-                    placeholder={pick(WORKSPACE_PLACEHOLDER, platform())}
-                    {...bindText('workspace_path', () => parsed().workspace_path, setWorkspacePath)}
-                  />
-                </label>
-                <label>
-                  <span>Worktrees path</span>
-                  <input
-                    type="text"
-                    placeholder={pick(WORKTREES_PLACEHOLDER, platform())}
-                    {...bindText('worktrees_path', () => parsed().worktrees_path, setWorktreesPath)}
-                  />
-                </label>
-                <label>
-                  <span>Resources directory</span>
-                  <input
-                    type="text"
-                    placeholder="resources"
-                    {...bindText('resources_path', () => parsed().resources_path, setResourcesPath)}
-                  />
-                  <span class="settings-field-hint">
-                    Relative to the conception root. Browsed by the Resources pane.
-                  </span>
-                </label>
-                <label>
-                  <span>Skills directory</span>
-                  <input
-                    type="text"
-                    placeholder=".claude/skills"
-                    {...bindText('skills_path', () => parsed().skills_path, setSkillsPath)}
-                  />
-                  <span class="settings-field-hint">
-                    Relative to the conception root. Markdown files here are editable from the
-                    Skills pane.
-                  </span>
-                </label>
-              </div>
-            </section>
-
-            {/* Repositories -------------------------------------------- */}
-            <section id="settings-section-repositories" class="settings-section">
-              <h2>Repositories</h2>
-              <p class="settings-hint">
-                Each entry is either just a name (resolved against <code>workspace_path</code>) or
-                an object with optional <code>label</code>, <code>run</code>,{' '}
-                <code>force_stop</code>, <code>install</code>, <code>env</code>, and{' '}
-                <code>submodules</code>. <code>env</code> lists files copied from the primary into a
-                new worktree on <code>condash-cli worktrees setup</code>.
-              </p>
-              <div class="settings-bucket">
-                <For each={repos()}>
-                  {(entry, index) => (
-                    <RepoRow
-                      entry={entry}
-                      idPrefix={`repo[${index()}]`}
-                      index={index()}
-                      total={repos().length}
-                      bindText={bindText}
-                      onMove={(delta) => void moveRepo(index(), delta)}
-                      onRemove={() => void removeRepo(index())}
-                      onPatch={(next) => updateRepoEntry(index(), () => next)}
-                    />
-                  )}
-                </For>
-                <div class="settings-list-actions">
-                  <button class="modal-button" onClick={() => void addRepo()}>
-                    + Add repo
-                  </button>
                 </div>
-              </div>
-            </section>
+                <p class="settings-hint">
+                  Three slots used by the per-folder &quot;Open in…&quot; menu.{' '}
+                  <code>{'{path}'}</code> is substituted with the absolute path. Clear the command
+                  to remove the slot.
+                </p>
+                <div class="settings-grid settings-grid--wide">
+                  <For each={OPEN_WITH_SLOTS}>
+                    {(slot) => {
+                      const current = (): { label?: string; command?: string } =>
+                        parsed().open_with?.[slot.key] ?? {};
+                      return (
+                        <div class="settings-open-with">
+                          <span class="settings-field-label">{slot.label}</span>
+                          <input
+                            type="text"
+                            placeholder={`Open in ${slot.label.toLowerCase()}`}
+                            {...bindText(
+                              `conception.open_with.${slot.key}.label`,
+                              () => current().label,
+                              (v) => updateOpenWithSlot(slot.key, { label: v }),
+                            )}
+                          />
+                          <input
+                            type="text"
+                            placeholder="idea {path}"
+                            {...bindText(
+                              `conception.open_with.${slot.key}.command`,
+                              () => current().command,
+                              (v) => updateOpenWithSlot(slot.key, { command: v }),
+                            )}
+                          />
+                        </div>
+                      );
+                    }}
+                  </For>
+                </div>
+              </section>
 
-            {/* Open with ----------------------------------------------- */}
-            <section id="settings-section-open-with" class="settings-section">
-              <h2>Open with</h2>
-              <p class="settings-hint">
-                Three slots used by the per-folder &quot;Open in…&quot; menu.{' '}
-                <code>{'{path}'}</code> is substituted with the absolute path. Clear the command to
-                remove the slot.
-              </p>
-              <div class="settings-grid settings-grid--wide">
-                <For each={OPEN_WITH_SLOTS}>
-                  {(slot) => {
-                    const current = (): { label?: string; command?: string } =>
-                      parsed().open_with?.[slot.key] ?? {};
-                    return (
-                      <div class="settings-open-with">
-                        <span class="settings-field-label">{slot.label}</span>
-                        <input
-                          type="text"
-                          placeholder={`Open in ${slot.label.toLowerCase()}`}
-                          {...bindText(
-                            `open_with.${slot.key}.label`,
-                            () => current().label,
-                            (v) => updateOpenWithSlot(slot.key, { label: v }),
-                          )}
-                        />
-                        <input
-                          type="text"
-                          placeholder="idea {path}"
-                          {...bindText(
-                            `open_with.${slot.key}.command`,
-                            () => current().command,
-                            (v) => updateOpenWithSlot(slot.key, { command: v }),
-                          )}
-                        />
-                      </div>
-                    );
-                  }}
-                </For>
-              </div>
-            </section>
+              {/* Appearance — conception ---------------------------- */}
+              <section id="settings-section-appearance:conception" class="settings-section">
+                <div class="settings-section-head">
+                  <h2>Appearance</h2>
+                </div>
+                <div class="settings-section-subhead">
+                  <h3>Theme</h3>
+                  <FieldBadgeRow
+                    state={stateOf('theme')}
+                    onRemove={() => void removeOverride('theme')}
+                  />
+                </div>
+                <ThemePicker
+                  current={themeFor('conception')}
+                  onChange={(t) => void setConceptionTheme(t)}
+                />
+                <div class="settings-section-subhead">
+                  <h3>Card density</h3>
+                  <FieldBadgeRow
+                    state={stateOf('cardMinWidth')}
+                    onRemove={() => void removeOverride('cardMinWidth')}
+                  />
+                </div>
+                <p class="settings-hint">
+                  Each grid keeps a row of <em>n</em> cards until the pane is wide enough to fit{' '}
+                  <em>n+1</em> cards each at this width — at which point the row reflows.
+                </p>
+                <CardDensityFields
+                  resolve={cardMinWidthFor('conception')}
+                  onChange={(patch) => void setConceptionCardMinWidth(patch)}
+                />
+              </section>
+
+              {/* Terminal — conception ------------------------------ */}
+              <section id="settings-section-terminal:conception" class="settings-section">
+                <div class="settings-section-head">
+                  <h2>Terminal</h2>
+                  <FieldBadgeRow
+                    state={stateOf('terminal')}
+                    onRemove={() => void removeOverride('terminal')}
+                  />
+                </div>
+                <p class="settings-section-hint">
+                  Override the entire <code>terminal</code> block for this conception. Editing any
+                  field here writes the whole block to <code>condash.json</code>.
+                </p>
+                <TerminalFields
+                  target="conception"
+                  bindText={bindText}
+                  prefs={() => terminalPrefsFor('conception')}
+                  xterm={() => xtermPrefsFor('conception')}
+                  setString={(k, v) => setTerminalString('conception', k, v)}
+                  updateXterm={(p) => updateXterm('conception', p)}
+                  updateColor={(k, v) => updateColor('conception', k, v)}
+                  platform={platform}
+                />
+              </section>
+            </div>
           </div>
         </div>
+
         <Show when={closeConfirm()}>
           <div class="settings-confirm-backdrop" onClick={() => setCloseConfirm(false)}>
             <div
@@ -1091,5 +1121,337 @@ export function SettingsModal(props: {
         </Show>
       </div>
     </div>
+  );
+}
+
+// --- Section helpers ---------------------------------------------------
+
+function parseRawConfig(text: string): RawConfig {
+  if (!text) return {};
+  try {
+    return JSON.parse(text) as RawConfig;
+  } catch {
+    return {};
+  }
+}
+
+function parseErrorOf(text: string): string | null {
+  if (!text) return null;
+  try {
+    JSON.parse(text);
+    return null;
+  } catch (err) {
+    return (err as Error).message;
+  }
+}
+
+/** Field row that pairs a labelled control with an inheritance badge.
+ *  Used on the conception tab; pass `state="inherits"` and `hide` from the
+ *  global tab if it ever needs the same shape. */
+function FieldWithBadge(props: {
+  label: string;
+  hint?: string;
+  state: InheritanceState;
+  onRemove: () => void;
+  children: JSX.Element;
+}): JSX.Element {
+  return (
+    <label class="settings-field-with-badge">
+      <span class="settings-field-row">
+        <span class="settings-field-label">{props.label}</span>
+        <FieldBadgeRow state={props.state} onRemove={props.onRemove} />
+      </span>
+      {props.children}
+      <Show when={props.hint}>
+        <span class="settings-field-hint">{props.hint}</span>
+      </Show>
+    </label>
+  );
+}
+
+/** Theme radios — shared between the Global and Conception tabs. */
+function ThemePicker(props: { current: Theme; onChange: (theme: Theme) => void }): JSX.Element {
+  return (
+    <div class="settings-field">
+      <span class="settings-field-label">Theme</span>
+      <div class="settings-radio-group" role="radiogroup">
+        <For each={THEME_OPTIONS}>
+          {(opt) => (
+            <label class="settings-radio">
+              <input
+                type="radio"
+                name={`theme-${Math.random().toString(36).slice(2, 8)}`}
+                checked={props.current === opt.value}
+                onChange={() => props.onChange(opt.value)}
+              />
+              <span>{opt.label}</span>
+            </label>
+          )}
+        </For>
+      </div>
+    </div>
+  );
+}
+
+/** Five card-min-width fields — shared between tabs. */
+function CardDensityFields(props: {
+  resolve: (key: keyof CardMinWidthPrefs) => number;
+  onChange: (patch: CardMinWidthPrefs) => void;
+}): JSX.Element {
+  return (
+    <div class="settings-grid">
+      <For
+        each={
+          [
+            { key: 'projects', label: 'Project cards (Projects pane)' },
+            { key: 'code', label: 'Code cards (Code pane)' },
+            { key: 'knowledge', label: 'Knowledge cards (Knowledge pane)' },
+            { key: 'resources', label: 'Resource cards (Resources pane)' },
+            { key: 'skills', label: 'Skill cards (Skills pane)' },
+          ] as const
+        }
+      >
+        {(field) => (
+          <label>
+            <span>{field.label}</span>
+            <input
+              type="number"
+              min="120"
+              max="2400"
+              step="10"
+              value={props.resolve(field.key)}
+              onChange={(e) => {
+                const raw = e.currentTarget.value;
+                const parsed = raw === '' ? DEFAULT_CARD_MIN_WIDTH[field.key] : Number(raw);
+                if (!Number.isFinite(parsed)) return;
+                props.onChange({ [field.key]: parsed });
+              }}
+            />
+            <small class="settings-field-hint">
+              Min width in CSS pixels. Default {DEFAULT_CARD_MIN_WIDTH[field.key]}.
+            </small>
+          </label>
+        )}
+      </For>
+    </div>
+  );
+}
+
+/** Terminal section content — string fields, xterm font/cursor/buffer,
+ *  colours. Shared between Global and Conception tabs. */
+function TerminalFields(props: {
+  target: SettingsTab;
+  bindText: (
+    id: string,
+    persisted: () => string | undefined,
+    save: (value: string) => Promise<void>,
+  ) => {
+    value: string;
+    onInput: (e: InputEvent & { currentTarget: HTMLInputElement }) => void;
+    onChange: (e: Event & { currentTarget: HTMLInputElement }) => void;
+  };
+  prefs: () => TerminalPrefs;
+  xterm: () => TerminalXtermPrefs;
+  setString: (key: (typeof TERMINAL_STRING_FIELDS)[number]['key'], value: string) => Promise<void>;
+  updateXterm: (patch: Partial<TerminalXtermPrefs>) => Promise<void>;
+  updateColor: (key: ColorEntry['key'], value: string) => void;
+  platform: () => Platform | undefined;
+}): JSX.Element {
+  const idPrefix = `${props.target}.terminal`;
+  return (
+    <>
+      <h3>Behaviour &amp; shortcuts</h3>
+      <div class="settings-grid">
+        <For each={TERMINAL_STRING_FIELDS}>
+          {(field) => (
+            <label>
+              <span>{field.label}</span>
+              <input
+                type="text"
+                placeholder={pick(field.placeholder, props.platform())}
+                {...props.bindText(
+                  `${idPrefix}.${field.key}`,
+                  () => (props.prefs() as Record<string, unknown>)[field.key] as string | undefined,
+                  (v) => props.setString(field.key, v),
+                )}
+              />
+              <Show when={field.hint}>
+                <small class="settings-field-hint">{field.hint}</small>
+              </Show>
+            </label>
+          )}
+        </For>
+      </div>
+
+      <h3>Font</h3>
+      <div class="settings-grid">
+        <label>
+          <span>Font family</span>
+          <input
+            type="text"
+            placeholder="ui-monospace, Menlo, Consolas, monospace"
+            {...props.bindText(
+              `${idPrefix}.xterm.font_family`,
+              () => props.xterm().font_family,
+              (v) => props.updateXterm({ font_family: v || undefined }),
+            )}
+          />
+        </label>
+        <label>
+          <span>Font size (px)</span>
+          <input
+            type="number"
+            min="6"
+            max="48"
+            value={props.xterm().font_size ?? ''}
+            placeholder="12"
+            onChange={(e) =>
+              void props.updateXterm({
+                font_size: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+              })
+            }
+          />
+        </label>
+        <label>
+          <span>Line height</span>
+          <input
+            type="number"
+            step="0.05"
+            min="0.8"
+            max="2"
+            value={props.xterm().line_height ?? ''}
+            placeholder="1.0"
+            onChange={(e) =>
+              void props.updateXterm({
+                line_height: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+              })
+            }
+          />
+        </label>
+        <label>
+          <span>Letter spacing (px)</span>
+          <input
+            type="number"
+            step="0.5"
+            value={props.xterm().letter_spacing ?? ''}
+            placeholder="0"
+            onChange={(e) =>
+              void props.updateXterm({
+                letter_spacing: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+              })
+            }
+          />
+        </label>
+        <label>
+          <span>Font weight</span>
+          <input
+            type="text"
+            placeholder="normal | 400 | 500"
+            {...props.bindText(
+              `${idPrefix}.xterm.font_weight`,
+              () =>
+                props.xterm().font_weight !== undefined
+                  ? String(props.xterm().font_weight)
+                  : undefined,
+              (v) => props.updateXterm({ font_weight: v || undefined }),
+            )}
+          />
+        </label>
+        <label>
+          <span>Bold weight</span>
+          <input
+            type="text"
+            placeholder="bold | 600 | 700"
+            {...props.bindText(
+              `${idPrefix}.xterm.font_weight_bold`,
+              () =>
+                props.xterm().font_weight_bold !== undefined
+                  ? String(props.xterm().font_weight_bold)
+                  : undefined,
+              (v) => props.updateXterm({ font_weight_bold: v || undefined }),
+            )}
+          />
+        </label>
+      </div>
+
+      <h3>Cursor &amp; buffer</h3>
+      <div class="settings-grid">
+        <label>
+          <span>Cursor style</span>
+          <select
+            value={props.xterm().cursor_style ?? 'block'}
+            onChange={(e) =>
+              void props.updateXterm({
+                cursor_style: e.currentTarget.value as 'block' | 'underline' | 'bar',
+              })
+            }
+          >
+            <For each={CURSOR_STYLES}>
+              {(opt) => <option value={opt.value}>{opt.label}</option>}
+            </For>
+          </select>
+        </label>
+        <label class="settings-checkbox">
+          <input
+            type="checkbox"
+            checked={props.xterm().cursor_blink !== false}
+            onChange={(e) => void props.updateXterm({ cursor_blink: e.currentTarget.checked })}
+          />
+          <span>Cursor blink</span>
+        </label>
+        <label>
+          <span>Scrollback (lines)</span>
+          <input
+            type="number"
+            min="0"
+            max="100000"
+            value={props.xterm().scrollback ?? ''}
+            placeholder="10000"
+            onChange={(e) =>
+              void props.updateXterm({
+                scrollback: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+              })
+            }
+          />
+        </label>
+        <label class="settings-checkbox">
+          <input
+            type="checkbox"
+            checked={props.xterm().ligatures === true}
+            onChange={(e) =>
+              void props.updateXterm({ ligatures: e.currentTarget.checked || undefined })
+            }
+          />
+          <span>Programming-font ligatures</span>
+        </label>
+      </div>
+
+      <h3>Colours</h3>
+      <p class="settings-hint">
+        Leave a field blank to inherit the active theme. Values are CSS colours (hex, named,{' '}
+        <code>color-mix(...)</code>).
+      </p>
+      <div class="settings-color-grid">
+        <For each={TERMINAL_COLORS}>
+          {(entry) => (
+            <label class="settings-color">
+              <span>{entry.label}</span>
+              <input
+                type="text"
+                placeholder="—"
+                {...props.bindText(
+                  `${idPrefix}.xterm.colors.${entry.key}`,
+                  () => props.xterm().colors?.[entry.key],
+                  (v) => {
+                    props.updateColor(entry.key, v);
+                    return Promise.resolve();
+                  },
+                )}
+              />
+            </label>
+          )}
+        </For>
+      </div>
+    </>
   );
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -114,6 +114,22 @@ export interface CondashApi {
   /** Absolute path to `~/.config/condash/settings.json` (or platform equivalent),
    * for the settings modal's "Open externally" button. */
   getSettingsPath(): Promise<string>;
+  /**
+   * Raw text content of `settings.json`. Returns `''` when the file is
+   * absent — the Settings modal treats that as "fresh defaults" and creates
+   * the file on first save. Used to drive the Global tab's editor and to
+   * compute inheritance badges by comparing against the conception's
+   * `condash.json`.
+   */
+  getGlobalSettingsRaw(): Promise<string>;
+  /**
+   * Atomic CAS write to `settings.json`. The main process canonicalises
+   * the JSON through `globalSettingsSchema` before writing — so the bytes
+   * that hit disk can differ from `newContent` (Zod reorders keys to
+   * schema order). Returns whatever was actually written so the caller can
+   * keep its CAS baseline aligned with disk.
+   */
+  writeGlobalSettings(expectedContent: string, newContent: string): Promise<string>;
   toggleStep(
     path: string,
     lineIndex: number,

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import { writeFile, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { bootApp } from './fixtures/electron-app';
+
+/**
+ * Two-tab Settings modal — switching tabs hides the other panel and
+ * surfaces the conception-side inheritance badges. Regression cover for
+ * the v2.15.0 ship that landed only the section-divider rendering and
+ * left tabs + badges out (project 2026-05-08-condash-unified-settings).
+ */
+test('settings modal: tabs swap panels and badges reflect inheritance', async () => {
+  const booted = await bootApp({
+    extraConfig: { theme: 'dark' },
+  });
+  try {
+    // Open Settings the same way the File menu does — fire the
+    // `open-settings` menu command into the renderer via the same channel
+    // the production menu uses. Keyboard accelerators on Electron menus
+    // are owned by the OS-app menu, which Playwright can't trigger
+    // synthetically; firing the IPC directly mirrors what the click
+    // handler ultimately does.
+    await booted.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      win.webContents.send('menu-command', 'open-settings');
+    });
+
+    const modal = booted.window.locator('.settings-modal');
+    await expect(modal).toBeVisible();
+
+    // Tablist is present with two tabs; Global is initially active.
+    const tablist = modal.locator('[role="tablist"]');
+    await expect(tablist).toBeVisible();
+    const tabs = tablist.locator('[role="tab"]');
+    await expect(tabs).toHaveCount(2);
+    await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
+    await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'false');
+
+    // Only the global panel is visible (the conception panel is in the DOM
+    // but display:none-hidden so drafts and scroll position survive a tab
+    // switch).
+    const globalPanel = modal.locator('#settings-panel-global');
+    const conceptionPanel = modal.locator('#settings-panel-conception');
+    await expect(globalPanel).toBeVisible();
+    await expect(conceptionPanel).not.toBeVisible();
+
+    // Switch to the conception tab via click.
+    await tabs.nth(1).click();
+    await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'false');
+    await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'true');
+    await expect(globalPanel).not.toBeVisible();
+    await expect(conceptionPanel).toBeVisible();
+
+    // The conception tab carries the inheritance badge layer — at minimum
+    // one badge per top-level overridable key. The fixture's condash.json
+    // sets `theme: 'dark'` (the only key in extraConfig), so the `theme`
+    // section should show "Overridden" while every other key shows
+    // "Inherits".
+    const badges = conceptionPanel.locator('.settings-badge');
+    expect(await badges.count()).toBeGreaterThanOrEqual(5);
+    // At least one Overridden badge — the fixture's theme override.
+    await expect(conceptionPanel.locator('.settings-badge--overridden').first()).toBeVisible();
+
+    // Reset-to-global button shows for overridden keys.
+    const resetButton = conceptionPanel.locator('button.settings-remove-override').first();
+    await expect(resetButton).toBeVisible();
+  } finally {
+    await booted.cleanup();
+  }
+});
+
+test('settings modal: reset-to-global drops the override key from condash.json', async () => {
+  const booted = await bootApp({
+    extraConfig: { skills_path: 'some/custom/skills' },
+  });
+  try {
+    await booted.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      win.webContents.send('menu-command', 'open-settings');
+    });
+    const modal = booted.window.locator('.settings-modal');
+    await expect(modal).toBeVisible();
+
+    // Switch to the conception tab.
+    await modal.locator('[role="tab"]').nth(1).click();
+    const conceptionPanel = modal.locator('#settings-panel-conception');
+    await expect(conceptionPanel).toBeVisible();
+
+    // Find the `skills_path` field by label. Settings.json doesn't
+    // declare skills_path, so the conception override (`some/custom/
+    // skills`) shows "Overridden" — distinct from the absent global.
+    const skillsField = conceptionPanel
+      .locator('.settings-field-with-badge', { hasText: 'Skills directory' })
+      .first();
+    await expect(skillsField.locator('.settings-badge--overridden')).toBeVisible();
+
+    // Click "Reset to global" — the button surfaced for overridden keys.
+    const resetButton = skillsField.locator('button.settings-remove-override');
+    await resetButton.click();
+
+    // After the click the badge flips to "Inherits" and the key is
+    // dropped from condash.json on disk.
+    await expect(skillsField.locator('.settings-badge--inherits')).toBeVisible();
+
+    const condashPath = join(booted.conceptionDir, 'condash.json');
+    await expect
+      .poll(async () => {
+        const text = await readFile(condashPath, 'utf8');
+        const parsed = JSON.parse(text) as Record<string, unknown>;
+        return Object.prototype.hasOwnProperty.call(parsed, 'skills_path');
+      })
+      .toBe(false);
+  } finally {
+    await booted.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- v2.15.0 closed the unified-settings project with Step 5 marked done, but only the section-divider rendering shipped — the two-tab UI and the per-key inheritance badge layer the design called for were never actually built. This PR ships them and bumps to 2.15.2 (2.15.1 was the parallel split-cli patch).
- Theme, cardMinWidth, and terminal prefs are now properly per-conception inheritable: each setting has a Global control writing settings.json plus a Conception control that writes condash.json with a badge calling out the inheritance state.
- Reads of those keys (`getTheme`, `getCardMinWidth`, `getTerminalPrefs`) are now routed through `getEffectiveConceptionConfig` so per-conception overrides take effect app-wide, not just inside the Settings modal.

## Changes

- New ARIA tablist (Global / This conception) replaces the v2.15.0 single-scroll layout. Both panels stay mounted; the inactive one is `display: none`-hidden so drafts and scroll position survive a tab switch. Last-active tab persists in localStorage. Arrow-key navigation between tabs.
- New `<InheritanceBadge>` + `<RemoveOverrideButton>` component (`src/renderer/settings-modal-parts/badges.tsx`). Three states — Inherits / Overridden / Matches global — computed by stable JSON-canonical deep-equal compare. Reset-to-global drops the key from condash.json; Remove-override does the same for redundant overrides.
- Per-field badges on the conception tab cover every overridable top-level key: `workspace_path`, `worktrees_path`, `resources_path`, `skills_path`, `repositories`, `open_with`, `theme`, `cardMinWidth`, `terminal`.
- New IPC pair `settings.readRaw` / `settings.writeRaw` (exposed via `CondashApi.getGlobalSettingsRaw` / `writeGlobalSettings`) powers the Global-tab editor through the same atomic-CAS flow condash.json uses. New `validateAndCanonicaliseGlobalSettings` validates against `globalSettingsSchema` before bytes hit disk.
- `EffectiveConfig` extended with `theme`, `cardMinWidth`, `layout`, `treeExpansion`. `getTheme`, `getCardMinWidth`, and `getTerminalPrefs` consult `getEffectiveConceptionConfig` first and fall back to settings.json.
- Docs updated: `docs/help/configuration.md` and `docs/reference/config.md` document the tab structure, the badge state machine, and the new IPC verbs.
- Playwright `tests/settings-tabs.spec.ts` covers tab swap (Global panel hidden when conception tab active and vice versa) and Reset-to-global writing through to disk.

## Impact

- The renderer's `getTheme` / `getCardMinWidth` / `termGetPrefs` IPC verbs change semantics: they now return the *effective* value (conception override > global default), not the raw settings.json field. Callers wanting the raw settings value should use `getGlobalSettingsRaw()` and parse.
- The Settings modal opens on whichever tab the user was last on (Global by default for first launch). No migration step — localStorage is empty on first run.
- File → Open externally now points at whichever tab is active; the v2.15.0 layout had per-group buttons.

## Watchpoints

- `getEffectiveConceptionConfig` reads both settings.json and condash.json on every theme / cardMinWidth / termGetPrefs IPC call. Rare enough today that this hasn't shown up in profiling, but if a future feature calls these in a tight loop, consider caching by mtime.
- Pre-existing failing tests on main (`dirty-badge.spec.ts`, `help-loader.spec.ts`, `resources-skills.spec.ts`) are unrelated to this PR; the new settings-tabs spec passes clean.