### PR TITLE
Pass 01 — finish condash.json migration and extract IPC modules

### DIFF
--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -112,7 +112,7 @@ F5 / View → Refresh covers both: it drops the git-status TTL cache, recomputes
 
 ### 7. IPC contract
 
-`CondashApi` in `src/shared/api.ts` is the *whole* IPC surface. The preload (`src/preload/index.ts`) implements every verb as a one-line `ipcRenderer.invoke`; the main process (`src/main/index.ts:registerIpc`) registers one handler per verb. No string-mux'd actions, no implicit channels.
+`CondashApi` in `src/shared/api.ts` is the *whole* IPC surface. The preload (`src/preload/index.ts`) implements every verb as a one-line `ipcRenderer.invoke`; the main process registers one handler per verb. `src/main/index.ts:registerIpc` is a thin dispatcher that calls each per-domain module under `src/main/ipc/` (`projects.ts`, `trees.ts`, `repos.ts`, `settings.ts`, `system.ts`, `terminal.ts`). No string-mux'd actions, no implicit channels.
 
 Subscriptions (`onTreeEvents`, `onTermData`, `onTermExit`, `onTermSessions`) return an unsubscribe function; the renderer holds it and calls it from `onCleanup`.
 

--- a/docs/help/quick-start.md
+++ b/docs/help/quick-start.md
@@ -100,17 +100,18 @@ sections:
 - **Terminal** — shell, xterm.js settings, screenshot directory.
 - **Workspace** — `workspace_path`, `worktrees_path`, `resources_path`,
   `skills_path`.
-- **Repositories** — primary + secondary repos and their `run` /
-  `force_stop` commands.
+- **Repositories** — flat ordered list of repos shown on the Code pane,
+  each with optional `run` / `force_stop` commands and submodules.
 - **Open with** — `main_ide`, `pdf_viewer`, `terminal` launcher entries.
 
-There is no in-modal JSON editor; the **Open configuration.json
-externally** button at the bottom hands the file to your `main_ide`.
+There is no in-modal JSON editor; the **Open externally** button at the
+bottom hands the active tab's file to your `main_ide`.
 
-Per-tree config (`<conception>/configuration.json`) is shared with
-teammates via git — workspace path, repos, launcher commands. Per-machine
-config (`settings.json`) is local to this laptop — your editor binary,
-your terminal, your theme.
+Per-tree config (`<conception>/condash.json`, with `configuration.json`
+read indefinitely as a legacy fallback) is shared with teammates via git
+— workspace path, repos, launcher commands. Per-machine config
+(`settings.json`) is local to this laptop — your editor binary, your
+terminal, your theme.
 
 ## More
 

--- a/docs/help/welcome.md
+++ b/docs/help/welcome.md
@@ -31,7 +31,7 @@ are still on disk; delete condash and the files don't move.
 **File → Open…** (`Ctrl+O`) opens the native folder picker again.
 
 **File → Settings…** (`Ctrl+,`) opens a tabbed editor for theme, the
-embedded terminal, and `configuration.json`.
+embedded terminal, and `condash.json`.
 
 ## Where to go next
 

