### PR TITLE
Pass 11 — sweep three-tutorials framing, finish auto-update prose, dedupe HelpDoc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
               -f make_latest=$MAKE_LATEST >/dev/null
             echo "Release for $TAG already exists ($REL_ID); state re-asserted, uploading into it."
           else
-            BODY=$'Unsigned Electron build of condash. Auto-update channel served from this release via `electron-updater`.\n\nInstall bypass per OS:\n- Windows: SmartScreen → "More info" → "Run anyway".\n- macOS: System Settings → Privacy & Security → "Open Anyway".\n- Linux: `chmod +x` the AppImage, run.'
+            BODY=$'Unsigned Electron build of condash.\n\nInstall bypass per OS:\n- Windows: SmartScreen → "More info" → "Run anyway".\n- macOS: System Settings → Privacy & Security → "Open Anyway".\n- Linux: `chmod +x` the AppImage, run.'
             gh api -X POST "repos/$GH_REPO/releases" \
               -f tag_name="$TAG" \
               -F draft=false \

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A desktop dashboard for a folder of Markdown files — **projects**, **incidents
 Everything lives at **[condash.vcoeur.com](https://condash.vcoeur.com)**:
 
 - [Get started](https://condash.vcoeur.com/get-started/) — install, first launch, releases.
-- [Tutorials](https://condash.vcoeur.com/tutorials/) — first run, first project, a day with condash.
+- [Tutorials](https://condash.vcoeur.com/tutorials/) — a day in the life of a condash workflow.
 - [Reference](https://condash.vcoeur.com/reference/) — every CLI verb, config key, shortcut, mutation.
 - [Background](https://condash.vcoeur.com/explanation/) — values, non-goals, internals, why Markdown-first.
 

--- a/docs/explanation/why-markdown.md
+++ b/docs/explanation/why-markdown.md
@@ -13,7 +13,7 @@ Every project tracker answers a few questions for you: what am I working on, wha
 2. **The dashboard is a view, not a second database.** Close the dashboard and the files don't go anywhere. Delete the dashboard and the files don't go anywhere.
 3. **Writing is cheap.** No form to fill, no modal to open, no required fields, no schema migration. You type Markdown.
 
-This page is the pitch. Read [tutorials/first-run](../get-started/index.md) for how to actually install the thing.
+This page is the pitch. Read [Get started](../get-started/index.md) for how to actually install the thing.
 
 ## Your project tracker should be plain files in git
 

--- a/docs/tutorials/daily-loop.md
+++ b/docs/tutorials/daily-loop.md
@@ -5,7 +5,7 @@ description: Open an existing item, edit code in the repo strip, run a build in 
 
 # A day with condash
 
-> **Audience.** New user becoming a daily user — you've finished the first two tutorials and want to see the realistic workflow.
+> **Audience.** New user becoming a daily user — you've worked through Get started and want to see the realistic workflow.
 
 **When to read this.** You've worked through [Get started](../get-started/index.md). You want to see the full workflow: not just "how do I create an item?", but "what does a day of real work look like when this tree is your work tracker?".
 

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,6 +1,6 @@
 ---
 title: Tutorials · condash
-description: Learn condash by doing. Three linear walkthroughs take you from a fresh install to managing real work.
+description: Learn condash by doing. A realistic walkthrough takes you from an open item to a closed PR.
 ---
 
 # Tutorials

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -39,8 +39,7 @@ asarUnpack:
 afterPack: build/after-pack.cjs
 
 # Auto-update channel: latest*.yml is uploaded next to the bundles in the
-# GitHub Release tied to the current `v*` tag. App reads it at runtime via
-# electron-updater.
+# GitHub Release tied to the current `v*` tag.
 #
 # `releaseType: prerelease` tells electron-builder to look for (and, if
 # missing, create) a prerelease for the tag. Drafts are invisible to the

--- a/src/renderer/help-modal.tsx
+++ b/src/renderer/help-modal.tsx
@@ -1,16 +1,11 @@
 import { createEffect, createResource, Show } from 'solid-js';
+import type { HelpDocName as HelpDoc } from '@shared/types';
 import { renderMarkdown, runMermaidIn } from './markdown';
 import { routeMarkdownClick, scrollToAnchor } from './md-link-router';
 import { useModalEscHandler } from './modal-helpers';
 import './code-theme.css';
 
-export type HelpDoc =
-  | 'welcome'
-  | 'quick-start'
-  | 'shortcuts'
-  | 'configuration'
-  | 'cli'
-  | 'why-markdown';
+export type { HelpDoc };
 
 const TITLE: Record<HelpDoc, string> = {
   welcome: 'Welcome to condash',


### PR DESCRIPTION
## Summary

- Pass 11 of the multipass review: three independent stale-text threads, each smaller than pass 10. Each shares the same root cause as pass 10 — a deletion or disable commit landed without sweeping the prose that referenced the old shape.
- One PR with three commits (one per sub-thread): tutorials sweep, auto-update build/release prose, third `HelpDoc` union dedupe.
- Pure docs + comment + type-import edits. Zero behaviour change. `make typecheck`, `npm run test:unit` (134/134), and `npm run build` all clean.

## Changes

- **Sweep stale "three tutorials" framing across README and docs** (`e2629fe`). After commit `f1507d6` collapsed `tutorials/first-run.md` and `tutorials/first-project.md` into the single-page `get-started/index.md`, four surfaces still described the old three-walkthrough shape:
  - `README.md:20`: `Tutorials — first run, first project, a day with condash` → `Tutorials — a day in the life of a condash workflow`.
  - `docs/tutorials/index.md:3` (front-matter `description`): `Three linear walkthroughs` → `A realistic walkthrough takes you from an open item to a closed PR`.
  - `docs/tutorials/daily-loop.md:8` (Audience callout): `you've finished the first two tutorials` → `you've worked through Get started`.
  - `docs/explanation/why-markdown.md:16`: link text `[tutorials/first-run]` → `[Get started]`. Target unchanged (`../get-started/index.md`).
- **Drop stale auto-update assertions from build and release config** (`fb108a7`). Pass 10 swept the `docs/` mentions of auto-update; two non-`docs/` surfaces still framed it as wired. With auto-update disabled in `src/main/index.ts:312-315` (commit `e040533`), these assertions are false-by-construction:
  - `electron-builder.yml:41-43`: drop `App reads it at runtime via electron-updater.`. The line about `latest*.yml` channel files being uploaded next to the bundles is kept (artifacts are still produced).
  - `.github/workflows/release.yml:221`: drop ` Auto-update channel served from this release via \`electron-updater\`.\n\n` from the GitHub Release `BODY` template applied on every new tag. Removes the false claim from every release page since `2026-05-05`.
- **Dedupe third `HelpDoc` union from `renderer/help-modal.tsx`** (`5c26d19`). Pass 09 lifted `HelpDocName` to `shared/types.ts:15-21` to dedupe `shared/api.ts` against `main/help.ts`, but missed a third copy in the renderer (`src/renderer/help-modal.tsx:7-13`). Replaced the local `export type HelpDoc = ...` with `import type { HelpDocName as HelpDoc } from "@shared/types"; export type { HelpDoc };` — preserves the existing `HelpDoc` symbol on the renderer side, so `src/renderer/main.tsx:36` and `src/renderer/menu-commands.ts:4` (and every other call site) compile unchanged. Renaming a help doc now touches one canonical union plus the `PATHS` map in `main/help.ts`, instead of three lockstep declarations.

## Impact

- README and tutorials index have been the GitHub-landing-page first-impression surface promising tutorials that were collapsed five days ago — that mismatch is gone.
- Every `github.com/vcoeur/condash/releases/tag/v*` page since `2026-05-05` has been announcing an auto-update channel the packaged app no longer reads — fixed for future releases.
- `HelpDoc` is now structurally tied to `HelpDocName` in `shared/types.ts`. Adding a doc still requires updating the `PATHS` map in `main/help.ts`; the local `TITLE: Record<HelpDoc, string>` map in `help-modal.tsx` is renderer-only display strings and stays put.
- Auto-update runtime dependency (`electron-updater`) intentionally untouched — disabling the in-app check is pass 10's decision; this PR only completes the prose sweep.