### PR TITLE
Ship /tidy as a condash-managed skill (resolves #96)

### DIFF
--- a/conception-template/.claude/skills/tidy/SKILL.md
+++ b/conception-template/.claude/skills/tidy/SKILL.md
@@ -1,0 +1,169 @@
+---
+description: Audit the conception tree (knowledge index orphans + dangling links, cross-repo refs, branch ↔ worktree drift, LFS coverage, large binaries, stale verification stamps), batch the auto-fixable issues into a single confirm-then-apply round, and surface the rest as a punch-list. Wraps `condash-cli audit --include all --json` and `condash-cli knowledge verify --json`.
+---
+
+# /tidy — audit + batched fix the conception tree
+
+`/tidy` runs every condash audit + the knowledge verification stamp check, groups the results, applies auto-fixable items in one batch after the user confirms once, and reports the rest as manual work to do later.
+
+## When to use
+
+- Periodically — once a week, or before opening a release-shaped PR off `main`.
+- After a bulk refactor of `knowledge/` or `projects/` — orphans and dangling index links pile up.
+- After a worktree-heavy week — branches that were merged or removed often leave stale items declaring `**Branch**` with no on-disk worktree.
+- When the dashboard's audit indicator shows issues.
+
+For an at-a-glance read without the triage walk, `condash-cli audit` and `condash-cli knowledge verify` directly are faster.
+
+## Trigger
+
+```
+/tidy [check=<list>] [dry-run]
+```
+
+| Arg                 | Meaning                                                                                       |
+|---------------------|-----------------------------------------------------------------------------------------------|
+| `check=<list>`      | Comma-separated subset of `lfs,binaries,cross-repo,worktrees,index,stale_verification`. Default: all. |
+| `dry-run`           | Print the proposed fixes but do not apply, even after confirmation.                           |
+
+## Procedure
+
+### 1. Collect issues
+
+Run both probes and concatenate their `issues[]` arrays:
+
+```bash
+condash-cli audit --include all --json
+condash-cli knowledge verify --json
+```
+
+If the user passed `check=...`:
+
+- For values in `lfs,binaries,cross-repo,worktrees,index`: forward as `--include <list>` to `audit` (drop `stale_verification` from the list).
+- If the list contains `stale_verification`: still call `verify`. Otherwise skip it.
+
+The two responses share the same per-issue shape:
+
+```json
+{
+  "check": "<name>",
+  "severity": "error | warn | info",
+  "file": "<path or null>",
+  "line": "<number or null>",
+  "message": "<human-readable>",
+  "fix": { "action": "<symbolic>", "autoFix": true | false, "...payload": "..." }
+}
+```
+
+`fix.autoFix` is the source of truth for whether the skill can mechanically apply the fix. Do not derive it from the check name.
+
+### 2. Group + partition
+
+- Group `issues[]` by `fix.action`.
+- Partition each group by `fix.autoFix`.
+- For `cross-repo` only, do the rename hunt described in step 3 *before* classifying as punch-list.
+
+### 3. Cross-repo special case (rename hunt)
+
+For each issue with `fix.action === 'flag_for_user_edit'`:
+
+1. Take the dangling reference's basename and the parent directory's last segment.
+2. Search the conception tree for a markdown file with a similar name (Levenshtein within 3, or same basename in a different parent path).
+3. If exactly one candidate exists, propose a *redirect*: rewrite the dangling link to point at the candidate.
+4. If zero or several candidates exist, leave the issue in the punch-list — the user has to decide.
+
+Promote redirect proposals from punch-list to auto-fix list (their effective `autoFix` becomes `true` once a single-candidate redirect is found).
+
+### 4. Single confirmation round
+
+Build one `AskUserQuestion` listing every proposed auto-fix grouped by check. Example shape:
+
+```
+Found 7 fixable issues across 4 checks:
+
+  lfs (2)
+    + git lfs track projects/2026-04/.../diagram.png  (122 kB)
+    + git lfs track projects/2026-04/.../slides.pdf   (310 kB)
+  worktrees (1)
+    + condash-cli worktrees setup retire-feature-x
+  index (3)
+    + remove dangling line in knowledge/topics/index.md:14
+    + remove dangling line in knowledge/internal/index.md:8
+    + condash-cli knowledge index  (orphan body files)
+  cross-repo (1)
+    + redirect ../conception/projects/2026-03/old-slug → ../conception/projects/2026-03/new-slug
+
+Apply all? (y / n / pick)
+```
+
+Decisions:
+
+- **y** — apply every line.
+- **n** — skip every line; jump to the punch-list and final report.
+- **pick** — present the same list as a multi-select; only checked items get applied.
+
+The single-round rule is non-negotiable. Never per-issue ping-pong; always one `AskUserQuestion`.
+
+### 5. Apply
+
+For each confirmed auto-fix:
+
+| `fix.action`              | How to apply                                                                                  |
+|---------------------------|-----------------------------------------------------------------------------------------------|
+| `lfs_track_path`          | `git lfs track <fix.path>` from the conception root, then `git add .gitattributes`. Tell the user to commit + push so the migration is durable. |
+| `offer_worktree_setup`    | `condash-cli worktrees setup <fix.branch> --json`.                                            |
+| `remove_index_line`       | `Edit` the index.md file: delete the matching `[label](path)` line whose `path` equals `fix.path` and whose `label` equals `fix.label`. |
+| `run_knowledge_index`     | `condash-cli knowledge index --json` once at the end of the batch (deduplicate; running it once covers every per-orphan instance). |
+| (rename redirect)         | `Edit` the dangling-reference file: replace the old path with the candidate path. The candidate file lives in the conception tree; both relative and same-branch absolute references resolve through `path.resolve` against `dirname(<file>)`. |
+
+After every batch, re-run the matching probe with `--json` to confirm the issue is gone — then collapse the result into the final report.
+
+### 6. Punch-list
+
+Surface every issue with `fix.autoFix === false` as a numbered list, grouped by check. Per-check guidance:
+
+- `binaries` — "consider migrating to LFS or removing". Decision is per-file: large fixtures legitimately stay; cached PDFs should usually go.
+- `cross-repo` (after the rename hunt found nothing) — print the file + line and the dangling reference. The user has to decide whether to update the link or drop the source paragraph.
+- `stale_verification` — print the path:line, the date, and the `**Verified:**` `where` field. Ask the user to either *re-confirm* (re-read the source, then `condash-cli knowledge stamp <path>` to bump the date) or *update the surrounding text*. Never bump the date on the user's behalf — that lies about freshness.
+- `install_git_lfs` (info from `lfs` check) — only emitted when `git-lfs` is missing on the host. One-line "install git-lfs to enable this check".
+- `create_knowledge_dir` — only emitted when `knowledge/` is missing. Could be intentional (early-stage conception). Surface and move on.
+- `unknown_check` / `investigate_crash` — bugs in condash itself; report the message verbatim and stop.
+
+### 7. Final report
+
+```
+=== /tidy report ===
+Tree:           <conception root>
+Issues found:   <total>
+By severity:    error=N, warn=N, info=N
+Fixed:          <count> (across <K> checks)
+  lfs:          tracked <N> file(s) → commit & push to publish
+  worktrees:    set up <N> worktree(s)
+  index:        cleaned <N> dangling line(s); regenerated <N> index.md
+  cross-repo:   redirected <N> reference(s)
+Deferred (punch-list, <count>):
+  binaries:     <N>
+  cross-repo:   <N>
+  stale_verification: <N>
+Re-run /tidy after committing the auto-fix changes.
+```
+
+If `dry-run` was passed: every "Fixed" line becomes "Would fix", and skip the re-run line.
+
+## Rules
+
+- **Never auto-bump `**Verified:**` stamps.** A stale stamp means "human must reread the source"; bumping the date silently is a freshness lie. The skill always emits stale stamps as punch-list items.
+- **Never auto-delete cross-repo references.** Always look for a likely-renamed file first (step 3); only the user can choose to drop a reference outright.
+- **`git lfs track` is reversible but changes history.** The single-confirmation round is the user's chance to opt out — do not skip it even on a bare `y`-then-go session.
+- **One `AskUserQuestion` per `/tidy` run.** Step 4 is the *only* prompt; step 6 (the punch-list) is informational, never a question.
+- **Re-run, don't loop.** After applying fixes, tell the user to commit and re-run `/tidy` rather than iterating in the same session — fresh probe runs against committed state are the source of truth, not stale in-memory deltas.
+- **`dry-run` skips writes everywhere**, including the `Edit` calls for `remove_index_line` and the rename-redirect step.
+
+## Why this skill exists
+
+The CLI alone covers every check (`audit --include all`, `knowledge verify`). What it can't do alone is the editorial layer: investigate dangling cross-repo refs for likely renames, batch every safe fix into one confirmation, and produce a single human-readable end-of-run report. That layer was previously per-conception code (`tidy.py` + a per-conception `SKILL.md`) — same logic copy-pasted across trees. Owning it in condash means fixes ship once and version with the audit they triage.
+
+Out of scope (intentionally):
+
+- The `memory_index` check from older per-conception versions — some conceptions ban the auto-memory feature it audits, so it is not universal. Re-add as an opt-in audit if a future conception needs it.
+- Folding `audit` and `knowledge verify` into one verb — they audit semantically distinct concerns (structural drift vs. content freshness). Two probes, one skill.

--- a/docs/guides/skill-extensions.md
+++ b/docs/guides/skill-extensions.md
@@ -1,6 +1,6 @@
 ---
 title: Extend the management skills · condash guide
-description: How to fork or wrap the shipped /projects, /knowledge, /skills, /pr Claude Code skills with team-specific behaviour.
+description: How to fork or wrap the shipped /projects, /knowledge, /tidy, /skills, /pr Claude Code skills with team-specific behaviour.
 ---
 
 # Extend the management skills
@@ -19,6 +19,7 @@ For the base reference (every action, every CLI verb each one wraps), see [the m
 # After running `condash-cli skills install`
 <conception>/.claude/skills/projects/
 <conception>/.claude/skills/knowledge/
+<conception>/.claude/skills/tidy/
 <conception>/.claude/skills/skills/
 <conception>/.claude/skills/pr/
 ```

--- a/docs/help/welcome.md
+++ b/docs/help/welcome.md
@@ -20,9 +20,9 @@ are still on disk; delete condash and the files don't move.
   on first launch — drop a file in `resources/` and the pane will
   surface it.
 - **Skills** (right pane, alternate, `Ctrl+L`) — markdown skills under
-  `.claude/skills/`, edited in place. Default location for the four
-  shipped skills (`/projects`, `/knowledge`, `/skills`, `/pr`) — they
-  appear automatically once `condash-cli skills install` has run.
+  `.claude/skills/`, edited in place. Default location for the five
+  shipped skills (`/projects`, `/knowledge`, `/tidy`, `/skills`, `/pr`)
+  — they appear automatically once `condash-cli skills install` has run.
 - **Terminal** — toggle with `` Ctrl+` ``.
 - **Search** — `Ctrl+Shift+F` for cross-tree fuzzy search.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -13,7 +13,7 @@ description: The condash-cli command-line surface — list projects, search, man
 condash-cli <noun> <verb> [args] [--flags]
 ```
 
-The CLI exists because skills (`/projects`, `/knowledge`) and shell scripts need a programmatic surface that shares condash's parser, validator, and indexer — without re-implementing them in `bash + grep + sed`.
+The CLI exists because skills (`/projects`, `/knowledge`, `/tidy`) and shell scripts need a programmatic surface that shares condash's parser, validator, and indexer — without re-implementing them in `bash + grep + sed`.
 
 ## At a glance
 
@@ -167,6 +167,8 @@ condash-cli audit --include lfs,binaries
 | `index` | `index.md` files out of sync with the on-disk tree |
 
 `--include <list>` restricts to a comma-separated subset.
+
+Each issue in `--json` mode carries a `fix` object: `{ action, autoFix, ...payload }`. `autoFix: true` flags issues a wrapping skill (e.g. `/tidy`) can mechanically apply once batched confirmation is given; `autoFix: false` flags items that need human judgment. The same shape is shared with `condash-cli knowledge verify --json`'s `issues[]` array, so triage skills consume audit + verify uniformly.
 
 ### `dirty`
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -23,5 +23,5 @@ Short pages, one per surface. Look things up here; learn them in **[Get started]
 - [Inline dev-server runner](inline-runner.md) — the per-repo Run/Stop button and the `run` field.
 - [IPC API](ipc-api.md) — every verb the renderer can call on the main process.
 - [Environment variables](env.md) — the short list.
-- [Management skill](skill.md) — the shipped `/projects` and `/knowledge` skills.
+- [Management skill](skill.md) — the shipped `/projects`, `/knowledge`, `/tidy`, `/skills`, `/pr` skills.
 - [Releases workflow](../get-started/releases.md) — what each version tag means and how the auto-updater behaves.

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -1,6 +1,6 @@
 ---
 title: Management skills · condash reference
-description: Reference for the four shipped Claude Code skills — /projects, /knowledge, /skills, /pr — and how they shell out to the condash CLI.
+description: Reference for the five shipped Claude Code skills — /projects, /knowledge, /tidy, /skills, /pr — and how they shell out to the condash CLI.
 ---
 
 # Management skills
@@ -9,12 +9,13 @@ description: Reference for the four shipped Claude Code skills — /projects, /k
 
 ## At a glance
 
-condash ships four [Claude Code](https://docs.claude.com/en/docs/claude-code/) skills. They live under [`conception-template/.claude/skills/`](https://github.com/vcoeur/condash/tree/main/conception-template/.claude/skills) in the repo and land at `<conception>/.claude/skills/` after running `condash-cli skills install` (or `/skills install` from a session).
+condash ships five [Claude Code](https://docs.claude.com/en/docs/claude-code/) skills. They live under [`conception-template/.claude/skills/`](https://github.com/vcoeur/condash/tree/main/conception-template/.claude/skills) in the repo and land at `<conception>/.claude/skills/` after running `condash-cli skills install` (or `/skills install` from a session).
 
 | Skill | Scope | What it does |
 |---|---|---|
 | **`/projects`** | items + worktrees | Create / read / update / close projects, incidents, and documents. Manage worktrees per branch. |
 | **`/knowledge`** | knowledge tree | Retrieve, update, index, and verify durable reference material in `<conception>/knowledge/`. |
+| **`/tidy`** | health | Run every audit + verify stamp check, batch the auto-fixable ones into one confirmation, surface the rest as a punch-list. |
 | **`/skills`** | meta | Install or update the shipped skills themselves — wraps `condash-cli skills install`. |
 | **`/pr`** | git | Open a GitHub PR from the current branch with the project README's timeline-append rule applied. |
 
@@ -52,6 +53,18 @@ Manage durable reference material in `<conception>/knowledge/`.
 
 Every body file carries a `**Verified:** YYYY-MM-DD` stamp; `verify` flags ones older than the freshness threshold.
 
+## `/tidy`
+
+Run every audit and verification check the CLI knows about, batch the safely auto-fixable issues into a single confirmation, and surface the rest as a punch-list.
+
+| Action | Trigger | Wraps |
+|---|---|---|
+| (default) | `/tidy [check=<list>] [dry-run]` | `condash-cli audit --include all --json` and `condash-cli knowledge verify --json` |
+
+The skill never auto-bumps `**Verified:**` stamps (a stale stamp means "human re-reads the source") and never auto-deletes cross-repo references — instead it searches for likely-renamed targets and proposes a redirect when there's a single candidate. Every other auto-fix (LFS track, worktree setup, dangling-index-line removal, `knowledge index` regen) goes through one `AskUserQuestion` round before applying.
+
+Each issue carries a `fix.action` symbol and a `fix.autoFix: bool` flag — the skill reads `autoFix` directly rather than deriving fixability from check names.
+
 ## `/skills`
 
 Install or refresh the shipped skills. Use it after upgrading condash to pull updated skill content while keeping local edits.
@@ -77,7 +90,7 @@ condash-cli skills install
 condash-cli skills install
 ```
 
-The skills land at `<conception>/.claude/skills/`. Reload Claude Code (or start a new session) and `/projects`, `/knowledge`, `/skills`, `/pr` are available.
+The skills land at `<conception>/.claude/skills/`. Reload Claude Code (or start a new session) and `/projects`, `/knowledge`, `/tidy`, `/skills`, `/pr` are available.
 
 `condash-cli skills install` writes one file at a time and asks for confirmation per file when local content differs from the shipped version — your customisations don't get clobbered silently.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.16.1",
+      "version": "2.17.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.16.1",
+  "version": "2.17.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/knowledge.ts
+++ b/src/cli/commands/knowledge.ts
@@ -197,9 +197,28 @@ async function verifyCommand(
     else fresh.push(report);
   }
 
+  // Materialise stale stamps as audit-shaped issues so wrapping skills (e.g.
+  // /tidy) consume audit + verify with one shape. autoFix is hardcoded to
+  // false: a stale stamp means "human reread the source and re-confirmed",
+  // never "bump the date for me".
+  const issues = stale.map((s) => ({
+    check: 'stale_verification',
+    severity: 'warn' as const,
+    file: s.relPath,
+    line: s.line,
+    message: `Verification stamp from ${s.verifiedAt} (${s.ageDays}d ago) is older than ${maxAge}-day threshold`,
+    fix: {
+      action: 'flag_for_user_review',
+      autoFix: false,
+      verifiedAt: s.verifiedAt,
+      ageDays: s.ageDays,
+      where: s.where,
+    },
+  }));
+
   emit(
     ctx,
-    { stale, fresh: fresh.length, unstamped, maxAge },
+    { stale, fresh: fresh.length, unstamped, maxAge, issues },
     (data) => {
       const d = data as { stale: StampReport[]; fresh: number; unstamped: string[] };
       const lines: string[] = [];

--- a/src/cli/commands/misc.ts
+++ b/src/cli/commands/misc.ts
@@ -292,18 +292,22 @@ export async function runAuditCommand(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
-  const include =
+  const includeRaw =
     typeof args.flags.include === 'string'
       ? args.flags.include
           .split(',')
           .map((s) => s.trim())
           .filter(Boolean)
       : ALL_AUDIT_CHECKS;
+  // `all` is a documented alias for "every check" — keeps wrapping skills
+  // (`/tidy`) able to write `--include all --json` without conditional flag
+  // construction.
+  const include = includeRaw.flatMap((c) => (c === 'all' ? ALL_AUDIT_CHECKS : [c]));
   for (const c of include) {
     if (!ALL_AUDIT_CHECKS.includes(c as AuditCheckName)) {
       throw new CliError(
         ExitCodes.USAGE,
-        `--include must be a comma-separated subset of {${ALL_AUDIT_CHECKS.join(', ')}}; got '${c}'`,
+        `--include must be 'all' or a comma-separated subset of {${ALL_AUDIT_CHECKS.join(', ')}}; got '${c}'`,
       );
     }
   }

--- a/src/main/audit.ts
+++ b/src/main/audit.ts
@@ -40,8 +40,13 @@ export interface AuditIssue {
   file: string | null;
   line: number | null;
   message: string;
-  /** Hint for the consuming skill on what kind of fix applies. */
-  fix?: { action: string; [key: string]: unknown };
+  /**
+   * Hint for the consuming skill on what kind of fix applies. Always present;
+   * `autoFix: false` flags issues that need human judgment (a punch-list item).
+   * `autoFix: true` flags issues a skill can mechanically apply once batched
+   * confirmation is given.
+   */
+  fix: { action: string; autoFix: boolean; [key: string]: unknown };
 }
 
 export interface AuditReport {
@@ -89,6 +94,7 @@ export async function runAudit(
             file: null,
             line: null,
             message: `unknown check: ${check}`,
+            fix: { action: 'unknown_check', autoFix: false },
           });
       }
     } catch (err) {
@@ -98,6 +104,7 @@ export async function runAudit(
         file: null,
         line: null,
         message: `check crashed: ${err instanceof Error ? err.message : String(err)}`,
+        fix: { action: 'investigate_crash', autoFix: false },
       });
     }
   }
@@ -136,6 +143,7 @@ async function checkLfs(conceptionPath: string): Promise<AuditIssue[]> {
         file: null,
         line: null,
         message: 'git-lfs not available; skipping LFS check',
+        fix: { action: 'install_git_lfs', autoFix: false },
       },
     ];
   }
