### PR TITLE
Pass 13 — fix conception-template repositories shape and sweep skill/fixture stale prose

### DIFF
--- a/conception-template/.claude/hooks/knowledge-retrieve-reminder.sh
+++ b/conception-template/.claude/hooks/knowledge-retrieve-reminder.sh
@@ -19,7 +19,7 @@
 #     match="knowledge/topics/ops/dev-ports.md (port allocation rules)" ;;
 #   *auth*|*token*|*session*.ts|*session*.py)
 #     match="knowledge/topics/security/auth.md (token storage rules)" ;;
-#   */conception/configuration.json|*/conception/configuration.yml)
+#   */conception/condash.json)
 #     match="the file's own header + .claude/skills/projects/worktree.md (configuration schema)" ;;
 
 set -euo pipefail

--- a/conception-template/.claude/skills/knowledge/verify.md
+++ b/conception-template/.claude/skills/knowledge/verify.md
@@ -61,7 +61,7 @@ A sibling app's `CLAUDE.md` references `../../conception/...` and the target doe
 
 ### `worktrees` (informational; offer setup)
 
-Items declaring an active `**Branch**` field but no on-disk worktree. Offer `/projects worktree setup <branch>` per missing branch. Don't auto-create — worktree setup has side effects (env copy, install).
+Items declaring an active `branch` field but no on-disk worktree. Offer `/projects worktree setup <branch>` per missing branch. Don't auto-create — worktree setup has side effects (env copy, install).
 
 ### `index` (auto-fix candidate)
 

--- a/conception-template/.claude/skills/pr/SKILL.md
+++ b/conception-template/.claude/skills/pr/SKILL.md
@@ -5,10 +5,10 @@ description: "Open a GitHub PR from the current branch. Project-aware wrapper: h
 
 # /pr — open a pull request (project-aware wrapper)
 
-This skill handles the **project-side mechanics** of opening a PR for any repo listed in `configuration.json` under `repositories:`:
+This skill handles the **project-side mechanics** of opening a PR for any repo listed in `condash.json` under `repositories:`:
 
 - Resolve the driving project from the current git branch.
-- Pick the base branch via the project's `**Base**` field (or `origin/HEAD`).
+- Pick the base branch via the project's `base` field (or `origin/HEAD`).
 - Push if needed and run `gh pr create`.
 - Append a timeline entry to the driving project's README on success.
 
@@ -41,7 +41,7 @@ Anything else about the body — title style, mandatory sections, prohibited tra
    | Source | Check |
    |--------|-------|
    | User call-site override | "`/pr base=develop`", "open PR to `release-4.2`", etc. |
-   | Project `**Base**` field | `condash-cli projects list --branch <current-branch> --json` returns one row per matching project with parsed `branch` / `base`. If exactly one match has a non-empty `base`, use that value. |
+   | Project `base` field | `condash-cli projects list --branch <current-branch> --json` returns one row per matching project with parsed `branch` / `base`. If exactly one match has a non-empty `base`, use that value. |
    | `origin/HEAD` on main checkout | `git rev-parse --git-common-dir` to find the main checkout; `git -C "$main" symbolic-ref refs/remotes/origin/HEAD` for the default. If unset, try `git remote set-head origin -a` once, then ask the user. |
 
    Sanity-check: `git log --oneline <base>..HEAD` must be a clean non-empty diff. Re-ask if it's empty or enormous.
@@ -77,4 +77,4 @@ Anything else about the body — title style, mandatory sections, prohibited tra
    - **Zero matches** → say so; the user may want to create an item.
    - **Multiple matches** → `AskUserQuestion` with the list; append to the chosen README only.
 
-   Don't change `**Status**`. Don't commit.
+   Don't change `status`. Don't commit.

--- a/conception-template/.claude/skills/projects/SKILL.md
+++ b/conception-template/.claude/skills/projects/SKILL.md
@@ -5,7 +5,7 @@ description: "Manage projects, incidents, and documents in the conception tree (
 
 # /projects — conception items + worktrees
 
