### PR TITLE
Pass 16 — sweep stale Settings-modal description in quick-start and terminal docs

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -109,7 +109,7 @@ A snippet sourced from a non-condash terminal (gnome-terminal, iTerm2, …) emit
 
 ## Live theming and font tweaks (Settings → Terminal)
 
-**File → Settings… → Terminal** (`Ctrl+,`, then the **Terminal** tab) live-edits the `terminal.xterm` block: font family / size / line-height / letter-spacing / weight, cursor style + blink, scrollback depth, the ligatures toggle, and the full ANSI colour palette. The Terminal tab sits under **Global Condash Settings**, so it writes to `settings.json` (per-machine). For a tree-wide default that teammates pick up automatically, hand-edit `terminal.xterm` in `condash.json` instead. Either way, changes apply to existing tabs without a relaunch — the renderer rebuilds the xterm options object on save.
+**File → Settings… → Terminal** (`Ctrl+,`, then the **Terminal** section) live-edits the `terminal.xterm` block: font family / size / line-height / letter-spacing / weight, cursor style + blink, scrollback depth, the ligatures toggle, and the full ANSI colour palette. The Terminal section ships on both Settings tabs: the **Global** copy writes to `settings.json` (per-machine default); the **This conception** copy writes to `condash.json` (per-tree override, picked up by teammates on git pull). Each field on the conception tab carries an inheritance badge with a Reset-to-global button. Either way, changes apply to existing tabs without a relaunch — the renderer rebuilds the xterm options object on save.
 
 See [`terminal.xterm` in the config reference](../reference/config.md#terminalxterm) for the full key table.
 

--- a/docs/help/quick-start.md
+++ b/docs/help/quick-start.md
@@ -98,19 +98,24 @@ condash picks it up live.
 
 ## Editing settings
 
-**File → Settings…** (`Ctrl+,`) opens a sidebar-rail modal with five
-sections:
+**File → Settings…** (`Ctrl+,`) opens a two-tab modal — **Global**
+(per-machine, writes to `settings.json`) and **This conception**
+(per-tree, writes to `condash.json`).
 
-- **Appearance** — theme, card-min-width sliders, font scale.
-- **Terminal** — shell, xterm.js settings, screenshot directory.
-- **Workspace** — `workspace_path`, `worktrees_path`, `resources_path`,
-  `skills_path`.
-- **Repositories** — flat ordered list of repos shown on the Code pane,
-  each with optional `run` / `force_stop` commands and submodules.
-- **Open with** — `main_ide`, `pdf_viewer`, `terminal` launcher entries.
+- **Global** carries Recent conceptions, Appearance, Terminal — all
+  per-machine defaults.
+- **This conception** carries Workspace, Repositories, Open with, plus
+  per-tree overrides for Appearance and Terminal. An inheritance badge
+  on each field calls out whether the conception value matches the
+  global default or overrides it; a **Reset to global** button drops
+  the override.
 
-There is no in-modal JSON editor; the **Open externally** button at the
-bottom hands the active tab's file to your `main_ide`.
+There is no in-modal JSON editor — each preference has its own form
+control. The **Open externally** button at the bottom of the rail
+opens the active tab's file (`condash.json` or `settings.json`) with
+your OS default handler.
+
+→ Full breakdown: [Configuration](configuration.md).
 
 Per-tree config (`<conception>/condash.json`, with `configuration.json`
 read indefinitely as a legacy fallback) is shared with teammates via git


### PR DESCRIPTION
## Summary

- The v2.15.2 Settings-modal refactor shipped a two-tab layout (Global / This conception) with per-key inheritance badges and Reset-to-global buttons; its same-commit doc sweep updated `docs/help/configuration.md` and `docs/reference/config.md` but missed `docs/help/quick-start.md` and `docs/guides/terminal.md`. This PR closes the gap.
- `quick-start.md` is the page first-launch users open from the Welcome screen, so the staleness was the most user-visible drift left in the help corpus. Pure docs change — no source, no build config, no version bump.

## Changes

- `docs/help/quick-start.md` — rewrite the `## Editing settings` section. Drop the pre-v2.15.2 "sidebar-rail modal with five sections" framing and the per-slot enumeration (which listed `pdf_viewer`, not in the modal, and omitted `secondary_ide`, which is). Describe the two-tab layout (Global writes to `settings.json`, This conception writes to `condash.json`) and the per-tab section breakdown. Mention the inheritance badge + Reset-to-global control on conception-tab fields. Fix the "Open externally" sentence to say the button uses the OS default handler (which is what `shell.openPath` actually does), not `main_ide`. Add a pointer to `docs/help/configuration.md` for the full breakdown.
- `docs/guides/terminal.md` — drop "Condash" from the non-existent "Global Condash Settings" label (the live tab label is just "Global"). Replace the misleading "hand-edit `terminal.xterm` in `condash.json`" advice with a pointer to the Conception-tab Terminal section, which ships the same form fields, writes to `condash.json`, and carries inheritance badges. Keep the existing no-relaunch sentence.

## Impact

- Pure docs. `make format` / `make typecheck` / `npm run test:unit` (134/134) / `npm run build` all clean.
- The bundled help is read at runtime from the `docs/` directory via `app.getAppPath()` in `src/main/help.ts` — there's no build-time copy step, so source-file edits ARE the contract. Verified by re-reading the help loader and confirming it resolves `help/quick-start.md` directly off `app.getAppPath()/docs/`.