### PR TITLE
Pass 12 — fix in-app CLI examples and switch README examples to YAML frontmatter

### DIFF
--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -17,14 +17,17 @@ Every project tracker answers a few questions: what am I working on, what's its 
 
 A README looks like this:
 
-```markdown
-# Migrate auth to session-cookie hybrid
+````markdown
+---
+date: 2026-04-10
+kind: project
+status: now
+apps:
+  - notes.vcoeur.com
+branch: feat/session-cookie-auth
+---
 
-**Date**: 2026-04-10
-**Kind**: project
-**Status**: now
-**Apps**: `notes.vcoeur.com`
-**Branch**: `feat/session-cookie-auth`
+# Migrate auth to session-cookie hybrid
 
 ## Goal
 
@@ -35,9 +38,11 @@ Drop the JWT dependency without breaking existing sessions.
 - [x] Audit session-cookie usage
 - [~] Implement hybrid read path
 - [ ] Migration script for existing tokens
-```
+````
 
-Every piece earns its keep. The `**Key**: value` headers render visually but parse with one regex. `## Steps` checkboxes work in any Markdown tool. `git diff` shows exactly what changed when you flip a step. `rg "session cookie"` finds it in 30 ms.
+Legacy bold-prose headers (`**Date**: 2026-04-10`, etc.) are still accepted — see [README format](../reference/readme-format.md).
+
+Every piece earns its keep. The YAML frontmatter parses straight into the metadata block; `## Steps` checkboxes work in any Markdown tool. `git diff` shows exactly what changed when you flip a step. `rg "session cookie"` finds it in 30 ms.
 
 → Full pitch with three good-fit scenarios: **[Why Markdown-first](why-markdown.md)**.
 

--- a/docs/explanation/values.md
+++ b/docs/explanation/values.md
@@ -78,7 +78,7 @@ Practical consequences:
 - **OSC 133 for terminal prompt boundaries.** Same protocol as iTerm2, WezTerm, kitty, Warp. Drop-in shell snippets, no custom protocol.
 - **`xterm-256color` for terminal capabilities.** Works with every modern terminal program.
 
-The exception: when a standard doesn't exist (the **Status** field syntax, the directory layout `projects/YYYY-MM/<slug>/`), pick the simplest possible plain-text shape and commit to it.
+The exception: when a standard doesn't exist (the Status field syntax, the directory layout `projects/YYYY-MM/<slug>/`), pick the simplest possible plain-text shape and commit to it.
 
 ## 7. The dashboard is a thin write surface
 

--- a/docs/explanation/why-markdown.md
+++ b/docs/explanation/why-markdown.md
@@ -31,14 +31,18 @@ Plain Markdown in git is the opposite on every axis. It's portable, greppable, d
 
 A README under a project folder looks like this:
 
-```markdown
-# Migrate auth to session-cookie hybrid
+````markdown
+---
+date: 2026-04-10
+kind: project
+status: now
+apps:
+  - notes.vcoeur.com
+  - vcoeur.com
+branch: feat/session-cookie-auth
+---
 
-**Date**: 2026-04-10
-**Kind**: project
-**Status**: now
-**Apps**: `notes.vcoeur.com`, `vcoeur.com`
-**Branch**: `feat/session-cookie-auth`
+# Migrate auth to session-cookie hybrid
 
 ## Goal
 
@@ -49,12 +53,14 @@ Drop the JWT dependency without breaking existing sessions.
 - [x] Audit session-cookie usage
 - [~] Implement hybrid read path
 - [ ] Migration script for existing tokens
-```
+````
+
+Legacy bold-prose headers (`**Date**: 2026-04-10`, etc.) are still accepted — see [README format](../reference/readme-format.md).
 
 Every piece of it earns its keep:
 
 - `# <title>` is the canonical human name. Markdown conventions; nothing special.
