### PR TITLE
Pass 09 — sweep dead exports and dedupe HelpDocName + META_LINE

### DIFF
--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -174,14 +174,6 @@ function emitNdjson<T>(data: T, shape: NdjsonShape): void {
   process.stdout.write(JSON.stringify(data) + '\n');
 }
 
-/**
- * Write a single record on a streaming path (`--ndjson`). The dispatcher
- * holds onto exit-code policy; this just lays a JSON line on stdout.
- */
-export function emitNdjsonRecord(record: unknown): void {
-  process.stdout.write(JSON.stringify(record) + '\n');
-}
-
 export function reportError(ctx: OutputContext, err: unknown): ExitCode {
   if (err instanceof CliError) {
     if (ctx.json || ctx.ndjson) {

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -108,9 +108,6 @@ const terminalSettings = z
   })
   .strict();
 
-export type XtermSettings = z.infer<typeof xtermSettings>;
-export type XtermColors = z.infer<typeof xtermColors>;
-
 const layoutSchema = z
   .object({
     projects: z.boolean(),
@@ -224,7 +221,6 @@ export const conceptionConfigSchema = z.object(sharedSchemaFields).strict();
  */
 export const configSchema = conceptionConfigSchema;
 
-export type GlobalSettings = z.infer<typeof globalSettingsSchema>;
 export type ConceptionConfig = z.infer<typeof conceptionConfigSchema>;
 
 /** Backwards-compat alias. */

--- a/src/main/help.ts
+++ b/src/main/help.ts
@@ -1,24 +1,15 @@
 import { app } from 'electron';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
+import type { HelpDocName } from '../shared/types';
 
 /**
- * Names of the doc files exposed to the renderer through `helpReadDoc`.
- * The whitelist is the only path-traversal defence — the renderer can pass
- * any string, but only these resolve to a file.
- *
- * Help docs live under `docs/help/` and are intentionally short and
- * self-contained — no relative wikilinks. Each one ends with a pointer
- * to the matching section on the public docs site.
+ * `PATHS` is the only path-traversal defence — the renderer can pass any
+ * string for `helpReadDoc(name)`, but only entries in this allowlist resolve
+ * to a file. Help docs live under `docs/help/` and are intentionally short
+ * and self-contained (no relative wikilinks). The `HelpDocName` union lives
+ * in `shared/types.ts` so the IPC contract stays in lock-step with this map.
  */
-export type HelpDocName =
-  | 'welcome'
-  | 'quick-start'
-  | 'shortcuts'
-  | 'configuration'
-  | 'cli'
-  | 'why-markdown';
-
 const PATHS: Record<HelpDocName, string> = {
   welcome: 'help/welcome.md',
   'quick-start': 'help/quick-start.md',

--- a/src/main/search/regions.ts
+++ b/src/main/search/regions.ts
@@ -1,6 +1,6 @@
+import { META_LINE } from '../../shared/header';
 import type { SearchRegion } from '../../shared/types';
 
-const META_LINE = /^\*\*[A-Za-z][\w -]*\*\*\s*:.*$/;
 const HEADING = /^#{1,6}\s+/;
 
 /**

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -174,10 +174,6 @@ async function writeSettingsRaw(next: Settings): Promise<void> {
   await fs.rename(tmp, path);
 }
 
-export function writeSettings(next: Settings): Promise<void> {
-  return withSettingsQueue(() => writeSettingsRaw(next));
-}
-
 /**
  * Atomic read-modify-write. Use this for every IPC verb that mutates a
  * narrow field (setLayout, setTheme, setWelcomeDismissed, termSetPrefs,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -2,6 +2,7 @@ import type {
   CardMinWidthPrefs,
   ConceptionInitState,
   DirtyDetails,
+  HelpDocName,
   KnowledgeNode,
   LayoutState,
   OpenWithSlotKey,
@@ -298,14 +299,6 @@ export type MenuCommand =
   | 'help-configuration'
   | 'help-cli'
   | 'help-why-markdown';
-
-export type HelpDocName =
-  | 'welcome'
-  | 'quick-start'
-  | 'shortcuts'
-  | 'configuration'
-  | 'cli'
-  | 'why-markdown';
 
 declare global {
   interface Window {

--- a/src/shared/header.ts
+++ b/src/shared/header.ts
@@ -27,11 +27,6 @@ const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/;
 
 export const KNOWN_KINDS = ['project', 'incident', 'document'] as const;
 
-export const ENUMS = {
-  KNOWN_STATUSES,
-  KNOWN_KINDS,
-} as const;
-
 const FOLDER_NAME_RE = /^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$/;
 
 export function isItemFolderName(name: string): boolean {

--- a/src/shared/path.ts
+++ b/src/shared/path.ts
@@ -8,11 +8,3 @@
 export function toPosix(path: string): string {
   return path.includes('\\') ? path.replace(/\\/g, '/') : path;
 }
-
-/** Last segment of a forward-slash path. Convenience for renderer code
- *  that previously did `p.split('/').pop()` — keeps the same behaviour
- *  but spells the intent. */
-export function posixBasename(path: string): string {
-  const i = path.lastIndexOf('/');
-  return i === -1 ? path : path.slice(i + 1);
-}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,20 @@ export type Platform = 'linux' | 'darwin' | 'win32' | (string & {});
 
 export type ItemKind = 'project' | 'incident' | 'document' | 'unknown';
 
+/**
+ * Names of the bundled help docs the renderer can request via `helpReadDoc`.
+ * Lifted to `shared/` so the IPC contract (`shared/api.ts`) and the main
+ * loader's `PATHS` allowlist (`main/help.ts`) reference one canonical union —
+ * additions/renames touch one file instead of two.
+ */
+export type HelpDocName =
+  | 'welcome'
+  | 'quick-start'
+  | 'shortcuts'
+  | 'configuration'
+  | 'cli'
+  | 'why-markdown';
+
 export type KnownStatus = 'now' | 'review' | 'later' | 'backlog' | 'done';
 
 export const KNOWN_STATUSES: readonly KnownStatus[] = ['now', 'review', 'later', 'backlog', 'done'];


### PR DESCRIPTION
## Summary

- Pass 09 of the multipass review: a small dead-code sweep plus a duplication fix.
- `HelpDocName` was declared identically in two files and had to stay in lock-step on every help-doc rename; consolidated to one home.
- One regex (`META_LINE`) was redeclared in the search-regions module despite already living in `shared/header.ts`.

## Changes

- Lift `HelpDocName` from `src/shared/api.ts` and `src/main/help.ts` into `src/shared/types.ts` (single canonical union; `main/` deliberately does not import from `shared/api.ts`, so the shared-types catalog is the right home).
- Delete dead exports — `posixBasename` (`src/shared/path.ts`), `emitNdjsonRecord` (`src/cli/output.ts`), `writeSettings` (`src/main/settings.ts`), `ENUMS` (`src/shared/header.ts`). All four had zero importers across `src/` and `tests/`.
- Delete the unused inferred type aliases `XtermSettings`, `XtermColors`, `GlobalSettings` in `src/main/config-schema.ts`. The underlying Zod schemas remain the only consumers.
- Replace the local `META_LINE` const in `src/main/search/regions.ts` with an import from `src/shared/header.ts`. The `.test()` callsite is unaffected by the shared variant's capture groups.

## Impact

- Net -31 LOC across 9 files. No runtime behaviour change.
- Renames or additions to the help-doc allowlist now touch one file (`shared/types.ts`) instead of two.