### PR TITLE
Pass 14 — fix dev-script tab selectors + finish auto-update sweep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 
-# Build unsigned cross-platform installers + publish them (and the
-# `latest*.yml` channel files electron-updater needs) to a single
+# Build unsigned cross-platform installers + publish them (plus the
+# `latest*.yml` metadata files electron-builder emits) to a single
 # GitHub Release tied to the pushed `v*` tag.
 #
 # Triggered by tags only — `git push origin v2.0.0`. The workflow does NOT

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -38,8 +38,10 @@ asarUnpack:
 #      `condash` (which is GUI-only from v2.14.0).
 afterPack: build/after-pack.cjs
 
-# Auto-update channel: latest*.yml is uploaded next to the bundles in the
-# GitHub Release tied to the current `v*` tag.
+# Publish: every tag pushes installers (and electron-builder's metadata
+# files latest*.yml / *.blockmap) into the GitHub Release for the tag.
+# Auto-update is disabled at runtime — see src/main/index.ts:312 — but
+# the metadata files are still emitted as a no-op side-effect.
 #
 # `releaseType: prerelease` tells electron-builder to look for (and, if
 # missing, create) a prerelease for the tag. Drafts are invisible to the

--- a/scripts/perf-baseline.mjs
+++ b/scripts/perf-baseline.mjs
@@ -93,21 +93,16 @@ async function captureRun(run) {
     });
 
     windowResults.tabswitch = await captureWindow(run, 'tabswitch', electronPid, async () => {
-      const tabs = ['Knowledge', 'History', 'Projects'];
+      const tabs = ['knowledge', 'projects'];
       const end = Date.now() + WINDOW_SECS * 1000;
       let i = 0;
       while (Date.now() < end) {
-        const label = tabs[i % tabs.length];
-        await win
-          .locator(`button.tab:has-text("${label}")`)
-          .first()
-          .click({ timeout: 1500 })
-          .catch(() => {});
+        await showPane(app, tabs[i % tabs.length]);
         i++;
         await sleep(500);
       }
       // Leave on Projects for the next window.
-      await win.locator('button.tab:has-text("Projects")').first().click().catch(() => {});
+      await showPane(app, 'projects');
     });
 
     windowResults.projectscroll = await captureWindow(run, 'projectscroll', electronPid, async () => {
@@ -235,6 +230,16 @@ function summarise(allRuns) {
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+// The composite layout has no in-window tab strip — pane visibility is
+// driven by the application menu, so the tabswitch workload goes through
+// the same channel a real menu click would. Mirrors tests/screenshots.spec.ts:122.
+async function showPane(app, label) {
+  await app.evaluate(({ BrowserWindow }, cmd) => {
+    const w = BrowserWindow.getAllWindows()[0];
+    if (w) w.webContents.send('menu-command', cmd);
+  }, label === 'projects' ? 'toggle-projects' : `show-${label}`);
 }
 
 function countDirs(path, depth) {

--- a/scripts/snap.mjs
+++ b/scripts/snap.mjs
@@ -18,7 +18,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const REAL_CONCEPTION = process.env.CONDASH_CONCEPTION_PATH ?? '/home/alice/src/vcoeur/conception';
 const OUT_DIR = '/tmp/condash-snap';
-const TABS = ['projects', 'code', 'knowledge', 'history', 'search'];
+const TABS = ['projects', 'code', 'knowledge'];
 
 async function main() {
   const requested = process.argv.slice(2);
@@ -63,8 +63,7 @@ async function main() {
       console.log(`[snap] terminal → ${out}`);
       continue;
     }
-    const label = tab[0].toUpperCase() + tab.slice(1);
-    await win.locator(`button.tab:has-text("${label}")`).first().click().catch(() => {});
+    await showPane(app, tab);
     await new Promise((r) => setTimeout(r, 800));
     const out = `${OUT_DIR}/${tab}.png`;
     await win.screenshot({ path: out, fullPage: false });
@@ -73,6 +72,16 @@ async function main() {
 
   await app.close();
   await rm(userData, { recursive: true, force: true });
+}
+
+// The composite layout has no in-window tab strip — pane visibility is
+// driven by the application menu, so screenshot prep goes through the same
+// channel a real menu click would. Mirrors tests/screenshots.spec.ts:122.
+async function showPane(app, label) {
+  await app.evaluate(({ BrowserWindow }, cmd) => {
+    const w = BrowserWindow.getAllWindows()[0];
+    if (w) w.webContents.send('menu-command', cmd);
+  }, label === 'projects' ? 'toggle-projects' : `show-${label}`);
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

- Fix two dev scripts (`scripts/snap.mjs`, `scripts/perf-baseline.mjs`) that have been silently broken since the v2.2.0 composite-layout refactor (d92ac23, 2026-04-25). Their `button.tab:has-text(...)` Playwright selector targets a tab strip that no longer exists; failures were swallowed by `.catch(() => {})`, so the scripts produced byte-identical PNGs and a no-op tabswitch perf workload while exiting 0.
- Finish pass 11's auto-update-disable sweep on the two surfaces it didn't fully walk: `electron-builder.yml`'s `# Auto-update channel:` header and `.github/workflows/release.yml`'s `electron-updater needs` framing. Auto-update has been disabled at runtime since v2.18.13 (e040533); these comments now match.

## Changes

- `scripts/snap.mjs` — drop `'history'` (removed by f8d84a3) and `'search'` (relocated to the File menu by 960dcdb) from `TABS`; replace the `button.tab:has-text(...)` click with a `menu-command` IPC call (`toggle-projects`, `show-code`, `show-knowledge`), mirroring the `sendMenu` helper at `tests/screenshots.spec.ts:122`.
- `scripts/perf-baseline.mjs` — drop `'History'` from the `tabswitch` loop; same IPC swap for the two `button.tab` locator clicks.
- `electron-builder.yml` — replace the stale `# Auto-update channel:` opener with neutral framing that names runtime auto-update as disabled and the `latest*.yml` files as a no-op metadata side-effect.
- `.github/workflows/release.yml` — swap the top-of-file comment's `(and the latest*.yml channel files electron-updater needs)` for `(plus the latest*.yml metadata files electron-builder emits)`.

## Impact

- Restores real measurement to `perf-baseline.mjs`'s `tabswitch` window — it has been measuring an idle baseline (no UI input) for two months.
- `node scripts/snap.mjs projects code knowledge` now produces three visibly-distinct PNGs (md5sum confirmed); previously byte-identical.
- No runtime / source-code change. Comment-only edit to `release.yml` does not change any CI step. `electron-builder.yml` comment edit does not touch the `publish:` block.

This is pass 14 of the multipass review of @condash. Pass 13 forecast pass 14 likely empty; the cluster surfaced by walking the standalone `scripts/` and `.github/` corners that no prior pass had paused on.