@@ -158,7 +166,7 @@ async function checkLfs(conceptionPath: string): Promise<AuditIssue[]> {
       file: rel,
       line: null,
       message: `${rel} (${sizeKb.toFixed(0)} kB) is not tracked by git-lfs`,
-      fix: { action: 'lfs_track_path', path: rel, sizeKb: Math.round(sizeKb) },
+      fix: { action: 'lfs_track_path', autoFix: true, path: rel, sizeKb: Math.round(sizeKb) },
     });
   }
   return issues;
@@ -193,6 +201,12 @@ async function checkBinaries(conceptionPath: string): Promise<AuditIssue[]> {
       file: rel,
       line: null,
       message: `${rel} is ${sizeKb.toFixed(0)} kB (> ${LARGE_BIN_KB} kB review threshold, not in git-lfs)`,
+      fix: {
+        action: 'consider_lfs_or_remove',
+        autoFix: false,
+        path: rel,
+        sizeKb: Math.round(sizeKb),
+      },
     });
   }
   return issues;
@@ -230,7 +244,7 @@ async function checkCrossRepo(conceptionPath: string): Promise<AuditIssue[]> {
         file: claudePath,
         line: lineNo,
         message: `Reference to ${ref} does not resolve`,
-        fix: { action: 'flag_for_user_edit', ref, inFile: claudePath },
+        fix: { action: 'flag_for_user_edit', autoFix: false, ref, inFile: claudePath },
       });
     }
   }
