### PR TITLE
Anchor reloaded code-card family at its original index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.29",
+  "version": "2.18.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.29",
+      "version": "2.18.30",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.18.28",
+  "version": "2.18.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.18.28",
+      "version": "2.18.29",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.29",
+  "version": "2.18.30",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.18.28",
+  "version": "2.18.29",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/repos-store.test.ts
+++ b/src/renderer/repos-store.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import type { RepoEntry } from '../shared/types';
+import { spliceFamilyAt } from './repos-store';
+
+function entry(name: string, parent?: string): RepoEntry {
+  return {
+    name: parent ? `${parent}/${name}` : name,
+    path: `/r/${parent ? `${parent}/${name}` : name}`,
+    parent,
+    dirty: 0,
+    missing: false,
+    hasForceStop: false,
+    hasRun: false,
+  } satisfies RepoEntry;
+}
+
+describe('spliceFamilyAt', () => {
+  it('keeps the primary at its original index after a structural reload', () => {
+    // Three top-level repos in declaration order, with a worktree event
+    // touching only the middle one.
+    const current: RepoEntry[] = [entry('alpha'), entry('beta'), entry('gamma')];
+    const updated: RepoEntry[] = [{ ...entry('beta'), dirty: 7 }];
+
+    const next = spliceFamilyAt(current, { name: 'beta', path: '/r/beta' }, updated);
+
+    expect(next.map((r) => r.name)).toEqual(['alpha', 'beta', 'gamma']);
+    expect(next[1].dirty).toBe(7);
+  });
+
+  it('preserves order when the primary is at the head or tail of the list', () => {
+    const current: RepoEntry[] = [entry('alpha'), entry('beta'), entry('gamma')];
+
+    const headNext = spliceFamilyAt(current, { name: 'alpha', path: '/r/alpha' }, [
+      { ...entry('alpha'), dirty: 1 },
+    ]);
+    expect(headNext.map((r) => r.name)).toEqual(['alpha', 'beta', 'gamma']);
+
+    const tailNext = spliceFamilyAt(current, { name: 'gamma', path: '/r/gamma' }, [
+      { ...entry('gamma'), dirty: 1 },
+    ]);
+    expect(tailNext.map((r) => r.name)).toEqual(['alpha', 'beta', 'gamma']);
+  });
+
+  it('replaces a parent + its submodules in place, in declaration order', () => {
+    const current: RepoEntry[] = [
+      entry('alpha'),
+      entry('beta'),
+      entry('child1', 'beta'),
+      entry('child2', 'beta'),
+      entry('gamma'),
+    ];
+    // Watcher event: beta gained a child3 and dropped child1.
+    const updated: RepoEntry[] = [entry('beta'), entry('child2', 'beta'), entry('child3', 'beta')];
+
+    const next = spliceFamilyAt(current, { name: 'beta', path: '/r/beta' }, updated);
+
+    expect(next.map((r) => r.name)).toEqual([
+      'alpha',
+      'beta',
+      'beta/child2',
+      'beta/child3',
+      'gamma',
+    ]);
+  });
+
+  it('does not jump the family to the bottom (regression for the append bug)', () => {
+    // The pre-fix behaviour did `[...survivors, ...updated]`, which would
+    // place the reloaded family after `gamma` here. The fix anchors it
+    // at the primary's original index instead.
+    const current: RepoEntry[] = [entry('alpha'), entry('beta'), entry('gamma')];
+    const updated: RepoEntry[] = [entry('beta')];
+
+    const next = spliceFamilyAt(current, { name: 'beta', path: '/r/beta' }, updated);
+
+    expect(next.indexOf(next.find((r) => r.name === 'beta')!)).toBe(1);
+    expect(next[next.length - 1].name).toBe('gamma');
+  });
+
+  it('appends when the primary is not in the current list (defensive)', () => {
+    const current: RepoEntry[] = [entry('alpha'), entry('gamma')];
+    const updated: RepoEntry[] = [entry('beta'), entry('child', 'beta')];
+
+    const next = spliceFamilyAt(current, { name: 'beta', path: '/r/beta' }, updated);
+
+    expect(next.map((r) => r.name)).toEqual(['alpha', 'gamma', 'beta', 'beta/child']);
+  });
+
+  it('treats `updated` as authoritative for family membership', () => {
+    // A submodule absent from `updated` is genuinely gone — preserving
+    // it would resurrect rows that the user removed from condash.json.
+    const current: RepoEntry[] = [
+      entry('beta'),
+      entry('removed', 'beta'),
+      entry('kept', 'beta'),
+      entry('gamma'),
+    ];
+    const updated: RepoEntry[] = [entry('beta'), entry('kept', 'beta')];
+
+    const next = spliceFamilyAt(current, { name: 'beta', path: '/r/beta' }, updated);
+
+    expect(next.map((r) => r.name)).toEqual(['beta', 'beta/kept', 'gamma']);
+  });
+});

