### PR TITLE
Pass 10 — sweep stale planning markers and align auto-update docs with the disabled feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,18 +6,18 @@ Project tracking + per-feature specs live in `vcoeur/conception/projects/2026-04
 
 ## Stack
 
-- **Main**: Node, TypeScript, **bundled with esbuild** (`scripts/build-electron.mjs`) to a single CJS file at `dist-electron/main/index.js`. Imports are inlined; ESM-only deps (chokidar 4, future libs) bundle to CJS transparently. Native modules (electron, node-pty when MVP-15 lands, fsevents, better-sqlite3) stay external — they have to load from `node_modules` so `electron-rebuild` can reach them.
+- **Main**: Node, TypeScript, **bundled with esbuild** (`scripts/build-electron.mjs`) to a single CJS file at `dist-electron/main/index.js`. Imports are inlined; ESM-only deps (chokidar 4, future libs) bundle to CJS transparently. Native modules (electron, node-pty, fsevents) stay external — they have to load from `node_modules` so `electron-rebuild` can reach them.
 - **Preload**: same bundler, output at `dist-electron/preload/index.js`. Stays CJS because `webPreferences.sandbox: true` + ESM preload don't mix on Electron.
 - **Typecheck**: `tsc -p tsconfig.main.json --noEmit` (and the renderer twin). `tsc` no longer emits — esbuild owns emission, tsc owns type-checking.
 - **Renderer**: Solid + Solid signals, Vite (with `vite-plugin-solid`), plain CSS files + CSS variables, `src/renderer/main.tsx`.
 - **Shared types**: `src/shared/types.ts` — plain serialisable objects, ISO strings, no methods.
 - **Packaging**: electron-builder, single `BrowserWindow`, all modals/panes are in-renderer overlays.
-- **Watcher (post-MVP-0)**: single global chokidar rooted at `<conception>/`, debounced 250 ms.
+- **Watcher**: single global chokidar rooted at `<conception>/`, debounced 250 ms.
 
 ### Adding a new main-process dep
 
 1. `npm install <pkg>`. ESM-only is fine — esbuild bundles it as CJS.
-2. If the dep is **native** (has a `binding.gyp` or ships prebuilt `.node` files — e.g. `node-pty`, `better-sqlite3`), add it to the `EXTERNAL` array in `scripts/build-electron.mjs` so esbuild leaves it alone, and wire `electron-rebuild` if needed.
+2. If the dep is **native** (has a `binding.gyp` or ships prebuilt `.node` files — e.g. `node-pty`), add it to the `EXTERNAL` array in `scripts/build-electron.mjs` so esbuild leaves it alone, and wire `electron-rebuild` if needed.
 3. Pure-JS deps need no further work.
 
 ## Locked decisions
@@ -79,7 +79,7 @@ macOS and Windows are unaffected.
 - Run `make format` after every code change.
 - All UI must work without per-OS CSS branches (Electron + Chromium = same renderer everywhere).
 - File-path conventions: every path crossing the IPC boundary is normalised to forward-slash form via `toPosix(p)` from `src/shared/path.ts`. Internal `fs` calls keep the native separator (use `path.join`); the renderer can then split on `/` without per-OS branches. Cross-OS shell wrapping (`bash -lc` / `cmd.exe /d /s /c` / `pwsh -Command`) lives in `src/main/terminals.ts`'s `wrapForShell`.
-- IPC contract is the single typed `CondashApi` interface in `src/shared/api.ts`. Functions, not URLs. Promises for request/response; events only for chokidar push (when wired).
+- IPC contract is the single typed `CondashApi` interface in `src/shared/api.ts`. Functions, not URLs. Promises for request/response; events only for chokidar push.
 - Hard interaction-to-paint budget: **≤ 16 ms** for any user-initiated action. Optimistic UI is the default; rollback on IPC failure.
 
 ## Pointers
@@ -95,17 +95,3 @@ The in-app Help menu reads files out of the asar via the allowlist in `src/main/
 The first-launch **welcome screen** lives in `src/renderer/welcome-screen.tsx` and renders inside `workspace-center` when the conception path is set, the projects list is empty, and the knowledge tree is empty (and the user hasn't dismissed it). Dismiss state persists at `welcome.dismissed` in `settings.json` via the `getWelcomeDismissed` / `setWelcomeDismissed` IPC verbs.
 
 When changing app behaviour, update the matching `docs/` file in the same commit. The schema in `src/main/config-schema.ts` and the public reference (`docs/reference/config.md`) must agree on every release.
-
-## What's deliberately not here (yet)
-
-Until each feature has its own spec under `conception/projects/2026-04/2026-04-26-condash-electron-port/notes/specs/`:
-
-- File watcher (MVP-1).
-- Step toggles, status drag, knowledge tab, terminal, notes modal, deliverables, repo strip, inline runner, search, preferences modal.
-- Markdown rendering (markdown-it + plugins per L8, lands with the notes modal).
-- CodeMirror 6 (lands with the notes editor).
-- Auto-update (`electron-updater`, deferred behind a flag).
-- `node-pty` (terminal feature only).
-- Code-signing.
-
-No spec, no code.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -46,7 +46,7 @@ Every piece earns its keep. The `**Key**: value` headers render visually but par
 - **No multi-user collaboration.** Single-user, local-only.
 - **No web UI / HTTP server.** End-to-end IPC.
 - **No code editing.** Source files open in your IDE via configurable launcher slots.
-- **No telemetry.** Nothing leaves your machine except the GitHub Releases feed for auto-updates.
+- **No telemetry.** Nothing leaves your machine, period.
 - **No general-purpose terminal.** The xterm pane is a log view + project-scoped shell, not a Konsole / iTerm replacement.
 - **No notes search index.** The conception tree is small enough that re-walking on every query is faster than maintaining an index.
 

--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -155,7 +155,7 @@ src/renderer/    ──vite─────► dist/
   release/{*.AppImage, *.deb, *.dmg, *.exe, latest*.yml}
 ```
 
-esbuild bundles main + preload into single CJS files. Native modules (`electron`, `node-pty`, future `better-sqlite3`) are kept external — they have to load from `node_modules` so `electron-rebuild` can reach them. Pure-JS deps, including ESM-only libraries (chokidar 4 and friends), are inlined.
+esbuild bundles main + preload into single CJS files. Native modules (`electron`, `node-pty`) are kept external — they have to load from `node_modules` so `electron-rebuild` can reach them. Pure-JS deps, including ESM-only libraries (chokidar 4 and friends), are inlined.
 
 `tsc` no longer emits — esbuild owns emission, tsc owns type-checking. `make typecheck` runs `tsc --noEmit` against `tsconfig.main.json` and `tsconfig.renderer.json`.
 

--- a/docs/explanation/non-goals.md
+++ b/docs/explanation/non-goals.md
@@ -65,7 +65,7 @@ condash ships unsigned `.deb`, `.AppImage`, `.dmg`, and `.exe` builds. Code-sign
 
 ## No telemetry / usage reporting
 
-condash collects nothing and phones home for nothing except the `electron-updater` check (a `GET` against the GitHub Releases feed that carries only the user-agent).
+condash collects nothing and phones home for nothing.
 
 **Why**: it's a personal-tool category. Telemetry would buy us nothing the user can't tell us directly.
 

--- a/docs/explanation/values.md
+++ b/docs/explanation/values.md
@@ -28,7 +28,7 @@ condash binds to nothing public. It speaks IPC to one renderer and `fs` to one t
 Practical consequences:
 
 - **No login screen, ever.** No accounts, no API keys, no OAuth flow.
-- **No opt-out telemetry either.** condash collects nothing about you. The only thing it ever fetches is the GitHub Releases feed during the auto-update check.
+- **No opt-out telemetry either.** condash collects nothing about you, and it does not phone home.
 - **No feature where "single-user" is in tension with how it's meant to work.** Real-time collaboration, presence indicators, "X is editing this" markers: not even on the long-term roadmap. Use git.
 
 ## 3. Simple over clever

--- a/docs/get-started/releases.md
+++ b/docs/get-started/releases.md
@@ -1,6 +1,6 @@
 ---
 title: Releases · condash
-description: How to find the latest condash release, what the version scheme means, and how the auto-updater behaves.
+description: How to find the latest condash release, what the version scheme means, and how to upgrade.
 ---
 
 # Releases
@@ -47,8 +47,8 @@ If the [latest-release](https://github.com/vcoeur/condash/releases/latest) URL 4
 
 If you're waiting on a specific fix, the GitHub **Actions** tab shows the build progress; the release appears under **All releases** the moment the maintainer flips the draft to published.
 
-## Auto-update
+## Upgrading
 
-condash ships with `electron-updater` wired against its GitHub Releases. On launch the packaged build checks the latest published release, downloads the matching artifact in the background, and prompts to restart when it's ready. See **[Install — Auto-update](releases.md)** for the per-OS behaviour and the apt-repository carve-out.
+condash does not auto-update. Install and upgrade are out-of-band — apt on Linux, dpkg or the `.deb` directly, or `make install` from source. The `electron-updater` wiring is shipped as a no-op so the dependency stays tracked; the packaged build does not check the GitHub Releases feed on launch.
 
-If you'd rather track releases manually, subscribe to the repo's **Releases** tab on GitHub — you'll get an email when a new version ships.
+To track releases, subscribe to the repo's **Releases** tab on GitHub — you'll get an email when a new version ships.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -96,23 +96,6 @@ The buttons spawn the command in `open_with.<slot>.command` from `settings.json`
 - The command isn't on `$PATH` (typical for macOS GUI editors that don't install a shell launcher). Use the `open -na` form on macOS — see [Config files — Per-OS recipes](../reference/config.md#per-os-recipes).
 - The path being passed isn't under `workspace_path` or `worktrees_path`. condash refuses to spawn launchers outside those sandboxes; check the toast message.
 
-## Auto-update
-
-### "An update was downloaded" toast, but condash doesn't restart
-
-`electron-updater` downloads the new build silently and prompts to restart. If the prompt appears but nothing happens after clicking restart:
-
-- **macOS** — re-flagged by Gatekeeper. Drop the quarantine attribute and reopen:
-  ```bash
-  xattr -dr com.apple.quarantine /Applications/condash.app
-  ```
-- **Linux AppImage** — make sure the AppImage lives somewhere writable by your user (not under `/opt/`). `electron-updater` rewrites the file in place.
-- **Linux apt** — apt-installed users are exempt from in-app updates. `sudo apt update && sudo apt upgrade` is the update path.
-
-### Auto-update is checking too often / not at all
-
-The check fires once per launch. If you keep condash open for days, the update toast may never appear — relaunch to trigger a check, or watch the [releases page](https://github.com/vcoeur/condash/releases) directly.
-
 ## File-edit conflicts
 
 ### "Reload before saving" toast on every save

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -24,4 +24,4 @@ Short pages, one per surface. Look things up here; learn them in **[Get started]
 - [IPC API](ipc-api.md) — every verb the renderer can call on the main process.
 - [Environment variables](env.md) — the short list.
 - [Management skill](skill.md) — the shipped `/projects`, `/knowledge`, `/tidy`, `/skills`, `/pr` skills.
-- [Releases workflow](../get-started/releases.md) — what each version tag means and how the auto-updater behaves.
+- [Releases workflow](../get-started/releases.md) — what each version tag means.

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -30,7 +30,6 @@ const EXTERNAL = [
   'electron',
   'node-pty',
   'fsevents',
-  'better-sqlite3',
   'electron-updater',
   'original-fs',
 ];

--- a/scripts/build-electron.mjs
+++ b/scripts/build-electron.mjs
@@ -23,11 +23,10 @@ const devMode = watchMode || process.argv.includes('--dev');
  *  runtime (Electron-internal wiring or native bindings). */
 const EXTERNAL = [
   'electron',
-  // Native modules — kept here for future-proofing; bundle skips them and they
-  // resolve from node_modules. Add new native deps to this list.
+  // Native modules — bundle skips them and they resolve from node_modules.
+  // Add new native deps to this list.
   'node-pty',
   'fsevents',
-  'better-sqlite3',
   // electron-updater pulls in `lzma-native`, `7zip-bin`, and reaches for
   // `original-fs` (an Electron-internal module). Inlining the whole graph
   // explodes the bundle and breaks runtime loading; keep it external so it


### PR DESCRIPTION
## Summary

- Tenth pass of the rolling multipass review. Documentation only — no source-code logic changes.
- Sweeps planning-era markers ("when MVP-15 lands", "(post-MVP-0)", "(when wired)", phantom `better-sqlite3` references, the "What's deliberately not here (yet)" section listing features that have all shipped) from `CLAUDE.md`, `docs/explanation/internals.md`, and the two `scripts/build-*.mjs` EXTERNAL arrays.
- Aligns six auto-update docs with the runtime: in-app auto-update was disabled five days ago (`electron-updater` wiring shipped as a no-op so the dep stays tracked) but the public + contributor docs still described a live feature.

## Changes

- **Commit A — `Sweep stale planning markers from CLAUDE.md and internals`** — `CLAUDE.md` line edits (drop `MVP-15` qualifier on `node-pty`, drop `(post-MVP-0)` from the watcher heading, drop `(when wired)` from the IPC bullet, drop `better-sqlite3` from the native-deps examples) and full deletion of the `## What's deliberately not here (yet)` section (13 of 14 items have already shipped; the only still-accurate item — code-signing — is already covered in `docs/explanation/non-goals.md`). `docs/explanation/internals.md` drops `future \`better-sqlite3\`` from the externals sentence. `scripts/build-electron.mjs` and `scripts/build-cli.mjs` drop `better-sqlite3` from their `EXTERNAL` arrays — it was never a real dep (not in `package.json`, absent from `package-lock.json`).
- **Commit B — `Update docs to reflect that auto-update is disabled`** — `docs/get-started/releases.md` rewrites the page sub-title and the `## Auto-update` section into an `## Upgrading` section that says install/upgrade is out-of-band (apt on Linux, dpkg or `.deb`, or `make install` from source) and that the `electron-updater` wiring ships as a no-op. `docs/guides/troubleshooting.md` deletes the entire `## Auto-update` section (every gotcha was about a feature that no longer fires). `docs/explanation/index.md` rewrites the telemetry bullet to "Nothing leaves your machine, period." `docs/explanation/values.md` rewrites the value-2 telemetry bullet to "condash collects nothing about you, and it does not phone home." `docs/explanation/non-goals.md` rewrites the "No telemetry / usage reporting" entry to "condash collects nothing and phones home for nothing." `docs/reference/index.md` drops the "and how the auto-updater behaves" trailing clause from the Releases-workflow cross-reference.

## Impact

- User-facing privacy claim is now stronger: docs previously said the dashboard fetched the GitHub Releases feed on launch; they now say nothing leaves the machine. This matches the runtime — the `checkForUpdatesAndNotify` call in `src/main/index.ts` is wrapped as a no-op and `electron-updater` is no longer imported.
- The `electron-updater` runtime dep stays in `package.json` and stays in both `EXTERNAL` arrays — the source code intentionally keeps the dependency tracked so re-enabling later is one wiring change away.
- `make typecheck` passes; `npm run test:unit` is 134/134; `npm run build` produces both the Electron and CLI bundles cleanly.

## Watchpoints

- The `docs/` site is published by `.github/workflows/docs.yml` on the next release tag — confirm the rebuilt mkdocs site renders the new `## Upgrading` section on `releases.md` and no longer carries the `## Auto-update` heading anywhere.