### PR TITLE
Make + Add repo in Settings produce a usable empty row

### DIFF
--- a/src/renderer/settings-modal-parts/data.test.ts
+++ b/src/renderer/settings-modal-parts/data.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildSavePayload, compactRepos } from './data';
+import { conceptionConfigSchema } from '../../main/config-schema';
+
+describe('buildSavePayload — repositories', () => {
+  it('keeps a freshly-added blank repo as { name: "" } so the schema accepts it', () => {
+    const payload = buildSavePayload({
+      repositories: [{ name: 'condash', label: 'Condash' }, { name: '' }],
+    });
+    expect(payload.repositories).toEqual([{ name: 'condash', label: 'Condash' }, { name: '' }]);
+    const result = conceptionConfigSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('still compacts a name-only entry to a bare string', () => {
+    const payload = buildSavePayload({
+      repositories: [{ name: 'PaintingManager' }],
+    });
+    expect(payload.repositories).toEqual(['PaintingManager']);
+  });
+
+  it('drops empty-string optional fields from object-shaped entries', () => {
+    const payload = buildSavePayload({
+      repositories: [{ name: 'foo', label: 'Foo', force_stop: '' }],
+    });
+    expect(payload.repositories).toEqual([{ name: 'foo', label: 'Foo' }]);
+  });
+
+  it('preserves blank-name placeholder entries inside submodules', () => {
+    const payload = buildSavePayload({
+      repositories: [{ name: 'parent', submodules: [{ name: '' }] }],
+    });
+    expect(payload.repositories).toEqual([{ name: 'parent', submodules: [{ name: '' }] }]);
+  });
+
+  it('still strips empty leaves outside the repositories array', () => {
+    const payload = buildSavePayload({
+      workspace_path: '/tmp',
+      open_with: { main_ide: { label: '', command: '' } } as never,
+    });
+    expect(payload.open_with).toBeUndefined();
+  });
+});
+
+describe('compactRepos — invariants', () => {
+  it('round-trips a blank-name entry without dropping the row', () => {
+    expect(compactRepos([{ name: '' }])).toEqual([{ name: '' }]);
+  });
+
+  it('compacts named-only entries to bare strings', () => {
+    expect(compactRepos([{ name: 'foo' }])).toEqual(['foo']);
+  });
+
+  it('keeps the object form when extras are present', () => {
+    expect(compactRepos([{ name: 'foo', label: 'Foo' }])).toEqual([{ name: 'foo', label: 'Foo' }]);
+  });
+
+  it('drops empty submodules arrays', () => {
+    expect(compactRepos([{ name: 'foo', submodules: [] }])).toEqual(['foo']);
+  });
+});

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -228,6 +228,11 @@ export interface RawConfig {
  * submodules) collapse back to the bare-string shape on save. The full
  * editor renders both shapes the same way, but condash.json keeps its
  * compact form for entries that don't need extra fields.
+ *
+ * Also drops empty-string / undefined optional fields from the object form,
+ * so a just-added row whose name is still blank stays as `{ "name": "" }` on
+ * disk (visible row in the JSON, schema-valid `repoEntry`) rather than being
+ * pruned away to `null` by the generic `pruneEmpty` pass.
  */
 export function compactRepos(repos: RawRepo[]): RawRepo[] {
   return repos.map((entry) => {
@@ -237,11 +242,16 @@ export function compactRepos(repos: RawRepo[]): RawRepo[] {
       copy.submodules = compactRepos(copy.submodules);
       if (copy.submodules.length === 0) delete copy.submodules;
     }
-    const extras = (Object.keys(copy) as (keyof typeof copy)[]).filter(
-      (k) => k !== 'name' && copy[k] !== undefined && copy[k] !== '',
-    );
-    if (extras.length === 0) return copy.name;
-    return copy;
+    for (const k of Object.keys(copy) as (keyof typeof copy)[]) {
+      if (k === 'name') continue;
+      if (copy[k] === undefined || copy[k] === '') delete copy[k];
+    }
+    const extras = (Object.keys(copy) as (keyof typeof copy)[]).filter((k) => k !== 'name');
+    // Only compact to a bare string when there is an actual name to compact
+    // to — a blank placeholder row keeps the object shape so the user sees
+    // it both in the editor and in the JSON file.
+    if (extras.length === 0 && copy.name) return copy.name;
+    return { ...copy, name: copy.name ?? '' };
   });
 }
 
@@ -263,6 +273,24 @@ export function pruneEmpty(value: unknown): unknown {
     return out;
   }
   return value;
+}
+
+/**
+ * Build the JSON payload that the Settings modal hands to `note.write` (or
+ * `settings.writeRaw`). Strips empty leaves with `pruneEmpty` for everything
+ * except the `repositories` array — `compactRepos` is the canonical
+ * normaliser there. Routing repos through `pruneEmpty` would erase a freshly
+ * added `{ name: '' }` row's only key, leaving an empty object that
+ * `compactRepos` then maps to `undefined` → `null` on serialisation, which
+ * the `repoEntry` schema rejects (`repositories.<index> — Invalid input`).
+ */
+export function buildSavePayload(config: RawConfig): RawConfig {
+  const { repositories, ...rest } = config;
+  const pruned = pruneEmpty(rest) as RawConfig;
+  if (repositories !== undefined) {
+    pruned.repositories = compactRepos(repositories);
+  }
+  return pruned;
 }
 
 export type BindTextFn = (

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@shared/types';
 import { DEFAULT_CARD_MIN_WIDTH } from '@shared/types';
 import {
+  buildSavePayload,
   type ColorEntry,
   pruneEmpty,
   type RawConfig,
@@ -17,7 +18,6 @@ import {
   type SettingsTab,
   TABS,
   TERMINAL_STRING_FIELDS,
-  compactRepos,
 } from './settings-modal-parts/data';
 import { inheritanceState } from './settings-modal-parts/badges';
 import type { InheritanceState } from './settings-modal-parts/badges';
@@ -281,11 +281,7 @@ export function SettingsModal(props: {
       return;
     }
     mutator(parsedConfig);
-    const pruned = pruneEmpty(parsedConfig) as RawConfig;
-    if (pruned.repositories) {
-      pruned.repositories = compactRepos(pruned.repositories);
-    }
-    const next = JSON.stringify(pruned, null, 2) + '\n';
+    const next = JSON.stringify(buildSavePayload(parsedConfig), null, 2) + '\n';
     if (next === text) return;
     setError(null);
     setPending(true);
@@ -343,11 +339,7 @@ export function SettingsModal(props: {
       return;
     }
     mutator(parsedSettings);
-    const pruned = pruneEmpty(parsedSettings) as RawConfig;
-    if (pruned.repositories) {
-      pruned.repositories = compactRepos(pruned.repositories);
-    }
-    const next = JSON.stringify(pruned, null, 2) + '\n';
+    const next = JSON.stringify(buildSavePayload(parsedSettings), null, 2) + '\n';
     if (next === text) return;
     setError(null);
     setPending(true);


### PR DESCRIPTION
## Summary

- Clicking **+ Add repo** in Settings → This conception → Repositories raised `Error invoking remote method 'note.write': Error: condash.json: repositories.N — Invalid input` and the new row never reached disk; the per-row **+ Add sub repo** affordance failed the same way.
- Root cause: `patchConfig()` / `patchSettings()` ran `pruneEmpty()` over the entire parsed config before normalising `repositories`. `pruneEmpty` stripped the just-added `{ name: '' }` row's only field, leaving `{}`, which `compactRepos()` then mapped to `undefined` → `null` on `JSON.stringify`. The `repoEntry` schema rejects `null`.

## Changes

- New `buildSavePayload(config)` in `src/renderer/settings-modal-parts/data.ts` runs `pruneEmpty` over everything except `repositories`, then routes the array through `compactRepos`.
- `patchConfig()` and `patchSettings()` in `src/renderer/settings-modal.tsx` call `buildSavePayload` instead of inlining the two-step normalisation.
- `compactRepos()` keeps blank-name placeholder rows as `{ name: '' }` (so a just-added row survives the round-trip) and now drops empty-string / undefined optional fields itself, taking over the cleanup `pruneEmpty` was doing for repo objects.
- `src/renderer/settings-modal-parts/data.test.ts` — new vitest suite covering the round-trip and the `conceptionConfigSchema` acceptance invariant.

## Impact

- Saves a freshly-added repo row as `{ "name": "" }` in `condash.json` (previously failed); the same JSON round-trips through the renderer unchanged. Named-only entries still compact to bare strings, matching the existing on-disk style.