### PR TITLE
Patch stale dirty-count chip after commit/push

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.20.0",
+      "version": "2.20.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/repo-events.test.ts
+++ b/src/renderer/repo-events.test.ts
@@ -1,0 +1,66 @@
+import { createStore } from 'solid-js/store';
+import { describe, expect, it } from 'vitest';
+import type { RepoEntry, RepoEvent } from '../shared/types';
+import { applyRepoEvents } from './repo-events';
+
+function primary(name: string, dirty: number, withWorktree = true): RepoEntry {
+  const path = `/r/${name}`;
+  return {
+    name,
+    path,
+    dirty,
+    missing: false,
+    hasForceStop: false,
+    hasRun: false,
+    worktrees: withWorktree ? [{ path, branch: 'main', primary: true, dirty }] : undefined,
+  } satisfies RepoEntry;
+}
+
+describe('applyRepoEvents → applyDirty', () => {
+  it('patches the primary worktree when the event path is the top-level repo path', () => {
+    // Regression: the card chip reads from `worktrees[*].dirty`, not from
+    // `repo.dirty`. When the watcher emits a `repo-dirty` event for the
+    // primary repo path, both cells must be patched — otherwise the chip
+    // stays stuck at its initial value (observed after commit/push:
+    // tooltip refreshes via a fresh git call, chip stays stale).
+    const [repos, setRepos] = createStore<RepoEntry[]>([primary('conception', 6)]);
+    const events: RepoEvent[] = [{ kind: 'repo-dirty', path: '/r/conception', dirty: 0 }];
+
+    applyRepoEvents(events, { repos, setRepos, onWorktreesChanged: () => undefined });
+
+    expect(repos[0].dirty).toBe(0);
+    expect(repos[0].worktrees?.[0].dirty).toBe(0);
+  });
+
+  it('patches a non-primary worktree when the event path matches one', () => {
+    const wtPath = '/r/condash/wt/feature';
+    const [repos, setRepos] = createStore<RepoEntry[]>([
+      {
+        ...primary('condash', 1),
+        worktrees: [
+          { path: '/r/condash', branch: 'main', primary: true, dirty: 1 },
+          { path: wtPath, branch: 'feature', primary: false, dirty: 4 },
+        ],
+      },
+    ]);
+    const events: RepoEvent[] = [{ kind: 'repo-dirty', path: wtPath, dirty: 0 }];
+
+    applyRepoEvents(events, { repos, setRepos, onWorktreesChanged: () => undefined });
+
+    expect(repos[0].dirty).toBe(1); // primary repo entry untouched
+    expect(repos[0].worktrees?.[0].dirty).toBe(1); // primary worktree untouched
+    expect(repos[0].worktrees?.[1].dirty).toBe(0); // the non-primary patched
+  });
+
+  it('still updates `repo.dirty` when the repo has no worktrees array (synthesised fallback)', () => {
+    // `ensureWorktrees` (in panes/code-parts/data.ts) synthesises a primary
+    // row from `repo.dirty` when `worktrees` is missing — so the top-level
+    // write still has to happen.
+    const [repos, setRepos] = createStore<RepoEntry[]>([primary('missing-repo', 3, false)]);
+    const events: RepoEvent[] = [{ kind: 'repo-dirty', path: '/r/missing-repo', dirty: 0 }];
+
+    applyRepoEvents(events, { repos, setRepos, onWorktreesChanged: () => undefined });
+
+    expect(repos[0].dirty).toBe(0);
+  });
+});

--- a/src/renderer/repo-events.ts
+++ b/src/renderer/repo-events.ts
@@ -63,10 +63,21 @@ function applyDirty(
   path: string,
   dirty: number | null,
 ): void {
-  // Top-level repo path?
+  // Top-level repo path? Patch `repo.dirty` AND the matching primary
+  // worktree's `dirty` in one go. Both share the same path, but the
+  // card chip reads from `worktrees[*].dirty` (see branch-badges.tsx);
+  // without the dual write the chip freezes at its initial value until
+  // a full reload.
   const ri = repos.findIndex((r) => r.path === path);
   if (ri >= 0) {
     if (repos[ri].dirty !== dirty) setRepos(ri, 'dirty', dirty);
+    const wts = repos[ri].worktrees;
+    if (wts) {
+      const wi = wts.findIndex((w) => w.path === path);
+      if (wi >= 0 && wts[wi].dirty !== dirty) {
+        setRepos(ri, 'worktrees', wi, 'dirty', dirty);
+      }
+    }
     return;
   }
   // Otherwise look for a worktree match. Linear scan is fine — repos.length


### PR DESCRIPTION
## Summary
- After committing or pushing in a watched repo, the Code-pane card's `N dirty` chip stayed frozen at its pre-commit count while the click-through popover correctly reported a clean tree.
- Bumps to 2.20.1.

## Changes
- `src/renderer/repo-events.ts` — `applyDirty` now patches **both** `repo.dirty` and the matching primary-worktree's `dirty` cell when the watcher event path equals the top-level repo path. Previously it short-circuited after writing only the top-level cell, leaving the worktree row (which the chip actually reads from) frozen.
- `src/renderer/repo-events.test.ts` (new) — 3 regression tests: primary-path event patches both cells; non-primary worktree event still patches only its row; missing-worktrees fallback still patches `repo.dirty`.

## Impact
- No watcher / IPC contract changes. Pure renderer-side fix. Open dropdowns and popovers continue to survive the patch via path-shaped `setRepos` writes.