### PR TITLE
Pass 18 — document missing menu accelerators in reference/shortcuts.md

### DIFF
--- a/docs/reference/shortcuts.md
+++ b/docs/reference/shortcuts.md
@@ -11,7 +11,7 @@ description: Every keyboard shortcut the dashboard and embedded terminal recogni
 
 | Area | Count | Configurable? |
 |---|---|---|
-| Application menu (File / View) | 12 | no |
+| Application menu (File / View) | 14 | no |
 | Dashboard global | 2 | no |
 | Project cards | 6 | no |
 | Note modal | 4 | no |
@@ -28,10 +28,11 @@ The OS menu bar carries every system-level shortcut. Each item also dispatches a
 | File | Open conception directory | — | Reveal the current conception in the OS file manager. |
 | File | Settings | `Ctrl+,` / `Cmd+,` | Open the Settings modal. |
 | File | Search… | `Ctrl+Shift+F` / `Cmd+Shift+F` | Open the global search modal. |
+| File | New project… | `Ctrl+N` / `Cmd+N` | Open the new-project modal. |
 | File | Quit | (no accelerator) | Trigger the quit-confirm flow. |
 | View | Show Projects | — | Toggle the Projects pane on the left edge. |
-| View | Show Code | — | Show the Code pane in the working slot. |
-| View | Show Knowledge | — | Show the Knowledge pane in the working slot. |
+| View | Show Code | `Ctrl+Shift+C` / `Cmd+Shift+C` | Show the Code pane in the working slot. |
+| View | Show Knowledge | `Ctrl+Shift+K` / `Cmd+Shift+K` | Show the Knowledge pane in the working slot. |
 | View | Show Resources | `Ctrl+R` / `Cmd+R` | Show the Resources pane in the working slot. |
 | View | Show Skills | `Ctrl+L` / `Cmd+L` | Show the Skills pane in the working slot. |
 | View | Hide working surface | — | Hide whichever pane (Code / Knowledge / Resources / Skills) is in the working slot. |


### PR DESCRIPTION
## Summary

- The canonical `docs/reference/shortcuts.md` Application-menu table omits three live menu accelerators that the dashboard has wired in `src/main/menu.ts` and advertises via in-app tooltips: `Ctrl+N` (New project), `Ctrl+Shift+C` (Show Code), `Ctrl+Shift+K` (Show Knowledge).
- The C/K accelerators landed in commit `2420319` (2026-05-06, *Pass-9 review phase D*) along with their tooltip strings; the docs file was never updated, so a "Daily user" reading the reference is told the shortcuts don't exist while the in-app UI says they do.
- One-file, four-line docs fix: the page now matches the menu wiring and the in-app tooltips.

## Changes

- Insert a `File | New project… | `Ctrl+N` / `Cmd+N`` row in the Application-menu table before the `Quit` row.
- Replace the `View | Show Code | —` placeholder with ``Ctrl+Shift+C` / `Cmd+Shift+C``.
- Replace the `View | Show Knowledge | —` placeholder with ``Ctrl+Shift+K` / `Cmd+Shift+K``.
- Update the "At a glance" Application-menu count from 12 to 14.

## Impact

- Pure documentation change. No runtime, no build config, no dependency change. The mkdocs site will rebuild on the usual workflow.