-- `**Key**: value` headers are both visually weighted in a rendered preview and trivially parseable with a regex. No `~~~yaml` frontmatter fence — the header is part of the document.
+- The YAML frontmatter parses straight into the metadata block — strict-mode validation catches typos before they hit the dashboard. The legacy bold-prose form (`**Date**: …`) is still accepted indefinitely; the parser tries YAML first and falls back.
 - `## Steps` with standard GitHub-style checkboxes are editable in every Markdown tool on the planet, and the status markers (`[x]`, `[~]`, `[-]`) survive round-trips through anything that doesn't understand them — they're just characters inside a bullet.
 
 And because it's a regular Markdown file:

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -106,11 +106,14 @@ From the Welcome screen, click **Create your first project**. The new-item modal
 Click **Create item**. condash writes `projects/<YYYY-MM>/<YYYY-MM-DD>-try-condash/README.md` with this template:
 
 ```markdown
-# Try condash
+---
+date: 2026-05-02
+kind: project
+status: now
+apps: []
+---
 
-**Date**: 2026-05-02
-**Kind**: project
-**Status**: now
+# Try condash
 
 ## Goal
 
@@ -127,7 +130,7 @@ Click **Create item**. condash writes `projects/<YYYY-MM>/<YYYY-MM-DD>-try-conda
 ## Notes
 ```
 
-That file is the whole item. The dashboard reads it on every refresh; mutations (toggle a step, change status, drag between groups) rewrite specific lines. The format is documented in **[README format](../reference/readme-format.md)**.
+That file is the whole item. The dashboard reads it on every refresh; mutations (toggle a step, change status, drag between groups) rewrite specific lines. The format is documented in **[README format](../reference/readme-format.md)** — YAML frontmatter is canonical, the legacy bold-prose form (`**Date**: …`, etc.) is still accepted.
 
 You can also create items by hand — just `mkdir projects/<YYYY-MM>/<YYYY-MM-DD>-<slug>/` and drop a `README.md` with the header above. condash picks it up live.
 

--- a/docs/guides/skill-extensions.md
+++ b/docs/guides/skill-extensions.md
@@ -55,7 +55,7 @@ When invoked, run the team-specific pre-step (below), then dispatch to the shipp
 
 1. Ask the user the standard fields plus the team-specific `**Linear ID**:` header.
 2. Run `/projects create` with the gathered fields.
-3. After creation, append the Linear ID line to the README header, between `**Apps**` and `## Goal`.
+3. After creation, append the Linear ID line to the README header, between `apps` and `## Goal`.
 4. Open the matching Linear ticket in the browser via `condash openExternal`.
 ```
 
@@ -73,7 +73,7 @@ The patterns below are realistic shapes — copy and adapt to your tree.
 
 ### Branch isolation on create
 
-**Problem.** Your projects-that-touch-code need to work in a git worktree, not the main checkout. The shipped `/projects create` writes the README and stops; you want it to also scaffold the worktree when the item declares a `**Branch**:`.
+**Problem.** Your projects-that-touch-code need to work in a git worktree, not the main checkout. The shipped `/projects create` writes the README and stops; you want it to also scaffold the worktree when the item declares a `branch`.
 
 **Wrapper sketch.** After `/projects create` returns:
 
@@ -81,7 +81,7 @@ The patterns below are realistic shapes — copy and adapt to your tree.
 condash-cli worktrees setup <branch> --copy-env
 ```
 
-Run it only when the new item has a `**Branch**:` field. The shipped `/projects create` already prompts for it; the wrapper just observes the result and runs the setup command. `condash-cli worktrees setup` itself is the canonical path — it knows where worktrees live (`<condash.json>.worktrees_path`), runs the per-repo `install:` hook by default, and copies env files from the main checkout when `--copy-env` is set.
+Run it only when the new item has a `branch` field. The shipped `/projects create` already prompts for it; the wrapper just observes the result and runs the setup command. `condash-cli worktrees setup` itself is the canonical path — it knows where worktrees live (`<condash.json>.worktrees_path`), runs the per-repo `install:` hook by default, and copies env files from the main checkout when `--copy-env` is set.
 
 ### Deliverable generation on close
 
@@ -107,7 +107,7 @@ Don't touch hand-written bullets for other files — only manage the bullet for 
 
 Each pattern assumes something the conception convention itself doesn't:
 
