### PR TITLE
Group repositories under named sections in Settings + Code pane

### DIFF
--- a/docs/help/configuration.md
+++ b/docs/help/configuration.md
@@ -41,7 +41,7 @@ always target `condash.json`.
 | `worktrees_path` | Sandbox for the "Open in IDE" buttons. |
 | `resources_path` | Folder backing the Resources pane. Default `resources`. |
 | `skills_path` | Folder backing the Skills pane. Default `.claude/skills`. |
-| `repositories` | Flat ordered list of repos to surface on the Code pane. Each entry is a string or an object with `name`, optional `submodules`, `run`, `force_stop`, `label`. |
+| `repositories` | Ordered list of repos to surface on the Code pane. Each entry is a string, a `{name, …}` object (optional `submodules`, `run`, `force_stop`, `label`, `install`, `env`, `pinned_branch`), or a `{"section": "<heading>"}` marker that groups every following repo under a header — see [Reference → Configuration → `repositories`](../reference/config.md#repositories) for the full table. |
 | `open_with` | Three launcher slots (`main_ide`, `secondary_ide`, `terminal`). `{path}` is replaced with the absolute target path. |
 
 A repo entry's `run` wires up an inline dev-server runner; `force_stop`

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -82,10 +82,12 @@ A single ordered array of repo entries — the Code pane renders cards in the or
 ```json
 {
   "repositories": [
+    { "section": "Sites" },
+    { "name": "alicepeintures.com", "run": "make dev" },
+    { "name": "notes.vcoeur.com", "run": "make dev", "force_stop": "fuser -k 8200/tcp" },
+    { "section": "Tools" },
     "condash",
-    { "name": "helio" },
-    { "name": "helio", "submodules": ["apps/web", "apps/api"] },
-    { "name": "notes.vcoeur.com", "run": "make dev", "force_stop": "fuser -k 8200/tcp" }
+    { "name": "helio", "submodules": ["apps/web", "apps/api"] }
   ]
 }
 ```
@@ -101,6 +103,7 @@ A single ordered array of repo entries — the Code pane renders cards in the or
 | `{"name": "repo", "install": "<cmd>"}`                    | Install command run after `condash-cli worktrees setup` creates a worktree — applied **unconditionally** when present (no flag needed); pass `--no-install` to skip. Typical: `npm install` for a Node repo, `pip install -e .` for a Python one. Same shell trust level as `run`.                                                                                                                                                                                                                            |
 | `{"name": "repo", "env": [".env", ".env.local"]}`         | Files copied from the primary checkout into a new worktree on `condash-cli worktrees setup` — applied **unconditionally** when present (no flag needed). Closes the silent-undefined-`VITE_*` footgun where forgetting `--copy-env` leaves a Vite SPA reading `import.meta.env.VITE_*` as `undefined`. Default empty → no copy. Path traversal is rejected (no `..`, no absolute paths).                                                                                                                       |
 | `{"name": "repo", "pinned_branch": "<branch>"}`           | Pin the repo to a fixed branch. `condash-cli worktrees setup` skips it instead of creating a worktree on the requested branch. Use for shared / vendored repos that should never track the project branch axis.                                                                                                                                                                                                                                                                                                  |
+| `{"section": "<heading>"}`                                | Section marker — not a repo. Every repo that follows in `repositories[]` belongs to this section until the next `{"section"}` entry. The Settings modal renders a header row; the Code pane groups cards under the heading with an in-memory collapse toggle. Repos placed before the first marker live in an implicit default bucket that renders as today's flat list (no header). **Top-level only** — `submodules` cannot contain section markers. Carries no other field. |
 
 Anything under `workspace_path` not named in `repositories` is ignored — only listed entries appear on the Code pane.
 

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -17,7 +17,7 @@ describe('configSchema repoEntry', () => {
     if (result.success) {
       const repo = result.data.repositories?.[0];
       expect(typeof repo).toBe('object');
-      if (repo && typeof repo !== 'string') {
+      if (repo && typeof repo !== 'string' && 'name' in repo) {
         expect(repo.env).toEqual(['.env', '.env.local']);
         expect(repo.install).toBe('npm install');
         expect(repo.pinned_branch).toBe('main');
@@ -49,6 +49,44 @@ describe('configSchema repoEntry', () => {
   it('rejects the legacy primary/secondary bucket shape', () => {
     const result = configSchema.safeParse({
       repositories: { primary: ['legacy-repo'] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a `{ section: "…" }` marker at the top level', () => {
+    const result = configSchema.safeParse({
+      repositories: [
+        { section: 'Sites' },
+        { name: 'alicepeintures.com', run: 'make dev' },
+        { section: 'Tools' },
+        'condash',
+      ],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty section name', () => {
+    const result = configSchema.safeParse({
+      repositories: [{ section: '' }, 'condash'],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a section marker inside `submodules`', () => {
+    const result = configSchema.safeParse({
+      repositories: [
+        {
+          name: 'parent',
+          submodules: [{ section: 'Inner' }, { name: 'child' }],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a section marker carrying any other field', () => {
+    const result = configSchema.safeParse({
+      repositories: [{ section: 'Sites', collapsed: true }],
     });
     expect(result.success).toBe(false);
   });

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -8,30 +8,74 @@ import { z } from 'zod';
  * `settings.json` at read time; the only fields a conception cannot set
  * are `lastConceptionPath` and `recentConceptionPaths`.
  */
-const repoEntry: z.ZodType<RawRepo> = z.lazy(() =>
-  z.union([
-    z.string(),
-    z
-      .object({
-        name: z.string(),
-        label: z.string().min(1).optional(),
-        run: z.string().optional(),
-        force_stop: z.string().optional(),
-        /** Install command run after `condash-cli worktrees setup` creates the
-         *  worktree. Applied unconditionally when set (#87) — pass
-         *  `--no-install` on the CLI to skip. */
-        install: z.string().optional(),
-        /** Pin: keep this repo on a fixed branch; `worktrees setup` skips it. */
-        pinned_branch: z.string().optional(),
-        /** Files to copy from the primary checkout into a new worktree on
-         *  `condash-cli worktrees setup`. Applied unconditionally when present —
-         *  no flag needed. Default empty → no copy. Closes #82. */
-        env: z.array(z.string().min(1)).optional(),
-        submodules: z.array(repoEntry).optional(),
-      })
-      .strict(),
-  ]),
-);
+/**
+ * Submodule entries: same shape as a top-level repo, minus the recursive
+ * `submodules` (no nested submodules) AND minus the section-marker variant
+ * (sections are top-level only — see `topLevelRepoEntry` below).
+ */
+const submoduleRepoEntry: z.ZodType<RawSubmoduleRepo> = z.union([
+  z.string(),
+  z
+    .object({
+      name: z.string(),
+      label: z.string().min(1).optional(),
+      run: z.string().optional(),
+      force_stop: z.string().optional(),
+      install: z.string().optional(),
+      pinned_branch: z.string().optional(),
+      env: z.array(z.string().min(1)).optional(),
+    })
+    .strict(),
+]);
+
+/**
+ * Top-level entries: a name string, a full repo object (with optional
+ * `submodules`), or a section marker that groups everything until the next
+ * marker into a labelled bucket. Section markers carry no behaviour — they
+ * only steer the Settings UI and the Code pane's card grouping. The walker
+ * in `config-walk.ts` strips them out before any consumer sees the list.
+ */
+const topLevelRepoEntry: z.ZodType<RawRepo> = z.union([
+  z.string(),
+  z
+    .object({
+      name: z.string(),
+      label: z.string().min(1).optional(),
+      run: z.string().optional(),
+      force_stop: z.string().optional(),
+      /** Install command run after `condash-cli worktrees setup` creates the
+       *  worktree. Applied unconditionally when set (#87) — pass
+       *  `--no-install` on the CLI to skip. */
+      install: z.string().optional(),
+      /** Pin: keep this repo on a fixed branch; `worktrees setup` skips it. */
+      pinned_branch: z.string().optional(),
+      /** Files to copy from the primary checkout into a new worktree on
+       *  `condash-cli worktrees setup`. Applied unconditionally when present —
+       *  no flag needed. Default empty → no copy. Closes #82. */
+      env: z.array(z.string().min(1)).optional(),
+      submodules: z.array(submoduleRepoEntry).optional(),
+    })
+    .strict(),
+  z
+    .object({
+      /** Non-empty heading text. Renders as a section header in the Settings
+       *  modal and groups Code-pane cards under the same label. */
+      section: z.string().min(1),
+    })
+    .strict(),
+]);
+
+export type RawSubmoduleRepo =
+  | string
+  | {
+      name: string;
+      label?: string;
+      run?: string;
+      force_stop?: string;
+      install?: string;
+      pinned_branch?: string;
+      env?: string[];
+    };
 
 export type RawRepo =
   | string
@@ -43,8 +87,14 @@ export type RawRepo =
       install?: string;
       pinned_branch?: string;
       env?: string[];
-      submodules?: RawRepo[];
-    };
+      submodules?: RawSubmoduleRepo[];
+    }
+  | { section: string };
+
+/** True when `entry` is the section-marker variant of `RawRepo`. */
+export function isSectionMarker(entry: RawRepo): entry is { section: string } {
+  return typeof entry === 'object' && entry !== null && 'section' in entry;
+}
 
 const openWithSlot = z
   .object({
@@ -172,7 +222,7 @@ const sharedSchemaFields = {
   resources_path: conceptionRelativePath.optional(),
   /** Directory browsed by the Skills pane (default `.claude/skills`). */
   skills_path: conceptionRelativePath.optional(),
-  repositories: z.array(repoEntry).optional(),
+  repositories: z.array(topLevelRepoEntry).optional(),
   open_with: z
     .object({
       main_ide: openWithSlot.optional(),

--- a/src/main/config-walk.test.ts
+++ b/src/main/config-walk.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isSectionMarker,
+  walkRepos,
+  type ConfigShape,
+  type RawRepo,
+  type RepoLookup,
+} from './config-walk';
+
+function collect(config: ConfigShape): RepoLookup[] {
+  const out: RepoLookup[] = [];
+  walkRepos(config, (e) => {
+    out.push(e);
+  });
+  return out;
+}
+
+describe('walkRepos sections', () => {
+  it('threads the current section through every emitted entry', () => {
+    const config: ConfigShape = {
+      workspace_path: '/ws',
+      repositories: [
+        { section: 'Sites' },
+        { name: 'alicepeintures.com' },
+        'vcoeur.com',
+        { section: 'Tools' },
+        { name: 'condash', submodules: ['frontend'] },
+      ],
+    };
+    const flat = collect(config);
+    expect(flat.map((e) => e.display)).toEqual([
+      'alicepeintures.com',
+      'vcoeur.com',
+      'condash',
+      'condash/frontend',
+    ]);
+    expect(flat.map((e) => e.section)).toEqual(['Sites', 'Sites', 'Tools', 'Tools']);
+  });
+
+  it('leaves `section` undefined for repos that precede the first marker', () => {
+    const config: ConfigShape = {
+      repositories: ['standalone', { section: 'Later' }, 'grouped'],
+    };
+    const flat = collect(config);
+    expect(flat.map((e) => [e.display, e.section])).toEqual([
+      ['standalone', undefined],
+      ['grouped', 'Later'],
+    ]);
+  });
+
+  it('emits nothing for a config without any repos at all', () => {
+    expect(collect({})).toEqual([]);
+    expect(collect({ repositories: [] })).toEqual([]);
+  });
+
+  it('treats consecutive markers by adopting the latest section', () => {
+    const config: ConfigShape = {
+      repositories: [{ section: 'First' }, { section: 'Second' }, 'only'],
+    };
+    const flat = collect(config);
+    expect(flat).toHaveLength(1);
+    expect(flat[0].section).toBe('Second');
+  });
+});
+
+describe('isSectionMarker', () => {
+  it('discriminates section markers from repo objects and strings', () => {
+    const marker: RawRepo = { section: 'Sites' };
+    const repo: RawRepo = { name: 'condash' };
+    const bare: RawRepo = 'standalone';
+    expect(isSectionMarker(marker)).toBe(true);
+    expect(isSectionMarker(repo)).toBe(false);
+    expect(isSectionMarker(bare)).toBe(false);
+  });
+});

--- a/src/main/config-walk.ts
+++ b/src/main/config-walk.ts
@@ -8,6 +8,15 @@ import { isAbsolute, join } from 'node:path';
  * the main process doesn't re-implement them.
  */
 
+export type RawSubmoduleRepo =
+  | string
+  | {
+      name: string;
+      label?: string;
+      run?: string;
+      force_stop?: string;
+    };
+
 export type RawRepo =
   | string
   | {
@@ -15,12 +24,18 @@ export type RawRepo =
       label?: string;
       run?: string;
       force_stop?: string;
-      submodules?: RawRepo[];
-    };
+      submodules?: RawSubmoduleRepo[];
+    }
+  | { section: string };
 
 export interface ConfigShape {
   workspace_path?: string;
   repositories?: RawRepo[];
+}
+
+/** True when `entry` is a section-marker variant of `RawRepo`. */
+export function isSectionMarker(entry: RawRepo): entry is { section: string } {
+  return typeof entry === 'object' && entry !== null && 'section' in entry;
 }
 
 export interface RepoLookup {
@@ -38,6 +53,11 @@ export interface RepoLookup {
   run?: string;
   /** Configured force_stop: command, if any. */
   forceStop?: string;
+  /** Name of the most-recent `{ section: … }` marker that preceded this
+   *  entry in `repositories[]`, when any. Undefined for entries before the
+   *  first marker — those belong to the implicit default bucket. Submodule
+   *  entries inherit their parent's section. */
+  section?: string;
 }
 
 /** Resolve an entry's absolute cwd from `workspace_path` + optional parent + name. */
@@ -62,15 +82,21 @@ export function resolveCwd(
 export function walkRepos(config: ConfigShape, visit: (entry: RepoLookup) => boolean | void): void {
   const workspace = config.workspace_path;
   if (!config.repositories) return;
+  let currentSection: string | undefined;
   for (const entry of config.repositories) {
-    if (visitOne(entry, undefined, workspace, visit)) return;
+    if (isSectionMarker(entry)) {
+      currentSection = entry.section;
+      continue;
+    }
+    if (visitOne(entry, undefined, workspace, currentSection, visit)) return;
   }
 }
 
 function visitOne(
-  entry: RawRepo,
+  entry: RawRepo | RawSubmoduleRepo,
   parent: string | undefined,
   workspace: string | undefined,
+  section: string | undefined,
   visit: (entry: RepoLookup) => boolean | void,
 ): boolean {
   if (typeof entry === 'string') {
@@ -79,9 +105,13 @@ function visitOne(
       name: entry,
       parent,
       cwd: resolveCwd(workspace, parent, entry),
+      section,
     };
     return visit(lookup) === false;
   }
+  // Section markers are stripped by the caller. By construction this branch
+  // only receives a repo-object variant.
+  if ('section' in entry) return false;
   const lookup: RepoLookup = {
     display: parent ? `${parent}/${entry.name}` : entry.name,
     name: entry.name,
@@ -90,11 +120,12 @@ function visitOne(
     cwd: resolveCwd(workspace, parent, entry.name),
     run: entry.run,
     forceStop: entry.force_stop,
+    section,
   };
   if (visit(lookup) === false) return true;
-  if (entry.submodules?.length) {
+  if ('submodules' in entry && entry.submodules?.length) {
     for (const sub of entry.submodules) {
-      if (visitOne(sub, entry.name, workspace, visit)) return true;
+      if (visitOne(sub, entry.name, workspace, section, visit)) return true;
     }
   }
   return false;

--- a/src/main/repos.ts
+++ b/src/main/repos.ts
@@ -69,6 +69,7 @@ async function buildEntry(
       missing: true,
       hasForceStop,
       hasRun,
+      section: entry.section,
     } satisfies RepoEntry;
   }
   const worktrees = entry.parent
@@ -89,6 +90,7 @@ async function buildEntry(
     hasForceStop,
     hasRun,
     worktrees: worktrees.length > 0 ? worktrees : undefined,
+    section: entry.section,
   } satisfies RepoEntry;
 }
 

--- a/src/main/worktree/shared.ts
+++ b/src/main/worktree/shared.ts
@@ -9,7 +9,7 @@ import { basename, join } from 'node:path';
 import { findProjectReadmes } from '../walk';
 import { readHeader } from '../header-io';
 import { exec } from '../exec';
-import { walkRepos, type ConfigShape } from '../config-walk';
+import { isSectionMarker, walkRepos, type ConfigShape } from '../config-walk';
 import { getEffectiveConceptionConfig } from '../effective-config';
 
 export interface ConfigWithPaths extends ConfigShape {
@@ -44,6 +44,7 @@ export function repoLookupMap(config: ConfigWithPaths): Map<string, RepoLookupEx
   // (those aren't currently in the RepoLookup shape).
   for (const raw of config.repositories ?? []) {
     if (typeof raw === 'string') continue;
+    if (isSectionMarker(raw)) continue;
     const lookup = map.get(raw.name);
     if (!lookup) continue;
     const ext = raw as unknown as RawRepoExtended;

--- a/src/renderer/note-modal-parts/config-summary.tsx
+++ b/src/renderer/note-modal-parts/config-summary.tsx
@@ -12,7 +12,7 @@ const CONFIG_SUMMARY: { key: string; purpose: string }[] = [
   {
     key: 'repositories',
     purpose:
-      'Flat ordered list of repos shown on the Code pane. Each entry: name, optional run / force_stop / submodules.',
+      'Ordered list of repos shown on the Code pane. Each entry: name, optional run / force_stop / submodules. Insert a { "section": "…" } entry to group every repo that follows it under a header.',
   },
   {
     key: 'open_with',

--- a/src/renderer/panes/code-pane.css
+++ b/src/renderer/panes/code-pane.css
@@ -30,6 +30,50 @@
   gap: 12px;
 }
 
+.repos-section {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 14px;
+}
+
+.repos-section:first-child {
+  margin-top: 0;
+}
+
+.repos-section-header {
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 4px 0 4px 2px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.repos-section-header:hover {
+  color: var(--text);
+}
+
+.repos-section-chevron {
+  display: inline-block;
+  width: 1ch;
+  font-weight: 500;
+}
+
+.repos-section-count {
+  font-weight: 400;
+  font-size: 11px;
+  letter-spacing: 0;
+  color: var(--text-muted);
+}
+
 .code-runs-dock {
   flex: 0 0 auto;
   /* Cap the dock so an expanded xterm can't starve the repo list. The

--- a/src/renderer/panes/code-parts/data.test.ts
+++ b/src/renderer/panes/code-parts/data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { RepoEntry, Worktree } from '../../../shared/types';
-import { collectFilterableBranches, filterWorktrees } from './data';
+import { collectFilterableBranches, filterWorktrees, groupRepos, orderedRepos } from './data';
 
 function wt(branch: string | null, primary = false): Worktree {
   return {
@@ -99,5 +99,52 @@ describe('collectFilterableBranches', () => {
       },
     ];
     expect(collectFilterableBranches(repos)).toEqual([]);
+  });
+});
+
+describe('groupRepos', () => {
+  function r(name: string, section?: string, parent?: string): RepoEntry {
+    return {
+      name,
+      path: `/r/${name}`,
+      dirty: 0,
+      missing: false,
+      hasForceStop: false,
+      hasRun: false,
+      section,
+      parent,
+    };
+  }
+
+  it('returns one default-bucket group when no repo has a section', () => {
+    const groups = groupRepos([r('alpha'), r('beta')]);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].section).toBeNull();
+    expect(groups[0].key).toBe('__default__');
+    expect(groups[0].repos.map((p) => p.name)).toEqual(['alpha', 'beta']);
+  });
+
+  it('splits repos by section in declaration order, keeping submodules in their parent group', () => {
+    // orderedRepos puts submodules right after their parent; groupRepos is
+    // called on that flat list. Submodules inherit their parent's section at
+    // walk time (see config-walk.ts), so they stay in the same group as the
+    // parent without any special-case logic here.
+    const ordered = orderedRepos([
+      r('alicepeintures.com', 'Sites'),
+      r('condash', 'Tools'),
+      r('frontend', 'Tools', 'condash'),
+    ]);
+    const groups = groupRepos(ordered);
+    expect(groups.map((g) => g.section)).toEqual(['Sites', 'Tools']);
+    expect(groups[0].repos.map((p) => p.name)).toEqual(['alicepeintures.com']);
+    expect(groups[1].repos.map((p) => p.name)).toEqual(['condash', 'frontend']);
+  });
+
+  it('emits a leading default-bucket group before the first section', () => {
+    const groups = groupRepos([r('standalone'), r('grouped', 'Later')]);
+    expect(groups.map((g) => [g.section, g.key, g.repos.length])).toEqual([
+      [null, '__default__', 1],
+      ['Later', 'Later', 1],
+    ]);
   });
 });

--- a/src/renderer/panes/code-parts/data.ts
+++ b/src/renderer/panes/code-parts/data.ts
@@ -30,6 +30,41 @@ export function buildBar(added: number, deleted: number): string {
   return '+'.repeat(plus) + '-'.repeat(BAR_WIDTH - plus);
 }
 
+/** One group in the section-grouped Code-pane view: the header label (null
+ *  for the implicit default bucket — repos that precede the first section
+ *  marker, or when the conception has no section markers at all) plus the
+ *  ordered repo cards that belong to it. */
+export interface RepoSectionGroup {
+  /** Section heading from `condash.json`, or null for the implicit pre-first-
+   *  section bucket. */
+  section: string | null;
+  /** Stable key — section name when present, '__default__' for the implicit
+   *  bucket. Used by the renderer's in-memory collapse `Set`. */
+  key: string;
+  repos: RepoEntry[];
+}
+
+/** Split an ordered repo list into one group per `section` value, preserving
+ *  declaration order. Submodules inherit their parent's section so they stay
+ *  in the same group as their parent. Empty groups are dropped. */
+export function groupRepos(ordered: readonly RepoEntry[]): RepoSectionGroup[] {
+  const groups: RepoSectionGroup[] = [];
+  let current: RepoSectionGroup | null = null;
+  for (const repo of ordered) {
+    const section = repo.section ?? null;
+    if (!current || current.section !== section) {
+      current = {
+        section,
+        key: section ?? '__default__',
+        repos: [],
+      };
+      groups.push(current);
+    }
+    current.repos.push(repo);
+  }
+  return groups;
+}
+
 /** Flatten the configured repo list into one ordered card sequence, with each
  *  submodule parent immediately followed by its children. Top-level entries
  *  with no children pass through in declaration order. */

--- a/src/renderer/panes/code.tsx
+++ b/src/renderer/panes/code.tsx
@@ -1,4 +1,4 @@
-import { createMemo, For } from 'solid-js';
+import { createMemo, createSignal, For, Show } from 'solid-js';
 import './code-pane.css';
 import type {
   OpenWithSlotKey,
@@ -10,7 +10,7 @@ import type {
 } from '@shared/types';
 import { CodeRunRows } from '../code-runs';
 import { BranchFilter } from './code-parts/branch-filter';
-import { collectFilterableBranches, orderedRepos } from './code-parts/data';
+import { collectFilterableBranches, groupRepos, orderedRepos } from './code-parts/data';
 import { RepoRow } from './code-parts/repo-row';
 import { usePaneScrollMemory } from './pane-scroll-memory';
 
@@ -46,6 +46,19 @@ export function CodeView(props: {
   // pane switches; the outer .repos-pane is no longer the scrolling box.
   const scrollRef = usePaneScrollMemory('code');
   const ordered = createMemo<readonly RepoEntry[]>(() => orderedRepos(props.repos));
+  const grouped = createMemo(() => groupRepos(ordered()));
+  // In-memory only — section collapse state is intentionally not persisted
+  // (per the 2026-05-13 design call: keep the renderer simple, re-expand on
+  // every reload).
+  const [collapsed, setCollapsed] = createSignal<ReadonlySet<string>>(new Set());
+  const toggleSection = (key: string): void => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
   // The filter dropdown lists every non-primary branch known across the
   // currently-visible cards. Recomputed when the repo list changes;
   // detached / no-branch worktrees are skipped (no name to pin).
@@ -71,9 +84,10 @@ export function CodeView(props: {
           activeProjectBranches={props.activeProjectBranches}
           onToggle={props.onToggleBranch}
         />
-        <div class="repos-grid">
-          <For each={ordered()}>
-            {(repo) => {
+        <For each={grouped()}>
+          {(group) => {
+            const isCollapsed = (): boolean => collapsed().has(group.key);
+            const renderCard = (repo: RepoEntry): ReturnType<typeof RepoRow> => {
               const liveBranch = (): string | null => {
                 const cwd = props.liveSessionCwds.get(repo.name);
                 if (!cwd) return null;
@@ -100,9 +114,37 @@ export function CodeView(props: {
                   onOpenInTerm={props.onOpenInTerm}
                 />
               );
-            }}
-          </For>
-        </div>
+            };
+            return (
+              <Show
+                when={group.section !== null}
+                fallback={
+                  <div class="repos-grid">
+                    <For each={group.repos}>{renderCard}</For>
+                  </div>
+                }
+              >
+                <div class="repos-section">
+                  <button
+                    type="button"
+                    class="repos-section-header"
+                    aria-expanded={!isCollapsed()}
+                    onClick={() => toggleSection(group.key)}
+                  >
+                    <span class="repos-section-chevron">{isCollapsed() ? '▸' : '▾'}</span>
+                    <span class="repos-section-title">{group.section}</span>
+                    <span class="repos-section-count">{group.repos.length}</span>
+                  </button>
+                  <Show when={!isCollapsed()}>
+                    <div class="repos-grid">
+                      <For each={group.repos}>{renderCard}</For>
+                    </div>
+                  </Show>
+                </div>
+              </Show>
+            );
+          }}
+        </For>
       </div>
       <div class="code-runs-dock">
         <CodeRunRows

--- a/src/renderer/settings-modal-parts/data.test.ts
+++ b/src/renderer/settings-modal-parts/data.test.ts
@@ -58,4 +58,28 @@ describe('compactRepos — invariants', () => {
   it('drops empty submodules arrays', () => {
     expect(compactRepos([{ name: 'foo', submodules: [] }])).toEqual(['foo']);
   });
+
+  it('preserves section markers verbatim, never adding a phantom name field', () => {
+    expect(
+      compactRepos([
+        { section: 'Sites' },
+        { name: 'alicepeintures.com' },
+        { section: 'Tools' },
+        { name: 'condash' },
+      ]),
+    ).toEqual([{ section: 'Sites' }, 'alicepeintures.com', { section: 'Tools' }, 'condash']);
+  });
+
+  it('keeps a compacted sectioned payload schema-valid', () => {
+    const payload = buildSavePayload({
+      repositories: [
+        { section: 'Sites' },
+        { name: 'alicepeintures.com', run: 'make dev' },
+        { section: 'Tools' },
+        { name: 'condash' },
+      ],
+    });
+    const result = conceptionConfigSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
 });

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -5,7 +5,7 @@ import type {
   TerminalXtermPrefs,
   Theme,
 } from '@shared/types';
-import type { RawRepo } from '../../main/config-schema';
+import { isSectionMarker, type RawRepo, type RawSubmoduleRepo } from '../../main/config-schema';
 
 export type SettingsTab = 'global' | 'conception';
 
@@ -237,9 +237,20 @@ export interface RawConfig {
 export function compactRepos(repos: RawRepo[]): RawRepo[] {
   return repos.map((entry) => {
     if (typeof entry === 'string') return entry;
-    const copy: Exclude<RawRepo, string> = { ...entry };
+    if (isSectionMarker(entry)) return { section: entry.section };
+    // Repo-object variant from here on.
+    const copy = { ...entry } as {
+      name: string;
+      label?: string;
+      run?: string;
+      force_stop?: string;
+      install?: string;
+      pinned_branch?: string;
+      env?: string[];
+      submodules?: RawSubmoduleRepo[];
+    };
     if (copy.submodules) {
-      copy.submodules = compactRepos(copy.submodules);
+      copy.submodules = compactRepos(copy.submodules) as RawSubmoduleRepo[];
       if (copy.submodules.length === 0) delete copy.submodules;
     }
     for (const k of Object.keys(copy) as (keyof typeof copy)[]) {

--- a/src/renderer/settings-modal-parts/repo-row.tsx
+++ b/src/renderer/settings-modal-parts/repo-row.tsx
@@ -1,5 +1,5 @@
 import { For, Show } from 'solid-js';
-import type { RawRepo } from '../../main/config-schema';
+import type { RawRepo, RawSubmoduleRepo } from '../../main/config-schema';
 import { type BindTextFn, moveItem } from './data';
 
 /**
@@ -7,10 +7,15 @@ import { type BindTextFn, moveItem } from './data';
  * (name, label, run, force_stop, sub repos) regardless of how the entry
  * is currently serialized — string-form entries are coerced to object on
  * render. The recursive `submodules` UI lets a parent repo carry its own
- * nested list with the same shape.
+ * nested list with the same shape. Section markers (`{ section: … }`) are
+ * rendered by `<SectionRow>` and never reach this component — the parent
+ * uses an `isSectionMarker` guard.
  */
+type RepoRowEntry = Exclude<RawRepo, { section: string }>;
+type RepoRowObject = Exclude<RepoRowEntry, string>;
+
 export function RepoRow(props: {
-  entry: RawRepo;
+  entry: RepoRowEntry;
   idPrefix: string;
   index: number;
   total: number;
@@ -19,16 +24,17 @@ export function RepoRow(props: {
   onRemove: () => void;
   onPatch: (next: RawRepo) => Promise<void>;
 }) {
-  const obj = (): Exclude<RawRepo, string> =>
+  const obj = (): RepoRowObject =>
     typeof props.entry === 'string' ? { name: props.entry } : props.entry;
 
-  const patchObj = (patch: Partial<Exclude<RawRepo, string>>): Promise<void> =>
+  const patchObj = (patch: Partial<RepoRowObject>): Promise<void> =>
     props.onPatch({ ...obj(), ...patch });
 
-  const submodules = (): RawRepo[] => obj().submodules ?? [];
+  const submodules = (): RawSubmoduleRepo[] => obj().submodules ?? [];
 
-  const updateSubmodules = (mutate: (subs: RawRepo[]) => RawRepo[]): Promise<void> =>
-    patchObj({ submodules: mutate(submodules()) });
+  const updateSubmodules = (
+    mutate: (subs: RawSubmoduleRepo[]) => RawSubmoduleRepo[],
+  ): Promise<void> => patchObj({ submodules: mutate(submodules()) });
 
   return (
     <div class="settings-repo-row">
@@ -157,7 +163,9 @@ export function RepoRow(props: {
                 onMove={(delta) => void updateSubmodules((all) => moveItem(all, idx(), delta))}
                 onRemove={() => void updateSubmodules((all) => all.filter((_, i) => i !== idx()))}
                 onPatch={(next) =>
-                  updateSubmodules((all) => all.map((e, i) => (i === idx() ? next : e)))
+                  updateSubmodules((all) =>
+                    all.map((e, i) => (i === idx() ? (next as RawSubmoduleRepo) : e)),
+                  )
                 }
               />
             )}

--- a/src/renderer/settings-modal-parts/section-row.tsx
+++ b/src/renderer/settings-modal-parts/section-row.tsx
@@ -1,0 +1,56 @@
+import type { JSX } from 'solid-js';
+import type { RawRepo } from '../../main/config-schema';
+import type { BindTextFn } from './data';
+
+/**
+ * One row in the repositories list that is a `{ section: "…" }` marker — a
+ * heading that groups every following repo into a labelled bucket in the
+ * Settings modal AND in the Code pane. Visually compact: a single text input
+ * styled as a heading, plus the same up/down/remove controls a repo row has.
+ */
+export function SectionRow(props: {
+  entry: { section: string };
+  idPrefix: string;
+  index: number;
+  total: number;
+  bindText: BindTextFn;
+  onMove: (delta: -1 | 1) => void;
+  onRemove: () => void;
+  onPatch: (next: RawRepo) => Promise<void>;
+}): JSX.Element {
+  return (
+    <div class="settings-repo-row settings-repo-row--section">
+      <div class="settings-repo-row-head">
+        <input
+          type="text"
+          class="settings-repo-section-name"
+          placeholder="Section heading"
+          {...props.bindText(
+            `${props.idPrefix}.section`,
+            () => props.entry.section,
+            (v) => props.onPatch({ section: v }),
+          )}
+        />
+        <button
+          class="modal-button"
+          title="Move up"
+          disabled={props.index === 0}
+          onClick={() => props.onMove(-1)}
+        >
+          ↑
+        </button>
+        <button
+          class="modal-button"
+          title="Move down"
+          disabled={props.index === props.total - 1}
+          onClick={() => props.onMove(1)}
+        >
+          ↓
+        </button>
+        <button class="modal-button" title="Remove section" onClick={() => props.onRemove()}>
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
+++ b/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
@@ -6,11 +6,12 @@
  * modal shell.
  */
 
-import { For, type JSX } from 'solid-js';
-import type { RawRepo } from '../../main/config-schema';
+import { For, Show, type JSX } from 'solid-js';
+import { isSectionMarker, type RawRepo } from '../../main/config-schema';
 import { type BindTextFn, OPEN_WITH_SLOTS, type RawConfig } from './data';
 import { FieldBadgeRow, type InheritanceState } from './badges';
 import { RepoRow } from './repo-row';
+import { SectionRow } from './section-row';
 
 interface RepositoriesSectionProps {
   parsed: () => RawConfig;
@@ -30,6 +31,9 @@ export function RepositoriesSection(props: RepositoriesSectionProps): JSX.Elemen
     });
 
   const addRepo = (): Promise<void> => updateRepos((entries) => [...entries, { name: '' }]);
+
+  const addSection = (): Promise<void> =>
+    updateRepos((entries) => [...entries, { section: 'New section' }]);
 
   const removeRepo = (index: number): Promise<void> =>
     updateRepos((entries) => entries.filter((_, i) => i !== index));
@@ -59,26 +63,47 @@ export function RepositoriesSection(props: RepositoriesSectionProps): JSX.Elemen
       <p class="settings-hint">
         Each entry is either just a name (resolved against <code>workspace_path</code>) or an object
         with optional <code>label</code>, <code>run</code>, <code>force_stop</code>,{' '}
-        <code>install</code>, <code>env</code>, and <code>submodules</code>.
+        <code>install</code>, <code>env</code>, and <code>submodules</code>. A{' '}
+        <code>{'{ "section": "…" }'}</code> entry inserts a header above the repos that follow it,
+        in this list and in the Code pane.
       </p>
       <div class="settings-bucket">
         <For each={repos()}>
           {(entry, index) => (
-            <RepoRow
-              entry={entry}
-              idPrefix={`repo[${index()}]`}
-              index={index()}
-              total={repos().length}
-              bindText={props.bindText}
-              onMove={(delta) => void moveRepo(index(), delta)}
-              onRemove={() => void removeRepo(index())}
-              onPatch={(next) => updateRepoEntry(index(), () => next)}
-            />
+            <Show
+              when={!isSectionMarker(entry)}
+              fallback={
+                <SectionRow
+                  entry={entry as { section: string }}
+                  idPrefix={`repo[${index()}]`}
+                  index={index()}
+                  total={repos().length}
+                  bindText={props.bindText}
+                  onMove={(delta) => void moveRepo(index(), delta)}
+                  onRemove={() => void removeRepo(index())}
+                  onPatch={(next) => updateRepoEntry(index(), () => next)}
+                />
+              }
+            >
+              <RepoRow
+                entry={entry as Exclude<RawRepo, { section: string }>}
+                idPrefix={`repo[${index()}]`}
+                index={index()}
+                total={repos().length}
+                bindText={props.bindText}
+                onMove={(delta) => void moveRepo(index(), delta)}
+                onRemove={() => void removeRepo(index())}
+                onPatch={(next) => updateRepoEntry(index(), () => next)}
+              />
+            </Show>
           )}
         </For>
         <div class="settings-list-actions">
           <button class="modal-button" onClick={() => void addRepo()}>
             + Add repo
+          </button>
+          <button class="modal-button" onClick={() => void addSection()}>
+            + Add section
           </button>
         </div>
       </div>

--- a/src/renderer/settings-modal.css
+++ b/src/renderer/settings-modal.css
@@ -553,6 +553,23 @@
   background: var(--bg-subtle);
 }
 
+.settings-repo-row--section {
+  background: var(--bg-subtle);
+  border-style: dashed;
+  margin-top: 12px;
+}
+
+.settings-repo-row--section:first-child {
+  margin-top: 0;
+}
+
+.settings-repo-section-name {
+  flex: 1;
+  min-width: 0;
+  font-weight: 600;
+  font-size: 14px;
+}
+
 .settings-repo-row-detail label {
   display: flex;
   flex-direction: column;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -305,6 +305,11 @@ export interface RepoEntry {
   hasRun?: boolean;
   /** Worktrees attached to this repo (always includes the primary checkout). */
   worktrees?: Worktree[];
+  /** Name of the most-recent `{ section: … }` marker that preceded this
+   *  entry in `repositories[]`. Undefined for entries before the first
+   *  marker (the implicit default bucket). Submodules inherit their parent's
+   *  section. Drives Code-pane card grouping. */
+  section?: string;
 }
 
 export type TermSide = 'my' | 'code';

--- a/tests/repo-sections.spec.ts
+++ b/tests/repo-sections.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { bootApp } from './fixtures/electron-app';
+
+/**
+ * End-to-end smoke for the repositories-list section feature:
+ *
+ *   - "+ Add section" inserts a `{ section: "…" }` entry in condash.json.
+ *   - The Code pane groups repos under the section header and the collapse
+ *     toggle hides the cards beneath without unmounting anything else.
+ *
+ * Uses a tiny seeded conception fixture (one project) and a `condash.json`
+ * containing two repos plus a section marker between them.
+ */
+
+const SEED_REPOS = [
+  { section: 'Sites' },
+  { name: 'site-one', label: 'Site One' },
+  { section: 'Tools' },
+  { name: 'tool-one', label: 'Tool One' },
+];
+
+test('Settings: + Add section appends a section marker to condash.json', async () => {
+  const booted = await bootApp({ extraConfig: { repositories: ['existing-repo'] } });
+  try {
+    await booted.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows()[0];
+      win.webContents.send('menu-command', 'open-settings');
+    });
+
+    const modal = booted.window.locator('.settings-modal');
+    await expect(modal).toBeVisible();
+    await modal.locator('[role="tab"]').nth(1).click(); // conception tab
+    const conceptionPanel = modal.locator('#settings-panel-conception');
+    await expect(conceptionPanel).toBeVisible();
+
+    const reposSection = conceptionPanel.locator(
+      'section#settings-section-repositories\\:conception',
+    );
+    const addSectionBtn = reposSection.locator('button.modal-button', {
+      hasText: '+ Add section',
+    });
+    await addSectionBtn.click();
+
+    const condashPath = join(booted.conceptionDir, 'condash.json');
+    await expect
+      .poll(async () => {
+        const parsed = JSON.parse(await readFile(condashPath, 'utf8')) as {
+          repositories?: unknown[];
+        };
+        return parsed.repositories;
+      })
+      .toEqual(['existing-repo', { section: 'New section' }]);
+
+    // The new section header is rendered inline with a section-marker row.
+    await expect(reposSection.locator('.settings-repo-row--section')).toHaveCount(1);
+  } finally {
+    await booted.cleanup();
+  }
+});
+
+test('Code pane: section headers group repos and collapse hides their cards', async () => {
+  const booted = await bootApp({
+    extraConfig: { workspace_path: '/nonexistent/workspace', repositories: SEED_REPOS },
+  });
+  try {
+    // Reveal the Code pane via the menu-command channel. The first
+    // `show-code` after boot occasionally drops on the renderer floor
+    // (timing race against the initial layout settle), so we retry until
+    // the pane mounts.
+    const reposPane = booted.window.locator('.repos-pane');
+    await expect
+      .poll(
+        async () => {
+          await booted.app.evaluate(({ BrowserWindow }) => {
+            const win = BrowserWindow.getAllWindows()[0];
+            win.webContents.send('menu-command', 'show-code');
+          });
+          return reposPane.count();
+        },
+        { timeout: 15_000 },
+      )
+      .toBeGreaterThan(0);
+    await expect(reposPane).toBeVisible();
+
+    const headers = reposPane.locator('.repos-section-header');
+    await expect(headers).toHaveCount(2);
+    await expect(headers.nth(0)).toContainText('Sites');
+    await expect(headers.nth(1)).toContainText('Tools');
+
+    // Both groups render their cards initially.
+    const sitesGroup = reposPane.locator('.repos-section').nth(0);
+    const toolsGroup = reposPane.locator('.repos-section').nth(1);
+    await expect(sitesGroup.locator('.repos-grid .repo-row')).toHaveCount(1);
+    await expect(toolsGroup.locator('.repos-grid .repo-row')).toHaveCount(1);
+
+    // Collapse the first group → its grid disappears, the other stays put.
+    await headers.nth(0).click();
+    await expect(sitesGroup.locator('.repos-grid')).toHaveCount(0);
+    await expect(toolsGroup.locator('.repos-grid .repo-row')).toHaveCount(1);
+
+    // Re-expand → cards come back.
+    await headers.nth(0).click();
+    await expect(sitesGroup.locator('.repos-grid .repo-row')).toHaveCount(1);
+  } finally {
+    await booted.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- Lets users group a long `repositories[]` (10+ entries is common) under labelled headers like "Sites" / "Tools" — both in the Settings modal and as collapsible groups in the Code pane.
- Additive schema: `{ "section": "<heading>" }` entries are interleaved in the existing array, so any current `condash.json` renders unchanged.

## Changes

- `RawRepo` union gains a third arm `{ section: string }`, top-level only — zod's `submodules[]` schema excludes it.
- `walkRepos` threads the most-recent section through every emitted `RepoLookup`; propagated onto `RepoEntry.section`. Submodules inherit their parent's section.
- Settings modal renders section markers via a new dashed header row (rename inline, up/down/remove) and gains a "+ Add section" button next to "+ Add repo".
- `compactRepos` short-circuits section markers so a saved `{ section }` never grows a phantom `name` field.
- Code pane swaps the flat `.repos-grid` for one `.repos-section` block per section, with a `Set<string>` collapse signal (in-memory only — re-expands on every reload).
- Docs: configuration reference + help page updated with the section example and a new row in the shapes table.
- Tests: 14 new vitest cases across schema / walker / `groupRepos` / `compactRepos`, plus a new Playwright spec covering the "+ Add section" → `condash.json` round-trip and the Code-pane collapse toggle.

## Impact

- Schema is additive: old condash builds (no `section` arm in the union) reading a sectioned `condash.json` would hit a zod rejection. Acceptable per the existing downgrades-not-supported policy — worth knowing if you run multiple versions side by side.

## Watchpoints

- Collapse state is intentionally in-memory only; if re-expand-on-reload feels lossy in practice, the design note keeps a persist-per-machine alternative on the shelf.