### PR TITLE
Constrain running-indicator cards to the configured card-min-width

### DIFF
--- a/src/renderer/panes/code-pane.css
+++ b/src/renderer/panes/code-pane.css
@@ -76,9 +76,21 @@
 }
 
 .code-runs-list {
-  display: flex;
-  flex-direction: column;
+  /* Mirror `.repos-grid` above so a running-indicator card respects the
+   * same `cardMinWidth.code` setting as the repo cards it sits below —
+   * without this the cards stretch to the full dock width even when the
+   * pane is wide enough to fit two side by side. `auto-fill` (not
+   * `auto-fit`) keeps the empty track so a single card stays capped at
+   * the configured min-width instead of expanding to fill the pane. */
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(var(--card-min-code, 650px), 100%), 1fr));
   gap: 8px;
+}
+
+/* When a card is expanded the embedded xterm needs the full dock width
+ * to be useful, so it spans every grid column. */
+.code-run-row.expanded {
+  grid-column: 1 / -1;
 }
 
 /* Active-run cards are deliberately styled differently from repo cards:


### PR DESCRIPTION
## Summary

- Running-indicator cards in the Code-pane dock stretched to the full dock width regardless of the user's `cardMinWidth.code` setting; the repo cards above them already respected that setting, so the two card classes looked inconsistent side by side.
- This PR makes the dock use the same auto-fill grid as the repo grid so running-indicator cards behave the same way.

## Changes

- `src/renderer/panes/code-pane.css`: `.code-runs-list` switches from a flex column to `display: grid` with `grid-template-columns: repeat(auto-fill, minmax(min(var(--card-min-code, 650px), 100%), 1fr))`, mirroring `.repos-grid`.
- `src/renderer/panes/code-pane.css`: `.code-run-row.expanded` gets `grid-column: 1 / -1` so an opened card still spans the full dock width and the embedded xterm has room to render.

## Impact

- The `cardMinWidth.code` setting now also drives the dock's running-indicator card layout. Users who lowered that value to keep repo cards narrow will get narrower running-indicator cards too.
- Side-by-side running-indicator cards become possible when the dock is wide enough for two columns at the configured min-width; before this change there was always exactly one card per row.

## Watchpoints

- Visual smoke was not performed locally (worktree without installed dev deps). The change is structurally identical to the existing repo-card grid pattern, but a quick post-merge sanity check on a wide window with multiple active runs is worth doing.