-Every conception item — feature project, incident, or document — lives at `projects/YYYY-MM/YYYY-MM-DD-slug/` with a `README.md` and a `notes/` directory. Items never move once created; **Status** alone signals done-ness.
+Every conception item — feature project, incident, or document — lives at `projects/YYYY-MM/YYYY-MM-DD-slug/` with a `README.md` and a `notes/` directory. Items never move once created; the `status` field alone signals done-ness.
 
 The skill is editorial only. **Every mechanical step shells out to `condash`.** This guarantees one parser owns every read and write of the tree — the dashboard, the CLI, and this skill all see the same canonical view.
 
@@ -35,15 +35,21 @@ One-off CLI verb without a skill action: `condash-cli projects backfill-closed [
 ## README header
 
 ```markdown
-# <Title>
+---
+date: YYYY-MM-DD
+kind: project    # or incident | document
+status: now      # now | review | later | backlog | done
+apps:
+  - app1
+  - app2/sub-path
+branch: branch-name   # optional
+base: branch-name     # optional
+---
 
-**Date**: YYYY-MM-DD
-**Kind**: project | incident | document
-**Status**: now | review | later | backlog | done
-**Apps**: `app1`, `app2/sub-path`
-**Branch**: `branch-name` (optional)
-**Base**: `branch-name` (optional)
+# <Title>
 ```
+
+Legacy bold-prose headers (`**Date**: …`, etc.) are still accepted by the parser; YAML is canonical.
 
 Status meanings:
 
@@ -53,9 +59,9 @@ Status meanings:
 - `backlog` — acknowledged but not scheduled.
 - `done` — finished. Folder does not move.
 
-Kind-specific additions (incidents only): `**Environment**: <PROD/STAGING/DEV>`, `**Severity**: <low/medium/high — impact>`.
+Kind-specific additions (incidents only): `environment: <PROD/STAGING/DEV>`, `severity: <low/medium/high — impact>`.
 
-`**Apps**` is backtick-delimited, comma-separated. `**Branch**`'s first backticked token is authoritative. `**Date**` always matches the month directory — changing it requires a `git mv`.
+`apps` is a YAML list (one entry per line). `branch`'s value is authoritative. `date` always matches the month directory — changing it requires a `git mv`.
 
 ## Slug resolution
 
@@ -69,13 +75,13 @@ Item folder names match `^\d{4}-\d{2}-\d{2}-[a-z0-9-]+$`. `<slug>` accepts three
 
 ## Branch isolation
 
-When an item has a `**Branch**` field:
+When an item has a `branch` field:
 
-1. Code edits go through the worktree at `<worktrees_path>/<branch>/<repo>/`. Both paths come from `configuration.json` at the conception root (`condash-cli config get worktrees_path`, `condash-cli config get workspace_path`).
+1. Code edits go through the worktree at `<worktrees_path>/<branch>/<repo>/`. Both paths come from `condash.json` at the conception root (`condash-cli config get worktrees_path`, `condash-cli config get workspace_path`).
 2. **Never edit code in `<workspace_path>/<repo>/`** — those are the main checkouts on different branches.
-3. Use `condash-cli worktrees check <branch>` to inspect state, `condash-cli worktrees setup <branch>` to create, `condash-cli worktrees remove <branch>` to clean up. `condash-cli worktrees mismatch` lists every active item declaring a `**Branch**` that has no on-disk worktree — run it when something feels off.
+3. Use `condash-cli worktrees check <branch>` to inspect state, `condash-cli worktrees setup <branch>` to create, `condash-cli worktrees remove <branch>` to clean up. `condash-cli worktrees mismatch` lists every active item declaring a `branch` that has no on-disk worktree — run it when something feels off.
 
-When no `**Branch**` field is set, the main checkouts at `<workspace_path>/<repo>/` are fine.
+When no `branch` field is set, the main checkouts at `<workspace_path>/<repo>/` are fine.
 
 ## Shared rules
 

--- a/conception-template/.claude/skills/projects/close.md
+++ b/conception-template/.claude/skills/projects/close.md
@@ -48,16 +48,16 @@ Trigger: `/projects close <slug>`.
    condash-cli projects close <slug> --summary "<one-line outcome>" --json
    ```
 