--- a/src/main/conception-init.ts
+++ b/src/main/conception-init.ts
@@ -49,7 +49,7 @@ export async function detectConceptionState(path: string): Promise<ConceptionIni
 
 /**
  * Copy the bundled conception-template/ into `targetPath`, expanding the
- * `*.example` files (`configuration.json.example` → `configuration.json`,
+ * `*.example` files (`condash.json.example` → `condash.json`,
  * `.claude/settings.example.json` → `.claude/settings.json`). `CLAUDE.md`
  * is shipped under its real name with a `## General` heading wrapping the
  * shipped region, so `condash-cli templates install` can push updates into
@@ -97,7 +97,6 @@ async function copyTreeRespecting(
 /** Drop the `.example` suffix on the two known templated files. */
 function mapTemplateName(rel: string): string {
   if (rel === 'condash.json.example') return 'condash.json';
-  if (rel === 'configuration.json.example') return 'condash.json';
   if (rel === '.claude/settings.example.json') return '.claude/settings.json';
   return rel;
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,51 +1,19 @@
-import { app, BrowserWindow, ipcMain, Menu, net, protocol, shell } from 'electron';
-import type { MenuItemConstructorOptions } from 'electron';
+import { app, BrowserWindow, net, protocol, shell } from 'electron';
 import { promises as fsp } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
-import { parseHeader } from '../shared/header';
 
-import { DEFAULT_LAYOUT, readSettings, settingsPath } from './settings';
-import { findProjectReadmes } from './walk';
-import { parseReadme } from './parse';
+import { DEFAULT_LAYOUT, readSettings } from './settings';
 import { setWatchedConception } from './watcher';
-import { addStep, editStepText, transitionStatus, toggleStep, writeNote } from './mutate';
-import { touchDirtyMarker } from './dirty';
-import { createProjectCore } from './create-project';
-import { checkBranchState } from './worktree-ops';
-import { listProjectFiles } from './files';
-import { requirePathUnder, requirePathUnderWorkspace } from './path-bounds';
-import { readKnowledgeTree } from './knowledge';
-import { readResourcesTree } from './resources';
-import { readSkillsTree } from './skills';
-import { treeCreateMd, treeImportFile, treeMkdir } from './tree-mutations';
-import { resolveConceptionPaths } from './conception-paths';
-import { createProjectNote, readNote } from './note';
-import { search } from './search';
-import { listRepos, listReposForPrimary } from './repos';
-import { invalidateAll } from './git-status-cache';
-import {
-  disposeRepoWatchers,
-  recomputeAllWatchedRepos,
-  setRepoWatchers,
-  watchTargetsFromRepos,
-} from './repo-watchers';
-import { getDirtyDetails } from './git-details';
-import { forceStopRepo, launchOpenWith, listOpenWith } from './launchers';
+import { disposeRepoWatchers } from './repo-watchers';
 import { killAll, migrateTerminalFromConfigIfNeeded } from './terminals';
-import { registerTerminalIpc } from './ipc/terminal';
+import { buildMenu, rebuildMenu, rebuildMenuFromSettings, setMenuWindow } from './menu';
+import { registerProjectsIpc } from './ipc/projects';
+import { registerReposIpc } from './ipc/repos';
 import { registerSettingsIpc } from './ipc/settings';
 import { registerSystemIpc } from './ipc/system';
-import type {
-  LayoutState,
-  OpenWithSlotKey,
-  Project,
-  ProjectCreateInput,
-  ProjectCreateResult,
-  StepMarker,
-  TreeRoot,
-} from '../shared/types';
-import { statusOrder } from '../shared/projects';
+import { registerTerminalIpc } from './ipc/terminal';
+import { registerTreesIpc } from './ipc/trees';
 
 // Hard flip from v2.14.0: CLI nouns belong on `condash-cli`, not `condash`.
 // If a user types a CLI noun on `condash`, error before any GUI init so the
@@ -220,314 +188,6 @@ async function createWindow(initialPath: string | null): Promise<BrowserWindow> 
 }
 
 /**
- * Build the application menu. The View submenu mirrors the unified
- * layout's pane-visibility state — Show/Hide Projects + Show/Hide
- * Terminal as toggles, plus a three-state group (Code | Knowledge |
- * neither) for the right-slot working surface. Pass the current layout
- * so check marks line up with what's actually shown; rebuild the menu
- * after any layout change so the marks refresh. No Quit accelerator on
- * purpose: Ctrl+Q is too easy to hit by accident, and File → Quit
- * routes through a renderer-side confirmation modal anyway.
- */
-function buildMenu(
-  layout: LayoutState = DEFAULT_LAYOUT,
-  recents: { paths: string[]; current: string | null } = { paths: [], current: null },
-): void {
-  const send = (command: string): void => {
-    mainWindow?.webContents.send('menu-command', command);
-  };
-
-  const openRecentSubmenu: MenuItemConstructorOptions[] = recents.paths.length
-    ? [
-        ...recents.paths.map((path) => ({
-          label: prettyRecentLabel(path),
-          type: 'checkbox' as const,
-          checked: path === recents.current,
-          click: () => {
-            mainWindow?.webContents.send('menu-open-recent', path);
-          },
-        })),
-        { type: 'separator' as const },
-        {
-          label: 'Clear menu',
-          click: () => {
-            mainWindow?.webContents.send('menu-clear-recents');
-          },
-        },
-      ]
-    : [{ label: '(no recent conceptions)', enabled: false }];
-
-  const fileSubmenu: MenuItemConstructorOptions[] = [
-    {
-      label: 'Open…',
-      accelerator: 'CommandOrControl+O',
-      click: () => send('open-folder'),
-    },
-    {
-      label: 'Open Recent',
-      submenu: openRecentSubmenu,
-    },
-    {
-      label: 'Open conception directory',
-      click: () => send('open-conception'),
-    },
-    {
-      label: 'New project…',
-      accelerator: 'CommandOrControl+N',
-      click: () => send('new-project'),
-    },
-    { type: 'separator' },
-    {
-      label: 'Settings',
-      accelerator: 'CommandOrControl+,',
-      click: () => send('open-settings'),
-    },
-    {
-      // Two accelerators for the same action — Electron menus only honour
-      // one accelerator per item, so the Ctrl+K binding is wired in the
-      // renderer's handleGlobalKeyDown (the cheat-sheet documents both).
-      label: 'Search…',
-      accelerator: 'CommandOrControl+Shift+F',
-      click: () => send('search'),
-    },
-    { type: 'separator' },
-    {
-      label: 'Quit',
-      // No accelerator on purpose — see the comment above buildMenu().
-      click: () => send('request-quit'),
-    },
-  ];
-
-  const viewSubmenu: MenuItemConstructorOptions[] = [
-    {
-      label: 'Show Projects',
-      type: 'checkbox',
-      checked: layout.projects,
-      click: () => send('toggle-projects'),
-    },
-    {
-      label: 'Show Code',
-      type: 'checkbox',
-      checked: layout.working === 'code',
-      accelerator: 'CommandOrControl+Shift+C',
-      click: () => send('show-code'),
-    },
-    {
-      label: 'Show Knowledge',
-      type: 'checkbox',
-      checked: layout.working === 'knowledge',
-      accelerator: 'CommandOrControl+Shift+K',
-      click: () => send('show-knowledge'),
-    },
-    {
-      label: 'Show Resources',
-      type: 'checkbox',
-      checked: layout.working === 'resources',
-      accelerator: 'CommandOrControl+R',
-      click: () => send('show-resources'),
-    },
-    {
-      label: 'Show Skills',
-      type: 'checkbox',
-      checked: layout.working === 'skills',
-      accelerator: 'CommandOrControl+L',
-      click: () => send('show-skills'),
-    },
-    {
-      label: 'Hide working surface',
-      enabled: layout.working !== null,
-      click: () => send('hide-working'),
-    },
-    {
-      label: 'Show Terminal',
-      type: 'checkbox',
-      checked: layout.terminal,
-      accelerator: 'CommandOrControl+`',
-      click: () => send('toggle-terminal'),
-    },
-    { type: 'separator' },
-    {
-      label: 'Refresh',
-      accelerator: 'F5',
-      click: () => send('refresh'),
-    },
-    { type: 'separator' },
-    {
-      role: 'reload',
-      label: 'Reload window',
-      // Reload normally lives at Ctrl+R, but we hand that accelerator to the
-      // Resources panel (more useful in day-to-day work). Reload moves to
-      // Ctrl+Shift+R, which still aligns with browser muscle memory for
-      // a hard reload.
-      accelerator: 'CommandOrControl+Shift+R',
-    },
-    { role: 'toggleDevTools' },
-    { type: 'separator' },
-    { role: 'resetZoom' },
-    { role: 'zoomIn' },
-    { role: 'zoomOut' },
-    { type: 'separator' },
-    { role: 'togglefullscreen' },
-  ];
-
-  const helpSubmenu: MenuItemConstructorOptions[] = [
-    {
-      label: 'About Condash',
-      click: () => send('about'),
-    },
-    { type: 'separator' },
-    { label: 'Welcome', click: () => send('help-welcome') },
-    { label: 'Quick start', click: () => send('help-quick-start') },
-    { label: 'Keyboard shortcuts', click: () => send('help-shortcuts') },
-    { type: 'separator' },
-    { label: 'Configuration', click: () => send('help-configuration') },
-    { label: 'CLI overview', click: () => send('help-cli') },
-    { label: 'Why Markdown-first', click: () => send('help-why-markdown') },
-    { type: 'separator' },
-    {
-      label: 'Open documentation site',
-      click: () => {
-        void shell
-          .openExternal('https://condash.vcoeur.com')
-          .catch((err) => console.error('[menu] openExternal failed', err));
-      },
-    },
-    {
-      label: 'Open issue tracker',
-      click: () => {
-        void shell
-          .openExternal('https://github.com/vcoeur/condash/issues')
-          .catch((err) => console.error('[menu] openExternal failed', err));
-      },
-    },
-  ];
-
-  const template: MenuItemConstructorOptions[] = [
-    { label: 'File', submenu: fileSubmenu },
-    {
-      label: 'Edit',
-      submenu: [
-        { role: 'undo' },
-        { role: 'redo' },
-        { type: 'separator' },
-        { role: 'cut' },
-        { role: 'copy' },
-        { role: 'paste' },
-        { role: 'selectAll' },
-      ],
-    },
-    { label: 'View', submenu: viewSubmenu },
-    { label: 'Help', role: 'help', submenu: helpSubmenu },
-  ];
-
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
-}
-
-/**
- * Rebuild the application menu against the latest layout. Used as the
- * `onLayoutChange` hook by registerSettingsIpc — the View submenu's check
- * marks need to refresh after every layout mutation.
- */
-let lastRecents: { paths: string[]; current: string | null } = { paths: [], current: null };
-let lastLayout: LayoutState = DEFAULT_LAYOUT;
-function rebuildMenu(layout: LayoutState): void {
-  lastLayout = layout;
-  buildMenu(layout, lastRecents);
-}
-async function rebuildMenuFromSettings(): Promise<void> {
-  const settings = await readSettings();
-  lastRecents = {
-    paths: settings.recentConceptionPaths ?? [],
-    current: settings.lastConceptionPath,
-  };
-  buildMenu(lastLayout, lastRecents);
-}
-
-/**
- * Format a recents path for the File → Open Recent submenu. The basename
- * (e.g. `conception`) carries the visual weight; the parent directory is
- * shown after a dimmed em-dash so two trees with the same basename don't
- * look identical.
- */
-function prettyRecentLabel(path: string): string {
-  const segments = path.split('/').filter((s) => s.length > 0);
-  if (segments.length === 0) return path;
-  const tail = segments[segments.length - 1];
-  const head = segments.slice(0, -1).join('/');
-  if (!head) return tail;
-  // The Electron menu strips raw `/` runs in some renders; collapse the
-  // parent path to a tilde-anchored form when it lives under HOME.
-  return `${tail} — ${head}`;
-}
-
-/**
- * Defence-in-depth: every IPC handler that accepts a `path` from the
- * renderer and reads or writes the filesystem at that path runs through
- * here first. Realpathed bound check against the current conception
- * root via shared/path-bounds — pass-4..6 deferred this sweep, pass-7
- * lands the conception-bound subset (note read/write, step ops,
- * getProject, listProjectFiles, project.createNote). Repos /
- * worktrees / screenshot_dir handlers stay open for now because their
- * threat model targets a different bound.
- */
-async function assertUnderConception(path: string): Promise<void> {
-  const { lastConceptionPath: conceptionPath } = await readSettings();
-  if (!conceptionPath) {
-    throw new Error('no conception path is set');
-  }
-  await requirePathUnder(path, conceptionPath);
-}
-
-async function listProjects(): Promise<Project[]> {
-  const { lastConceptionPath: conceptionPath } = await readSettings();
-  if (!conceptionPath) return [];
-
-  const readmes = await findProjectReadmes(conceptionPath);
-  const projects = await Promise.all(readmes.map(parseReadme));
-
-  return projects.sort((a, b) => {
-    const o = statusOrder(a.status) - statusOrder(b.status);
-    if (o !== 0) return o;
-    return a.slug.localeCompare(b.slug);
-  });
-}
-
-async function readBranchFromReadme(readmePath: string): Promise<string | null> {
-  try {
-    const raw = await fsp.readFile(readmePath, 'utf8');
-    return parseHeader(raw).branch;
-  } catch {
-    return null;
-  }
-}
-
-function buildBranchWarning(
-  branch: string,
-  lingeringWorktrees: { expectedWorktree: string }[],
-  lingeringBranches: { name: string }[],
-): string {
-  const parts: string[] = [];
-  if (lingeringWorktrees.length > 0) {
-    const paths = lingeringWorktrees.map((r) => r.expectedWorktree).join(', ');
-    parts.push(`worktree(s) still on disk at ${paths}`);
-  }
-  if (lingeringBranches.length > 0) {
-    const repos = lingeringBranches.map((r) => r.name).join(', ');
-    parts.push(`local branch '${branch}' still exists in ${repos}`);
-  }
-  return `${parts.join('; ')} — run \`condash-cli worktrees remove ${branch}\` then \`git branch -d ${branch}\` to clean up.`;
-}
-
-async function getProject(path: string): Promise<Project | null> {
-  try {
-    return await parseReadme(path);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    throw err;
-  }
-}
-
-/**
  * Serve files referenced from note-view markdown (images via relative path)
  * over a `condash-file:///abs/path` URL. Sandboxed: the requested path must
  * resolve under the current conception path. The renderer rewrites relative
@@ -581,128 +241,27 @@ function isPathUnder(child: string, parent: string): boolean {
   return c === p || c.startsWith(p);
 }
 
+/**
+ * Wire every IPC handler. Per-domain modules under `ipc/` own the actual
+ * handler bodies; this dispatcher just calls each module's
+ * `register*Ipc(opts?)` once at app start. New verbs go in (or alongside)
+ * the matching domain module — keep this body a flat list of registrations.
+ *
+ * The per-domain split:
+ *   • projects — listProjects, getProject, step.*, listProjectFiles,
+ *     setStatus, createProject, note.*, settings.read/writeRaw,
+ *     project.createNote.
+ *   • trees — read{Knowledge,Resources,Skills}Tree, tree.*, search.
+ *   • repos — listRepos, listReposForPrimary, invalidateGitStatus,
+ *     getDirtyDetails, listOpenWith, launchOpenWith, forceStopRepo.
+ *   • settings — theme/layout/welcome/cardMinWidth/treeExpansion/getSettingsPath.
+ *   • system — shell-out + app-info + conception path mutation.
+ *   • terminal — every term.* verb.
+ */
 function registerIpc(): void {
-  ipcMain.handle('listProjects', () => listProjects());
-
-  ipcMain.handle('getProject', async (_, path: string) => {
-    await assertUnderConception(path);
-    return getProject(path);
-  });
-
-  ipcMain.handle('readKnowledgeTree', async () => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return null;
-    return readKnowledgeTree(conceptionPath);
-  });
-
-  ipcMain.handle('readResourcesTree', async () => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return null;
-    const { resources } = await resolveConceptionPaths(conceptionPath);
-    return readResourcesTree(conceptionPath, resources);
-  });
-
-  ipcMain.handle('readSkillsTree', async () => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return null;
-    const { skills } = await resolveConceptionPaths(conceptionPath);
-    return readSkillsTree(conceptionPath, skills);
-  });
-
-  ipcMain.handle('tree.createMd', (_, root: TreeRoot, dirRelPath: string, filename: string) =>
-    treeCreateMd(root, dirRelPath, filename),
-  );
-
-  ipcMain.handle('tree.mkdir', (_, root: TreeRoot, dirRelPath: string, name: string) =>
-    treeMkdir(root, dirRelPath, name),
-  );
-
-  ipcMain.handle('tree.importFile', (_, root: TreeRoot, dirRelPath: string) =>
-    treeImportFile(root, dirRelPath),
-  );
-
-  ipcMain.handle('search', async (_, query: string) => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return [];
-    return search(conceptionPath, query);
-  });
-
-  ipcMain.handle('listRepos', async () => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return [];
-    const repos = await listRepos(conceptionPath);
-    // Sync the per-repo FS watchers to the live repo set: a config edit
-    // that adds or removes a repo is reflected here, since this handler
-    // re-runs on every renderer-driven repos refresh.
-    await setRepoWatchers(watchTargetsFromRepos(repos));
-    return repos;
-  });
-
-  // Per-primary partial reload — driven by the structural FS watcher when
-  // `.git/HEAD` or `.git/worktrees/` changes. Returns the primary's
-  // RepoEntry plus its submodule children, freshly re-read. Watchers are
-  // re-synced for the affected paths so a freshly-added worktree gets a
-  // scalar watcher pair right away (and a freshly-removed one is dropped).
-  ipcMain.handle('listReposForPrimary', async (_, primaryName: string) => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return [];
-    const entries = await listReposForPrimary(conceptionPath, primaryName);
-    // Re-list the *full* watcher set: the simplest correct way to make sure
-    // an added or removed worktree under this primary is reflected in the
-    // watch set without diffing the per-primary subset against the global
-    // one. The cost is one extra `listRepos` call on a structural event,
-    // which is rare (worktree mutation, branch checkout) — far cheaper
-    // than getting the watch-set delta logic wrong.
-    const repos = await listRepos(conceptionPath);
-    await setRepoWatchers(watchTargetsFromRepos(repos));
-    return entries;
-  });
-
-  // Drop the per-worktree git status cache + force-recompute every watched
-  // repo and broadcast `repo-events`. Wired to the renderer's F5 / Refresh
-  // path so the user sees fresh counts without waiting for an FS event,
-  // and without the renderer needing to refetch the whole repo list (which
-  // would tear down dropdowns/popovers).
-  ipcMain.handle('invalidateGitStatus', async () => {
-    invalidateAll();
-    await recomputeAllWatchedRepos();
-  });
-
-  // Click-to-inspect on the per-branch dirty badge. Returns the parsed
-  // `git status` line set + a `git diff --stat HEAD` snippet so the user
-  // can see what's dirty without dropping into a shell. Bound to the
-  // workspace + worktrees roots so a compromised renderer can't drive a
-  // shell-out `git status` against an arbitrary directory on disk.
-  ipcMain.handle(
-    'getDirtyDetails',
-    async (_, path: string, opts?: { scopeToSubtree?: boolean }) => {
-      const realPath = await requirePathUnderWorkspace(path);
-      return getDirtyDetails(realPath, opts ?? {});
-    },
-  );
-
-  ipcMain.handle('listOpenWith', async () => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) return {};
-    return listOpenWith(conceptionPath);
-  });
-
-  ipcMain.handle('launchOpenWith', async (_, slot: OpenWithSlotKey, path: string) => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) throw new Error('No conception path set');
-    // Bound to workspace + worktrees + conception so the renderer can
-    // launch the user's IDE on a project README, a workspace repo, or a
-    // worktree — but not on `/etc/passwd` or `~/.ssh/`.
-    const realPath = await requirePathUnderWorkspace(path);
-    return launchOpenWith(conceptionPath, slot, realPath);
-  });
-
-  ipcMain.handle('forceStopRepo', async (_, repoName: string) => {
-    const { lastConceptionPath: conceptionPath } = await readSettings();
-    if (!conceptionPath) throw new Error('No conception path set');
-    return forceStopRepo(conceptionPath, repoName);
-  });
-
+  registerProjectsIpc();
+  registerTreesIpc();
+  registerReposIpc();
   registerTerminalIpc();
   registerSettingsIpc({ onLayoutChange: rebuildMenu });
   registerSystemIpc({
@@ -713,147 +272,6 @@ function registerIpc(): void {
     onRecentsChange: () => {
       void rebuildMenuFromSettings();
     },
-  });
-
-  ipcMain.handle(
-    'step.toggle',
-    async (
-      _,
-      path: string,
-      lineIndex: number,
-      expectedMarker: StepMarker,
-      newMarker: StepMarker,
-    ) => {
-      await assertUnderConception(path);
-      return toggleStep(path, lineIndex, expectedMarker, newMarker);
-    },
-  );
-
-  ipcMain.handle(
-    'step.editText',
-    async (_, path: string, lineIndex: number, expectedText: string, newText: string) => {
-      await assertUnderConception(path);
-      return editStepText(path, lineIndex, expectedText, newText);
-    },
-  );
-
-  ipcMain.handle('step.add', async (_, path: string, text: string) => {
-    await assertUnderConception(path);
-    return addStep(path, text);
-  });
-
-  ipcMain.handle('listProjectFiles', async (_, path: string) => {
-    await assertUnderConception(path);
-    return listProjectFiles(path);
-  });
-
-  ipcMain.handle(
-    'setStatus',
-    async (_, path: string, newStatus: string, opts?: { summary?: string }) => {
-      const result = await transitionStatus(path, newStatus, opts);
-      // Touch the dirty marker so a follow-up `condash-cli projects index` is
-      // surfaced. Best-effort: if the conception path isn't set we just
-      // skip it — the in-memory list rebuild still happens via the watcher.
-      const { lastConceptionPath: conceptionPath } = await readSettings();
-      if (conceptionPath) {
-        await touchDirtyMarker(conceptionPath, 'projects').catch((err) => {
-          console.error('[setStatus] touchDirtyMarker failed', err);
-        });
-        // On close (done-edge: prev !== done, new === done), surface any
-        // leftover-branch warnings so the GUI can toast them — silently
-        // swallowing the miss let the same broken cleanup ship twice in
-        // April. Keep the call best-effort so a failed probe never blocks
-        // the close itself.
-        if (result.timelineAppended && /^- .* — Closed/.test(result.timelineAppended)) {
-          const branch = await readBranchFromReadme(path);
-          if (branch) {
-            try {
-              const state = await checkBranchState(conceptionPath, branch);
-              const lingeringWorktrees = state.repos.filter((r) => r.worktreeExists);
-              const lingeringBranches = state.repos.filter((r) => r.localBranchExists);
-              if (lingeringWorktrees.length > 0 || lingeringBranches.length > 0) {
-                result.branchWarning = buildBranchWarning(
-                  branch,
-                  lingeringWorktrees,
-                  lingeringBranches,
-                );
-              }
-            } catch {
-              // Best-effort probe — never block the close on its own failure.
-            }
-          }
-        }
-      }
-      return result;
-    },
-  );
-
-  ipcMain.handle(
-    'createProject',
-    async (_, input: ProjectCreateInput): Promise<ProjectCreateResult> => {
-      const { lastConceptionPath: conceptionPath } = await readSettings();
-      if (!conceptionPath) throw new Error('No conception path set');
-      const result = await createProjectCore(conceptionPath, {
-        kind: input.kind,
-        slug: input.slug,
-        title: input.title,
-        // Apps stays empty for the GUI quick-create form; users fill it in
-        // by editing the README or via the popup.
-        apps: [],
-        branch: null,
-        base: null,
-        severity: input.severity ?? null,
-        severityImpact: input.severityImpact ?? null,
-        environment: input.environment ?? null,
-      });
-      // The renderer asked for status `now | review | later | backlog`, but
-      // createProjectCore always renders `Status: now`. If the user picked
-      // anything else, flip it now via the same transitionStatus primitive
-      // — that keeps the status-write path single-source.
-      if (input.status !== 'now') {
-        await transitionStatus(result.readme, input.status);
-      }
-      return {
-        slug: result.slug,
-        path: result.path,
-        relPath: result.relPath,
-        readme: result.readme,
-      };
-    },
-  );
-
-  ipcMain.handle('note.read', async (_, path: string) => {
-    await assertUnderConception(path);
-    return readNote(path);
-  });
-
-  ipcMain.handle(
-    'note.write',
-    async (_, path: string, expectedContent: string, newContent: string) => {
-      await assertUnderConception(path);
-      return writeNote(path, expectedContent, newContent);
-    },
-  );
-
-  // Raw read of the per-machine `settings.json`. Used by the Settings modal
-  // to compute inheritance badges (compare global vs. condash.json values)
-  // and to drive the Global-tab editor through the same patchConfig flow it
-  // uses for condash.json. Returns `''` when the file doesn't exist yet —
-  // the modal treats that as "fresh defaults" and creates the file on first
-  // save.
-  ipcMain.handle('settings.readRaw', async () => readNote(settingsPath()));
-
-  // Atomic CAS write to settings.json. Canonicalises through
-  // `globalSettingsSchema` (handled by `writeNote`'s basename dispatch).
-  // Returns the bytes actually written so the caller can keep its CAS
-  // baseline aligned with disk after Zod re-orders keys.
-  ipcMain.handle('settings.writeRaw', async (_, expectedContent: string, newContent: string) =>
-    writeNote(settingsPath(), expectedContent, newContent),
-  );
-
-  ipcMain.handle('project.createNote', async (_, projectPath: string, slug: string) => {
-    await assertUnderConception(projectPath);
-    return createProjectNote(projectPath, slug);
   });
 }
 
