### PR TITLE
Run Playwright suite on every PR (under xvfb)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,6 +1,6 @@
 name: pr
 
-# PR-level CI. Two jobs:
+# PR-level CI. Three jobs:
 #
 #   1. quick-checks (ubuntu) — typecheck + renderer/main build. Catches
 #      TypeScript regressions and trivial bundler breakage in ~1-2 min.
@@ -10,6 +10,15 @@ name: pr
 #      the .deb/.AppImage (Linux). Skips the AppImage AppRun repack
 #      step that release.yml does; that's purely a runtime-launch
 #      concern, not a build-time concern, so PR CI doesn't need it.
+#
+#   3. playwright (ubuntu) — runs the full Electron Playwright suite
+#      (15 specs, 27 tests) under xvfb. This is the behaviour-level
+#      regression gate: rendered DOM, IPC round-trips, terminal sessions,
+#      help-doc loads. Ubuntu-only because (a) the suite is OS-agnostic
+#      at the assertion level and (b) the xvfb display recipe doesn't
+#      cleanly port to windows-latest. Help-loader's `help-loader.spec.ts`
+#      rotted out of sync with `docs/help/*.md` pre-v2.18.27 because no
+#      pipeline ran it on PRs; this job closes that gap.
 #
 # The installer-smoke Windows job is the load-bearing one: NSIS warning
 # 6010 (unreferenced Function) is treated as an error by electron-builder
@@ -83,3 +92,51 @@ jobs:
 
       - name: Build installers
         run: npx electron-builder --publish never
+
+  playwright:
+    name: Playwright suite
+    runs-on: ubuntu-latest
+    # The suite takes ~1-2 min locally; CI runners are slower and need
+    # generous headroom for the screenshots spec (~20 s) and Electron's
+    # first cold start.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install xvfb
+        # Electron Playwright needs a display server on Linux. xvfb-run -a
+        # wraps the suite so each invocation gets an isolated virtual
+        # display.
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        # `@playwright/test` ships the Electron driver, but the
+        # `_electron` API still relies on Playwright's bundled bits being
+        # downloaded. `--with-deps` covers any extra system libs.
+        run: npx playwright install --with-deps chromium
+
+      - name: Build renderer + main
+        run: npm run build
+
+      - name: Run Playwright suite
+        run: xvfb-run -a npm test -- --reporter=list
+
+      - name: Upload Playwright artefacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-artefacts
+          path: |
+            test-results/
+            tests/screenshots-out/
+          if-no-files-found: ignore

