### PR TITLE
Add PR-level CI: typecheck, format check, installer smoke

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,85 @@
+name: pr
+
+# PR-level CI. Two jobs:
+#
+#   1. quick-checks (ubuntu) — typecheck + renderer/main build. Catches
+#      TypeScript regressions and trivial bundler breakage in ~1-2 min.
+#
+#   2. installer-smoke (ubuntu + windows) — runs `electron-builder
+#      --publish never` to compile the full NSIS installer (Windows) and
+#      the .deb/.AppImage (Linux). Skips the AppImage AppRun repack
+#      step that release.yml does; that's purely a runtime-launch
+#      concern, not a build-time concern, so PR CI doesn't need it.
+#
+# The installer-smoke Windows job is the load-bearing one: NSIS warning
+# 6010 (unreferenced Function) is treated as an error by electron-builder
+# and only surfaces when makensis runs against the full assembled
+# installer template, which is what `electron-builder --publish never`
+# produces. v2.18.24/.25 shipped broken because that pipeline only
+# ran on tag-push and the failures only appeared after the tag was
+# already pushed.
+#
+# macOS is omitted: the macOS DMG build is reliable, doesn't depend on
+# any of the platform-specific hooks (`build/installer.nsh`,
+# `build/linux-after-install.sh`), and the macos-latest runner is the
+# slowest of the three. Skipping it on PRs trades a small coverage gap
+# for ~5 min per PR.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  quick-checks:
+    name: Typecheck + build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Format check
+        run: npx prettier --check "src/**/*.{ts,tsx,css,html,json}"
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build renderer + main
+        run: npm run build
+
+  installer-smoke:
+    name: Installer smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build renderer + main
+        run: npm run build
+
+      - name: Build installers
+        run: npx electron-builder --publish never

--- a/docs/explanation/contributing.md
+++ b/docs/explanation/contributing.md
@@ -107,7 +107,10 @@ make package     # → release/{*.AppImage, *.deb, *.dmg, *.exe, latest*.yml}
 
 Native modules (`electron`, `node-pty`) stay external — esbuild leaves them as `require()` calls so they load from `node_modules`. `electron-rebuild` rebuilds them against the bundled Electron's Node ABI; `electron-builder` runs it again at package time.
 
-The release pipeline (`.github/workflows/release.yml`) builds all four installers on tag push, uploads them to the GitHub Release as draft assets, and rebuilds the apt repository at `condash.vcoeur.com/apt/` from every published `.deb`.
+Two GitHub Actions workflows guard `main`:
+
+- **`.github/workflows/pr.yml`** runs on every `pull_request` to `main`. A `quick-checks` job (Ubuntu) runs `prettier --check` + `npm run typecheck` + `npm run build`; an `installer-smoke` matrix job (Ubuntu + Windows) runs `npx electron-builder --publish never` to compile the full `.deb` / `.AppImage` / NSIS installer. macOS is not in the PR matrix — the DMG build path doesn't depend on platform-specific hooks, so it's only exercised on tag-push. The Windows installer-smoke is the load-bearing job: `build/installer.nsh`'s NSIS hooks only get assembled into the full installer template when `electron-builder` runs, so warnings-as-errors regressions there only surface here (or at release time, which is too late).
+- **`.github/workflows/release.yml`** builds all four installers on tag push (`v*`), uploads them to the GitHub Release as draft assets, and rebuilds the apt repository at `condash.vcoeur.com/apt/` from every published `.deb`.
 
 ## Documentation changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.26",
+  "version": "2.18.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.26",
+      "version": "2.18.27",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.26",
+  "version": "2.18.27",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- Adds the PR-level CI that v2.18.24/.25/.26 made painfully necessary. Three consecutive Windows release builds shipped broken because the NSIS warning-as-error pipeline only ran on tag-push; this workflow moves that signal to every PR so regressions surface pre-merge instead of post-tag.
- First step of a broader follow-up project tracking the items the recently-closed multipass review flagged as out-of-scope (Playwright in CI, IPC API hygiene, doc cross-references, screenshot orphans, renderer-shell residue). The remaining steps will land on per-step branches off `main`.

## Changes

- `.github/workflows/pr.yml` (new). Two jobs on `pull_request`:
  - `quick-checks` (ubuntu-latest): `prettier --check` + `npm run typecheck` + `npm run build`. ~1-2 min.
  - `installer-smoke` (ubuntu-latest + windows-latest): `npx electron-builder --publish never` to compile the full `.deb` / `.AppImage` / NSIS installer. ~5-7 min on Windows. macOS is omitted from the PR matrix (DMG path doesn't depend on platform-specific hooks; tag-push coverage is sufficient).
- `docs/explanation/contributing.md`: documents both `pr.yml` and `release.yml` and the rationale for the macOS omission.
- `package.json` + lockfile: bump to v2.18.27.

## Impact

- All future PRs will spend ~5-7 min in CI before merge becomes available. Existing `release.yml` still owns tag-push.
- The Windows installer-smoke is what would have caught NSIS warning 6010 on `un.StrStr` (v2.18.24) and `StrStr` (v2.18.25) before merge instead of after tag.

## Watchpoints

- This is the first PR run against the new workflow itself. If `pr.yml` triggers on its own PR (it does — `on: pull_request` covers any change merging into `main`), watch for chicken-and-egg failures (e.g. the PR build fails in a way that retroactively prevents merge of the workflow that defines the build).
- Format-check uses `prettier --check`, not `prettier --write` — verified `main` is currently prettier-clean. New PRs will need to run `make format` locally before pushing.
