### PR TITLE
worktrees remove: distinguish partial removes + add --force / --force-rm

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -147,7 +147,7 @@ Worktree-centric operations on top of `condash.json`'s repositories. Both `repos
 | `check <branch>` | Per-branch state: which items declare it, per-repo `worktree✓`/`branch✓`/`primary-on-branch`/`pinned` flags, missing or orphan dirs |
 | `mismatch` | Report worktrees referenced by an item's `branch` field that don't exist on disk (or vice versa) |
 | `setup <branch> [--repo <r>...] [--copy-env] [--no-env] [--no-install] [--base <ref>]` | Create the worktree for `<branch>` in every primary (or the listed `--repo` subset). `--copy-env` copies `.env*` from the main checkout; `--no-env` skips env wiring; `--no-install` skips the per-repo `install:` hook; `--base <ref>` branches off `<ref>` instead of the repo's default branch |
-| `remove <branch> [--repo <r>...]` | Tear down `<branch>` worktrees and (if safe) the local branch |
+| `remove <branch> [--repo <r>...] [--force] [--force-rm]` | Tear down `<branch>` worktrees and (if safe) the local branch. `--force` passes through to `git worktree remove --force` (deletes even if dirty); `--force-rm` implies `--force` and `rm -rf`'s the leftover dir if git deregistered the worktree but left files behind (typical with `node_modules`). Without `--force-rm`, half-removed entries are reported under `partiallyRemoved[]` so the caller can distinguish them from genuinely protected repos |
 
 ### `audit`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.27",
+  "version": "2.18.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.27",
+      "version": "2.18.28",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.27",
+  "version": "2.18.28",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/worktrees.ts
+++ b/src/cli/commands/worktrees.ts
@@ -179,13 +179,15 @@ async function worktreeRemove(
   if (!branch) {
     throw new CliError(
       ExitCodes.USAGE,
-      'Usage: condash-cli worktrees remove <branch> [--repo <r>...]',
+      'Usage: condash-cli worktrees remove <branch> [--repo <r>...] [--force] [--force-rm]',
     );
   }
   const repos = parseCsvFlag(args.flags.repo) ?? undefined;
-  delete args.flags.repo;
+  const force = args.flags.force === true;
+  const forceRm = args.flags['force-rm'] === true;
+  for (const k of ['repo', 'force', 'force-rm']) delete args.flags[k];
   assertNoExtraFlags(args);
-  const result = await removeBranchWorktrees(conceptionPath, branch, { repos });
+  const result = await removeBranchWorktrees(conceptionPath, branch, { repos, force, forceRm });
   emit(ctx, result, formatRemoveResult);
 }
 
