### PR TITLE
Surface + Add note button on projects with no notes/ dir yet

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.3",
+      "version": "2.18.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.3",
+  "version": "2.18.4",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/project-preview.tsx
+++ b/src/renderer/project-preview.tsx
@@ -75,7 +75,10 @@ function compareDirNames(a: string, b: string): number {
   return a.localeCompare(b);
 }
 
-function buildFileTree(files: readonly ProjectFileEntry[]): FileTree {
+function buildFileTree(
+  files: readonly ProjectFileEntry[],
+  options?: { ensureNotesDir?: boolean },
+): FileTree {
   const rootFiles: ProjectFileEntry[] = [];
   const subBuckets = new Map<string, ProjectFileEntry[]>();
   for (const file of files) {
@@ -94,6 +97,13 @@ function buildFileTree(files: readonly ProjectFileEntry[]): FileTree {
   }
 
   rootFiles.sort((a, b) => a.name.localeCompare(b.name));
+
+  // Surface a synthetic empty notes/ dir when the caller wants the
+  // "+ Add note" affordance available even on projects that haven't
+  // had their notes/ folder created on disk yet.
+  if (options?.ensureNotesDir && !subBuckets.has('notes')) {
+    subBuckets.set('notes', []);
+  }
 
   const dirs: FileTreeDir[] = [];
   const dirNames = Array.from(subBuckets.keys()).sort(compareDirNames);
@@ -504,7 +514,12 @@ export function ProjectPreview(props: {
                   </button>
                 </Show>
 
-                <Show when={(files() ?? []).filter((f) => f.relPath !== 'README.md').length > 0}>
+                <Show
+                  when={
+                    (files() ?? []).filter((f) => f.relPath !== 'README.md').length > 0 ||
+                    !!props.onCreateNote
+                  }
+                >
                   <section class="preview-section sidebar-block">
                     <h3 class="preview-section-head">
                       Files
@@ -516,6 +531,7 @@ export function ProjectPreview(props: {
                       <FileTreeRows
                         tree={buildFileTree(
                           (files() ?? []).filter((f) => f.relPath !== 'README.md'),
+                          { ensureNotesDir: !!props.onCreateNote },
                         )}
                         depth={0}
                         onOpenFile={(file) => props.onOpenFile(file.path)}


### PR DESCRIPTION
## Summary

- Newly-created projects with only `README.md` and no `notes/` folder hid the entire Files section in the project preview modal, leaving no UI path to add a first note.
- Render the Files section whenever the modal supports note creation, and inject a synthetic `notes/` row in the file tree so the existing **+ Add note** button stays reachable.

## Changes

- `src/renderer/project-preview.tsx` — `buildFileTree` gains an `ensureNotesDir` option that adds an empty `notes/` bucket when none exists on disk. The Files section gate now also opens for note-capable items, not just items with at least one non-README file.
- `package.json` / `package-lock.json` — bump to 2.18.4.

## Impact

- The Files section now appears on note-capable items even when only `README.md` is on disk. The section count still reflects the real on-disk file total (zero in that case), and the existing backend `createProjectNote` already does `fs.mkdir(notesDir, { recursive: true })` so creating the first note is unchanged.