-   The CLI sets `**Status**: done`, appends `- YYYY-MM-DD — Closed. <summary>.` under `## Timeline`, and touches `projects/.index-dirty`. Skip `--summary` to land a bare `- YYYY-MM-DD — Closed.`.
+   The CLI sets the status to `done` (rewriting `status:` for YAML-frontmatter READMEs or `**Status**:` for the legacy bold-prose form), appends `- YYYY-MM-DD — Closed. <summary>.` under `## Timeline`, and touches `projects/.index-dirty`. Skip `--summary` to land a bare `- YYYY-MM-DD — Closed.`.
 
-6. **Worktree + branch cleanup.** If the item has a `**Branch**` field:
+6. **Worktree + branch cleanup.** If the item has a `branch` field:
 
    ```bash
    condash-cli worktrees check <branch> --json
    condash-cli worktrees remove <branch> --json
    ```
 
-   `worktrees check` shows which repos still have worktrees on this branch. `worktrees remove` is **protected-set aware**: it only removes worktrees for repos in the closing item's `**Apps**` that no other active item still claims on the same branch.
+   `worktrees check` shows which repos still have worktrees on this branch. `worktrees remove` is **protected-set aware**: it only removes worktrees for repos in the closing item's `apps` that no other active item still claims on the same branch.
 
    The CLI does **not** delete local branches — that stays here so the `git -C <repo> branch -d` refusal can surface to the user. After `worktrees remove` reports success, for each `data.removed[].repo`:
 
@@ -104,4 +104,4 @@ Trigger: `/projects reopen <slug>` or "reopen <slug>".
 condash-cli projects reopen <slug> [--status <now|review|later|backlog>] --summary "<reason>" --json
 ```
 
-Default target status is `now`. The CLI flips `**Status**`, appends `- YYYY-MM-DD — Reopened. <summary>.` under `## Timeline`, and touches `projects/.index-dirty`. If the item carried a `**Branch**` whose worktrees were torn down at close time, offer `/projects worktree setup <branch>` afterwards — reopen is a status edit only, it never re-creates worktrees.
+Default target status is `now`. The CLI flips the status (in either YAML or bold-prose form), appends `- YYYY-MM-DD — Reopened. <summary>.` under `## Timeline`, and touches `projects/.index-dirty`. If the item carried a `branch` whose worktrees were torn down at close time, offer `/projects worktree setup <branch>` afterwards — reopen is a status edit only, it never re-creates worktrees.