@@ -868,23 +286,25 @@ app.whenReady().then(async () => {
   const settings = await readSettings();
   const conceptionPath = settings.lastConceptionPath;
   await setWatchedConception(conceptionPath);
-  lastLayout = settings.layout ?? DEFAULT_LAYOUT;
-  lastRecents = {
+  buildMenu(settings.layout ?? DEFAULT_LAYOUT, {
     paths: settings.recentConceptionPaths ?? [],
     current: conceptionPath,
-  };
-  buildMenu(lastLayout, lastRecents);
+  });
   mainWindow = await createWindow(conceptionPath);
+  setMenuWindow(mainWindow);
   mainWindow.on('closed', () => {
     mainWindow = null;
+    setMenuWindow(null);
   });
 
   app.on('activate', async () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       const settings = await readSettings();
       mainWindow = await createWindow(settings.lastConceptionPath);
+      setMenuWindow(mainWindow);
       mainWindow.on('closed', () => {
         mainWindow = null;
+        setMenuWindow(null);
       });
     }
   });

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -1,0 +1,239 @@
+import { ipcMain } from 'electron';
+import { promises as fsp } from 'node:fs';
+import { parseHeader } from '../../shared/header';
+import { statusOrder } from '../../shared/projects';
+import type {
+  Project,
+  ProjectCreateInput,
+  ProjectCreateResult,
+  StepMarker,
+} from '../../shared/types';
+import { createProjectCore } from '../create-project';
+import { touchDirtyMarker } from '../dirty';
+import { listProjectFiles } from '../files';
+import { addStep, editStepText, toggleStep, transitionStatus, writeNote } from '../mutate';
+import { createProjectNote, readNote } from '../note';
+import { parseReadme } from '../parse';
+import { requirePathUnder } from '../path-bounds';
+import { readSettings, settingsPath } from '../settings';
+import { findProjectReadmes } from '../walk';
+import { checkBranchState } from '../worktree-ops';
+
+/**
+ * Defence-in-depth: every IPC handler that accepts a `path` from the
+ * renderer and reads or writes the filesystem at that path runs through
+ * here first. Realpathed bound check against the current conception
+ * root via shared/path-bounds.
+ */
+async function assertUnderConception(path: string): Promise<void> {
+  const { lastConceptionPath: conceptionPath } = await readSettings();
+  if (!conceptionPath) {
+    throw new Error('no conception path is set');
+  }
+  await requirePathUnder(path, conceptionPath);
+}
+
+async function listProjects(): Promise<Project[]> {
+  const { lastConceptionPath: conceptionPath } = await readSettings();
+  if (!conceptionPath) return [];
+
+  const readmes = await findProjectReadmes(conceptionPath);
+  const projects = await Promise.all(readmes.map(parseReadme));
+
+  return projects.sort((a, b) => {
+    const o = statusOrder(a.status) - statusOrder(b.status);
+    if (o !== 0) return o;
+    return a.slug.localeCompare(b.slug);
+  });
+}
+
+async function getProject(path: string): Promise<Project | null> {
+  try {
+    return await parseReadme(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+async function readBranchFromReadme(readmePath: string): Promise<string | null> {
+  try {
+    const raw = await fsp.readFile(readmePath, 'utf8');
+    return parseHeader(raw).branch;
+  } catch {
+    return null;
+  }
+}
+
+function buildBranchWarning(
+  branch: string,
+  lingeringWorktrees: { expectedWorktree: string }[],
+  lingeringBranches: { name: string }[],
+): string {
+  const parts: string[] = [];
+  if (lingeringWorktrees.length > 0) {
+    const paths = lingeringWorktrees.map((r) => r.expectedWorktree).join(', ');
+    parts.push(`worktree(s) still on disk at ${paths}`);
+  }
+  if (lingeringBranches.length > 0) {
+    const repos = lingeringBranches.map((r) => r.name).join(', ');
+    parts.push(`local branch '${branch}' still exists in ${repos}`);
+  }
+  return `${parts.join('; ')} — run \`condash-cli worktrees remove ${branch}\` then \`git branch -d ${branch}\` to clean up.`;
+}
+
+/**
+ * Wire IPC verbs covering project enumeration, README parsing, step
+ * mutations, status transitions, project creation, note read/write, and
+ * raw settings.json access (settings.read/writeRaw target a project-style
+ * note path so they live with the rest of the note plumbing).
+ */
+export function registerProjectsIpc(): void {
+  ipcMain.handle('listProjects', () => listProjects());
+
+  ipcMain.handle('getProject', async (_, path: string) => {
+    await assertUnderConception(path);
+    return getProject(path);
+  });
+
+  ipcMain.handle(
+    'step.toggle',
+    async (
+      _,
+      path: string,
+      lineIndex: number,
+      expectedMarker: StepMarker,
+      newMarker: StepMarker,
+    ) => {
+      await assertUnderConception(path);
+      return toggleStep(path, lineIndex, expectedMarker, newMarker);
+    },
+  );
+
+  ipcMain.handle(
+    'step.editText',
+    async (_, path: string, lineIndex: number, expectedText: string, newText: string) => {
+      await assertUnderConception(path);
+      return editStepText(path, lineIndex, expectedText, newText);
+    },
+  );
+
+  ipcMain.handle('step.add', async (_, path: string, text: string) => {
+    await assertUnderConception(path);
+    return addStep(path, text);
+  });
+
+  ipcMain.handle('listProjectFiles', async (_, path: string) => {
+    await assertUnderConception(path);
+    return listProjectFiles(path);
+  });
+
+  ipcMain.handle(
+    'setStatus',
+    async (_, path: string, newStatus: string, opts?: { summary?: string }) => {
+      const result = await transitionStatus(path, newStatus, opts);
+      // Touch the dirty marker so a follow-up `condash-cli projects index` is
+      // surfaced. Best-effort: if the conception path isn't set we just
+      // skip it — the in-memory list rebuild still happens via the watcher.
+      const { lastConceptionPath: conceptionPath } = await readSettings();
+      if (conceptionPath) {
+        await touchDirtyMarker(conceptionPath, 'projects').catch((err) => {
+          console.error('[setStatus] touchDirtyMarker failed', err);
+        });
+        // On close (done-edge: prev !== done, new === done), surface any
+        // leftover-branch warnings so the GUI can toast them — silently
+        // swallowing the miss let the same broken cleanup ship twice in
+        // April. Keep the call best-effort so a failed probe never blocks
+        // the close itself.
+        if (result.timelineAppended && /^- .* — Closed/.test(result.timelineAppended)) {
+          const branch = await readBranchFromReadme(path);
+          if (branch) {
+            try {
+              const state = await checkBranchState(conceptionPath, branch);
+              const lingeringWorktrees = state.repos.filter((r) => r.worktreeExists);
+              const lingeringBranches = state.repos.filter((r) => r.localBranchExists);
+              if (lingeringWorktrees.length > 0 || lingeringBranches.length > 0) {
+                result.branchWarning = buildBranchWarning(
+                  branch,
+                  lingeringWorktrees,
+                  lingeringBranches,
+                );
+              }
+            } catch {
+              // Best-effort probe — never block the close on its own failure.
+            }
+          }
+        }
+      }
+      return result;
+    },
+  );
+
+  ipcMain.handle(
+    'createProject',
+    async (_, input: ProjectCreateInput): Promise<ProjectCreateResult> => {
+      const { lastConceptionPath: conceptionPath } = await readSettings();
+      if (!conceptionPath) throw new Error('No conception path set');
+      const result = await createProjectCore(conceptionPath, {
+        kind: input.kind,
+        slug: input.slug,
+        title: input.title,
+        // Apps stays empty for the GUI quick-create form; users fill it in
+        // by editing the README or via the popup.
+        apps: [],
+        branch: null,
+        base: null,
+        severity: input.severity ?? null,
+        severityImpact: input.severityImpact ?? null,
+        environment: input.environment ?? null,
+      });
+      // The renderer asked for status `now | review | later | backlog`, but
+      // createProjectCore always renders `Status: now`. If the user picked
+      // anything else, flip it now via the same transitionStatus primitive
+      // — that keeps the status-write path single-source.
+      if (input.status !== 'now') {
+        await transitionStatus(result.readme, input.status);
+      }
+      return {
+        slug: result.slug,
+        path: result.path,
+        relPath: result.relPath,
+        readme: result.readme,
+      };
+    },
+  );
+
+  ipcMain.handle('note.read', async (_, path: string) => {
+    await assertUnderConception(path);
+    return readNote(path);
+  });
+
+  ipcMain.handle(
+    'note.write',
+    async (_, path: string, expectedContent: string, newContent: string) => {
+      await assertUnderConception(path);
+      return writeNote(path, expectedContent, newContent);
+    },
+  );
+
+  // Raw read of the per-machine `settings.json`. Used by the Settings modal
+  // to compute inheritance badges (compare global vs. condash.json values)
+  // and to drive the Global-tab editor through the same patchConfig flow it
+  // uses for condash.json. Returns `''` when the file doesn't exist yet —
+  // the modal treats that as "fresh defaults" and creates the file on first
+  // save.
+  ipcMain.handle('settings.readRaw', async () => readNote(settingsPath()));
+
+  // Atomic CAS write to settings.json. Canonicalises through
+  // `globalSettingsSchema` (handled by `writeNote`'s basename dispatch).
+  // Returns the bytes actually written so the caller can keep its CAS
+  // baseline aligned with disk after Zod re-orders keys.
+  ipcMain.handle('settings.writeRaw', async (_, expectedContent: string, newContent: string) =>
+    writeNote(settingsPath(), expectedContent, newContent),
+  );
+
+  ipcMain.handle('project.createNote', async (_, projectPath: string, slug: string) => {
+    await assertUnderConception(projectPath);
+    return createProjectNote(projectPath, slug);
+  });
+}

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -1,0 +1,92 @@
+import { ipcMain } from 'electron';
+import { listRepos, listReposForPrimary } from '../repos';
+import { invalidateAll } from '../git-status-cache';
+import { recomputeAllWatchedRepos, setRepoWatchers, watchTargetsFromRepos } from '../repo-watchers';
+import { getDirtyDetails } from '../git-details';
+import { forceStopRepo, launchOpenWith, listOpenWith } from '../launchers';
+import { requirePathUnderWorkspace } from '../path-bounds';
+import { readSettings } from '../settings';
+import type { OpenWithSlotKey } from '../../shared/types';
+import { requireConception, withConception } from './utils';
+
+/**
+ * Wire repo / git-status / launcher IPC handlers. The two listRepos verbs
+ * also drive watcher reconciliation: every renderer-driven repo refresh
+ * re-syncs the per-repo FS watchers to the live repo set so config edits
+ * that add or remove a repo are reflected without a full reload.
+ */
+export function registerReposIpc(): void {
+  ipcMain.handle('listRepos', () =>
+    withConception(async (conceptionPath) => {
+      const repos = await listRepos(conceptionPath);
+      // Sync the per-repo FS watchers to the live repo set: a config edit
+      // that adds or removes a repo is reflected here, since this handler
+      // re-runs on every renderer-driven repos refresh.
+      await setRepoWatchers(watchTargetsFromRepos(repos));
+      return repos;
+    }, []),
+  );
+
+  // Per-primary partial reload — driven by the structural FS watcher when
+  // `.git/HEAD` or `.git/worktrees/` changes. Returns the primary's
+  // RepoEntry plus its submodule children, freshly re-read. Watchers are
+  // re-synced for the affected paths so a freshly-added worktree gets a
+  // scalar watcher pair right away (and a freshly-removed one is dropped).
+  ipcMain.handle('listReposForPrimary', (_, primaryName: string) =>
+    withConception(async (conceptionPath) => {
+      const entries = await listReposForPrimary(conceptionPath, primaryName);
+      // Re-list the *full* watcher set: the simplest correct way to make sure
+      // an added or removed worktree under this primary is reflected in the
+      // watch set without diffing the per-primary subset against the global
+      // one. The cost is one extra `listRepos` call on a structural event,
+      // which is rare (worktree mutation, branch checkout) — far cheaper
+      // than getting the watch-set delta logic wrong.
+      const repos = await listRepos(conceptionPath);
+      await setRepoWatchers(watchTargetsFromRepos(repos));
+      return entries;
+    }, []),
+  );
+
+  // Drop the per-worktree git status cache + force-recompute every watched
+  // repo and broadcast `repo-events`. Wired to the renderer's F5 / Refresh
+  // path so the user sees fresh counts without waiting for an FS event,
+  // and without the renderer needing to refetch the whole repo list (which
+  // would tear down dropdowns/popovers).
+  ipcMain.handle('invalidateGitStatus', async () => {
+    invalidateAll();
+    await recomputeAllWatchedRepos();
+  });
+
+  // Click-to-inspect on the per-branch dirty badge. Returns the parsed
+  // `git status` line set + a `git diff --stat HEAD` snippet so the user
+  // can see what's dirty without dropping into a shell. Bound to the
+  // workspace + worktrees roots so a compromised renderer can't drive a
+  // shell-out `git status` against an arbitrary directory on disk.
+  ipcMain.handle(
+    'getDirtyDetails',
+    async (_, path: string, opts?: { scopeToSubtree?: boolean }) => {
+      const realPath = await requirePathUnderWorkspace(path);
+      return getDirtyDetails(realPath, opts ?? {});
+    },
+  );
+
+  ipcMain.handle('listOpenWith', async () => {
+    const { lastConceptionPath: conceptionPath } = await readSettings();
+    if (!conceptionPath) return {};
+    return listOpenWith(conceptionPath);
+  });
+
+  ipcMain.handle('launchOpenWith', (_, slot: OpenWithSlotKey, path: string) =>
+    requireConception(async (conceptionPath) => {
+      // Bound to workspace + worktrees + conception so the renderer can
+      // launch the user's IDE on a project README, a workspace repo, or a
+      // worktree — but not on `/etc/passwd` or `~/.ssh/`.
+      const realPath = await requirePathUnderWorkspace(path);
+      return launchOpenWith(conceptionPath, slot, realPath);
+    }),
+  );
+
+  ipcMain.handle('forceStopRepo', (_, repoName: string) =>
+    requireConception((conceptionPath) => forceStopRepo(conceptionPath, repoName)),
+  );
+}

--- a/src/main/ipc/trees.ts
+++ b/src/main/ipc/trees.ts
@@ -1,0 +1,57 @@
+import { ipcMain } from 'electron';
+import { resolveConceptionPaths } from '../conception-paths';
+import { readKnowledgeTree } from '../knowledge';
+import { readResourcesTree } from '../resources';
+import { readSkillsTree } from '../skills';
+import { search } from '../search';
+import { readSettings } from '../settings';
+import { treeCreateMd, treeImportFile, treeMkdir } from '../tree-mutations';
+import type { TreeRoot } from '../../shared/types';
+import { withConception } from './utils';
+
+/**
+ * Wire the read/write IPC for the three conception-scoped trees
+ * (knowledge, resources, skills) plus the cross-tree search verb.
+ * Tree mutation handlers (`tree.createMd`, `tree.mkdir`, `tree.importFile`)
+ * are conception-scoped through the shared tree-mutations layer.
+ */
+export function registerTreesIpc(): void {
+  ipcMain.handle('readKnowledgeTree', () =>
+    withConception((conceptionPath) => readKnowledgeTree(conceptionPath), null),
+  );
+
+  ipcMain.handle('readResourcesTree', () =>
+    withConception(async (conceptionPath) => {
+      const { resources } = await resolveConceptionPaths(conceptionPath);
+      return readResourcesTree(conceptionPath, resources);
+    }, null),
+  );
+
+  ipcMain.handle('readSkillsTree', () =>
+    withConception(async (conceptionPath) => {
+      const { skills } = await resolveConceptionPaths(conceptionPath);
+      return readSkillsTree(conceptionPath, skills);
+    }, null),
+  );
+
+  ipcMain.handle('tree.createMd', (_, root: TreeRoot, dirRelPath: string, filename: string) =>
+    treeCreateMd(root, dirRelPath, filename),
+  );
+
+  ipcMain.handle('tree.mkdir', (_, root: TreeRoot, dirRelPath: string, name: string) =>
+    treeMkdir(root, dirRelPath, name),
+  );
+
+  ipcMain.handle('tree.importFile', (_, root: TreeRoot, dirRelPath: string) =>
+    treeImportFile(root, dirRelPath),
+  );
+
+  // The original handler returned `[]` when no conception path was set;
+  // typed as `SearchResults` by the api but the renderer guards against
+  // either shape. Preserve verbatim — behaviour-preserving extract.
+  ipcMain.handle('search', async (_, query: string) => {
+    const { lastConceptionPath: conceptionPath } = await readSettings();
+    if (!conceptionPath) return [];
+    return search(conceptionPath, query);
+  });
+}

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -1,0 +1,260 @@
+import { BrowserWindow, Menu, shell } from 'electron';
+import type { MenuItemConstructorOptions } from 'electron';
+import { DEFAULT_LAYOUT, readSettings } from './settings';
+import type { LayoutState } from '../shared/types';
+
+type Recents = { paths: string[]; current: string | null };
+
+let mainWindowRef: BrowserWindow | null = null;
+let lastLayout: LayoutState = DEFAULT_LAYOUT;
+let lastRecents: Recents = { paths: [], current: null };
+
+/** Inject the live window reference. Menu callbacks fire IPC at the window. */
+export function setMenuWindow(win: BrowserWindow | null): void {
+  mainWindowRef = win;
+}
+
+/**
+ * Format a recents path for the File → Open Recent submenu. The basename
+ * (e.g. `conception`) carries the visual weight; the parent directory is
+ * shown after a dimmed em-dash so two trees with the same basename don't
+ * look identical.
+ */
+function prettyRecentLabel(path: string): string {
+  const segments = path.split('/').filter((s) => s.length > 0);
+  if (segments.length === 0) return path;
+  const tail = segments[segments.length - 1];
+  const head = segments.slice(0, -1).join('/');
+  if (!head) return tail;
+  // The Electron menu strips raw `/` runs in some renders; collapse the
+  // parent path to a tilde-anchored form when it lives under HOME.
+  return `${tail} — ${head}`;
+}
+
+/**
+ * Build the application menu. The View submenu mirrors the unified
+ * layout's pane-visibility state — Show/Hide Projects + Show/Hide
+ * Terminal as toggles, plus a three-state group (Code | Knowledge |
+ * neither) for the right-slot working surface. Pass the current layout
+ * so check marks line up with what's actually shown; rebuild the menu
+ * after any layout change so the marks refresh. No Quit accelerator on
+ * purpose: Ctrl+Q is too easy to hit by accident, and File → Quit
+ * routes through a renderer-side confirmation modal anyway.
+ */
+export function buildMenu(
+  layout: LayoutState = DEFAULT_LAYOUT,
+  recents: Recents = { paths: [], current: null },
+): void {
+  lastLayout = layout;
+  lastRecents = recents;
+  const send = (command: string): void => {
+    mainWindowRef?.webContents.send('menu-command', command);
+  };
+
+  const openRecentSubmenu: MenuItemConstructorOptions[] = recents.paths.length
+    ? [
+        ...recents.paths.map((path) => ({
+          label: prettyRecentLabel(path),
+          type: 'checkbox' as const,
+          checked: path === recents.current,
+          click: () => {
+            mainWindowRef?.webContents.send('menu-open-recent', path);
+          },
+        })),
+        { type: 'separator' as const },
+        {
+          label: 'Clear menu',
+          click: () => {
+            mainWindowRef?.webContents.send('menu-clear-recents');
+          },
+        },
+      ]
+    : [{ label: '(no recent conceptions)', enabled: false }];
+
+  const fileSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'Open…',
+      accelerator: 'CommandOrControl+O',
+      click: () => send('open-folder'),
+    },
+    {
+      label: 'Open Recent',
+      submenu: openRecentSubmenu,
+    },
+    {
+      label: 'Open conception directory',
+      click: () => send('open-conception'),
+    },
+    {
+      label: 'New project…',
+      accelerator: 'CommandOrControl+N',
+      click: () => send('new-project'),
+    },
+    { type: 'separator' },
+    {
+      label: 'Settings',
+      accelerator: 'CommandOrControl+,',
+      click: () => send('open-settings'),
+    },
+    {
+      // Two accelerators for the same action — Electron menus only honour
+      // one accelerator per item, so the Ctrl+K binding is wired in the
+      // renderer's handleGlobalKeyDown (the cheat-sheet documents both).
+      label: 'Search…',
+      accelerator: 'CommandOrControl+Shift+F',
+      click: () => send('search'),
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit',
+      // No accelerator on purpose — see the comment above buildMenu().
+      click: () => send('request-quit'),
+    },
+  ];
+
+  const viewSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'Show Projects',
+      type: 'checkbox',
+      checked: layout.projects,
+      click: () => send('toggle-projects'),
+    },
+    {
+      label: 'Show Code',
+      type: 'checkbox',
+      checked: layout.working === 'code',
+      accelerator: 'CommandOrControl+Shift+C',
+      click: () => send('show-code'),
+    },
+    {
+      label: 'Show Knowledge',
+      type: 'checkbox',
+      checked: layout.working === 'knowledge',
+      accelerator: 'CommandOrControl+Shift+K',
+      click: () => send('show-knowledge'),
+    },
+    {
+      label: 'Show Resources',
+      type: 'checkbox',
+      checked: layout.working === 'resources',
+      accelerator: 'CommandOrControl+R',
+      click: () => send('show-resources'),
+    },
+    {
+      label: 'Show Skills',
+      type: 'checkbox',
+      checked: layout.working === 'skills',
+      accelerator: 'CommandOrControl+L',
+      click: () => send('show-skills'),
+    },
+    {
+      label: 'Hide working surface',
+      enabled: layout.working !== null,
+      click: () => send('hide-working'),
+    },
+    {
+      label: 'Show Terminal',
+      type: 'checkbox',
+      checked: layout.terminal,
+      accelerator: 'CommandOrControl+`',
+      click: () => send('toggle-terminal'),
+    },
+    { type: 'separator' },
+    {
+      label: 'Refresh',
+      accelerator: 'F5',
+      click: () => send('refresh'),
+    },
+    { type: 'separator' },
+    {
+      role: 'reload',
+      label: 'Reload window',
+      // Reload normally lives at Ctrl+R, but we hand that accelerator to the
+      // Resources panel (more useful in day-to-day work). Reload moves to
+      // Ctrl+Shift+R, which still aligns with browser muscle memory for
+      // a hard reload.
+      accelerator: 'CommandOrControl+Shift+R',
+    },
+    { role: 'toggleDevTools' },
+    { type: 'separator' },
+    { role: 'resetZoom' },
+    { role: 'zoomIn' },
+    { role: 'zoomOut' },
+    { type: 'separator' },
+    { role: 'togglefullscreen' },
+  ];
+
+  const helpSubmenu: MenuItemConstructorOptions[] = [
+    {
+      label: 'About Condash',
+      click: () => send('about'),
+    },
+    { type: 'separator' },
+    { label: 'Welcome', click: () => send('help-welcome') },
+    { label: 'Quick start', click: () => send('help-quick-start') },
+    { label: 'Keyboard shortcuts', click: () => send('help-shortcuts') },
+    { type: 'separator' },
+    { label: 'Configuration', click: () => send('help-configuration') },
+    { label: 'CLI overview', click: () => send('help-cli') },
+    { label: 'Why Markdown-first', click: () => send('help-why-markdown') },
+    { type: 'separator' },
+    {
+      label: 'Open documentation site',
+      click: () => {
+        void shell
+          .openExternal('https://condash.vcoeur.com')
+          .catch((err) => console.error('[menu] openExternal failed', err));
+      },
+    },
+    {
+      label: 'Open issue tracker',
+      click: () => {
+        void shell
+          .openExternal('https://github.com/vcoeur/condash/issues')
+          .catch((err) => console.error('[menu] openExternal failed', err));
+      },
+    },
+  ];
+
+  const template: MenuItemConstructorOptions[] = [
+    { label: 'File', submenu: fileSubmenu },
+    {
+      label: 'Edit',
+      submenu: [
+        { role: 'undo' },
+        { role: 'redo' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'selectAll' },
+      ],
+    },
+    { label: 'View', submenu: viewSubmenu },
+    { label: 'Help', role: 'help', submenu: helpSubmenu },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+}
+
+/**
+ * Rebuild the application menu against the latest layout. Used as the
+ * `onLayoutChange` hook by registerSettingsIpc — the View submenu's check
+ * marks need to refresh after every layout mutation.
+ */
+export function rebuildMenu(layout: LayoutState): void {
+  buildMenu(layout, lastRecents);
+}
+
+/**
+ * Re-read settings.json for the recents list and rebuild against the
+ * cached layout. Used after the conception path or recents list changes.
+ */
+export async function rebuildMenuFromSettings(): Promise<void> {
+  const settings = await readSettings();
+  lastRecents = {
+    paths: settings.recentConceptionPaths ?? [],
+    current: settings.lastConceptionPath,
+  };
+  buildMenu(lastLayout, lastRecents);
+}

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -135,8 +135,9 @@ function isMarkdown(path: string): boolean {
   return path.toLowerCase().endsWith('.md');
 }
 