--- a/tests/dirty-badge.spec.ts
+++ b/tests/dirty-badge.spec.ts
@@ -31,7 +31,10 @@ test('getDirtyDetails returns parsed file list + numstat for a dirty worktree', 
     await writeFile(join(repoDir, 'README.md'), '# initial\nplus a new line\n', 'utf8');
     await writeFile(join(repoDir, 'note.txt'), 'fresh\n', 'utf8');
 
-    const booted = await bootApp();
+    // requirePathUnderWorkspace gates getDirtyDetails: the repoDir lives
+    // under tmpdir(), so declare that as workspace_path in the booted
+    // conception so the bounds check accepts it.
+    const booted = await bootApp({ extraConfig: { workspace_path: tmpdir() } });
     try {
       const details = await booted.window.evaluate(
         (path) => window.condash.getDirtyDetails(path),
@@ -77,7 +80,10 @@ test('getDirtyDetails returns an empty list for a clean worktree', async () => {
   try {
     await seedRepo(repoDir);
 
-    const booted = await bootApp();
+    // requirePathUnderWorkspace gates getDirtyDetails: the repoDir lives
+    // under tmpdir(), so declare that as workspace_path in the booted
+    // conception so the bounds check accepts it.
+    const booted = await bootApp({ extraConfig: { workspace_path: tmpdir() } });
     try {
       const details = await booted.window.evaluate(
         (path) => window.condash.getDirtyDetails(path),

--- a/tests/resources-skills.spec.ts
+++ b/tests/resources-skills.spec.ts
@@ -113,10 +113,25 @@ test('Skills pane: SKILL.md badge + shipped chip + diverged warning', async () =
     await skillsHandle.click();
 
     await expect(window.locator('.skills-pane')).toBeVisible();
-    // SKILL.md surfaces as the [SKILL] section badge with the "shipped" tag.
-    const skillBadge = window.locator('.skills-section-index').first();
+    // Expand the `projects/` sub-directory so its SKILL.md surfaces. The
+    // skills-pane uppercases directory names for display (`PROJECTS`), so
+    // the locator is case-insensitive. Directories start collapsed when
+    // there is no persisted expansion state — a fresh per-test conception
+    // never has one.
+    const projectsHeader = window
+      .locator('.tree-dir-header')
+      .filter({ has: window.locator('.tree-dir-name', { hasText: /^projects$/i }) });
+    await expect(projectsHeader).toBeVisible();
+    if ((await projectsHeader.getAttribute('data-open')) !== 'true') {
+      await projectsHeader.click();
+    }
+    // SKILL.md surfaces as a tree-special-file button (the [SKILL] badge
+    // sits inside it). When the SHA matches the manifest, the button
+    // carries a `shipped` class but not `diverged`.
+    const skillBadge = window.locator('.skill-special-file').first();
     await expect(skillBadge).toBeVisible();
-    await expect(skillBadge).toHaveClass(/shipped/);
+    await expect(skillBadge).toHaveClass(/\bshipped\b/);
+    await expect(skillBadge).not.toHaveClass(/diverged/);
     // The body file's SHA mismatches → diverged chip on its card.
     const createCard = window.locator('.skills-card', { hasText: 'Create' });
     await expect(createCard).toBeVisible();


### PR DESCRIPTION
## Summary

- Adds the third PR-CI job: a Playwright run on every pull request. Together with the existing `quick-checks` and `installer-smoke` (ubuntu + windows) jobs, PRs now get behaviour-level regression coverage instead of just build-time.
- Closes the gap that let `help-loader.spec.ts` rot out of sync with `docs/help/*.md` pre-v2.18.27 — no pipeline was running it on PRs.

## Changes

- `.github/workflows/pr.yml`: new `playwright` job on `ubuntu-latest` with a 15-minute timeout. Installs `xvfb`, downloads Playwright's bundled browsers (`--with-deps chromium`), builds renderer + main, then `xvfb-run -a npm test -- --reporter=list`. Uploads `test-results/` and `tests/screenshots-out/` on failure.
- `tests/dirty-badge.spec.ts` (× 2 tests): pass `extraConfig: { workspace_path: tmpdir() }` so the path-bounds check (`requirePathUnderWorkspace`) accepts the test `repoDir`. This check was added defensively and was rejecting the test's tmpdir repo with `path is outside the workspace`.
- `tests/resources-skills.spec.ts` (Skills pane test): the UI was refactored to render SKILL.md as a `.skill-special-file` button inside a collapsible `projects/` directory. Test now expands the directory and asserts on the new selector + class.

## Impact

- PRs feel a bit slower — the Playwright job is ~3-5 min on cold CI runners. Failures upload screenshots + traces to the run page for triage.
- The `screenshots` test alone is ~20 s — it's the slowest path in the suite, but it's the load-bearing one for catching renderer regressions before they ship.
- Windows + macOS continue to skip the Playwright job; Linux + xvfb is the canonical assertion runner.

## Watchpoints

- First few PRs may hit flaky Electron-startup timeouts on cold runners — the suite is `workers: 1` with a 30 s test timeout (10 s expect). If that's too tight for CI, the next escalation is bumping `expect.timeout` to 20 s in `playwright.config.ts`. Don't bump the global `timeout` (it hides real slowdowns).
- The `@playwright/test` driver and Electron version are pinned in `package.json`; an Electron major-version bump should re-run this suite locally before merging the bump.