@@ -301,7 +315,7 @@ async function checkWorktrees(conceptionPath: string): Promise<AuditIssue[]> {
       file: relative(conceptionPath, readme),
       line: null,
       message: `Item declares Branch '${header.branch}' but no worktree at ${wt}`,
-      fix: { action: 'offer_worktree_setup', branch: header.branch },
+      fix: { action: 'offer_worktree_setup', autoFix: true, branch: header.branch },
     });
   }
   return issues;
@@ -321,6 +335,7 @@ async function checkIndex(conceptionPath: string): Promise<AuditIssue[]> {
       file: 'knowledge/',
       line: null,
       message: 'knowledge/ directory missing',
+      fix: { action: 'create_knowledge_dir', autoFix: false },
     });
     return issues;
   }
@@ -335,6 +350,7 @@ async function checkIndex(conceptionPath: string): Promise<AuditIssue[]> {
         file: relative(conceptionPath, idx),
         line: null,
         message: `Directory has no index.md — run condash-cli knowledge index`,
+        fix: { action: 'run_knowledge_index', autoFix: true },
       });
       continue;
     }
@@ -363,7 +379,7 @@ async function checkIndex(conceptionPath: string): Promise<AuditIssue[]> {
           file: relative(conceptionPath, idx),
           line: lineNo,
           message: `Index entry [${m[1]}](${rawLink}) points to a file that does not exist`,
-          fix: { action: 'remove_index_line', path: rawLink, label: m[1] },
+          fix: { action: 'remove_index_line', autoFix: true, path: rawLink, label: m[1] },
         });
         continue;
       }
