### PR TITLE
Pin tab titles for launcher and code-card sessions

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -33,7 +33,13 @@ Each side header carries three buttons:
 - **Launcher `+`** (if `terminal.launcher_command` is set) — spawn a new tab whose child process is the launcher command instead of the shell. Default is `claude`, so this slot opens a Claude Code session. Set `launcher_command = ""` to hide the button.
 - **Tab strip** — click to focus the tab; middle-click to close. Clicking inside the xterm itself also promotes the tab to active (the click+focus listener was wired so a stray click never silently sends keys to a different tab than the one you're looking at).
 
-Each tab is labelled with its child's argv[0] (e.g. `bash 1`, `claude 2`). Once the shell emits an OSC 7 cwd hint, the label switches to the cwd basename (`condash`, `notes`, …); a manual rename overrides. The full path always shows in the title attribute. Tabs **auto-close on process exit** — the previous "[process exited N]" stale-tab behaviour is gone. If you want the buffer before close lands, use the toolbar's **Save buffer** button (powered by xterm's serialize addon).
+Tab titles depend on how the tab was spawned:
+
+- **`+` plain shell** — labelled `shell`; once the shell emits an OSC 7 cwd hint, the label switches to the cwd basename (`condash`, `notes`, …) and follows subsequent `cd`s.
+- **Launcher `+`** — labelled with the launcher command (e.g. `claude`, `lambda`). The label is **pinned**: OSC 7 cwd updates do *not* override it.
+- **Code-card "open in term"** — labelled `<repo> · <branch>` (e.g. `condash · my-feature`). Also pinned, so the branch stays visible even after the shell `cd`s inside the worktree.
+
+A manual double-click rename always wins. The full path shows in the title attribute. Tabs **auto-close on process exit** — the previous "[process exited N]" stale-tab behaviour is gone. If you want the buffer before close lands, use the toolbar's **Save buffer** button (powered by xterm's serialize addon).
 
 `TERM=xterm-256color`, and the shell is launched with `-l` so your login rc-files run.
 
@@ -54,7 +60,7 @@ URLs in the buffer are clickable thanks to the web-links addon — clicking open
 Drop-in snippets for bash, zsh, and fish make the terminal render **semantic prompts** — a coloured gutter mark next to each prompt boundary (green = exit 0, red = non-zero) and `Ctrl+Up` / `Ctrl+Down` to jump between them. They emit two standard OSC sequences:
 
 - **OSC 133** — prompt-boundary protocol (`A` prompt-start, `B` prompt-end, `C` command-start, `D;<exit>` command-end with exit code). Same protocol used by iTerm2, WezTerm, kitty, and Warp.
-- **OSC 7** — current working directory (`file://host/path`). Drives the cwd-basename tab label.
+- **OSC 7** — current working directory (`file://host/path`). Drives the cwd-basename tab label for the plain `+` shell tabs (pinned tabs ignore OSC 7).
 
 ### Where the snippets live
 

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -67,12 +67,16 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     try {
       // No `repo`/`command` → spawns the user's default shell at the worktree
       // path inside the existing terminal pane (no popup window).
+      // `pinned`: keep the `<repo> · <branch>` label as the tab title even
+      // after the shell emits OSC 7 (which would otherwise replace it with
+      // the worktree basename and hide the branch).
       await handle.spawn(
         {
           side: 'my',
           cwd: worktree.path,
         },
         label,
+        { pinned: true },
       );
     } catch (err) {
       deps.flashToast(`Open in term failed: ${(err as Error).message}`, 'error');

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -40,8 +40,14 @@ import './terminal-pane.css';
 
 export type { Column, Tab } from './terminal-pane/types';
 
+export interface SpawnOptions {
+  /** Lock the tab title to `label` so OSC 7 cwd updates from the shell
+   *  don't override it. Default false (current "+" new-shell behavior). */
+  pinned?: boolean;
+}
+
 export interface TerminalPaneHandle {
-  spawn(request: TermSpawnRequest, label: string): Promise<string>;
+  spawn(request: TermSpawnRequest, label: string, opts?: SpawnOptions): Promise<string>;
   switchTo(side: TermSide, id?: string): void;
   /** Add a fresh user shell tab to "My terms". */
   spawnUserShell(launcherCommand?: string | null, side?: TermSide): Promise<string>;
@@ -257,10 +263,11 @@ export function TerminalPane(props: {
         column,
         label,
         customName: meta?.customName,
+        pinned: meta?.pinned,
         exited: s.exited,
       };
       setTabs((prev) => [...prev, tab]);
-      setMeta(s.id, { label, customName: meta?.customName, column });
+      setMeta(s.id, { label, customName: meta?.customName, column, pinned: meta?.pinned });
       const attach = await window.condash.termAttach(s.id);
       mountForSession(s.id, column, attach?.output);
       setActiveIn(column, s.id);
@@ -318,9 +325,20 @@ export function TerminalPane(props: {
     return base;
   };
 
-  const spawn = async (request: TermSpawnRequest, label: string): Promise<string> => {
+  const spawn = async (
+    request: TermSpawnRequest,
+    label: string,
+    opts?: SpawnOptions,
+  ): Promise<string> => {
     const { id } = await window.condash.termSpawn(request);
-    setMeta(id, { label, column: nextSpawnColumn });
+    const pinned = opts?.pinned;
+    setMeta(id, { label, column: nextSpawnColumn, pinned });
+    // `broadcastSessions()` in main fires before the `termSpawn` invoke
+    // reply resolves here, so reconcile typically inserts the Tab with the
+    // fallback label ('shell' / '<repo> (run)') and no `pinned` flag —
+    // readMeta returns nothing because we hadn't written yet. Patch the
+    // Tab with the caller's intent now that we know the id.
+    setTabs((prev) => prev.map((t) => (t.id === id ? { ...t, label, pinned } : t)));
     return id;
   };
 
@@ -328,15 +346,21 @@ export function TerminalPane(props: {
     launcherCommand?: string | null,
     sd: TermSide = 'my',
   ): Promise<string> => {
-    const base = launcherCommand?.trim() || 'shell';
+    const trimmed = launcherCommand?.trim() || '';
+    const base = trimmed || 'shell';
     const label = uniqueLabel(base);
+    // Pin the label only when the caller passed a real launcher command
+    // (the lambda button). The bare `+` button leaves it unpinned so the
+    // shell's OSC 7 cwd basename drives the displayed title.
+    const pinned = trimmed.length > 0;
     return spawn(
       {
         side: sd,
-        command: launcherCommand?.trim() || undefined,
+        command: trimmed || undefined,
         cwd: props.cwd ?? undefined,
       },
       label,
+      { pinned },
     );
   };
 
@@ -380,6 +404,7 @@ export function TerminalPane(props: {
         label: tab.label,
         customName: trimmed || undefined,
         column: tab.column,
+        pinned: tab.pinned,
       });
     }
     setRenamingId(null);

--- a/src/renderer/terminal-pane/persistence.ts
+++ b/src/renderer/terminal-pane/persistence.ts
@@ -9,6 +9,11 @@ export interface PersistedTabMeta {
   label: string;
   customName?: string;
   column: Column;
+  /** When true, `displayName` ignores OSC 7 cwd updates and keeps `label`
+   *  (unless `customName` is set). Pinned at spawn time by launchers that
+   *  supply a deliberate title — lambda button, code-card "open in term".
+   *  The "+" new-shell path leaves this falsy so cwd basename wins. */
+  pinned?: boolean;
 }
 
 export interface PersistedLayout {

--- a/src/renderer/terminal-pane/types.test.ts
+++ b/src/renderer/terminal-pane/types.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { displayName, type Tab } from './types';
+
+function tab(overrides: Partial<Tab>): Tab {
+  return {
+    id: 'id',
+    side: 'my',
+    column: 'left',
+    label: 'shell',
+    ...overrides,
+  } satisfies Tab;
+}
+
+describe('displayName', () => {
+  it('falls back to the spawn-time label when no cwd / customName is set', () => {
+    expect(displayName(tab({ label: 'shell' }))).toBe('shell');
+  });
+
+  it('uses the cwd basename when the shell emitted OSC 7', () => {
+    expect(displayName(tab({ label: 'shell', cwd: '/home/alice/src/vcoeur/condash' }))).toBe(
+      'condash',
+    );
+  });
+
+  it('customName always wins, even over cwd', () => {
+    expect(displayName(tab({ label: 'shell', customName: 'my-term', cwd: '/tmp/foo' }))).toBe(
+      'my-term',
+    );
+  });
+
+  describe('pinned', () => {
+    it('keeps the spawn-time label when the shell emits OSC 7', () => {
+      expect(
+        displayName(
+          tab({
+            label: 'condash · my-feature',
+            pinned: true,
+            cwd: '/home/alice/src/worktrees/my-feature/condash',
+          }),
+        ),
+      ).toBe('condash · my-feature');
+    });
+
+    it('still defers to customName when the user renamed', () => {
+      expect(
+        displayName(
+          tab({ label: 'lambda', pinned: true, customName: 'session 7', cwd: '/tmp/foo' }),
+        ),
+      ).toBe('session 7');
+    });
+  });
+});

--- a/src/renderer/terminal-pane/types.ts
+++ b/src/renderer/terminal-pane/types.ts
@@ -20,17 +20,23 @@ export interface Tab {
   /** User-renamed label, if any. Persisted by id in localStorage. */
   customName?: string;
   /** Most recent cwd reported via OSC 7 (`file://host/path`). Used for the
-   *  display label when the user hasn't supplied a custom name. */
+   *  display label when the user hasn't supplied a custom name and the tab
+   *  isn't `pinned`. */
   cwd?: string;
+  /** When true, OSC 7 cwd is ignored for display — `label` stays the title
+   *  until the user manually renames. Set at spawn time for sources that
+   *  carry a deliberate title (lambda launcher, code-card "open in term"). */
+  pinned?: boolean;
   /** Process exit code; the tab can still be cleared via close. */
   exited?: number;
 }
 
 /** Display name for a tab. Custom rename wins; otherwise the cwd basename if
- *  the shell emitted OSC 7; otherwise the spawn-time label. */
+ *  the shell emitted OSC 7 (and the tab isn't pinned); otherwise the
+ *  spawn-time label. */
 export function displayName(tab: Tab): string {
   if (tab.customName) return tab.customName;
-  if (tab.cwd) {
+  if (!tab.pinned && tab.cwd) {
     const basename = tab.cwd.split('/').filter(Boolean).pop();
     if (basename) return basename;
   }

--- a/tests/fixtures/electron-app.ts
+++ b/tests/fixtures/electron-app.ts
@@ -16,8 +16,20 @@ export interface BootedApp {
 /**
  * Build a tiny conception fixture (one project, one knowledge note) and launch
  * the production Electron build pointed at it.
+ *
+ * Pass `prepare` to drop extra files into the conception *before* Electron
+ * launches — anything that should be visible on the initial tree read
+ * (skills, resources, etc.) belongs there. Files written after `bootApp`
+ * returns rely on the chokidar watcher to fire `tree-events`, which is racy
+ * under CI's xvfb (the watcher can miss events for files created inside a
+ * freshly-mkdir'd directory before its inotify hook attaches).
  */
-export async function bootApp(options: { extraConfig?: Record<string, unknown> } = {}): Promise<BootedApp> {
+export async function bootApp(
+  options: {
+    extraConfig?: Record<string, unknown>;
+    prepare?: (conceptionDir: string) => Promise<void>;
+  } = {},
+): Promise<BootedApp> {
   const conceptionDir = await mkdtemp(join(tmpdir(), 'condash-test-conception-'));
   const userDataDir = await mkdtemp(join(tmpdir(), 'condash-test-userdata-'));
 
@@ -53,6 +65,12 @@ export async function bootApp(options: { extraConfig?: Record<string, unknown> }
     ) + '\n',
     'utf8',
   );
+
+  // Caller-provided fixture writes — go in before launch so the initial tree
+  // read sees them without depending on the chokidar watcher.
+  if (options.prepare) {
+    await options.prepare(conceptionDir);
+  }
 
   const app = await electron.launch({
     args: ['.', '--no-sandbox'],

--- a/tests/resources-skills.spec.ts
+++ b/tests/resources-skills.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { createHash } from 'node:crypto';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { bootApp } from './fixtures/electron-app';
@@ -68,50 +69,50 @@ test('Resources pane: handle, render, copy path, view markdown', async () => {
 });
 
 test('Skills pane: SKILL.md badge + shipped chip + diverged warning', async () => {
-  const booted = await bootApp();
-  const { window, conceptionDir, cleanup } = booted;
-  try {
-    const skillsRoot = join(conceptionDir, '.claude', 'skills');
-    await mkdir(join(skillsRoot, 'projects'), { recursive: true });
-    const skillBody = '# Projects skill\n\nLead paragraph.\n';
+  const skillBody = '# Projects skill\n\nLead paragraph.\n';
+  // Compute the SHA without a renderer (matches Node's crypto). The fixture
+  // is dropped onto disk before Electron launches, so we can't go via
+  // `window.evaluate` for the hash — and we don't need to: SHA-256 is the
+  // same algorithm everywhere.
+  const skillSha = createHash('sha256').update(skillBody, 'utf8').digest('hex');
 
-    // Pre-compute the SHA so SKILL.md is "clean shipped" and create.md is
-    // "diverged shipped" — then we can assert both badge variants in one go.
-    const skillSha = await window.evaluate(async (text: string) => {
-      const enc = new TextEncoder();
-      const buf = await crypto.subtle.digest('SHA-256', enc.encode(text));
-      return Array.from(new Uint8Array(buf))
-        .map((b) => b.toString(16).padStart(2, '0'))
-        .join('');
-    }, skillBody);
-
-    // Manifest first, then the `.md` files. The watcher classifies only
-    // `.md` paths (and unlinks) under the skills root as `skills` events,
-    // so the manifest write itself never triggers a refetch. Writing it
-    // first means the skills-tree reload driven by the SKILL.md / create.md
-    // `add` events finds the manifest already on disk.
-    await writeFile(
-      join(skillsRoot, '.condash-skills.json'),
-      JSON.stringify({
-        version: 1,
-        skills: {
-          projects: {
-            files: {
-              'SKILL.md': { sha256: skillSha, shippedVersion: '2.10.15' },
-              'create.md': { sha256: 'deadbeef', shippedVersion: '2.10.15' },
+  const booted = await bootApp({
+    // Skill files go in before launch so the initial `readSkillsTree` picks
+    // them up. Relying on the chokidar watcher to fire `add` events for
+    // files created inside a freshly-mkdir'd directory was flaky under
+    // CI's xvfb — events for the inner SKILL.md were occasionally
+    // dropped when the inotify hook hadn't attached to the new dir yet.
+    prepare: async (conceptionDir) => {
+      const skillsRoot = join(conceptionDir, '.claude', 'skills');
+      await mkdir(join(skillsRoot, 'projects'), { recursive: true });
+      // Manifest first, then the `.md` files. The watcher classifies only
+      // `.md` paths (and unlinks) under the skills root as `skills` events,
+      // so the manifest write itself never triggers a refetch.
+      await writeFile(
+        join(skillsRoot, '.condash-skills.json'),
+        JSON.stringify({
+          version: 1,
+          skills: {
+            projects: {
+              files: {
+                'SKILL.md': { sha256: skillSha, shippedVersion: '2.10.15' },
+                'create.md': { sha256: 'deadbeef', shippedVersion: '2.10.15' },
+              },
             },
           },
-        },
-      }),
-      'utf8',
-    );
-    await writeFile(join(skillsRoot, 'projects', 'SKILL.md'), skillBody, 'utf8');
-    await writeFile(
-      join(skillsRoot, 'projects', 'create.md'),
-      '# Create\n\nCreate body.\n',
-      'utf8',
-    );
-
+        }),
+        'utf8',
+      );
+      await writeFile(join(skillsRoot, 'projects', 'SKILL.md'), skillBody, 'utf8');
+      await writeFile(
+        join(skillsRoot, 'projects', 'create.md'),
+        '# Create\n\nCreate body.\n',
+        'utf8',
+      );
+    },
+  });
+  const { window, cleanup } = booted;
+  try {
     const skillsHandle = window
       .locator('.edge-strip-right .edge-handle')
       .filter({ hasText: 'Skills' });

--- a/tests/terminal-tab-titles.spec.ts
+++ b/tests/terminal-tab-titles.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { bootApp } from './fixtures/electron-app';
+
+test('terminal pane: + spawns an unpinned shell, λ spawns a pinned launcher tab', async ({}, testInfo) => {
+  testInfo.setTimeout(60_000);
+  // Use `cat` as the launcher command: it's on every PATH and blocks on stdin,
+  // so the pty stays alive for the full test (otherwise the renderer's
+  // auto-close-on-exit drops the tab before we can read its label). Per the
+  // wired-in semantics, the tab label is the launcher command's trimmed
+  // first token — so we expect the label "cat".
+  const booted = await bootApp({
+    extraConfig: {
+      terminal: { launcher_command: 'cat' },
+    },
+  });
+  try {
+    const win = booted.window;
+
+    // Sanity probe: the renderer must see the launcher_command from condash.json.
+    const prefs = await win.evaluate(() => window.condash.termGetPrefs());
+    expect(prefs.launcher_command).toBe('cat');
+
+    // The terminal pane is mounted but starts collapsed; the column header
+    // (with the +/λ buttons) is rendered regardless of `open`. Click each
+    // button and assert the resulting tab label.
+
+    // First +: plain shell. We expect the label to be `shell` initially.
+    // OSC 7 will eventually arrive from the started shell and rewrite it to
+    // the cwd basename — that's the legacy behavior we deliberately keep.
+    const plusButton = win.locator('button.terminal-tab-add[title^="New shell tab"]').first();
+    await plusButton.click();
+    const tabs = win.locator('.terminal-tab-label');
+    await expect(tabs).toHaveCount(1);
+
+    // Launcher λ: must show literal "cat" (the launcher_command), and the
+    // pin must keep that label even after OSC 7 would otherwise have
+    // rewritten it.
+    const lambdaButton = win.locator('button.terminal-tab-add.launcher');
+    await expect(lambdaButton).toBeVisible();
+    await lambdaButton.click();
+    await expect(tabs).toHaveCount(2);
+    await expect(tabs.nth(1)).toHaveText('cat');
+
+    // Wait through any OSC 7 the shell might emit (`cat` itself won't, but
+    // the wrapper bash -lc could PROMPT_COMMAND on some configs).
+    await win.waitForTimeout(500);
+    await expect(tabs.nth(1)).toHaveText('cat');
+
+    // Clean up: ask main to kill both sessions so the test exits cleanly.
+    await win.evaluate(async () => {
+      const list = await window.condash.termList();
+      await Promise.all(list.map((s) => window.condash.termClose(s.id)));
+    });
+  } finally {
+    await booted.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- The launcher (λ) and Code-card "open in terminal" buttons construct deliberate spawn-time labels — the launcher command, or `<repo> · <branch>` — but the shell's OSC 7 cwd basename was overwriting both, losing the launcher name and the branch suffix.
- Pin those two sources so OSC 7 never wins. The plain `+` button stays unpinned and keeps tracking the shell's cwd as before.
- Surfaced a pre-existing race in the spawn flow: `broadcastSessions()` in main fires before the `termSpawn` invoke reply, so `reconcile()` ran before `spawn()` wrote the meta. Patched in `spawn()` after the await.

## Changes

- `src/renderer/terminal-pane/types.ts`: new `Tab.pinned` field; `displayName()` skips the OSC 7 cwd branch when set.
- `src/renderer/terminal-pane/persistence.ts`: `PersistedTabMeta.pinned` added so the pin survives reload.
- `src/renderer/terminal-pane.tsx`: `spawn(request, label, { pinned })` signature; `spawnUserShell` pins iff a launcher command is supplied; `reconcile` and `commitRename` propagate `pinned`. `spawn()` patches the Tab in `tabs()` after the invoke reply lands.
- `src/renderer/terminal-bridge.ts`: code-card "open in term" spawns with `{ pinned: true }`.
- `src/renderer/terminal-pane/types.test.ts`: new vitest covering `displayName()` precedence under the new flag.
- `tests/terminal-tab-titles.spec.ts`: new Playwright spec driving the `+` and λ buttons end-to-end.
- `docs/guides/terminal.md`: tab-title section rewritten to describe the three sources.

## Impact

- Persisted meta gains an optional field; old localStorage entries deserialise as `pinned: undefined` → unchanged behavior. No migration needed.