--- a/conception-template/.claude/skills/projects/create.md
+++ b/conception-template/.claude/skills/projects/create.md
@@ -45,7 +45,7 @@ Trigger: `/projects create <kind>` with kind ∈ {`project`, `incident`, `docume
 
    On success, parse the envelope's `data.path` and `data.relPath`.
 
-4. **Worktree check.** If `**Branch**` was provided, run `condash-cli worktrees check <branch> --json`:
+4. **Worktree check.** If `branch` was provided, run `condash-cli worktrees check <branch> --json`:
    - If `data.repos[].worktreeExists` is true everywhere expected, remind the user that code edits go through the worktree paths.
    - Otherwise, offer `/projects worktree setup <branch>`.
 

--- a/conception-template/.claude/skills/projects/update.md
+++ b/conception-template/.claude/skills/projects/update.md
@@ -20,7 +20,7 @@ Trigger: `/projects update <slug>` or implicit ("add a note to <slug>", "change 
 
 4. **Timeline entries.** One line: `<YYYY-MM-DD> — <what happened>`. Terse.
 
-5. **Worktree check.** If the update involves code and `**Branch**` is set, enforce branch isolation (edits go through `<worktrees_path>/<branch>/<repo>/`).
+5. **Worktree check.** If the update involves code and `branch` is set, enforce branch isolation (edits go through `<worktrees_path>/<branch>/<repo>/`).
 
 ## Rules
 

--- a/conception-template/.claude/skills/projects/worktree.md
+++ b/conception-template/.claude/skills/projects/worktree.md
@@ -1,6 +1,6 @@
 # /projects — worktree (multi-repo branch management)
 
-Multi-repo items use git worktrees at `<worktrees_path>/<branch>/<repo>/`, grouped by branch name. Worktrees let us work on several items simultaneously without switching branches in the main working copies at `<workspace_path>/<repo>/`. Both paths come from `configuration.json` at the conception tree root.
+Multi-repo items use git worktrees at `<worktrees_path>/<branch>/<repo>/`, grouped by branch name. Worktrees let us work on several items simultaneously without switching branches in the main working copies at `<workspace_path>/<repo>/`. Both paths come from `condash.json` at the conception tree root.
 
 The CLI owns the multi-app derivation, the protected-set logic, and the per-repo `git worktree` calls. The skill just translates user intent into CLI calls.
 
@@ -10,10 +10,10 @@ The CLI owns the multi-app derivation, the protected-set logic, and the per-repo
 
 | Action            | Meaning                                                                                              |
 |-------------------|------------------------------------------------------------------------------------------------------|
-| `setup <branch>`  | Create worktrees for every repo in the union of `**Apps**` across items declaring `<branch>`.         |
+| `setup <branch>`  | Create worktrees for every repo in the union of `apps` across items declaring `<branch>`.             |
 | `remove <branch>` | Remove this branch's worktrees, protected-set aware.                                                  |
 | `check <branch>`  | Per-repo state for one branch (declaring items, on-disk worktrees, local branches).                   |
-| `list` / `status` | All repos with their worktrees + `**Branch**` mismatch audit.                                         |
+| `list` / `status` | All repos with their worktrees + `branch` mismatch audit.                                             |
 
 ## `setup <branch>`
 
@@ -26,14 +26,14 @@ The CLI owns the multi-app derivation, the protected-set logic, and the per-repo
    condash-cli worktrees setup <branch> [--no-env] [--no-install] [--copy-env] [--base <ref>] --json
    ```
 
-   **Per-repo `env: [...]`** in `configuration.json` is the canonical way to copy gitignored files (e.g. `[".env", ".env.local"]`) from the primary into the new worktree. Applied **unconditionally when set** — pass `--no-env` to skip. `--copy-env` is a legacy fallback that copies `.env` / `.env.local` only for repos *without* an `env:` declaration.
+   **Per-repo `env: [...]`** in `condash.json` is the canonical way to copy gitignored files (e.g. `[".env", ".env.local"]`) from the primary into the new worktree. Applied **unconditionally when set** — pass `--no-env` to skip. `--copy-env` is a legacy fallback that copies `.env` / `.env.local` only for repos *without* an `env:` declaration.
 
-   **Per-repo `install: <cmd>`** in `configuration.json` runs after the worktree is created (npm/pnpm/uv/etc.). Run **unconditionally when set** — pass `--no-install` to skip. Repos without an `install:` declaration are silently no-op.
+   **Per-repo `install: <cmd>`** in `condash.json` runs after the worktree is created (npm/pnpm/uv/etc.). Run **unconditionally when set** — pass `--no-install` to skip. Repos without an `install:` declaration are silently no-op.
 
-   **Base ref.** The CLI reads `**Base**` from every item declaring `<branch>` and uses it as the start point for new branches. All declaring items must agree on the base (the call fails with the disagreeing slugs otherwise). `--base <ref>` overrides the README field for one-shot setups. When no item declares `**Base**` and `--base` isn't passed, new branches are created off the repo's default tip.
+   **Base ref.** The CLI reads `base` from every item declaring `<branch>` and uses it as the start point for new branches. All declaring items must agree on the base (the call fails with the disagreeing slugs otherwise). `--base <ref>` overrides the README field for one-shot setups. When no item declares `base` and `--base` isn't passed, new branches are created off the repo's default tip.
 
    The CLI:
-   - reads `**Apps**` from every item declaring `<branch>` and unions the top-level repos,
+   - reads `apps` from every item declaring `<branch>` and unions the top-level repos,
    - skips repos with `pinned_branch:` (those track a different axis),
    - calls `git worktree add` per repo (creates the branch with `-b <branch> <base>` when missing),
    - blocks any repo whose declared `<base>` doesn't resolve locally — the reason field tells you to `git fetch` or create the base first,
@@ -89,12 +89,12 @@ condash-cli repos list --include-worktrees --json
 condash-cli worktrees mismatch --json
 ```
 
-The first call returns every configured repo with its worktrees (path / branch / primary / dirty count). The second flags items declaring `**Branch**` but missing the on-disk worktree — offer `/projects worktree setup <branch>` per missing branch.
+The first call returns every configured repo with its worktrees (path / branch / primary / dirty count). The second flags items declaring `branch` but missing the on-disk worktree — offer `/projects worktree setup <branch>` per missing branch.
 
 Format the directory listing so the absolute path is the first line of each block, copy-paste ready.
 
 ## Per-repo overrides
 
-A repo entry in `configuration.json` may carry a `pinned_branch:` field; when set, the repo always stays on that branch and is **never** included in worktree setup, even when listed in a project's Apps. The CLI honours this automatically. Use this for repos whose branch tracks a different axis (e.g. a benchmark harness pinned to `main`, with the version under test selected by an in-tree config file).
+A repo entry in `condash.json` may carry a `pinned_branch:` field; when set, the repo always stays on that branch and is **never** included in worktree setup, even when listed in a project's Apps. The CLI honours this automatically. Use this for repos whose branch tracks a different axis (e.g. a benchmark harness pinned to `main`, with the version under test selected by an in-tree config file).
 
 **Multiple items on the same branch** is fine — worktrees are per-branch, not per-item. `remove` honours the protected set so closing one item never yanks worktrees out from under another.

--- a/conception-template/.claude/skills/tidy/SKILL.md
+++ b/conception-template/.claude/skills/tidy/SKILL.md
@@ -10,7 +10,7 @@ description: Audit the conception tree (knowledge index orphans + dangling links
 
 - Periodically — once a week, or before opening a release-shaped PR off `main`.
 - After a bulk refactor of `knowledge/` or `projects/` — orphans and dangling index links pile up.
-- After a worktree-heavy week — branches that were merged or removed often leave stale items declaring `**Branch**` with no on-disk worktree.
+- After a worktree-heavy week — branches that were merged or removed often leave stale items declaring `branch` with no on-disk worktree.
 - When the dashboard's audit indicator shows issues.
 
 For an at-a-glance read without the triage walk, `condash-cli audit` and `condash-cli knowledge verify` directly are faster.

--- a/conception-template/condash.json.example
+++ b/conception-template/condash.json.example
@@ -2,10 +2,7 @@
   "$schema_doc": "Source of truth for condash. See docs/reference/config.md for the full schema and per-OS recipes.",
   "workspace_path": "/path/to/workspace",
   "worktrees_path": "/path/to/workspace/../worktrees",
-  "repositories": {
-    "primary": [],
-    "secondary": []
-  },
+  "repositories": [],
   "open_with": {
     "main_ide": {
       "label": "Open in main IDE",

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -133,7 +133,7 @@ condash-cli search "session cookie" --scope all
 List configured repositories from `condash.json`.
 
 ```bash
-condash-cli repos list                       # primary + secondary, no worktrees
+condash-cli repos list                       # configured repos, no worktrees
 condash-cli repos list --include-worktrees   # add worktrees in <worktrees_path>/
 ```
 

--- a/docs/tutorials/daily-loop.md
+++ b/docs/tutorials/daily-loop.md
@@ -100,7 +100,7 @@ git push -u origin fix/search-large-logs
 gh pr create --fill
 ```
 
-If you've installed the [`/pr` skill](https://github.com/vcoeur/conception/tree/main/.claude/skills/pr), the PR body will pull its structure from the item's README automatically. The incident is now **waiting on external signal** — the merge. Change the item's status from `now` to `review` by clicking its status pill. The dashboard rewrites the README's `**Status**:` line.
+If you've installed the [`/pr` skill](https://github.com/vcoeur/conception/tree/main/.claude/skills/pr), the PR body will pull its structure from the item's README automatically. The incident is now **waiting on external signal** — the merge. Change the item's status from `now` to `review` by clicking its status pill. The dashboard rewrites the README's status line — `status:` for YAML-frontmatter READMEs, `**Status**:` for the legacy bold-prose form.
 
 In the Current sub-pane, the item moves from the `NOW` group to the `REVIEW` group. You can see exactly this split in the screenshot below — the `CLI config migration to layered TOML` item is already in review while three others are still under NOW.
 

--- a/tests/fixtures/conception-demo/projects/2026-03/2026-03-20-helio-0.3-release/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-03/2026-03-20-helio-0.3-release/README.md
@@ -1,9 +1,14 @@
-# helio 0.3 release
+---
+date: 2026-03-20
+kind: project
+status: done
+apps:
+  - helio
+  - helio-web
+  - helio-docs
+---
 
-**Date**: 2026-03-20
-**Kind**: project
-**Status**: done
-**Apps**: `helio`, `helio-web`, `helio-docs`
+# helio 0.3 release
 
 ## Goal
 

--- a/tests/fixtures/conception-demo/projects/2026-03/2026-03-25-docs-site-404s/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-03/2026-03-25-docs-site-404s/README.md
@@ -1,11 +1,14 @@
-# helio-docs 404s after 0.3 deploy
+---
+date: 2026-03-25
+kind: incident
+status: done
+apps:
+  - helio-docs
+environment: PROD — helio-docs.example.com, post 0.3 deploy
+severity: low — every guide page under `/guides/*` returned 404 for ~40 minutes; root and reference pages were unaffected
+---
 
-**Date**: 2026-03-25
-**Kind**: incident
-**Status**: done
-**Apps**: `helio-docs`
-**Environment**: PROD — helio-docs.example.com, post 0.3 deploy
-**Severity**: low — every guide page under `/guides/*` returned 404 for ~40 minutes; root and reference pages were unaffected
+# helio-docs 404s after 0.3 deploy
 
 ## Description
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-02-fuzzy-search-v2/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-02-fuzzy-search-v2/README.md
@@ -1,10 +1,14 @@
-# fuzzy search v2
+---
+date: 2026-04-02
+kind: project
+status: now
+apps:
+  - helio
+  - helio-web
+branch: search/fuzzy-v2
+---
 
-**Date**: 2026-04-02
-**Kind**: project
-**Status**: now
-**Apps**: `helio`, `helio-web`
-**Branch**: `search/fuzzy-v2`
+# fuzzy search v2
 
 ## Goal
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-08-search-crash-large-logs/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-08-search-crash-large-logs/README.md
@@ -1,11 +1,14 @@
-# `helio search` crashes on large logs
+---
+date: 2026-04-08
+kind: incident
+status: now
+apps:
+  - helio
+environment: PROD — user running helio 0.4.0-alpha.2 (trigram-index branch) against nginx access logs from their production edge tier
+severity: high — reproducible OOM on any corpus above ~800 MB; the CLI process dies with SIGKILL from the kernel OOM killer, losing all streamed-but-unflushed output
+---
 
-**Date**: 2026-04-08
-**Kind**: incident
-**Status**: now
-**Apps**: `helio`
-**Environment**: PROD — user running helio 0.4.0-alpha.2 (trigram-index branch) against nginx access logs from their production edge tier
-**Severity**: high — reproducible OOM on any corpus above ~800 MB; the CLI process dies with SIGKILL from the kernel OOM killer, losing all streamed-but-unflushed output
+# `helio search` crashes on large logs
 
 ## Description
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-10-plugin-api-proposal/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-10-plugin-api-proposal/README.md
@@ -1,10 +1,13 @@
-# plugin API proposal
+---
+date: 2026-04-10
+kind: document
+status: now
+apps:
+  - helio
+languages: en
+---
 
-**Date**: 2026-04-10
-**Kind**: document
-**Status**: now
-**Apps**: `helio`
-**Languages**: en
+# plugin API proposal
 
 ## Goal
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-12-cli-config-migration/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-12-cli-config-migration/README.md
@@ -1,10 +1,13 @@
-# CLI config migration to layered TOML
+---
+date: 2026-04-12
+kind: project
+status: review
+apps:
+  - helio
+branch: config/layered-toml
+---
 
-**Date**: 2026-04-12
-**Kind**: project
-**Status**: review
-**Apps**: `helio`
-**Branch**: `config/layered-toml`
+# CLI config migration to layered TOML
 
 ## Goal
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-15-json-export/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-15-json-export/README.md
@@ -1,9 +1,12 @@
-# JSON / NDJSON export for read-only commands
+---
+date: 2026-04-15
+kind: project
+status: later
+apps:
+  - helio
+---
 
-**Date**: 2026-04-15
-**Kind**: project
-**Status**: later
-**Apps**: `helio`
+# JSON / NDJSON export for read-only commands
 
 ## Goal
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-16-windows-installer/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-16-windows-installer/README.md
@@ -1,9 +1,12 @@
-# Windows MSI installer
+---
+date: 2026-04-16
+kind: project
+status: later
+apps:
+  - helio
+---
 
-**Date**: 2026-04-16
-**Kind**: project
-**Status**: later
-**Apps**: `helio`
+# Windows MSI installer
 
 ## Status note
 

--- a/tests/fixtures/conception-demo/projects/2026-04/2026-04-17-plugin-api/README.md
+++ b/tests/fixtures/conception-demo/projects/2026-04/2026-04-17-plugin-api/README.md
@@ -1,9 +1,12 @@
-# plugin API implementation
+---
+date: 2026-04-17
+kind: project
+status: backlog
+apps:
+  - helio
+---
 
-**Date**: 2026-04-17
-**Kind**: project
-**Status**: backlog
-**Apps**: `helio`
+# plugin API implementation
 
 ## Goal
 


### PR DESCRIPTION
## Summary

- `conception-template/condash.json.example` shipped a `repositories: {primary, secondary}` object — invalid against the post-v2.14.0 `z.array(repoEntry)` schema (`src/main/config-schema.ts:175`). The init flow copies this file as the new tree’s first `condash.json`, so opening Settings on a freshly-initialised tree hit `Expected array, received object` from strict zod. Replaced with `repositories: []`.
- Bundled Claude skill templates under `conception-template/.claude/skills/` and the demo READMEs under `tests/fixtures/conception-demo/projects/` still referenced `configuration.json` (renamed to `condash.json` six versions ago) and the pre-v2.16.0 bold-prose README scaffold (`**Date**:`, `**Kind**:` …). Both surfaces propagate into user trees — the templates via `condash-cli skills install`, the demo via the get-started tutorial walk-through.
- Three-commit split for review (single-file schema fix, template sweep, fixture conversion).

## Changes

- `conception-template/condash.json.example` — `repositories: {primary: [], secondary: []}` → `repositories: []`.
- `conception-template/.claude/skills/projects/SKILL.md` — replaced bold-prose README scaffold with YAML frontmatter (legacy bold-prose still accepted, noted inline); normalised `**Apps**` / `**Branch**` / `**Date**` / `**Kind**` / `**Status**` / `**Base**` field-name references; `configuration.json` → `condash.json`.
- `conception-template/.claude/skills/projects/worktree.md` — `configuration.json` → `condash.json`; field-name references normalised.
- `conception-template/.claude/skills/pr/SKILL.md` — same `configuration.json` → `condash.json` and field-name normalisation.
- `conception-template/.claude/skills/tidy/SKILL.md` — single `**Branch**` → `branch` mention.
- `conception-template/.claude/hooks/knowledge-retrieve-reminder.sh` — commented example dropped the retired-Tauri `configuration.yml` form, switched to `condash.json`.
- `tests/fixtures/conception-demo/projects/**/README.md` — converted 9 of 10 READMEs from bold-prose to YAML frontmatter. Deliberately left `2026-04-18-typo-status-demo/README.md` in legacy form so the dual-mode parser still has a fixture-based regression target — its slug signals it as the edge-case demo of the set.
- `docs/tutorials/daily-loop.md:103` — single-form `**Status**:` mention rewritten as dual-form (`status:` for YAML-frontmatter READMEs, `**Status**:` for legacy bold-prose).
- `docs/reference/cli.md:136` — stale `# primary + secondary, no worktrees` comment → `# configured repos, no worktrees`. Neighbouring legitimate `primary` / `primary-on-branch` references at lines 146-149 untouched.

## Impact

- Unblocks the first-run flow on freshly-initialised trees: opening Settings on a new `condash.json` no longer fails strict-mode validation.
- Every `/projects create` Claude scaffolds via the bundled skill now writes YAML frontmatter (the canonical form) instead of legacy bold-prose. Existing user-modified skills are safe — `condash-cli skills install` walks files one-by-one and surfaces edited ones for review before clobbering.
- Tutorial coherence restored: the get-started page that says YAML is canonical now points at a demo where 9/10 READMEs are YAML; the remaining bold-prose fixture is the dual-mode parser test target.
- No source-code change. `make typecheck` clean. `npm run test:unit` 134/134. `npm run build` clean.

## Watchpoints

- Do not re-flag the deliberately-preserved `2026-04-18-typo-status-demo` bold-prose README in a later pass — it is the fixture-based regression target for the dual-mode parser.