@@ -390,7 +406,7 @@ async function checkIndex(conceptionPath: string): Promise<AuditIssue[]> {
           file: rel,
           line: null,
           message: `Body file not referenced from ${relative(conceptionPath, d)}/index.md — run condash-cli knowledge index`,
-          fix: { action: 'run_knowledge_index', path: rel },
+          fix: { action: 'run_knowledge_index', autoFix: true, path: rel },
         });
       }
     }


### PR DESCRIPTION
## Summary

- Adds `/tidy`, a fifth shipped Claude Code skill that wraps `condash-cli audit --include all --json` + `condash-cli knowledge verify --json`, batches auto-fixable issues into one confirmation, and surfaces the rest as a punch-list.
- Per-issue JSON contract is now uniform across both probes — every issue carries `fix: { action, autoFix, ...payload }`, so wrapping skills consume audit + verify with one shape and never derive fixability from check names.
- Resolves #96.

## Changes

- New `conception-template/.claude/skills/tidy/SKILL.md` — auto-discovered by `condash-cli skills list/install`. Encodes the triage rules verbatim (stale_verification never auto-bumped; cross-repo dangling refs hunt for likely renames before falling back to a punch-list; `git lfs track` requires the single confirmation round).
- `src/main/audit.ts` — `fix` is now mandatory on every issue. Issues that previously had no `fix` (binaries, the "git-lfs not available" info, `unknown_check`, `investigate_crash`, missing `knowledge/`) gain symbolic actions with `autoFix: false`. Existing fix payloads keep their fields; only the `autoFix` flag is new.
- `src/cli/commands/knowledge.ts` — `knowledge verify --json` keeps its existing fields (`stale`, `fresh`, `unstamped`, `maxAge`) and adds an audit-shaped `issues[]` array (each stale stamp becomes `check: stale_verification` with `autoFix: false`).
- `src/cli/commands/misc.ts` — `condash-cli audit --include all` is now a documented alias for "every check", matching the invocation the new skill writes.
- `docs/reference/skill.md`, `docs/reference/cli.md`, `docs/reference/index.md`, `docs/help/welcome.md`, `docs/guides/skill-extensions.md` — list five shipped skills and document the `fix.autoFix` contract.
- Bump to 2.17.0 (`package.json` + lockfile).

## Impact

- `condash-cli audit --json` and `condash-cli knowledge verify --json` are the public contract for downstream skills. The audit shape change is additive (new `autoFix` key); the verify shape change is additive (new `issues[]` alongside existing keys). No internal callers read these JSON shapes today.
- Conceptions that ship their own per-conception `tidy.py` + `SKILL.md` can install the shipped skill (`condash-cli skills install tidy`) and remove the local copy once 2.17.0 is on disk.