### PR TITLE
Pass 15 — fix broken help-loader spec and stale screenshots spec docstrings

### DIFF
--- a/tests/help-loader.spec.ts
+++ b/tests/help-loader.spec.ts
@@ -3,26 +3,32 @@ import { bootApp } from './fixtures/electron-app';
 
 /**
  * The Help menu in the toolbar reads its documents out of the asar via the
- * allowlist in `src/main/help.ts`. The Diátaxis migration (v2.0.6) renamed
- * the on-disk paths but kept the loader's short keys (`architecture`,
- * `configuration`, `non-goals`, `index`) — so a typo in the allowlist
- * mapping wouldn't fail the build, only the in-app modal at runtime.
+ * allowlist in `src/main/help.ts`. Since v2.10.5 (`cae83b7`, 2026-05-02
+ * "simplify docs site, self-contained Help docs") the menu is six entries:
+ * `welcome`, `quick-start`, `shortcuts`, `configuration`, `cli`,
+ * `why-markdown` — each short key maps to a single file under `help/`.
+ * A typo in the allowlist mapping wouldn't fail the build, only the in-app
+ * modal at runtime.
  *
  * This spec asserts that every key in the loader's allowlist resolves to a
  * non-empty document body. It's a near-zero-cost regression net for the
  * "Help menu opens a blank modal" failure mode.
  */
 test.describe('Help loader', () => {
-  const KEYS = ['architecture', 'configuration', 'non-goals', 'index'] as const;
+  const KEYS = [
+    'welcome',
+    'quick-start',
+    'shortcuts',
+    'configuration',
+    'cli',
+    'why-markdown',
+  ] as const;
 
   for (const key of KEYS) {
     test(`help.readDoc('${key}') returns a non-empty body`, async () => {
       const booted = await bootApp();
       try {
-        const body = await booted.window.evaluate(
-          (k) => window.condash.helpReadDoc(k),
-          key,
-        );
+        const body = await booted.window.evaluate((k) => window.condash.helpReadDoc(k), key);
         expect(typeof body).toBe('string');
         expect((body ?? '').length).toBeGreaterThan(20);
       } finally {
@@ -31,14 +37,14 @@ test.describe('Help loader', () => {
     });
   }
 
-  test('non-goals body mentions the post-2026-04-30 terminal scope revision', async () => {
+  test("cli body mentions 'condash-cli'", async () => {
     const booted = await bootApp();
     try {
-      const body = await booted.window.evaluate(() => window.condash.helpReadDoc('non-goals'));
-      // The 2026-04-30 revision adds a "Revision log" section. Asserting on
-      // its presence makes sure the help loader is reading the *current*
-      // file, not a stale bundled copy.
-      expect(body).toMatch(/Revision log/);
+      const body = await booted.window.evaluate(() => window.condash.helpReadDoc('cli'));
+      // Asserting on a string the live `docs/help/cli.md` body must contain
+      // makes sure the help loader is reading the *current* file, not a
+      // stale bundled copy.
+      expect(body).toMatch(/condash-cli/);
     } finally {
       await booted.cleanup();
     }

--- a/tests/screenshots.spec.ts
+++ b/tests/screenshots.spec.ts
@@ -2,18 +2,24 @@
  * Screenshot harness.
  *
  * Drives the packaged Electron build against the bundled `tests/fixtures/conception-demo`
- * and captures the 31 PNGs that the public docs site references.
+ * and captures the 19 PNGs (× 2 themes = 38 files) that the public docs site can reference.
  *
  * Run as `npm run test -- --reporter=list screenshots.spec.ts`. Output lands in
  * `tests/screenshots-out/{light,dark}/<name>.png`. The matching pair is then
- * copied into `docs/assets/screenshots/<name>-{light,dark}.png` by hand or by
- * the helper script in `scripts/sync-screenshots.mjs`.
+ * copied by hand into `docs/assets/screenshots/<name>-{light,dark}.png`
+ * (e.g. `cp tests/screenshots-out/{light,dark}/*.png docs/assets/screenshots/`).
  *
  * Window is forced to 1600×1100 logical px with deviceScaleFactor=2 so the
  * captured PNGs come out at 3200×2200 — matching the Tauri-era originals.
  */
 
-import { test, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
+import {
+  test,
+  expect,
+  _electron as electron,
+  type ElectronApplication,
+  type Page,
+} from '@playwright/test';
 import { mkdtemp, mkdir, writeFile, cp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
@@ -289,7 +295,9 @@ async function captureForTheme(theme: Theme): Promise<void> {
     //    `menu-command` IPC ('search').
     await sendMenu(b.app, 'search');
     await settle(page);
-    const searchInput = page.locator('.search-modal input, .search-input, input[placeholder*="search" i]').first();
+    const searchInput = page
+      .locator('.search-modal input, .search-input, input[placeholder*="search" i]')
+      .first();
     if (await searchInput.count()) {
       await searchInput.fill('fuzzy');
       await settle(page);
@@ -363,7 +371,7 @@ async function captureForTheme(theme: Theme): Promise<void> {
   }
 }
 
-test('capture all 33 screenshots in light + dark', async () => {
+test('capture all 19 screenshots in light + dark', async () => {
   test.setTimeout(240_000);
   await rm(outRoot, { recursive: true, force: true });
   await captureForTheme('light');


### PR DESCRIPTION
## Summary

- Restore real coverage to `tests/help-loader.spec.ts` — its allowlist drifted out of sync with `src/main/help.ts` at `cae83b7` (v2.10.5, 2026-05-02 "simplify docs site, self-contained Help docs") and has been silently broken for 8 days × 8 version bumps because CI doesn't invoke Playwright.
- Fold in three documentation-rot fixes in `tests/screenshots.spec.ts` while the `tests/` directory is open: two stale screenshot counts and a ghost reference to a helper script that has never existed in any branch.

## Changes

- `tests/help-loader.spec.ts` — replace the 4-name `KEYS` array (`architecture`, `configuration`, `non-goals`, `index`; three of those four are not in `HelpDocName` since `cae83b7`) with the live 6-name allowlist (`welcome`, `quick-start`, `shortcuts`, `configuration`, `cli`, `why-markdown`); rewrite the second test to assert `helpReadDoc('cli')` mentions `condash-cli` (the previous `helpReadDoc('non-goals')` test broke the same way); refresh the docstring to drop the v2.0.6-era Diátaxis-migration framing and reflect the post-v2.10.5 simplified mapping.
- `tests/screenshots.spec.ts` — fix the docstring's stale `31 PNGs` to `19 PNGs (× 2 themes = 38 files) that the public docs site can reference`; fix the test name from `capture all 33 screenshots in light + dark` to `capture all 19 screenshots in light + dark` (actual count = 19 distinct `shoot` calls × 2 themes); drop the docstring reference to a helper script in `scripts/sync-screenshots.mjs` — that path has never existed in any branch — and document the actual hand-copy workflow instead.

## Impact

- Pure test-spec changes; no runtime, build config, or CI surface affected. Vitest unit suite still 134/134; `make typecheck` and `npm run build` clean.
- The help-loader Playwright spec turns from 5 failing tests to 7 passing locally — the "Help menu opens a blank modal" regression net the spec was originally written to catch is real coverage again.

## Watchpoints

- CI does not currently run Playwright (`.github/workflows/release.yml` and `docs.yml` invoke neither `npm run test` nor `playwright test`). The reason this drift went unnoticed for 8 version bumps still exists; "should CI run Playwright?" is a separate item, not folded into this PR.