-- Branch isolation assumes you have a `worktrees_path` configured and that `**Branch**:` is part of your workflow.
+- Branch isolation assumes you have a `worktrees_path` configured and that `branch` is part of your workflow.
 - Deliverable generation assumes a specific `md_to_pdf` pipeline is available and that `document` items have a canonical note.
 - Notes index assumes the README has a `## Notes` section and that notes have first-paragraph summaries.
 

--- a/docs/help/cli.md
+++ b/docs/help/cli.md
@@ -26,9 +26,11 @@ condash-cli <noun> <verb> [args] [--flags]
 | `search` | `condash-cli search "<query>" [--scope all\|projects\|knowledge]` |
 | `repos` | `list [--include-worktrees]` |
 | `worktrees` | `list`, `setup <branch>`, `remove <branch>`, `check <branch>` |
+| `audit` | `--include lfs,binaries,cross-repo,worktrees,index` |
 | `dirty` | `list`, `touch <tree>`, `clear <tree\|all>` |
 | `skills` | `list`, `install`, `status` |
-| `config` | `conception-path [<path>]`, `list`, `get <key>` |
+| `templates` | `list`, `install [<path>...]`, `status` |
+| `config` | `conception-path [<path>]`, `path`, `list`, `get <key>`, `set <key> <value>` (`--global` / `--effective` on read verbs) |
 | `help` | `condash-cli help <noun>` |
 
 ## Universal flags

--- a/docs/help/configuration.md
+++ b/docs/help/configuration.md
@@ -133,18 +133,18 @@ paths** section lets you remove individual entries or clear all.
 
 ## CLI
 
-The `condash config` verbs read and write the same files:
+The `condash-cli config` verbs read and write the same files:
 
 ```sh
-condash config path                       # show both file paths
-condash config list                       # show condash.json
-condash config list --global              # show settings.json
-condash config list --effective           # show merged view (conception ⊕ global)
-condash config get repositories[0]        # query the conception layer
-condash config get theme --effective      # query the merged view
-condash config get theme --global         # query settings.json
-condash config set theme dark             # write to condash.json
-condash config set theme dark --global    # write to settings.json
+condash-cli config path                       # show both file paths
+condash-cli config list                       # show condash.json
+condash-cli config list --global              # show settings.json
+condash-cli config list --effective           # show merged view (conception ⊕ global)
+condash-cli config get repositories[0]        # query the conception layer
+condash-cli config get theme --effective      # query the merged view
+condash-cli config get theme --global         # query settings.json
+condash-cli config set theme dark             # write to condash.json
+condash-cli config set theme dark --global    # write to settings.json
 ```
 
 ## When changes apply

--- a/docs/help/quick-start.md
+++ b/docs/help/quick-start.md
@@ -69,11 +69,14 @@ condash writes `projects/<YYYY-MM>/<YYYY-MM-DD>-<slug>/README.md` with
 this template:
 
 ```markdown
-# My title
+---
+date: 2026-05-02
+kind: project
+status: now
+apps: []
+---
 
-**Date**: 2026-05-02
-**Kind**: project
-**Status**: now
+# My title
 
 ## Goal
 
@@ -89,7 +92,9 @@ this template:
 ```
 
 You can also hand-create items — just `mkdir` the folder and drop a
-README with that header. condash picks it up live.
+README with that header. Legacy bold-prose headers (`**Date**: 2026-05-02`,
+etc.) are still accepted; see the [README format reference](../reference/readme-format.md).
+condash picks it up live.
 
 ## Editing settings
 

--- a/docs/help/why-markdown.md
+++ b/docs/help/why-markdown.md
@@ -12,14 +12,17 @@ three of these at once:
 
 ## A README looks like this
 
