### PR TITLE
Hand-roll NSIS substring scan to fix Windows release

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,68 +1,71 @@
 ; Custom electron-builder NSIS hook — append the install directory to
 ; the per-user PATH so `condash` and `condash-cli` are reachable from any
 ; shell, matching Linux's /usr/bin/condash[-cli] symlinks. See GitHub
-; issue #119: prior installers wrote condash.exe + condash-cli.cmd into
-; $INSTDIR but didn't touch PATH, leaving every condash-cli-shelling
-; skill broken on Windows.
+; issue #119.
 ;
-; electron-builder defaults: oneClick=true, perMachine=false → per-user
-; install. Per-user PATH lives at HKCU\Environment\PATH and needs no
-; admin token. If a future release switches to perMachine, this hook
-; needs the HKLM equivalent (HKLM "System\CurrentControlSet\Control\Session Manager\Environment").
+; Implementation notes:
+;
+; - electron-builder defaults are oneClick=true, perMachine=false → per-user
+;   install. Per-user PATH lives at HKCU\Environment\PATH and needs no
+;   admin token. If a future release switches to perMachine, this hook
+;   needs the HKLM equivalent under
+;   "System\CurrentControlSet\Control\Session Manager\Environment".
+;
+; - electron-builder builds NSIS with warnings-as-errors. StrFunc.nsh's
+;   `${StrStr}` / `${UnStrRep}` declarations emit Function definitions
+;   that NSIS reports as "not referenced" (warning 6010), so we avoid
+;   StrFunc entirely. The substring scan below uses only built-in
+;   StrCpy/IntOp/StrCmp + LogicLib's `${If}`.
+;
+; - customUnInstall is intentionally a no-op. Reliable substring removal
+;   in pure NSIS without a string-helper plugin adds significant code
+;   without much payoff: stale PATH entries pointing at a deleted dir
+;   are harmless on Windows (the loader ignores them), and the install
+;   side dedups so reinstalls don't accumulate duplicates.
 
 !include "LogicLib.nsh"
-!include "StrFunc.nsh"
 !include "WinMessages.nsh"
 
-; StrFunc functions must be declared once before use. The Un-prefixed
-; variants are required inside uninstaller-context macros. Declare only
-; what the macros below actually call — NSIS treats unreferenced
-; uninstaller-side functions as warning 6010, and electron-builder
-; promotes warnings to errors (so a stray ${UnStrStr} declaration
-; without a matching ${UnStrStr} call fails the build).
-${StrStr}
-${UnStrRep}
-
 !macro customInstall
-  Push $0
-  Push $1
+  Push $0  ; current PATH
+  Push $1  ; INSTDIR length
+  Push $2  ; PATH length
+  Push $3  ; scan offset
+  Push $4  ; current slice
+  Push $5  ; "found" flag
+
   ReadRegStr $0 HKCU "Environment" "PATH"
+  StrLen $1 "$INSTDIR"
+
   ${If} $0 == ""
     WriteRegExpandStr HKCU "Environment" "PATH" "$INSTDIR"
   ${Else}
-    ; Substring check — skip the write if $INSTDIR is already somewhere
-    ; in PATH (idempotent reinstall). False positives are theoretically
-    ; possible if another entry shares $INSTDIR as a prefix; install
-    ; dirs don't collide that way in practice.
-    ${StrStr} $1 "$0" "$INSTDIR"
-    ${If} $1 == ""
+    StrLen $2 $0
+    StrCpy $5 ""
+    StrCpy $3 0
+    condash_path_scan:
+      IntCmp $3 $2 0 0 condash_path_done
+      StrCpy $4 $0 $1 $3
+      StrCmp $4 "$INSTDIR" condash_path_found
+      IntOp $3 $3 + 1
+      Goto condash_path_scan
+    condash_path_found:
+      StrCpy $5 "1"
+    condash_path_done:
+    ${If} $5 == ""
       WriteRegExpandStr HKCU "Environment" "PATH" "$0;$INSTDIR"
     ${EndIf}
   ${EndIf}
+
   ; Broadcast WM_SETTINGCHANGE so already-running shells / Explorer pick
   ; up the new PATH without a logoff.
   SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
+
+  Pop $5
+  Pop $4
+  Pop $3
+  Pop $2
   Pop $1
   Pop $0
 !macroend
 
-!macro customUnInstall
-  Push $0
-  Push $1
-  ReadRegStr $0 HKCU "Environment" "PATH"
-  ${If} $0 != ""
-    ; Try semicolon-prefixed form first (most common: $INSTDIR appended
-    ; to a non-empty PATH), then suffix form, then bare (only entry).
-    ${UnStrRep} $1 "$0" ";$INSTDIR" ""
-    ${If} $1 == $0
-      ${UnStrRep} $1 "$0" "$INSTDIR;" ""
-    ${EndIf}
-    ${If} $1 == $0
-      ${UnStrRep} $1 "$0" "$INSTDIR" ""
-    ${EndIf}
-    WriteRegExpandStr HKCU "Environment" "PATH" "$1"
-  ${EndIf}
-  SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=5000
-  Pop $1
-  Pop $0
-!macroend

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.25",
+  "version": "2.18.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.25",
+      "version": "2.18.26",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.25",
+  "version": "2.18.26",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- v2.18.25 still failed on `windows-latest` (run [25633231232](https://github.com/vcoeur/condash/actions/runs/25633231232)). The `${StrStr}` declaration in `installer.nsh` creates a `Function StrStr` definition, but the `${StrStr} ...` macro invocation expands to inline code rather than a `Call StrStr` — so the function stays unreferenced and NSIS emits warning 6010, which electron-builder treats as an error.
- Drop StrFunc.nsh entirely. The substring scan is short enough to inline (~12 NSIS instructions using only built-in `StrCpy`/`IntOp`/`StrCmp` plus LogicLib `${If}`), and that removes the unreferenced-function class of warnings outright.

## Changes

- `build/installer.nsh`: drop `!include "StrFunc.nsh"` and the `${StrStr}` / `${UnStrRep}` declarations. Replace the substring check with a hand-rolled scan loop using static labels (`condash_path_scan` / `condash_path_found` / `condash_path_done`). Drop `customUnInstall` — reliable substring removal in pure NSIS adds significant complexity, and stale PATH entries pointing to deleted dirs are harmless on Windows.
- `package.json` + lockfile: bump to v2.18.26.

## Impact

- Uninstall no longer strips `$INSTDIR` from PATH. The orphan entry is harmless (Windows ignores nonexistent dirs in PATH); the install-side dedup keeps reinstalls from accumulating duplicates.
- File header explicitly records the StrFunc trade-off so future contributors don't reintroduce it.

## Watchpoints

- Verify on the v2.18.26 release run that the Build (windows-latest) job reports success and a `condash Setup 2.18.26.exe` asset lands on the GitHub Release.
- After install on a real Windows host, verify in a fresh `cmd` shell that `where condash` and `where condash-cli` both resolve. After uninstall, the install dir stays in PATH (intentional; documented).