@@ -199,6 +201,14 @@ function formatRemoveResult(result: RemoveResult): string {
   if (result.protected.length > 0) {
     lines.push(`Kept (protected, ${result.protected.length}):`);
     for (const p of result.protected) lines.push(`  · ${p.repo}: ${p.reason}`);
+  }
+  if (result.partiallyRemoved.length > 0) {
+    lines.push(`Partially removed (${result.partiallyRemoved.length}):`);
+    for (const p of result.partiallyRemoved) {
+      lines.push(`  ! ${p.repo}  →  ${p.path}`);
+      lines.push(`      ${p.reason}`);
+    }
+    lines.push(`  Re-run with --force-rm to delete the leftover directories.`);
   }
   if (result.notPresent.length > 0) {
     lines.push(`Not present: ${result.notPresent.join(', ')}`);
@@ -224,7 +234,11 @@ function printWorktreesHelp(): void {
       '                   opts out. --copy-env is the legacy opportunistic .env / .env.local copy for repos',
       '                   without `env:` declared.',
       '  remove <branch>  Remove worktrees for this branch, protected-set aware.',
-      '                   Flags: --repo <r>... (override).',
+      '                   Flags: --repo <r>... (override) --force --force-rm.',
+      '                   --force passes through to `git worktree remove --force` (deletes even if dirty).',
+      '                   --force-rm implies --force; if git deregisters but leaves files behind',
+      '                   (e.g. node_modules), `rm -rf` the leftover dir to finish the job.',
+      '                   Without --force-rm, half-removed entries land in `partiallyRemoved[]`.',
       '',
     ].join('\n'),
   );

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -30,6 +30,7 @@ const BOOL_FLAGS = new Set([
   'include-worktrees',
   'header',
   'force',
+  'force-rm',
   'diff',
   'no-touch-dirty',
   'copy-env',

--- a/src/main/worktree/remove.test.ts
+++ b/src/main/worktree/remove.test.ts
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { exec as execFile } from '../exec';
+import { removeBranchWorktrees } from './remove';
+
+let prevXdgConfigHome: string | undefined;
+let xdgHome: string;
+
+let tmp: string;
+let conception: string;
+let repo: string;
+let worktreesRoot: string;
+const branch = 'partial-test';
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFile('git', args, {
+    cwd,
+    env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+  });
+  return stdout;
+}
+
+beforeAll(() => {
+  prevXdgConfigHome = process.env.XDG_CONFIG_HOME;
+  xdgHome = mkdtempSync(join(tmpdir(), 'condash-xdg-'));
+  process.env.XDG_CONFIG_HOME = xdgHome;
+});
+
+afterEach(() => {
+  if (tmp) {
+    // Restore writable bits before rm to avoid EACCES on the read-only file
+    // we plant to provoke a partial remove.
+    try {
+      chmodSync(join(worktreesRoot, branch, 'demo', 'node_modules'), 0o755);
+      chmodSync(join(worktreesRoot, branch, 'demo', 'node_modules', 'pinned.js'), 0o644);
+    } catch {
+      // dir may already be partially gone — ignore.
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+beforeEach(async () => {
+  tmp = mkdtempSync(join(tmpdir(), 'condash-remove-'));
+  conception = join(tmp, 'conception');
+  repo = join(tmp, 'workspace', 'demo');
+  worktreesRoot = join(tmp, 'wt');
+  mkdirSync(conception, { recursive: true });
+  mkdirSync(join(tmp, 'workspace'), { recursive: true });
+  mkdirSync(worktreesRoot, { recursive: true });
+
+  // Conception config: one repo `demo` under `workspace_path`, worktrees in
+  // `worktrees_path`. No projects directory needed — we pass `repos:` to
+  // `removeBranchWorktrees` directly so it skips item discovery.
+  writeFileSync(
+    join(conception, 'condash.json'),
+    JSON.stringify(
+      {
+        workspace_path: join(tmp, 'workspace'),
+        worktrees_path: worktreesRoot,
+        repositories: [{ name: 'demo' }],
+      },
+      null,
+      2,
+    ),
+  );
+
+  // Bare git repo + first commit so we can branch off it.
+  await git(join(tmp, 'workspace'), 'init', '-q', '-b', 'main', 'demo');
+  await git(repo, 'config', 'user.email', 'test@example.com');
+  await git(repo, 'config', 'user.name', 'Test');
+  await git(repo, 'commit', '-q', '--allow-empty', '-m', 'init');
+
+  // Worktree on the test branch with rebuildable artifacts that block git's
+  // own rm: a read-only file inside `node_modules/`. With `--force`, git
+  // deregisters first then fails on the chmod-restricted unlink — exactly
+  // the partial-removed state issue #124 reports.
+  const target = join(worktreesRoot, branch, 'demo');
+  await git(repo, 'worktree', 'add', '-q', target, '-b', branch);
+  mkdirSync(join(target, 'node_modules'));
+  writeFileSync(join(target, 'node_modules', 'pinned.js'), 'x');
+  chmodSync(join(target, 'node_modules', 'pinned.js'), 0o444);
+  chmodSync(join(target, 'node_modules'), 0o555);
+});
+
+describe('removeBranchWorktrees', () => {
+  it('reports partiallyRemoved when --force deregisters but rm fails', async () => {
+    const result = await removeBranchWorktrees(conception, branch, {
+      repos: ['demo'],
+      force: true,
+    });
+    expect(result.removed).toEqual([]);
+    expect(result.protected).toEqual([]);
+    expect(result.partiallyRemoved).toHaveLength(1);
+    expect(result.partiallyRemoved[0]).toMatchObject({
+      repo: 'demo',
+      path: join(worktreesRoot, branch, 'demo'),
+    });
+    expect(result.partiallyRemoved[0].reason).toContain('git worktree remove failed');
+    // Registry was deregistered: `git worktree list` no longer mentions it.
+    const wts = await git(repo, 'worktree', 'list', '--porcelain');
+    expect(wts).not.toContain(join(worktreesRoot, branch, 'demo'));
+    // Disk still has the leftover dir.
+    expect(existsSync(join(worktreesRoot, branch, 'demo'))).toBe(true);
+  });
+
+  it('classifies refusal-without-deregister as protected, not partially removed', async () => {
+    // Without --force, git refuses outright: no registry mutation, dir intact.
+    const result = await removeBranchWorktrees(conception, branch, { repos: ['demo'] });
+    expect(result.removed).toEqual([]);
+    expect(result.partiallyRemoved).toEqual([]);
+    expect(result.protected).toHaveLength(1);
+    expect(result.protected[0].repo).toBe('demo');
+    expect(result.protected[0].reason).toContain('git worktree remove failed');
+    const wts = await git(repo, 'worktree', 'list', '--porcelain');
+    expect(wts).toContain(join(worktreesRoot, branch, 'demo'));
+  });
+
+  it('--force-rm completes the cleanup and reports the repo under removed[]', async () => {
+    const result = await removeBranchWorktrees(conception, branch, {
+      repos: ['demo'],
+      forceRm: true,
+    });
+    expect(result.partiallyRemoved).toEqual([]);
+    expect(result.protected).toEqual([]);
+    expect(result.removed).toHaveLength(1);
+    expect(result.removed[0]).toMatchObject({
+      repo: 'demo',
+      path: join(worktreesRoot, branch, 'demo'),
+    });
+    // Both the registry and the disk are clean now.
+    const wts = await git(repo, 'worktree', 'list', '--porcelain');
+    expect(wts).not.toContain(join(worktreesRoot, branch, 'demo'));
+    expect(existsSync(join(worktreesRoot, branch, 'demo'))).toBe(false);
+    // Parent branch dir was empty after — it should have been rmdir'd too.
+    expect(result.parentRemoved).toBe(true);
+  });
+});
+
+// Restore env at module unload so the test process leaves no trace.
+process.on('exit', () => {
+  if (prevXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = prevXdgConfigHome;
+});

--- a/src/main/worktree/remove.ts
+++ b/src/main/worktree/remove.ts
@@ -19,14 +19,33 @@ import {
 export interface RemoveOptions {
   /** Optional explicit repo allow-list. */
   repos?: string[];
+  /**
+   * Pass `--force` to `git worktree remove`. Without this, git refuses any
+   * worktree with modified or untracked files.
+   */
+  force?: boolean;
+  /**
+   * Implies `force`. After git deregisters the worktree, if the directory
+   * still has files (typically rebuildable artifacts like `node_modules` or
+   * build output blocking git's own rm), `fs.rm` it recursively. The repo is
+   * then reported under `removed[]`.
+   */
+  forceRm?: boolean;
 }
 
 export interface RemoveResult {
   branch: string;
   /** Repos whose worktree we removed. */
   removed: { repo: string; path: string }[];
-  /** Repos kept because another active item still claims them on this branch. */
+  /** Repos kept because another active item still claims them on this branch,
+   *  or because `git worktree remove` failed *without* deregistering the
+   *  worktree (registry still consistent with disk — caller can retry). */
   protected: { repo: string; reason: string }[];
+  /** Repos whose git registry entry was removed but whose on-disk directory
+   *  still has files. Caller decides whether to `rm -rf` (e.g. via
+   *  `--force-rm`), resume manual cleanup, or leave the orphan for
+   *  `worktrees check`. */
+  partiallyRemoved: { repo: string; path: string; reason: string }[];
   /** Repos that had no worktree at this branch in the first place. */
   notPresent: string[];
   /** Whether `<worktrees_path>/<branch>/` was rmdir'd (only if empty after). */
@@ -42,6 +61,8 @@ export async function removeBranchWorktrees(
   const config = await readConfig(conceptionPath);
   const worktreesRoot = config.worktrees_path ?? defaultWorktreesPath();
   const reposByName = repoLookupMap(config);
+  const force = options.force === true || options.forceRm === true;
+  const forceRm = options.forceRm === true;
 
   // Resolve target repos: explicit list, or the union of Apps across items
   // declaring the branch. Then remove the protected set (repos still claimed
@@ -70,6 +91,7 @@ export async function removeBranchWorktrees(
     branch,
     removed: [],
     protected: [],
+    partiallyRemoved: [],
     notPresent: [],
     parentRemoved: false,
   };
@@ -89,14 +111,37 @@ export async function removeBranchWorktrees(
       result.notPresent.push(name);
       continue;
     }
+    const args = force ? ['worktree', 'remove', '--force', target] : ['worktree', 'remove', target];
     try {
-      await exec('git', ['worktree', 'remove', target], { cwd: lookup.cwd });
+      await exec('git', args, { cwd: lookup.cwd });
       result.removed.push({ repo: name, path: target });
     } catch (err) {
-      result.protected.push({
-        repo: name,
-        reason: `git worktree remove failed: ${err instanceof Error ? err.message : String(err)}`,
-      });
+      const reason = `git worktree remove failed: ${err instanceof Error ? err.message : String(err)}`;
+      // Disambiguate: did git deregister the worktree before failing on the
+      // rm step (partial remove — disk dirty, registry clean), or did it
+      // refuse outright (genuinely protected)? `--force` removes the registry
+      // entry first, then tries to delete the dir; a failure on the second
+      // half leaves the registry-vs-disk inconsistency users hit.
+      const stillRegistered = await isStillRegistered(lookup.cwd, target);
+      if (stillRegistered) {
+        result.protected.push({ repo: name, reason });
+        continue;
+      }
+      if (forceRm && (await pathExists(target))) {
+        try {
+          await rmrfWithChmodFallback(target);
+          result.removed.push({ repo: name, path: target });
+          continue;
+        } catch (rmErr) {
+          result.partiallyRemoved.push({
+            repo: name,
+            path: target,
+            reason: `${reason}; --force-rm cleanup also failed: ${rmErr instanceof Error ? rmErr.message : String(rmErr)}`,
+          });
+          continue;
+        }
+      }
+      result.partiallyRemoved.push({ repo: name, path: target, reason });
     }
   }
 
@@ -129,4 +174,79 @@ export async function removeBranchWorktrees(
   }
 
   return result;
+}
+
+/**
+ * `fs.rm(target, { recursive: true, force: true })`, with a chmod-walk
+ * fallback on EACCES / EPERM. Node's `force: true` only swallows ENOENT —
+ * read-only files and read-only parent dirs still throw. The common
+ * `--force-rm` use case is rebuildable artifacts (`node_modules`, build
+ * output) that are usually writable, but stray read-only files do happen
+ * (npm caches, vendored dependencies); making the flag pay off when it
+ * matters is worth the second pass.
+ */
+async function rmrfWithChmodFallback(target: string): Promise<void> {
+  try {
+    await fs.rm(target, { recursive: true, force: true });
+    return;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'EACCES' && code !== 'EPERM') throw err;
+  }
+  await chmodWritableRecursive(target);
+  await fs.rm(target, { recursive: true, force: true });
+}
+
+async function chmodWritableRecursive(target: string): Promise<void> {
+  let stat;
+  try {
+    stat = await fs.lstat(target);
+  } catch {
+    return;
+  }
+  if (stat.isSymbolicLink()) return;
+  // u+rwx on dirs (need x to traverse), u+rw on files. We only fix the owner
+  // bits — anything else is the caller's problem and we shouldn't be silently
+  // promoting visibility.
+  await fs
+    .chmod(target, stat.isDirectory() ? 0o700 | (stat.mode & 0o077) : 0o600 | (stat.mode & 0o077))
+    .catch(() => {});
+  if (stat.isDirectory()) {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = await fs.readdir(target, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      await chmodWritableRecursive(join(target, entry.name));
+    }
+  }
+}
+
+/**
+ * True if `git worktree list --porcelain` (run in `cwd`) still lists the
+ * worktree at `target`. Used after a failed `git worktree remove` to tell
+ * "git refused" (registry intact) from "git deregistered then failed on rm"
+ * (partial remove).
+ */
+async function isStillRegistered(cwd: string, target: string): Promise<boolean> {
+  let stdout: string;
+  try {
+    ({ stdout } = await exec('git', ['worktree', 'list', '--porcelain'], { cwd }));
+  } catch {
+    // If we can't query the registry, default to the safer assumption: the
+    // failure was a plain refusal and the caller should retry rather than
+    // see a phantom partial-removed entry.
+    return true;
+  }
+  const targetReal = await fs.realpath(target).catch(() => target);
+  for (const line of stdout.split('\n')) {
+    if (!line.startsWith('worktree ')) continue;
+    const path = line.slice('worktree '.length).trim();
+    if (path === target) return true;
+    const real = await fs.realpath(path).catch(() => path);
+    if (real === targetReal) return true;
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary
- Closes #124. `git worktree remove` can deregister a worktree before failing on the rm step (read-only files, mounted dirs, leftover artifacts), and the CLI was lumping that half-removed state into `protected[]` alongside genuinely-skipped repos.
- Disambiguate via `git worktree list --porcelain` after a failed remove and surface the half-removed case under a new `partiallyRemoved[]` field.
- Add `--force` (passes through to `git worktree remove --force`) and `--force-rm` (implies `--force`, finishes cleanup with a chmod-walk + `fs.rm` fallback) so the common `node_modules`-blocked case is one flag away.

## Changes
- `src/main/worktree/remove.ts`: `RemoveOptions` gains `force` and `forceRm`; `RemoveResult` gains `partiallyRemoved[]`. Detection runs after a failed `git worktree remove` via a new `isStillRegistered` probe; `--force-rm` uses a `rmrfWithChmodFallback` helper so EACCES/EPERM doesn't strand the caller.
- `src/cli/commands/worktrees.ts`: parses `--force` / `--force-rm`, prints a `Partially removed (N):` block when populated, updates help text.
- `src/cli/parser.ts`: registers `force-rm` as a boolean flag.
- `src/main/worktree/remove.test.ts`: vitest covering all three paths (refusal -> `protected`, partial -> `partiallyRemoved`, `--force-rm` -> `removed`) using a hermetic git fixture under `XDG_CONFIG_HOME`.
- `docs/reference/cli.md`: documents the new flags + `partiallyRemoved[]`.
- `package.json` / `package-lock.json`: bump 2.18.28.

## Impact
- New JSON key `partiallyRemoved[]` on the remove envelope. Existing consumers ignore unknown keys; any caller that was specifically branching on the `git worktree remove failed` reason inside `protected[]` should also look at `partiallyRemoved[]` now.
- Pre-existing `protected[]` semantics are tightened: post-fix, that array only contains genuinely-skipped repos (logic-protected, or `git worktree remove` refused without registry mutation).