-```markdown
-# Migrate auth to session-cookie hybrid
+````markdown
+---
+date: 2026-04-10
+kind: project
+status: now
+apps:
+  - notes.vcoeur.com
+branch: feat/session-cookie-auth
+---
 
-**Date**: 2026-04-10
-**Kind**: project
-**Status**: now
-**Apps**: `notes.vcoeur.com`
-**Branch**: `feat/session-cookie-auth`
+# Migrate auth to session-cookie hybrid
 
 ## Goal
 
@@ -30,11 +33,13 @@ Drop the JWT dependency without breaking existing sessions.
 - [x] Audit session-cookie usage
 - [~] Implement hybrid read path
 - [ ] Migration script for existing tokens
-```
+````
+
+Legacy bold-prose headers are still accepted.
 
 Every piece earns its keep:
 
-- The `**Key**: value` headers render visually but parse with one regex.
+- The YAML frontmatter parses straight into the metadata block.
 - `## Steps` checkboxes work in any Markdown tool.
 - `git diff` shows exactly what changed when you flip a step.
 - `rg "session cookie"` finds it in 30 ms.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,7 +91,7 @@ Item lifecycle and reads.
 | `resolve <slug>` | Resolve a slug to its absolute path |
 | `search <query>` | Full-text search across items, optional `--status` / `--kind` / `--limit` |
 | `validate [<slug>]` | Validate header fields against the schema; pass `--all` for the whole tree, or `--path <readme>` to check one file outside the resolved conception |
-| `status get <slug>` / `status set <slug> <new-status>` | Read or change the `**Status**` field |
+| `status get <slug>` / `status set <slug> <new-status>` | Read or change the `status` field |
 | `close <slug>` | Set status to `done` (or `--status <name>`) and append a `Closed.` timeline entry |
 | `reopen <slug>` | Move `done` back to `now` (or `--status <s>`) and append a `Reopened.` timeline entry |
 | `backfill-closed [--dry-run]` | Append a `Closed.` timeline entry to legacy `done` items missing one |
@@ -145,7 +145,7 @@ Worktree-centric operations on top of `condash.json`'s repositories. Both `repos
 |---|---|
 | `list` | Print every worktree, grouped by primary, with branch + dirty status |
 | `check <branch>` | Per-branch state: which items declare it, per-repo `worktree✓`/`branch✓`/`primary-on-branch`/`pinned` flags, missing or orphan dirs |
-| `mismatch` | Report worktrees referenced by an item's `**Branch**` field that don't exist on disk (or vice versa) |
+| `mismatch` | Report worktrees referenced by an item's `branch` field that don't exist on disk (or vice versa) |
 | `setup <branch> [--repo <r>...] [--copy-env] [--no-env] [--no-install] [--base <ref>]` | Create the worktree for `<branch>` in every primary (or the listed `--repo` subset). `--copy-env` copies `.env*` from the main checkout; `--no-env` skips env wiring; `--no-install` skips the per-repo `install:` hook; `--base <ref>` branches off `<ref>` instead of the repo's default branch |
 | `remove <branch> [--repo <r>...]` | Tear down `<branch>` worktrees and (if safe) the local branch |
 
@@ -163,7 +163,7 @@ condash-cli audit --include lfs,binaries
 | `lfs` | Files that should probably live in Git LFS but are tracked as blobs |
 | `binaries` | Binary files (PDF, .docx, images > size threshold) that may need migrating |
 | `cross-repo` | Cross-repo wikilinks or relative paths that escape the conception |
-| `worktrees` | Same shape as `worktrees mismatch` — items declaring a `**Branch**` with no on-disk worktree, or vice versa |
+| `worktrees` | Same shape as `worktrees mismatch` — items declaring a `branch` with no on-disk worktree, or vice versa |
 | `index` | `index.md` files out of sync with the on-disk tree |
 
 `--include <list>` restricts to a comma-separated subset.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -214,8 +214,10 @@ Read or change condash configuration.
 |---|---|
 | `conception-path` | Print the saved conception path |
 | `conception-path <path>` | Save a new conception path to `settings.json` |
