### PR TITLE
Pass 17 — split F5 and Ctrl+Shift+R in help/shortcuts.md

### DIFF
--- a/docs/help/shortcuts.md
+++ b/docs/help/shortcuts.md
@@ -11,7 +11,8 @@ The few you'll actually use.
 | `Ctrl+Shift+F` | **Search…** — cross-tree fuzzy search |
 | `Ctrl+R` | Show **Resources** pane |
 | `Ctrl+L` | Show **Skills** pane |
-| `Ctrl+Shift+R` / `F5` | Reload window |
+| `F5` | **Refresh** — re-read repos, drop git-status cache |
+| `Ctrl+Shift+R` | **Reload window** — full hard reload |
 | `Ctrl+Shift+I` | Toggle DevTools |
 | `Ctrl+0` / `Ctrl+ +` / `Ctrl+ -` | Zoom reset / in / out |
 | `F11` | Toggle fullscreen |


### PR DESCRIPTION
## Summary

- The in-app *Help → Keyboard shortcuts* page conflated `F5` and `Ctrl+Shift+R` into a single row labelled *Reload window*, but the two are distinct actions in the live menu wiring.
- The other two sources of truth in the repo — the cheat-sheet overlay shown on `?` (`src/renderer/shortcuts-overlay.tsx`) and the canonical reference page (`docs/reference/shortcuts.md`) — already split them; only the help-page excerpt was wrong.

## Changes

- `docs/help/shortcuts.md`: replace the single ```Ctrl+Shift+R`/`F5```-Reload-window row with two distinct rows: `F5` → *Refresh — re-read repos, drop git-status cache*; `Ctrl+Shift+R` → *Reload window — full hard reload*.

## Impact

- User-visible help text only. No source code, build config, or dependency change. The mkdocs site picks up the new wording on next deploy.
- Pressing `F5` in the running app calls `handleRefresh()` (drops the git-status TTL cache and re-runs `reloadRepos`); `Ctrl+Shift+R` triggers Electron's `role: 'reload'` (full renderer reload that closes modals and drops terminal sessions). The new wording aligns the in-app help page with that distinction.