--- a/src/renderer/repos-store.ts
+++ b/src/renderer/repos-store.ts
@@ -43,37 +43,6 @@ export interface ReposStore {
  * `path` keeps row identity stable so any open dropdowns / popovers
  * survive the swap.
  */
-/**
- * Replace `primary`'s family rows in `current` with `updated`, keeping the
- * family anchored at the primary's current index. Appending the updated
- * family to the tail (the previous behaviour) would jump it to the bottom
- * of the list on every structural watcher event — visible to the user as
- * the Code panel reshuffling on every `git worktree add/remove` or
- * `.git/HEAD` write.
- *
- * `updated` is treated as authoritative for the family's membership: a
- * submodule absent from `updated` is genuinely gone (e.g. removed from
- * `condash.json`) and is not preserved from `current`. If `primary` isn't
- * in `current` (defensive: shouldn't happen because the caller already
- * resolves it from the store), the family is appended at the tail.
- */
-export function spliceFamilyAt(
-  current: readonly RepoEntry[],
-  primary: { name: string; path: string },
-  updated: readonly RepoEntry[],
-): RepoEntry[] {
-  const updatedPaths = new Set(updated.map((e) => e.path));
-  const isFamily = (r: RepoEntry): boolean =>
-    updatedPaths.has(r.path) || r.parent === primary.name || r.path === primary.path;
-  const primaryIdx = current.findIndex((r) => r.path === primary.path);
-  if (primaryIdx === -1) {
-    return [...current.filter((r) => !isFamily(r)), ...updated];
-  }
-  const before = current.slice(0, primaryIdx).filter((r) => !isFamily(r));
-  const after = current.slice(primaryIdx + 1).filter((r) => !isFamily(r));
-  return [...before, ...updated, ...after];
-}
-
 export function createReposStore(deps: ReposStoreDeps): ReposStore {
   const [repos, setRepos] = createStore<RepoEntry[]>([]);
   const [reposLoaded, setReposLoaded] = createSignal(false);
@@ -164,4 +133,35 @@ export function createReposStore(deps: ReposStoreDeps): ReposStore {
   onCleanup(offRepoEvents);
 
   return { repos, setRepos, reposLoaded, reloadRepos };
+}
+
+/**
+ * Replace `primary`'s family rows in `current` with `updated`, keeping the
+ * family anchored at the primary's current index. Appending the updated
+ * family to the tail (the previous behaviour) would jump it to the bottom
+ * of the list on every structural watcher event — visible to the user as
+ * the Code panel reshuffling on every `git worktree add/remove` or
+ * `.git/HEAD` write.
+ *
+ * `updated` is treated as authoritative for the family's membership: a
+ * submodule absent from `updated` is genuinely gone (e.g. removed from
+ * `condash.json`) and is not preserved from `current`. If `primary` isn't
+ * in `current` (defensive: shouldn't happen because the caller already
+ * resolves it from the store), the family is appended at the tail.
+ */
+export function spliceFamilyAt(
+  current: readonly RepoEntry[],
+  primary: Pick<RepoEntry, 'name' | 'path'>,
+  updated: readonly RepoEntry[],
+): RepoEntry[] {
+  const updatedPaths = new Set(updated.map((e) => e.path));
+  const isFamily = (r: RepoEntry): boolean =>
+    updatedPaths.has(r.path) || r.parent === primary.name || r.path === primary.path;
+  const primaryIdx = current.findIndex((r) => r.path === primary.path);
+  if (primaryIdx === -1) {
+    return [...current.filter((r) => !isFamily(r)), ...updated];
+  }
+  const before = current.slice(0, primaryIdx).filter((r) => !isFamily(r));
+  const after = current.slice(primaryIdx + 1).filter((r) => !isFamily(r));
+  return [...before, ...updated, ...after];
 }

--- a/src/renderer/repos-store.ts
+++ b/src/renderer/repos-store.ts
@@ -43,6 +43,37 @@ export interface ReposStore {
  * `path` keeps row identity stable so any open dropdowns / popovers
  * survive the swap.
  */
+/**
+ * Replace `primary`'s family rows in `current` with `updated`, keeping the
+ * family anchored at the primary's current index. Appending the updated
+ * family to the tail (the previous behaviour) would jump it to the bottom
+ * of the list on every structural watcher event — visible to the user as
+ * the Code panel reshuffling on every `git worktree add/remove` or
+ * `.git/HEAD` write.
+ *
+ * `updated` is treated as authoritative for the family's membership: a
+ * submodule absent from `updated` is genuinely gone (e.g. removed from
+ * `condash.json`) and is not preserved from `current`. If `primary` isn't
+ * in `current` (defensive: shouldn't happen because the caller already
+ * resolves it from the store), the family is appended at the tail.
+ */
+export function spliceFamilyAt(
+  current: readonly RepoEntry[],
+  primary: { name: string; path: string },
+  updated: readonly RepoEntry[],
+): RepoEntry[] {
+  const updatedPaths = new Set(updated.map((e) => e.path));
+  const isFamily = (r: RepoEntry): boolean =>
+    updatedPaths.has(r.path) || r.parent === primary.name || r.path === primary.path;
+  const primaryIdx = current.findIndex((r) => r.path === primary.path);
+  if (primaryIdx === -1) {
+    return [...current.filter((r) => !isFamily(r)), ...updated];
+  }
+  const before = current.slice(0, primaryIdx).filter((r) => !isFamily(r));
+  const after = current.slice(primaryIdx + 1).filter((r) => !isFamily(r));
+  return [...before, ...updated, ...after];
+}
+
 export function createReposStore(deps: ReposStoreDeps): ReposStore {
   const [repos, setRepos] = createStore<RepoEntry[]>([]);
   const [reposLoaded, setReposLoaded] = createSignal(false);
@@ -78,13 +109,10 @@ export function createReposStore(deps: ReposStoreDeps): ReposStore {
       void reloadRepos();
       return;
     }
-    // Build the next snapshot: keep rows outside this primary's family,
-    // append the freshly-fetched rows. Reconcile keyed on `path` does
-    // the diff/merge, preserving row identity for unaffected rows and
-    // any popovers anchored on them.
-    const familyPaths = new Set(updated.map((e) => e.path));
-    const survivors = repos.filter((r) => !familyPaths.has(r.path) && r.parent !== primary.name);
-    setRepos(reconcile([...survivors, ...updated], { key: 'path' }));
+    // Splice the freshly-fetched family back in at the primary's *current*
+    // index. Reconcile keyed on `path` does the diff/merge, preserving row
+    // identity for unaffected rows and any popovers anchored on them.
+    setRepos(reconcile(spliceFamilyAt(repos, primary, updated), { key: 'path' }));
   };
 
   // Per-primary reload debouncer. Coalesces bursts of structural events


### PR DESCRIPTION
## Summary
- The Code panel was reordering itself on every structural watcher event (`git worktree add/remove`, `.git/HEAD` write): the affected primary's family kept jumping to the bottom of the list, contradicting the "declaration order" guarantee documented in `docs/guides/repositories-and-open-with.md`.
- Root cause was a single line in `reloadPrimaryByPath` that appended `updated` after `survivors` instead of splicing it back in at the primary's current index.

## Changes
- `src/renderer/repos-store.ts`: extract the merge as a pure `spliceFamilyAt(current, primary, updated)` helper that anchors the family at the primary's current index and falls back to a tail append when the primary isn't in `current` (defensive). `reloadPrimaryByPath` calls it; the surrounding `reconcile({ key: 'path' })` semantics are unchanged.
- `src/renderer/repos-store.test.ts`: 6 vitest cases — primary in middle / head / tail, parent + submodules with one removed and one added, regression for the append-to-tail bug, defensive append-when-primary-missing path, and the `updated`-is-authoritative invariant.
- `package.json` / `package-lock.json`: bump 2.18.29.

## Impact
- `updated` semantics are unchanged: it remains authoritative for family membership, so a submodule removed from `condash.json` between the watcher event and the fetch still disappears as before.
- No IPC shape change. Full-list `reloadRepos` already preserves declaration order; only the per-primary partial-reload path was wrong.

## Watchpoints
- User also reported "sometimes not all cards visible". The most plausible explanation was the order bug pushing a card off the visible region; if that symptom persists after this lands, open a follow-up incident with a stable repro (which structural event preceded the disappearance, what `listReposForPrimary` returned at that moment).