-| `list` | Print every key from `condash.json` and `settings.json` (merged view) |
-| `get <key>` | Print one key's value, dot-separated path (`terminal.shell`) |
+| `path` | Print both config file paths (`settings.json` + `condash.json`) |
+| `list [--global\|--effective]` | Print every key. Default reads `condash.json`; `--global` reads `settings.json`; `--effective` shows the merged view (conception ⊕ global) |
+| `get <key> [--global\|--effective]` | Print one key's value, dot-separated path (`terminal.shell`). Same flag axis as `list` |
+| `set <key> <value> [--global]` | Write a key. Default writes `condash.json`; `--global` writes `settings.json` |
 
 `config conception-path` is the only verb that does not need an existing conception path — it sets one.
 

--- a/docs/reference/conception-convention.md
+++ b/docs/reference/conception-convention.md
@@ -9,7 +9,7 @@ description: The content-level syntax condash reads out of each README body — 
 
 ## At a glance
 
-Every item is a directory under `projects/YYYY-MM/YYYY-MM-DD-slug/` containing a `README.md`. There is no top-level `incidents/` or `documents/` folder — the `**Kind**` field in the header discriminates. Three body sections are parsed: `## Steps`, `## Deliverables`, and anything whose heading is used by the step-add-by-section flow (`## Timeline`, etc., are left alone).
+Every item is a directory under `projects/YYYY-MM/YYYY-MM-DD-slug/` containing a `README.md`. There is no top-level `incidents/` or `documents/` folder — the `kind` field in the header discriminates. Three body sections are parsed: `## Steps`, `## Deliverables`, and anything whose heading is used by the step-add-by-section flow (`## Timeline`, etc., are left alone).
 
 For the header format, see [README format](readme-format.md).
 
@@ -40,7 +40,7 @@ Rules, enforced or conventional:
 | Items live at `projects/YYYY-MM/YYYY-MM-DD-slug/README.md` | parser glob | Anything not matching `projects/*/*/README.md` is invisible. |
 | Month folder is `YYYY-MM` | convention | The parser does not validate the folder name, but the wikilink resolver expects it. |
 | Item folder starts with `YYYY-MM-DD-` | convention | Dashes; no spaces. The part after the date prefix is the short slug wikilinks resolve against. |
-| Kind lives in the body as `**Kind**: …` | convention | Defaults to `project`. No separate directory per kind — they coexist under one month folder. |
+| Kind lives in the metadata block as `kind: …` | convention | Defaults to `project`. No separate directory per kind — they coexist under one month folder. |
 
 The flat-month layout was a deliberate simplification of an earlier `projects/<slug>/` + `projects/YYYY-MM/<slug>/` split. Items never move between active and archive; a `Status: done` flip is the only archive signal, and there's nothing for `condash` to rename. See [why Markdown-first](../explanation/why-markdown.md) for the rationale.
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -21,7 +21,7 @@ Both files share the **same schema** modulo the two path-tracking keys above. An
 ### Reading and writing
 
 - **Read precedence**: condash reads `<conception>/condash.json` when present, falling back to `<conception>/configuration.json` for legacy trees. The legacy filename is supported indefinitely with no deprecation date.
-- **Write target**: every save through the GUI or `condash config set` writes to `condash.json`. The first save in a legacy tree creates `condash.json` and leaves `configuration.json` orphaned for you to delete by hand (no auto-rename, no auto-delete).
+- **Write target**: every save through the GUI or `condash-cli config set` writes to `condash.json`. The first save in a legacy tree creates `condash.json` and leaves `configuration.json` orphaned for you to delete by hand (no auto-rename, no auto-delete).
 - **Override scope**: a conception's `condash.json` is forbidden from setting `lastConceptionPath` or `recentConceptionPaths` — a tree cannot describe its own location, by design.
 - **Environment override**: `CONDASH_CONCEPTION_PATH` still wins for the session, matching the legacy behaviour.
 

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -45,7 +45,7 @@ Every mutation carries the **expected** state of the region it's about to change
 | `toggleStep(path, lineIndex, expectedMarker, newMarker)` | Compare line's existing marker (`[ ]`, `[~]`, `[x]`, `[-]`) to `expectedMarker`. |
 | `editStepText(path, lineIndex, expectedText, newText)` | Compare line's existing text to `expectedText`. |
 | `addStep(path, text)` | Append-only — no drift check. |