-function isConfigurationJson(path: string): boolean {
-  return path.toLowerCase().endsWith('/configuration.json');
+function isConceptionConfig(path: string): boolean {
+  const lower = path.toLowerCase();
+  return lower.endsWith('/condash.json') || lower.endsWith('/configuration.json');
 }
 
 const CONFIG_SUMMARY: { key: string; purpose: string }[] = [
@@ -726,7 +727,7 @@ export function NoteModal(props: {
           tabIndex={-1}
           onClick={handleBodyClick}
         >
-          <Show when={props.state && isConfigurationJson(props.state.path)}>
+          <Show when={props.state && isConceptionConfig(props.state.path)}>
             <ConfigSummaryPanel onOpenFullDoc={() => props.onOpenHelp?.('configuration')} />
           </Show>
           <Show when={content.loading}>


### PR DESCRIPTION
## Summary

- Pass 01 of the multipass review of condash. Picks up the trailing edges of the `configuration.json` → `condash.json` rename and finishes the half-done IPC-module extraction in `src/main/`.
- Behaviour-preserving across the board — no schema changes, no IPC contract changes, no user-visible feature work.

## Changes

- **Renamed `isConfigurationJson` → `isConceptionConfig`** in `src/renderer/note-modal.tsx` and broadened the matcher to accept `/condash.json` *or* `/configuration.json`. The in-app config-summary panel was previously locked to the legacy filename and never showed for the canonical file.
- **Dropped the dead `configuration.json.example` branch** in `src/main/conception-init.ts:mapTemplateName`. The bundled `conception-template/` only ships `condash.json.example`; the legacy example file was deleted weeks ago. Tightened the function docstring to match.
- **Help docs caught up to the post-rename UI:** `docs/help/quick-start.md` no longer describes a "primary + secondary repos" Settings shape (the schema rejects that bucket form) and now points at `condash.json` with the legacy fallback called out. `docs/help/welcome.md` swapped `configuration.json` → `condash.json` in the Settings sentence.
- **Extracted IPC handlers** from `src/main/index.ts` into three new modules under `src/main/ipc/`, mirroring the existing `ipc/{settings,system,terminal}.ts` pattern:
  - `ipc/projects.ts` — `listProjects`, `getProject`, `step.*`, `listProjectFiles`, `setStatus` (carrying the lingering-branch-warning logic), `createProject`, `note.*`, `settings.read/writeRaw`, `project.createNote`. `assertUnderConception` lives here too since every caller is in this module.
  - `ipc/trees.ts` — `read{Knowledge,Resources,Skills}Tree`, `tree.*`, `search`.
  - `ipc/repos.ts` — `listRepos`, `listReposForPrimary`, `invalidateGitStatus`, `getDirtyDetails`, `listOpenWith`, `launchOpenWith`, `forceStopRepo`. Watcher reconciliation stays inline with the `listRepos` verbs.
- **Extracted the application menu** into `src/main/menu.ts` (`buildMenu`, `rebuildMenu`, `rebuildMenuFromSettings`, `prettyRecentLabel`). The window reference is injected via `setMenuWindow` so menu callbacks fire IPC at the active window without referencing a module-scope `mainWindow`.
- `registerIpc()` collapses to a flat sequence of `register*Ipc()` calls. `src/main/index.ts` shrinks from **909 → 329 LOC**.
- Updated the "IPC contract" paragraph in `docs/explanation/internals.md` to point at the per-domain modules.

## Impact

- No user-visible behaviour change. The renderer's config-summary panel now appears for `condash.json` as well as the legacy file — strictly an additive fix.
- The IPC contract (`src/shared/api.ts`) is unchanged. Preload + renderer call sites continue to work unmodified.
- New users following Help → Quick start no longer hit the pre-rename UI tour and the wrong filename before reaching the canonical Configuration page.