### PR TITLE
Pass 19 — document Ctrl+K as the primary search shortcut

### DIFF
--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -12,6 +12,7 @@ description: Use the search modal's full-text search across every README, note, 
 condash's search is a **modal**, not a pane. It's available from anywhere in the app:
 
 - **`Ctrl+Shift+F`** / **`Cmd+Shift+F`** — opens the modal.
+- **`Ctrl+K`** / **`Cmd+K`** — alias of the above; matches the cheat-sheet's primary, intended for VS Code / Linear / Slack muscle memory.
 - **File → Search…** — same.
 
 The query box takes focus the moment the modal opens. Start typing; results render live, ranked and grouped by item. `Esc` closes the modal.

--- a/docs/help/shortcuts.md
+++ b/docs/help/shortcuts.md
@@ -8,7 +8,7 @@ The few you'll actually use.
 |---|---|
 | `Ctrl+O` | **Open…** — pick a different conception folder |
 | `Ctrl+,` | **Settings…** — open the configuration modal |
-| `Ctrl+Shift+F` | **Search…** — cross-tree fuzzy search |
+| `Ctrl+K` / `Ctrl+Shift+F` | **Search…** — cross-tree fuzzy search |
 | `Ctrl+R` | Show **Resources** pane |
 | `Ctrl+L` | Show **Skills** pane |
 | `F5` | **Refresh** — re-read repos, drop git-status cache |

--- a/docs/reference/shortcuts.md
+++ b/docs/reference/shortcuts.md
@@ -12,7 +12,7 @@ description: Every keyboard shortcut the dashboard and embedded terminal recogni
 | Area | Count | Configurable? |
 |---|---|---|
 | Application menu (File / View) | 14 | no |
-| Dashboard global | 2 | no |
+| Dashboard global | 3 | no |
 | Project cards | 6 | no |
 | Note modal | 4 | no |
 | Terminal — pane | 3 | yes (`[terminal]`) |
@@ -47,6 +47,7 @@ The View toggles round-trip through `getLayout` / `setLayout` — see [Config fi
 
 | Shortcut | Action | Configurable |
 |---|---|---|
+| `Ctrl+K` / `Cmd+K` | Open the global search modal (same effect as `Ctrl+Shift+F`). | no |
 | `Escape` | Close the topmost modal | no |
 | `?` | Toggle the keyboard-shortcut cheat-sheet overlay | no |
 


### PR DESCRIPTION
## Summary

- The in-app cheat-sheet labels `Ctrl+K` as the primary trigger for the global search modal and `Ctrl+Shift+F` as its alias. The runtime binding is wired (since commit 2420319, phase D bullet D1b), but the public docs never propagated the change — the canonical reference doc and the help doc both still listed only `Ctrl+Shift+F`.
- Pass 19 of the multipass review caught the residual drift (same shape as passes 17 & 18, same root commit). One commit, three documentation files touched.

## Changes

- `docs/reference/shortcuts.md` — added a `Ctrl+K` / `Cmd+K` row to the *Dashboard global* table and bumped the *At a glance* Dashboard-global count from 2 to 3.
- `docs/help/shortcuts.md` — folded `Ctrl+K` into the existing **Search…** row so the accelerator column reads `Ctrl+K` / `Ctrl+Shift+F`.
- `docs/guides/search.md` — added a third entry-point bullet for `Ctrl+K` / `Cmd+K` as the alias of `Ctrl+Shift+F`.

## Impact

- Documentation only. No source, no build config. Source-of-truth for the binding (cheat-sheet overlay + global keymap handler) is unchanged.