-| `setStatus(path, newStatus, opts?)` | Verify the metadata block contains a `**Status**:` line. On done-edges (close: prev → done, reopen: done → prev) also append a `Closed.` / `Reopened.` line to `## Timeline`. Returns `TransitionResult` with `timelineAppended` non-null exactly when a timeline line was written. |
+| `setStatus(path, newStatus, opts?)` | Verify the metadata block contains a Status line. On done-edges (close: prev → done, reopen: done → prev) also append a `Closed.` / `Reopened.` line to `## Timeline`. Returns `TransitionResult` with `timelineAppended` non-null exactly when a timeline line was written. |
 | `createProject(input)` | Allocate `projects/<YYYY-MM>/<YYYY-MM-DD>-<slug>/` from the canonical kind template. Returns `{ slug, readmePath }`. |
 | `createProjectNote(projectPath, slug)` | Create `<projectPath>/notes/NN-<slug>.md`. Scans `notes/` for the highest existing `NN-` prefix, increments by one, sanitises the slug, writes an empty file, returns the absolute path. |
 | `writeNote(path, expectedContent, newContent)` | Full-file content compare. For `condash.json`, the main process canonicalises the JSON through the Zod schema before writing — the bytes that hit disk can differ from `newContent`. Returns the bytes actually written so the caller can keep its CAS baseline aligned with disk. |


### PR DESCRIPTION
## Summary

- The in-app `Help → Configuration` page (and a few reference rows) still showed the pre-v2.14.0 `condash <noun>` shape; every example errors out post-split because the GUI binary hard-rejects CLI nouns. This PR sweeps the prose onto `condash-cli`.
- The in-app `Help → CLI` noun table predates the `audit` and `templates` nouns, and the `config` row is missing `set` plus the `--effective` / `--global` flag axis; the reference `### config` table has the same gaps. Both are caught up here.
- Three doc pages still illustrated project READMEs in the pre-v2.16.0 bold-prose form with no YAML alternative, six months after YAML became canonical. The illustrative examples are now YAML frontmatter with a one-line note that the legacy form is still accepted; prose field-name references (`Status`, `Branch`, `Kind`) are normalised away from `**Status**` etc. wherever the surrounding sentence is talking about the field as a concept rather than a literal token.

## Changes

- `docs/help/configuration.md` — prefix every `condash config <verb>` invocation in the CLI examples block with `-cli`; update the leading prose accordingly.
- `docs/help/cli.md` — add table rows for `audit` and `templates`; expand the `config` row to list `path`, `set`, and the `--effective` / `--global` flag axis.
- `docs/reference/cli.md` — expand the `### config` verb table with `path`, `set <key> <value>`, and the flag axis on `list` / `get`. Normalise prose references to the `status` and `branch` fields.
- `docs/reference/config.md` — `condash config set` → `condash-cli config set` (one-token swap on the write-target bullet).
- `docs/explanation/index.md`, `docs/explanation/why-markdown.md`, `docs/help/why-markdown.md` — replace the five-line bold-prose README example with a YAML frontmatter example; append a one-liner that the legacy bold-prose form is still accepted.
- `docs/explanation/values.md`, `docs/guides/skill-extensions.md`, `docs/reference/conception-convention.md`, `docs/reference/ipc-api.md` — normalise prose references to fields by name (`Status` / `Branch` / `Kind` / `apps`). Dual-mode passages (`internals.md:61`, `conception-convention.md:59`, the canonical `reference/readme-format.md`, `reference/mutations.md`) are intentionally left intact.

## Impact

- The in-app `Help → Configuration` modal will rebuild on the next bump (the `docs/help/*.md` files are bundled into the asar via the existing build pipeline). Users copy-pasting from that modal post-merge will hit working invocations instead of the `error: condash-cli config …` usage hint.
- Pure documentation change — zero runtime impact, no source files touched. `make typecheck`, `npm run test:unit` (134/134), and `npm run build` are clean.