### PR TITLE
Fix v2.18.24 Windows release: drop unused UnStrStr from installer.nsh

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -15,9 +15,12 @@
 !include "WinMessages.nsh"
 
 ; StrFunc functions must be declared once before use. The Un-prefixed
-; variants are required inside uninstaller-context macros.
+; variants are required inside uninstaller-context macros. Declare only
+; what the macros below actually call — NSIS treats unreferenced
+; uninstaller-side functions as warning 6010, and electron-builder
+; promotes warnings to errors (so a stray ${UnStrStr} declaration
+; without a matching ${UnStrStr} call fails the build).
 ${StrStr}
-${UnStrStr}
 ${UnStrRep}
 
 !macro customInstall

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.24",
+  "version": "2.18.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.24",
+      "version": "2.18.25",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.24",
+  "version": "2.18.25",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- The v2.18.24 release build failed on `windows-latest` (run [25632999515](https://github.com/vcoeur/condash/actions/runs/25632999515)). NSIS emitted `warning 6010: uninstall function "un.StrStr" not referenced - zeroing code (0-33) out`; electron-builder promotes warnings to errors so `makensis.exe` exited 1 and no `.exe` was published.
- The `customUnInstall` macro in `build/installer.nsh` only calls `UnStrRep`; the `${UnStrStr}` declaration at module scope generated a `un.StrStr` function with no callers, tripping the warning.

## Changes

- `build/installer.nsh`: drop the `${UnStrStr}` declaration. Inline comment now records the constraint (declare only what the macros call, since electron-builder treats NSIS warnings as errors).
- `package.json` + lockfile: bump to v2.18.25.

## Watchpoints

- The Linux dev host cannot exercise the NSIS toolchain. Verify on the v2.18.25 release run that the `Build (windows-latest)` job goes green and a `condash Setup 2.18.25.exe` asset lands on the GitHub Release.