### PR TITLE
Add install directory to per-user PATH on Windows

### DIFF
--- a/build/after-pack.cjs
+++ b/build/after-pack.cjs
@@ -28,8 +28,8 @@
 // Windows (NSIS):
 //   <install>/condash.exe        ← Electron binary (untouched)
 //   <install>/condash-cli.cmd    ← .cmd shim
-//   The install dir isn't added to PATH automatically — users add it
-//   manually or invoke with the full path.
+//   The install dir is appended to per-user PATH (HKCU\Environment\PATH)
+//   by build/installer.nsh on install, removed on uninstall.
 
 const fs = require('node:fs');
 const path = require('node:path');

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,65 @@
+; Custom electron-builder NSIS hook — append the install directory to
+; the per-user PATH so `condash` and `condash-cli` are reachable from any
+; shell, matching Linux's /usr/bin/condash[-cli] symlinks. See GitHub
+; issue #119: prior installers wrote condash.exe + condash-cli.cmd into
+; $INSTDIR but didn't touch PATH, leaving every condash-cli-shelling
+; skill broken on Windows.
+;
+; electron-builder defaults: oneClick=true, perMachine=false → per-user
+; install. Per-user PATH lives at HKCU\Environment\PATH and needs no
+; admin token. If a future release switches to perMachine, this hook
+; needs the HKLM equivalent (HKLM "System\CurrentControlSet\Control\Session Manager\Environment").
+
+!include "LogicLib.nsh"
+!include "StrFunc.nsh"
+!include "WinMessages.nsh"
+
+; StrFunc functions must be declared once before use. The Un-prefixed
+; variants are required inside uninstaller-context macros.
+${StrStr}
+${UnStrStr}
+${UnStrRep}
+
+!macro customInstall
+  Push $0
+  Push $1
+  ReadRegStr $0 HKCU "Environment" "PATH"
+  ${If} $0 == ""
+    WriteRegExpandStr HKCU "Environment" "PATH" "$INSTDIR"
+  ${Else}
+    ; Substring check — skip the write if $INSTDIR is already somewhere
+    ; in PATH (idempotent reinstall). False positives are theoretically
+    ; possible if another entry shares $INSTDIR as a prefix; install
+    ; dirs don't collide that way in practice.
+    ${StrStr} $1 "$0" "$INSTDIR"
+    ${If} $1 == ""
+      WriteRegExpandStr HKCU "Environment" "PATH" "$0;$INSTDIR"
+    ${EndIf}
+  ${EndIf}
+  ; Broadcast WM_SETTINGCHANGE so already-running shells / Explorer pick
+  ; up the new PATH without a logoff.
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  Pop $1
+  Pop $0
+!macroend
+
+!macro customUnInstall
+  Push $0
+  Push $1
+  ReadRegStr $0 HKCU "Environment" "PATH"
+  ${If} $0 != ""
+    ; Try semicolon-prefixed form first (most common: $INSTDIR appended
+    ; to a non-empty PATH), then suffix form, then bare (only entry).
+    ${UnStrRep} $1 "$0" ";$INSTDIR" ""
+    ${If} $1 == $0
+      ${UnStrRep} $1 "$0" "$INSTDIR;" ""
+    ${EndIf}
+    ${If} $1 == $0
+      ${UnStrRep} $1 "$0" "$INSTDIR" ""
+    ${EndIf}
+    WriteRegExpandStr HKCU "Environment" "PATH" "$1"
+  ${EndIf}
+  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  Pop $1
+  Pop $0
+!macroend

--- a/docs/get-started/index.md
+++ b/docs/get-started/index.md
@@ -73,6 +73,8 @@ xattr -dr com.apple.quarantine /Applications/condash.app
 
 Double-click the installer. Windows shows "Windows protected your PC" — click **More info → Run anyway**. Each new release re-prompts (expected for unsigned binaries).
 
+The installer appends its install directory to your per-user `PATH`, so `condash` (the GUI launcher) and `condash-cli` (the command-line companion) are reachable from any new shell. Already-open shells need to be restarted to pick up the change. Uninstall removes the entry.
+
 ## First launch
 
 The first time you run `condash`, a **native folder picker** opens and asks where your conception tree lives. Pick (or create) any directory that will hold your Markdown items, for example `~/src/conception/`. condash writes the choice into `settings.json` and reuses it next time.

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -89,3 +89,12 @@ win:
     - nsis
   # No code-signing cert. SmartScreen will warn on first install; users
   # click "More info" → "Run anyway".
+
+# build/installer.nsh appends $INSTDIR to per-user PATH on install (and
+# strips it on uninstall) so `condash` and `condash-cli` are reachable
+# from any shell, matching the Linux postinst's /usr/bin/condash[-cli]
+# symlinks. electron-builder picks build/installer.nsh up by default;
+# the explicit `include:` is here so the wiring isn't load-bearing on a
+# default-discovery convention. See GitHub issue #119.
+nsis:
+  include: build/installer.nsh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.23",
+  "version": "2.18.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.23",
+      "version": "2.18.24",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.23",
+  "version": "2.18.24",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- Closes #119. The Windows NSIS installer wrote `condash.exe` and `condash-cli.cmd` into the install directory but didnt add that directory to `PATH`, so neither binary was reachable from any shell. Linux drops `/usr/bin/condash[-cli]` symlinks via the `.deb` postinst; macOS still expects users to `ln -s` themselves.
- Every condash-shipped skill shells out to `condash-cli` for its mechanical steps. With the binary missing from `PATH` on Windows, every skill would fall back to manual file edits.

## Changes

- `build/installer.nsh` (new): NSIS hook with `customInstall` / `customUnInstall` macros. Append `$INSTDIR` to `HKCU\Environment\PATH` on install (with substring-dedup so reinstalls dont grow PATH), strip on uninstall, broadcast `WM_SETTINGCHANGE`. Standard NSIS includes only (`LogicLib`, `StrFunc`, `WinMessages`).
- `electron-builder.yml`: explicit `nsis: include: build/installer.nsh` block.
- `build/after-pack.cjs`: header comment updated.
- `docs/get-started/index.md`: Windows section now documents the new behaviour.
- `package.json` + lockfile: bump to v2.18.24.

## Impact

- electron-builder defaults are `oneClick: true`, `perMachine: false` — per-user install. Hook writes to `HKCU`. If `perMachine` is later switched on, the hook needs the HKLM equivalent.
- Existing Windows installs upgrade-in-place without the new PATH entry. Users on < v2.18.24 need to re-run the installer once.

## Watchpoints

- The NSIS build cant be exercised from the Linux dev host. Verify locally on Windows that `where condash` + `where condash-cli` resolve after a fresh install, and that uninstall removes them.
- Substring-dedup has a theoretical false positive if another PATH entry shares `$INSTDIR` as a prefix. Install dirs dont collide that way in practice.