### PR TITLE
Keep cards mounted on refresh: stores + reconcile, drop Suspense

### DIFF
--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -1,21 +1,16 @@
 import { render } from 'solid-js/web';
-import {
-  createEffect,
-  createMemo,
-  createResource,
-  createSignal,
-  onCleanup,
-  Show,
-  Suspense,
-} from 'solid-js';
+import { createEffect, createMemo, createSignal, onCleanup, Show } from 'solid-js';
 import type {
   CardMinWidthPrefs,
   Deliverable,
+  KnowledgeNode,
   LayoutState,
   OpenWithSlotKey,
   OpenWithSlots,
   Project,
   RepoEntry,
+  ResourceNode,
+  SkillNode,
   Step,
   TermSession,
   TerminalPrefs,
@@ -55,6 +50,8 @@ import { createTerminalBridge } from './terminal-bridge';
 import { applyTreeEvents } from './tree-events';
 import { createTreeExpansion } from './tree-expansion';
 import { createReposStore } from './repos-store';
+import { createProjectsStore } from './projects-store';
+import { createTreeStore } from './tree-store';
 import { createGlobalKeyboard } from './global-keyboard';
 import { createMenuRouter } from './menu-commands';
 import { QuitConfirmModal } from './quit-confirm-modal';
@@ -99,7 +96,6 @@ function applyCardMinWidth(prefs: Required<CardMinWidthPrefs>): void {
 
 function App() {
   const [conceptionPath, setConceptionPath] = createSignal<string | null>(null);
-  const [refreshKey, setRefreshKey] = createSignal(0);
   const [theme, setTheme] = createSignal<Theme>('system');
   type ToastKind = 'success' | 'error' | 'info';
   const [toast, setToast] = createSignal<{ msg: string; kind: ToastKind } | null>(null);
@@ -248,12 +244,15 @@ function App() {
 
   const unsubscribe = window.condash.onTreeEvents((events) => {
     void applyTreeEvents(events, {
-      mutate,
-      bumpRefreshKey: () => setRefreshKey((k) => k + 1),
-      // Repos no longer depend on refreshKey — refetch them explicitly when
-      // a config edit (potentially adding/removing repos) or an unknown event
-      // arrives. Dirty changes flow through `repo-events` instead and don't
-      // need this path.
+      mutateProjects: mutate,
+      reloadProjects: reloadProjects,
+      reloadKnowledge: knowledgeStore.reload,
+      reloadResources: resourcesStore.reload,
+      reloadSkills: skillsStore.reload,
+      reloadConfig: reloadConfig,
+      // Repos do not subscribe to tree events directly — repo-events
+      // covers scalar / structural updates; `config` is the only path
+      // through which the repo list itself can change.
       refetchRepos: () => {
         void reloadRepos();
       },
@@ -305,65 +304,72 @@ function App() {
     void window.condash.setTheme(next);
   };
 
-  const [projects, { mutate }] = createResource(
-    () => [conceptionPath(), refreshKey()] as const,
-    async ([path]) => {
-      if (!path) return [] as Project[];
-      return window.condash.listProjects();
-    },
-  );
+  // Projects + the three tree panes are backed by Solid stores keyed on a
+  // stable identity field (`path` for projects, `relPath` for tree nodes).
+  // `reconcile` reuses prior node references across refresh, so `<For>`
+  // keeps card / row DOM identity and per-card popover state (drag-drop
+  // dropdowns, the Step menu, hover anchors) survives every watcher tick.
+  // Switching panes does not refetch — the stores stay populated for the
+  // active conception until it changes.
+  const projectsStore = createProjectsStore({ conceptionPath });
+  const { projects, loaded: projectsLoaded, mutate, reload: reloadProjects } = projectsStore;
 
-  // Knowledge / Resources / Skills trees are cached once the conception
-  // path is set and re-fetched only when `refreshKey` bumps. The latter
-  // is wired to `onTreeEvents` (config / knowledge / resources / skills
-  // subtree changes), so cached data stays correct between switches.
-  // Dropping `layout().working` from the source key is what makes pane
-  // switches instant — without it, leaving the pane reset the resource
-  // to `null` and re-entry forced a full disk read every time.
-  const [knowledge] = createResource(
-    () => [conceptionPath(), refreshKey()] as const,
-    async ([path]) => {
-      if (!path) return null;
-      return window.condash.readKnowledgeTree();
-    },
-  );
+  const knowledgeStore = createTreeStore<KnowledgeNode>({
+    conceptionPath,
+    fetcher: () => window.condash.readKnowledgeTree(),
+    key: 'relPath',
+  });
+  const knowledge = knowledgeStore.root;
 
-  const [resources] = createResource(
-    () => [conceptionPath(), refreshKey()] as const,
-    async ([path]) => {
-      if (!path) return null;
-      return window.condash.readResourcesTree();
-    },
-  );
+  const resourcesStore = createTreeStore<ResourceNode>({
+    conceptionPath,
+    fetcher: () => window.condash.readResourcesTree(),
+    key: 'relPath',
+  });
+  const resources = resourcesStore.root;
 
-  const [skills] = createResource(
-    () => [conceptionPath(), refreshKey()] as const,
-    async ([path]) => {
-      if (!path) return null;
-      return window.condash.readSkillsTree();
-    },
-  );
+  const skillsStore = createTreeStore<SkillNode>({
+    conceptionPath,
+    fetcher: () => window.condash.readSkillsTree(),
+    key: 'relPath',
+  });
+  const skills = skillsStore.root;
 
   // Code-pane repos store. Owns the scalar/set-membership split and the
   // structural-event debouncer; see `./repos-store.ts` for the contract.
   const reposStore = createReposStore({ conceptionPath, flashToast });
   const { repos, reposLoaded, reloadRepos } = reposStore;
 
-  const [openWithSlots] = createResource(
-    () => [conceptionPath(), refreshKey()] as const,
-    async ([path]) => {
-      if (!path) return {} as OpenWithSlots;
-      return window.condash.listOpenWith();
-    },
-  );
-
-  const [terminalPrefs] = createResource(
-    () => [conceptionPath(), refreshKey()] as const,
-    async ([path]) => {
-      if (!path) return {} as TerminalPrefs;
-      return window.condash.termGetPrefs();
-    },
-  );
+  // Open With slots + terminal prefs are config-bound — they change
+  // only on a `'config'` tree event (or an explicit user save). Plain
+  // signals keep them out of the Suspense/resource graph so a knowledge
+  // edit doesn't refetch them.
+  const [openWithSlots, setOpenWithSlots] = createSignal<OpenWithSlots>({});
+  const [terminalPrefs, setTerminalPrefs] = createSignal<TerminalPrefs | undefined>(undefined);
+  const reloadConfig = async (): Promise<void> => {
+    if (!conceptionPath()) {
+      setOpenWithSlots({});
+      setTerminalPrefs(undefined);
+      return;
+    }
+    const [slots, prefs] = await Promise.all([
+      window.condash.listOpenWith(),
+      window.condash.termGetPrefs(),
+    ]);
+    setOpenWithSlots(slots);
+    setTerminalPrefs(prefs);
+  };
+  // Reload on every conception-path change. Mirrors the per-store
+  // effect so the three config-bound reads stay in sync without a
+  // shared `refreshKey`.
+  createEffect(() => {
+    if (!conceptionPath()) {
+      setOpenWithSlots({});
+      setTerminalPrefs(undefined);
+      return;
+    }
+    void reloadConfig();
+  });
 
   const ensureTerminalOpen = (): void => {
     if (!layout().terminal) updateLayout({ terminal: true });
@@ -430,7 +436,6 @@ function App() {
     conceptionPath,
     layout,
     setConceptionPath,
-    bumpRefreshKey: () => setRefreshKey((k) => k + 1),
     setSearchModalOpen,
     setSettingsOpen,
     setNewProjectOpen,
@@ -470,8 +475,12 @@ function App() {
   const handlePick = async () => {
     const picked = await window.condash.pickConceptionPath();
     if (!picked) return;
+    const prior = conceptionPath();
     setConceptionPath(picked);
-    setRefreshKey((k) => k + 1);
+    // Picking the same path is a "refresh me" gesture — the
+    // per-store createEffect only fires on actual change, so fan out
+    // a full reload to honour that.
+    if (prior === picked) void reloadAll();
 
     // Surface the bundled-template init when the picked folder lacks the
     // conception markers (projects/ + condash.json). Init never
@@ -495,26 +504,34 @@ function App() {
     try {
       const { created } = await window.condash.initConception(path);
       flashToast(`Initialised conception template — ${created.length} files created.`, 'success');
-      setRefreshKey((k) => k + 1);
+      void reloadAll();
     } catch (err) {
       flashToast(`Init failed: ${(err as Error).message}`, 'error');
     }
   };
 
+  // Full fan-out reload. Used by View → Refresh and as the success
+  // tail of `initConception`. Each store applies `reconcile` on swap-in
+  // so card / row DOM identity survives — the visible effect is content
+  // updating in place, not the pane blanking and rebuilding.
+  const reloadAll = async (): Promise<void> => {
+    await Promise.all([
+      reloadProjects(),
+      knowledgeStore.reload(),
+      resourcesStore.reload(),
+      skillsStore.reload(),
+      reloadConfig(),
+      reloadRepos(),
+    ]);
+  };
+
   const handleRefresh = () => {
-    // F5 / View → Refresh covers both axes:
-    //   1. Drop the per-worktree git-status cache + force-recompute
-    //      every watched path so dirty/upstream are fresh.
-    //   2. Bump refreshKey so projects, knowledge, openWith, terminal
-    //      prefs all re-fetch.
-    //   3. Re-list repos so any worktree add/remove that happened
-    //      outside the running app (CLI worktree mutation, manual git
-    //      worktree add) is reflected immediately. The reconcile-with-
-    //      key contract on the repos store keeps open popovers /
-    //      dropdowns alive across the swap.
+    // F5 / View → Refresh: drop the per-worktree git-status cache so
+    // dirty/upstream recompute on the next listRepos, then fan out a
+    // full reload across every store. Repos are explicit because the
+    // reposStore's createEffect only fires on conception-path change.
     void window.condash.invalidateGitStatus();
-    setRefreshKey((k) => k + 1);
-    void reloadRepos();
+    void reloadAll();
   };
 
   const handleOpenInEditor = (path: string) => {
@@ -637,7 +654,13 @@ function App() {
     kind: TreeAffordance,
     sourceDirRelPath: string,
   ): void => {
-    setRefreshKey((k) => k + 1);
+    // Reload the affected tree explicitly — the chokidar watcher does
+    // fire on the new file, but the open-the-newly-created-file branch
+    // below runs synchronously and we want the tree pane to reflect
+    // the new entry on the same frame.
+    if (treeKey === 'knowledge') void knowledgeStore.reload();
+    else if (treeKey === 'resources') void resourcesStore.reload();
+    else void skillsStore.reload();
     expandTreeDir(treeKey, sourceDirRelPath);
     if (kind === 'mkdir') return;
     if (treeKey === 'knowledge') {
@@ -690,8 +713,10 @@ function App() {
   const shouldShowWelcome = (): boolean => {
     if (welcomeDismissed()) return false;
     if (!conceptionPath()) return false;
-    if (projects.loading) return false;
-    if ((projects() ?? []).length > 0) return false;
+    // Wait for the first projects load — otherwise the welcome screen
+    // flashes for one frame on cold start before the IPC resolves.
+    if (!projectsLoaded()) return false;
+    if (projects().length > 0) return false;
     if (!knowledgeIsEmpty()) return false;
     return true;
   };
@@ -793,11 +818,10 @@ function App() {
     try {
       const result = await window.condash.setStatus(path, newStatus);
       // The main process appended a Closed./Reopened. timeline entry on
-      // done-edges; bump the refresh key so the popup's timeline pane and
-      // the card's last-date both pick up the new entry.
-      if (result.timelineAppended) {
-        setRefreshKey((k) => k + 1);
-      }
+      // done-edges; the watcher fires a 'project' event for the README
+      // that patches the card via `mutateProjects`. No explicit reload
+      // here — reconcile updates the timeline / closedAt in place and
+      // the popup re-reads through the live projects accessor.
       if (result.branchWarning) {
         flashToast(result.branchWarning, 'info');
       }
@@ -945,21 +969,19 @@ function App() {
               <div class="top-band" ref={(el) => (topBandRef = el)} style={topBandStyle()}>
                 <Show when={layout().projects}>
                   <section class="pane pane-projects">
-                    <Suspense fallback={<div class="empty">Loading…</div>}>
-                      <Show
-                        when={(projects() ?? []).length > 0}
-                        fallback={<div class="empty">No projects found under projects/.</div>}
-                      >
-                        <ProjectsView
-                          buckets={projectsTabGroups()}
-                          onOpen={handleOpenProject}
-                          onToggleStep={handleToggleStep}
-                          onDropProject={handleDropOnColumn}
-                          onWorkOn={(p) => void bridge.handleWorkOn(p)}
-                          onNewProject={() => setNewProjectOpen(true)}
-                        />
-                      </Show>
-                    </Suspense>
+                    <Show
+                      when={(projects() ?? []).length > 0}
+                      fallback={<div class="empty">No projects found under projects/.</div>}
+                    >
+                      <ProjectsView
+                        buckets={projectsTabGroups()}
+                        onOpen={handleOpenProject}
+                        onToggleStep={handleToggleStep}
+                        onDropProject={handleDropOnColumn}
+                        onWorkOn={(p) => void bridge.handleWorkOn(p)}
+                        onNewProject={() => setNewProjectOpen(true)}
+                      />
+                    </Show>
                   </section>
                 </Show>
 
@@ -973,126 +995,117 @@ function App() {
 
                 <Show when={layout().working === 'knowledge'}>
                   <section class="pane pane-working">
-                    <Suspense fallback={<div class="empty">Loading…</div>}>
-                      <Show
-                        when={knowledge()}
-                        fallback={
-                          <div class="empty">
-                            No knowledge/ directory under the selected conception path.
-                          </div>
+                    <Show
+                      when={knowledge()}
+                      fallback={
+                        <div class="empty">
+                          No knowledge/ directory under the selected conception path.
+                        </div>
+                      }
+                    >
+                      <KnowledgeView
+                        root={knowledge()!}
+                        onOpen={handleOpenKnowledgeFile}
+                        expanded={knowledgeExpanded}
+                        onToggleExpand={(rel) => toggleTreeExpand('knowledge', rel)}
+                        mutations={treeMutations}
+                        prompts={treePrompts}
+                        onAfterMutation={(newPath, kind, source) =>
+                          handleAfterTreeMutation('knowledge', newPath, kind, source)
                         }
-                      >
-                        <KnowledgeView
-                          root={knowledge()!}
-                          onOpen={handleOpenKnowledgeFile}
-                          expanded={knowledgeExpanded}
-                          onToggleExpand={(rel) => toggleTreeExpand('knowledge', rel)}
-                          mutations={treeMutations}
-                          prompts={treePrompts}
-                          onAfterMutation={(newPath, kind, source) =>
-                            handleAfterTreeMutation('knowledge', newPath, kind, source)
-                          }
-                          onError={treeError}
-                        />
-                      </Show>
-                    </Suspense>
+                        onError={treeError}
+                      />
+                    </Show>
                   </section>
                 </Show>
 
                 <Show when={layout().working === 'resources'}>
                   <section class="pane pane-working">
-                    <Suspense fallback={<div class="empty">Loading…</div>}>
-                      <ResourcesView
-                        root={resources() ?? null}
-                        actions={resourcesActions}
-                        onOpenSettings={() => setSettingsOpen(true)}
-                        onOpenConceptionDir={() => {
-                          void window.condash.openConceptionDirectory().catch((err) => {
-                            flashToast(`Open failed: ${(err as Error).message}`, 'error');
-                          });
-                        }}
-                        expanded={resourcesExpanded}
-                        onToggleExpand={(rel) => toggleTreeExpand('resources', rel)}
-                        mutations={treeMutations}
-                        prompts={treePrompts}
-                        onAfterMutation={(newPath, kind, source) =>
-                          handleAfterTreeMutation('resources', newPath, kind, source)
-                        }
-                        onError={treeError}
-                      />
-                    </Suspense>
+                    <ResourcesView
+                      root={resources() ?? null}
+                      actions={resourcesActions}
+                      onOpenSettings={() => setSettingsOpen(true)}
+                      onOpenConceptionDir={() => {
+                        void window.condash.openConceptionDirectory().catch((err) => {
+                          flashToast(`Open failed: ${(err as Error).message}`, 'error');
+                        });
+                      }}
+                      expanded={resourcesExpanded}
+                      onToggleExpand={(rel) => toggleTreeExpand('resources', rel)}
+                      mutations={treeMutations}
+                      prompts={treePrompts}
+                      onAfterMutation={(newPath, kind, source) =>
+                        handleAfterTreeMutation('resources', newPath, kind, source)
+                      }
+                      onError={treeError}
+                    />
                   </section>
                 </Show>
 
                 <Show when={layout().working === 'skills'}>
                   <section class="pane pane-working">
-                    <Suspense fallback={<div class="empty">Loading…</div>}>
-                      <SkillsView
-                        root={skills() ?? null}
-                        onOpen={handleOpenSkillFile}
-                        onOpenSettings={() => setSettingsOpen(true)}
-                        onCopyInstallCommand={() => {
-                          void navigator.clipboard
-                            .writeText('condash-cli skills install')
-                            .then(() => flashToast('Copied install command', 'success'))
-                            .catch((err) =>
-                              flashToast(`Copy failed: ${(err as Error).message}`, 'error'),
-                            );
-                        }}
-                        expanded={skillsExpanded}
-                        onToggleExpand={(rel) => toggleTreeExpand('skills', rel)}
-                        mutations={treeMutations}
-                        prompts={treePrompts}
-                        onAfterMutation={(newPath, kind, source) =>
-                          handleAfterTreeMutation('skills', newPath, kind, source)
-                        }
-                        onError={treeError}
-                      />
-                    </Suspense>
+                    <SkillsView
+                      root={skills() ?? null}
+                      onOpen={handleOpenSkillFile}
+                      onOpenSettings={() => setSettingsOpen(true)}
+                      onCopyInstallCommand={() => {
+                        void navigator.clipboard
+                          .writeText('condash-cli skills install')
+                          .then(() => flashToast('Copied install command', 'success'))
+                          .catch((err) =>
+                            flashToast(`Copy failed: ${(err as Error).message}`, 'error'),
+                          );
+                      }}
+                      expanded={skillsExpanded}
+                      onToggleExpand={(rel) => toggleTreeExpand('skills', rel)}
+                      mutations={treeMutations}
+                      prompts={treePrompts}
+                      onAfterMutation={(newPath, kind, source) =>
+                        handleAfterTreeMutation('skills', newPath, kind, source)
+                      }
+                      onError={treeError}
+                    />
                   </section>
                 </Show>
 
                 <Show when={layout().working === 'code'}>
                   <section class="pane pane-working">
-                    <Suspense fallback={<div class="empty">Loading…</div>}>
-                      <Show
-                        when={repos.length > 0}
-                        fallback={
-                          <Show when={reposLoaded()} fallback={<div class="empty">Loading…</div>}>
-                            <div class="empty">
-                              <p>No repositories configured.</p>
-                              <p>
-                                Add entries to <code>repositories</code> in{' '}
-                                <code>condash.json</code>.
-                              </p>
-                              <button
-                                type="button"
-                                class="empty-cta"
-                                onClick={() => setSettingsOpen(true)}
-                              >
-                                + Add repository
-                              </button>
-                            </div>
-                          </Show>
-                        }
-                      >
-                        <CodeView
-                          repos={repos}
-                          slots={openWithSlots() ?? {}}
-                          liveRepos={liveRepos()}
-                          liveSessionCwds={liveSessionCwds()}
-                          codeRunSessions={codeRunSessions()}
-                          xtermPrefs={terminalPrefs()?.xterm}
-                          onOpen={handleOpenInEditor}
-                          onLaunch={(slot, path) => void handleLaunch(slot, path)}
-                          onForceStop={(r) => void handleForceStop(r)}
-                          onStop={handleStopRepo}
-                          onRun={(r, wt) => void handleRunRepo(r, wt)}
-                          onOpenInTerm={(r, wt) => void bridge.handleOpenInTerm(r, wt)}
-                          onCloseSession={(id) => void window.condash.termClose(id)}
-                        />
-                      </Show>
-                    </Suspense>
+                    <Show
+                      when={repos.length > 0}
+                      fallback={
+                        <Show when={reposLoaded()} fallback={<div class="empty">Loading…</div>}>
+                          <div class="empty">
+                            <p>No repositories configured.</p>
+                            <p>
+                              Add entries to <code>repositories</code> in <code>condash.json</code>.
+                            </p>
+                            <button
+                              type="button"
+                              class="empty-cta"
+                              onClick={() => setSettingsOpen(true)}
+                            >
+                              + Add repository
+                            </button>
+                          </div>
+                        </Show>
+                      }
+                    >
+                      <CodeView
+                        repos={repos}
+                        slots={openWithSlots() ?? {}}
+                        liveRepos={liveRepos()}
+                        liveSessionCwds={liveSessionCwds()}
+                        codeRunSessions={codeRunSessions()}
+                        xtermPrefs={terminalPrefs()?.xterm}
+                        onOpen={handleOpenInEditor}
+                        onLaunch={(slot, path) => void handleLaunch(slot, path)}
+                        onForceStop={(r) => void handleForceStop(r)}
+                        onStop={handleStopRepo}
+                        onRun={(r, wt) => void handleRunRepo(r, wt)}
+                        onOpenInTerm={(r, wt) => void bridge.handleOpenInTerm(r, wt)}
+                        onCloseSession={(id) => void window.condash.termClose(id)}
+                      />
+                    </Show>
                   </section>
                 </Show>
               </div>
@@ -1262,9 +1275,9 @@ function App() {
             setNewProjectOpen(false);
             // Refresh the project list and prime the popup. The popup
             // resolves the Project object via `previewProject()`, which
-            // re-reads `projects()`, so the popup mounts as soon as the
-            // resource refetch settles.
-            setRefreshKey((k) => k + 1);
+            // re-reads `projects()`, so the popup mounts as soon as
+            // reload settles.
+            void reloadProjects();
             setPreviewPath(result.readme);
             flashToast(`Created ${result.relPath}`, 'success');
           }}

--- a/src/renderer/menu-commands.ts
+++ b/src/renderer/menu-commands.ts
@@ -7,7 +7,6 @@ export interface MenuRouterDeps {
   conceptionPath: Accessor<string | null>;
   layout: Accessor<LayoutState>;
   setConceptionPath: (next: string | null) => void;
-  bumpRefreshKey: () => void;
   setSearchModalOpen: (open: boolean) => void;
   setSettingsOpen: (open: boolean) => void;
   setNewProjectOpen: (open: boolean) => void;
@@ -105,8 +104,10 @@ export function createMenuRouter(deps: MenuRouterDeps): void {
     void window.condash
       .openConception(path)
       .then((newPath) => {
+        // Setting the conception path cascades through every store's
+        // `createEffect(conceptionPath)` (projects, knowledge, resources,
+        // skills, repos, config), so no explicit refresh bump is needed.
         deps.setConceptionPath(newPath);
-        deps.bumpRefreshKey();
       })
       .catch((err) => {
         deps.flashToast(`Open failed: ${(err as Error).message}`, 'error');

--- a/src/renderer/projects-store.ts
+++ b/src/renderer/projects-store.ts
@@ -1,0 +1,89 @@
+import { createEffect, createSignal } from 'solid-js';
+import type { Accessor } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+import type { Project } from '@shared/types';
+
+/**
+ * Mutator passed to `applyTreeEvents` for per-project patches (add /
+ * change / delete). The callback receives the current list and returns
+ * the next; reconcile then walks the diff keyed by `path` so unchanged
+ * card rows keep their DOM identity. Same shape as the prior
+ * `createResource`-backed `mutate`, retained so the tree-events handler
+ * didn't need a second refactor pass.
+ */
+export type ProjectsMutator = (next: (items: Project[]) => Project[]) => void;
+
+export interface ProjectsStore {
+  /** Reactive accessor returning the current project list. Always
+   *  defined — empty array when no conception is selected or the
+   *  fetcher hasn't resolved yet. Consumers should check `loaded()` to
+   *  tell "still loading" from "loaded, empty". */
+  projects: Accessor<Project[]>;
+  /** True once the first `listProjects()` call has resolved for the
+   *  active conception. Flips back to false on conception-path drop. */
+  loaded: Accessor<boolean>;
+  /** Apply a path-shaped patch to the list. Used by the chokidar event
+   *  handler so a single README save patches one card instead of
+   *  refetching the whole list. */
+  mutate: ProjectsMutator;
+  /** Re-fetch the list and reconcile against the current store. */
+  reload: () => Promise<void>;
+}
+
+export interface ProjectsStoreDeps {
+  /** Read-only accessor for the active conception path. */
+  conceptionPath: Accessor<string | null>;
+}
+
+/**
+ * Projects-pane list store. Mirrors `repos-store.ts` — a Solid store
+ * fed by an explicit `reload()` that applies `reconcile({ key: 'path' })`
+ * — so per-event patches (`mutate`) and full reloads both preserve
+ * `Project` reference identity, keeping `<For>` row mounts stable and
+ * any per-card popover state alive across refresh.
+ *
+ * Lives outside the resource graph on purpose: a chokidar burst can
+ * fire many tree events per second, and a `createResource` source
+ * change cascades a Suspense transition on every bump. The store path
+ * stays synchronous on the read side.
+ */
+export function createProjectsStore(deps: ProjectsStoreDeps): ProjectsStore {
+  const [box, setBox] = createStore<{ list: Project[] }>({ list: [] });
+  const [loaded, setLoaded] = createSignal(false);
+
+  const reload = async (): Promise<void> => {
+    if (!deps.conceptionPath()) {
+      setBox('list', reconcile([] as Project[], { key: 'path' }));
+      setLoaded(false);
+      return;
+    }
+    const list = await window.condash.listProjects();
+    setBox('list', reconcile(list, { key: 'path' }));
+    setLoaded(true);
+  };
+
+  const mutate: ProjectsMutator = (fn) => {
+    const next = fn(box.list);
+    setBox('list', reconcile(next, { key: 'path' }));
+  };
+
+  // Same eager-load pattern as the repos store — first paint of the
+  // Projects pane is instant because the list has already been fetched
+  // by the time the user looks at it.
+  createEffect(() => {
+    const path = deps.conceptionPath();
+    if (!path) {
+      setBox('list', reconcile([] as Project[], { key: 'path' }));
+      setLoaded(false);
+      return;
+    }
+    void reload();
+  });
+
+  return {
+    projects: () => box.list,
+    loaded,
+    mutate,
+    reload,
+  };
+}

--- a/src/renderer/tree-events.ts
+++ b/src/renderer/tree-events.ts
@@ -1,63 +1,88 @@
 import type { Project, TreeEvent } from '@shared/types';
-import type { Resource } from 'solid-js';
 
-type Mutator = (next: (items: Project[] | undefined) => Project[]) => void;
-
+/**
+ * Per-channel callbacks for the renderer. The watcher emits typed
+ * `TreeEvent`s (`'project' | 'knowledge' | 'resources' | 'skills' |
+ * 'config' | 'unknown'`); this module dispatches each kind to the
+ * matching reloader so an edit in one pane doesn't refetch the others.
+ */
 export interface TreeEventsDeps {
-  /** SolidJS resource mutator for the projects list. */
-  mutate: Mutator;
-  /** Bump the renderer's `refreshKey` to force a full re-fetch of the
-   *  resources still keyed on it (knowledge, openWithSlots, terminalPrefs). */
-  bumpRefreshKey: () => void;
-  /** Trigger a refetch of the repos resource. Repos dropped their
-   *  `refreshKey` dependency in v2.8.0 (in-place updates flow through
-   *  `repo-events` instead) so config / unknown events that may have
-   *  changed the repo list need an explicit nudge. */
+  /** Path-shaped patch to the projects list. Used for `'project'`
+   *  events — one card moves; the rest don't blink. */
+  mutateProjects: (next: (items: Project[]) => Project[]) => void;
+  /** Full reload of the projects list. Called only as part of the
+   *  `'unknown'` fan-out (last-resort backstop). */
+  reloadProjects: () => Promise<void>;
+  /** Reload knowledge / resources / skills trees. Each one fires only
+   *  when its kind appears in the batch (or on the unknown backstop). */
+  reloadKnowledge: () => Promise<void>;
+  reloadResources: () => Promise<void>;
+  reloadSkills: () => Promise<void>;
+  /** Re-read condash.json-backed bits the renderer caches: Open With
+   *  slots and per-conception terminal prefs. Fires on `'config'`
+   *  events. */
+  reloadConfig: () => Promise<void>;
+  /** Re-fetch repos. Repo events flow through `repo-events` for
+   *  scalar / structural updates; the `'config'` path is for repo-list
+   *  add / remove (which only `config` events surface to the renderer). */
   refetchRepos: () => void;
 }
 
-/** Apply chokidar-driven tree events to the projects resource. Handles
- *  per-project patch, deletes, and falls through to a full refresh when
- *  knowledge / config changed or an unknown event arrived. */
+/**
+ * Apply a batch of chokidar-driven tree events. Per-project events
+ * patch in place via `mutateProjects`; pane-level events fire the
+ * matching `reload*` exactly once even when multiple events of the
+ * same kind appear in the batch. The watcher coalesces bursts into a
+ * single batch (250 ms debounce); we coalesce within the batch.
+ */
 export async function applyTreeEvents(events: TreeEvent[], deps: TreeEventsDeps): Promise<void> {
-  let knowledgeOrConfigDirty = false;
+  let knowledgeDirty = false;
+  let resourcesDirty = false;
+  let skillsDirty = false;
+  let configDirty = false;
   let unknownSeen = false;
 
   for (const event of events) {
     if (event.kind === 'unknown') {
-      // Unknown events trigger the bumpRefreshKey/refetchRepos full-refresh
-      // path below — but keep iterating so per-project patches in the same
-      // burst still apply. Otherwise a single unknown in the middle of a
-      // batch drops every later event and the UI flashes back to pre-event
-      // state until the resource refetch resolves.
+      // Unknown events trigger the full fan-out below — but keep
+      // iterating so per-project patches earlier in the batch still
+      // apply. A single unknown in the middle of a burst would
+      // otherwise drop every later event and the UI would flash back
+      // to pre-event state until the reload resolves.
       unknownSeen = true;
       continue;
     }
-    if (
-      event.kind === 'config' ||
-      event.kind === 'knowledge' ||
-      event.kind === 'resources' ||
-      event.kind === 'skills'
-    ) {
-      knowledgeOrConfigDirty = true;
+    if (event.kind === 'config') {
+      configDirty = true;
       continue;
     }
-    // Per-project patch.
+    if (event.kind === 'knowledge') {
+      knowledgeDirty = true;
+      continue;
+    }
+    if (event.kind === 'resources') {
+      resourcesDirty = true;
+      continue;
+    }
+    if (event.kind === 'skills') {
+      skillsDirty = true;
+      continue;
+    }
+    // Per-project patch (`event.kind === 'project'`).
     try {
       if (event.op === 'unlink') {
-        deps.mutate((items) => (items ?? []).filter((p) => p.path !== event.path));
+        deps.mutateProjects((items) => items.filter((p) => p.path !== event.path));
         continue;
       }
       const project = await window.condash.getProject(event.path);
       if (!project) {
-        deps.mutate((items) => (items ?? []).filter((p) => p.path !== event.path));
+        deps.mutateProjects((items) => items.filter((p) => p.path !== event.path));
         continue;
       }
-      deps.mutate((items) => {
-        const list = items ?? [];
-        const idx = list.findIndex((p) => p.path === project.path);
-        if (idx === -1) return [...list, project];
-        const next = list.slice();
+      deps.mutateProjects((items) => {
+        const idx = items.findIndex((p) => p.path === project.path);
+        if (idx === -1) return [...items, project];
+        const next = items.slice();
         next[idx] = project;
         return next;
       });
@@ -66,12 +91,34 @@ export async function applyTreeEvents(events: TreeEvent[], deps: TreeEventsDeps)
     }
   }
 
-  if (unknownSeen || knowledgeOrConfigDirty) {
-    deps.bumpRefreshKey();
+  if (unknownSeen) {
+    // Backstop — same shape as the pre-split fan-out, just routed
+    // through per-channel reloaders. Includes repos because an unknown
+    // event could be anything (repo file changes outside the watched
+    // roots, etc.).
+    await Promise.all([
+      deps.reloadProjects(),
+      deps.reloadKnowledge(),
+      deps.reloadResources(),
+      deps.reloadSkills(),
+      deps.reloadConfig(),
+    ]);
+    deps.refetchRepos();
+    return;
+  }
+
+  const tasks: Promise<unknown>[] = [];
+  if (knowledgeDirty) tasks.push(deps.reloadKnowledge());
+  // `condash.json` can remap `resources_path` / `skills_path`; the
+  // watcher already rebuilds its watch set on a `config` event, but
+  // the in-memory trees still point at the old roots until reloaded.
+  if (resourcesDirty || configDirty) tasks.push(deps.reloadResources());
+  if (skillsDirty || configDirty) tasks.push(deps.reloadSkills());
+  if (configDirty) {
+    tasks.push(deps.reloadConfig());
+    // Repos can be added / removed only via a config edit — repo-events
+    // handles everything else.
     deps.refetchRepos();
   }
+  if (tasks.length) await Promise.all(tasks);
 }
-
-// `Resource` is re-exported here only so callers don't need a second import
-// when they already type their resources from this module.
-export type { Resource };

--- a/src/renderer/tree-store.ts
+++ b/src/renderer/tree-store.ts
@@ -1,0 +1,108 @@
+import { createEffect, createSignal } from 'solid-js';
+import type { Accessor } from 'solid-js';
+import { createStore, reconcile } from 'solid-js/store';
+
+/**
+ * Generic in-place store for the three tree panes (Knowledge, Resources,
+ * Skills). Each pane reads its root through a Solid store whose contents
+ * are reconciled by a stable identity key (`relPath` for every supported
+ * node type), so refresh reuses prior node objects when their `relPath`
+ * matches. That keeps `<For>` row identity stable across refetches and
+ * any DOM nodes / popovers anchored on them survive the swap — same shape
+ * `repos-store.ts` already uses for the Code pane.
+ *
+ * Returning a tree rather than a list means `reconcile` walks every level
+ * and matches children by the same key. SolidJS reconcile docs: when the
+ * same key string is provided, nested arrays are diffed by that key
+ * throughout — so the directory-tree shape Just Works as long as every
+ * node carries the identity field.
+ */
+export interface TreeStore<T> {
+  /** Reactive accessor returning the current tree root, or null when the
+   *  pane has no data (no conception selected, or the on-disk root is
+   *  missing). */
+  root: Accessor<T | null>;
+  /** True once the first fetcher call has resolved for the active
+   *  conception. Stays true across subsequent refreshes — flips back to
+   *  false only when the conception path goes null. Lets panes
+   *  distinguish "still loading first paint" from "loaded, genuinely
+   *  empty / absent". */
+  loaded: Accessor<boolean>;
+  /** Re-fetch the tree from disk and reconcile into the store. The
+   *  conception-path effect already calls this on conception switch; the
+   *  tree-events handler calls it on chokidar events for this pane's
+   *  kind, and View → Refresh fans it out alongside the other reloaders. */
+  reload: () => Promise<void>;
+}
+
+export interface TreeStoreDeps<T> {
+  /** Read-only accessor for the active conception path. The store clears
+   *  whenever this goes null and re-fetches whenever it changes. */
+  conceptionPath: Accessor<string | null>;
+  /** IPC fetcher returning the tree root for the active conception
+   *  (`window.condash.readKnowledgeTree`, `readResourcesTree`,
+   *  `readSkillsTree`). Returns `null` when the on-disk root is missing
+   *  — surfaced as `root() === null` so the pane can show its empty
+   *  state without flickering the rest of the UI. */
+  fetcher: () => Promise<T | null>;
+  /** Identity field reconcile uses at every level of the tree. Must be
+   *  a property name shared by every node type in the tree (`relPath`
+   *  for KnowledgeNode / ResourceNode / SkillNode). */
+  key: keyof T & string;
+}
+
+export function createTreeStore<T extends object>(deps: TreeStoreDeps<T>): TreeStore<T> {
+  // Box the nullable tree inside a store so the consumer reads
+  // `box.value` (a reactive store path) instead of a top-level signal.
+  // Solid stores require an object target; wrapping is the conventional
+  // way to make the value itself nullable.
+  const [box, setBox] = createStore<{ value: T | null }>({ value: null });
+  const [loaded, setLoaded] = createSignal(false);
+
+  const applySnapshot = (next: T | null): void => {
+    if (next === null) {
+      // Drop the prior tree wholesale. Reconcile against null is not
+      // well-defined when the store had a value — direct assignment
+      // releases the old references cleanly.
+      setBox('value', null);
+      return;
+    }
+    if (box.value === null) {
+      // First non-null snapshot — nothing to reconcile against.
+      setBox('value', next);
+      return;
+    }
+    setBox('value', reconcile(next, { key: deps.key }));
+  };
+
+  const reload = async (): Promise<void> => {
+    if (!deps.conceptionPath()) {
+      applySnapshot(null);
+      setLoaded(false);
+      return;
+    }
+    const next = await deps.fetcher();
+    applySnapshot(next);
+    setLoaded(true);
+  };
+
+  // Clear on conception-path drop; reload on every non-null path. The
+  // store is therefore eagerly populated for the active conception even
+  // while the matching pane is hidden — pane switches are paint-only
+  // and don't pay an extra IPC round-trip.
+  createEffect(() => {
+    const path = deps.conceptionPath();
+    if (!path) {
+      applySnapshot(null);
+      setLoaded(false);
+      return;
+    }
+    void reload();
+  });
+
+  return {
+    root: () => box.value,
+    loaded,
+    reload,
+  };
+}


### PR DESCRIPTION
## Summary

- Watcher events were swapping each pane through a `Loading…` Suspense fallback every refresh — cards visibly disappeared for a frame on every save / config edit.
- Move Projects, Knowledge, Resources, Skills off `createResource(refreshKey)` onto Solid stores fed by an explicit `reload()` that applies `reconcile()` keyed on a stable identity field; drop the five Suspense wrappers.
- Split the single `refreshKey()` signal into per-channel reload callbacks so a knowledge edit no longer refetches projects, and a config edit no longer refetches knowledge.

## Changes

- `src/renderer/tree-store.ts` — new generic factory for the three tree panes (Knowledge / Resources / Skills). Stores the tree root in a boxed Solid store; `reload()` applies `reconcile({ key: "relPath" })` so nested nodes keep reference identity across refresh.
- `src/renderer/projects-store.ts` — projects list as a Solid store reconciled on `path`. Mirrors `repos-store.ts`. Carries the `mutate` API the watcher uses for per-project patches plus an explicit `reload()`.
- `src/renderer/tree-events.ts` — `TreeEventsDeps` switched to per-channel callbacks: `reloadKnowledge`, `reloadResources`, `reloadSkills`, `reloadConfig`, `mutateProjects`. Per-event dispatch by `TreeEvent.kind`; an `unknown` event fans out as a backstop.
- `src/renderer/main.tsx` — wire the new stores; drop the `refreshKey` signal entirely; remove the five `<Suspense fallback="Loading…">` wrappers (Projects / Knowledge / Resources / Skills / Code); convert `openWithSlots` + `terminalPrefs` from resources to plain signals driven by an explicit `reloadConfig()` so they refetch only on config events.
- `src/renderer/menu-commands.ts` — `bumpRefreshKey` dependency removed; Open Recent relies on the conception-path cascade through each store's `createEffect`.

## Impact

- Cards keep DOM identity across watcher ticks. Open popovers (Step menu, drag-drop status dropdown), inline hover anchors, and the running-indicator card animations now survive refresh instead of being torn down and rebuilt.
- IPC traffic per event drops: a knowledge save no longer triggers `listProjects` / `listOpenWith` / `termGetPrefs`. A `project` event patches one Project via `mutateProjects` and nothing else.
- Pane-switch latency unchanged — the stores were already populated for the active conception; the prior Suspense wrappers only flashed on refetch.
- F5 / View → Refresh and the post-init reload still fan out across every store; behaviour is equivalent.

## Watchpoints

- `reconcile({ key: "relPath" })` walks every nested array — the three tree types all share that field today, but any future divergence (a tree node type without `relPath`) would silently lose row identity.
- The welcome screen now gates on the new `projectsLoaded()` accessor instead of `projects.loading`. Logic is equivalent (suppress on first paint) but worth a glance on cold start.