### PR TITLE
Restore terminal prefs override + scrub condash.json + redesign Logs top bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ When changing the dev port, update **every** file:
 - **Per-conception logs**: `<conception>/.condash/logs/YYYY/MM/DD/HHMMSS-<sid>.jsonl`. One file per pty spawn; gitignored alongside `settings.json`. Janitor (`src/main/terminal-logger-janitor.ts`) evicts day-directories past `terminal.logging.retentionDays` (default 14) and oldest-first while over `terminal.logging.maxDirMb` (default 500). Runs at startup + every 24 h. The Logs working surface (`Cmd+Shift+L`) browses the tree.
 - `CONDASH_CONCEPTION_PATH` env var override: wired in both Electron (`src/main/settings.ts`) and CLI (`src/cli/conception.ts`). See [`docs/guides/configure-conception-path.md`](docs/guides/configure-conception-path.md) for the resolution chain. The conception-detector accepts any of the three recognised config files when validating a candidate path.
 - The merge resolver lives in `src/main/effective-config.ts`. Every reader (`repos.ts`, `worktree-ops.ts`, `launchers.ts`, `audit.ts`, `terminals.ts`, `conception-paths.ts`, the CLI's `config` verbs) goes through it.
+- **Merge rule**: top-level replace for every key, with **one exception**: `terminal` merges one level deep so a conception customising `terminal.logging` keeps the per-machine `terminal.launcher_command` / `screenshot_dir` / shortcuts. The exception is documented in `docs/reference/config.md` and tested in `effective-config.test.ts`.
 
 ## Sandbox: dev vs. production
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -18,6 +18,8 @@ condash reads two JSON files. Both share **the same schema**. The per-machine `s
 
 Both files share the **same schema** modulo the two path-tracking keys above. Any other top-level key — `workspace_path`, `worktrees_path`, `resources_path`, `skills_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal`, `theme`, `layout`, `welcome`, `cardMinWidth`, `treeExpansion`, `selectedBranches` — may live in either file. When the same key appears in both, the conception's value **replaces** the global one entirely (top-level replace; arrays replace, objects replace whole, no deep merge).
 
+**Exception: `terminal` merges one level deep.** Its sub-schema straddles per-machine input / device prefs (`shell`, `shortcut`, `screenshot_dir`, `launcher_command`, `xterm`, `screenshot_paste_shortcut`, `move_tab_{left,right}_shortcut`) and per-tree retention policy (`logging.{retentionDays, maxDirMb, maxFileMb, ansiPolicy}`). A pure replace meant any conception that customised `terminal.logging` silently lost every per-machine terminal pref — the launcher button vanished, the screenshot-paste shortcut toasted "no screenshot directory". Conception sub-keys win at the first level; sub-keys absent from the conception fall through to the global block. Nested values inside `terminal.xterm` and `terminal.logging` still replace whole — only the immediate sub-keys of `terminal` merge.
+
 ### The `.condash/` workspace directory
 
 `.condash/` is condash's per-conception state directory — the home of `settings.json` plus terminal logs at `.condash/logs/YYYY/MM/DD/HHMMSS-<sid>.jsonl`. **The whole directory is gitignored by default** (the auto-migrator appends a `.condash/` line to your `.gitignore` on first run when the conception is a git repo), so settings + logs are per-host state with no commit-leak risk. Teams that want to share a baseline config either commit `condash.json` alongside (legacy path still reads) or manually un-ignore `settings.json` in their `.gitignore`.
@@ -68,7 +70,7 @@ Lives at `<conception_path>/.condash/settings.json`. Don't commit it — the aut
 
 Paths may use `~` (expanded to `$HOME`) or absolute paths. JSON does not carry comments — keep prose documentation in the project README or the per-tree `CLAUDE.md`.
 
-A `terminal` block at this level is a valid per-conception override. The boot-time migration in older condash builds lifted any pre-existing `terminal` block out of `configuration.json` and into `settings.json`; that migration still runs and is idempotent. With the unified schema, a fresh `.condash/settings.json` may carry its own `terminal` block — the conception value replaces the global one for that tree.
+A `terminal` block at this level is a valid per-conception override. The boot-time migration in older condash builds lifted any pre-existing `terminal` block out of `configuration.json` and into `settings.json`; that migration still runs and is idempotent. With the unified schema, a fresh `.condash/settings.json` may carry its own `terminal` block — and unlike every other top-level key, the per-conception block **merges with** the global one (see the exception called out at the top of this page). A conception declaring `terminal.logging.retentionDays` keeps the global `terminal.launcher_command` / `terminal.screenshot_dir` it inherited.
 
 ### Terminal logging
 

--- a/src/cli/commands/worktrees.ts
+++ b/src/cli/commands/worktrees.ts
@@ -122,7 +122,7 @@ async function worktreeSetup(
   const skipInstall = args.flags['no-install'] === true;
   if (args.flags.install === true) {
     process.stderr.write(
-      '[deprecated] --install is now the default for repos that declare install: in condash.json. Use --no-install to skip.\n',
+      '[deprecated] --install is now the default for repos that declare install: in .condash/settings.json. Use --no-install to skip.\n',
     );
   }
   const baseFlag = args.flags.base;
@@ -229,7 +229,7 @@ function printWorktreesHelp(): void {
       '  setup <branch>   Create worktrees for every repo in the union of **Apps** declaring this branch.',
       '                   Flags: --repo <r>... (override) --no-env --no-install --copy-env --base <ref>',
       '                   Base ref defaults to the **Base** field on declaring item READMEs (must agree).',
-      '                   Repos with `env: [...]` in condash.json have those files copied by default;',
+      '                   Repos with `env: [...]` in .condash/settings.json have those files copied by default;',
       '                   --no-env opts out. Repos with `install: <cmd>` have it run by default; --no-install',
       '                   opts out. --copy-env is the legacy opportunistic .env / .env.local copy for repos',
       '                   without `env:` declared.',

--- a/src/main/effective-config.test.ts
+++ b/src/main/effective-config.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   conceptionConfigWritePath,
+  getEffectiveConceptionConfig,
   readConceptionConfigRaw,
   resolveConceptionConfigPath,
 } from './effective-config';
@@ -83,5 +84,62 @@ describe('readConceptionConfigRaw', () => {
 
   it('returns {} when nothing is present', async () => {
     expect(await readConceptionConfigRaw(tmp)).toEqual({});
+  });
+});
+
+describe('getEffectiveConceptionConfig', () => {
+  it('merges terminal one level deep so per-conception logging keeps per-machine prefs', async () => {
+    const global = join(tmp, 'settings.json');
+    writeFileSync(
+      global,
+      JSON.stringify({
+        terminal: {
+          launcher_command: 'claude',
+          screenshot_dir: '/home/alice/Pictures/Screenshots',
+        },
+      }),
+    );
+    mkdirSync(join(tmp, CONDASH_DIR));
+    writeFileSync(
+      condashSettingsPath(tmp),
+      JSON.stringify({
+        terminal: { logging: { retentionDays: 28 } },
+      }),
+    );
+    const eff = await getEffectiveConceptionConfig(tmp, global);
+    expect(eff.terminal).toEqual({
+      launcher_command: 'claude',
+      screenshot_dir: '/home/alice/Pictures/Screenshots',
+      logging: { retentionDays: 28 },
+    });
+  });
+
+  it('lets conception terminal sub-keys override the global ones', async () => {
+    const global = join(tmp, 'settings.json');
+    writeFileSync(
+      global,
+      JSON.stringify({ terminal: { launcher_command: 'claude', screenshot_dir: '/a' } }),
+    );
+    mkdirSync(join(tmp, CONDASH_DIR));
+    writeFileSync(condashSettingsPath(tmp), JSON.stringify({ terminal: { screenshot_dir: '/b' } }));
+    const eff = await getEffectiveConceptionConfig(tmp, global);
+    expect(eff.terminal).toEqual({ launcher_command: 'claude', screenshot_dir: '/b' });
+  });
+
+  it('still replaces non-terminal keys whole (open_with stays one-or-the-other)', async () => {
+    const global = join(tmp, 'settings.json');
+    writeFileSync(
+      global,
+      JSON.stringify({
+        open_with: { main_ide: { command: 'idea {path}' }, terminal: { command: 'ghostty' } },
+      }),
+    );
+    mkdirSync(join(tmp, CONDASH_DIR));
+    writeFileSync(
+      condashSettingsPath(tmp),
+      JSON.stringify({ open_with: { terminal: { command: 'kitty' } } }),
+    );
+    const eff = await getEffectiveConceptionConfig(tmp, global);
+    expect(eff.open_with).toEqual({ terminal: { command: 'kitty' } });
   });
 });

--- a/src/main/effective-config.ts
+++ b/src/main/effective-config.ts
@@ -37,6 +37,17 @@ import { settingsPath } from './settings';
  * replace; objects replace whole. No deep merge — predictable beats
  * convenient. A conception that wants to override only one `open_with`
  * slot has to restate the others.
+ *
+ * One exception: `terminal`. Its sub-schema straddles per-machine input /
+ * device prefs (`shell`, `shortcut`, `screenshot_dir`, `launcher_command`,
+ * `xterm`, …) and per-tree retention policy (`logging.{retentionDays,
+ * maxDirMb, …}`). A pure replace meant any tree that customised
+ * `terminal.logging` silently lost every per-machine terminal pref — the
+ * λ launcher button vanished and the screenshot-paste shortcut toasted
+ * "no screenshot_dir". `terminal` therefore merges one level deep:
+ * conception fields win at the sub-key level, missing sub-keys fall
+ * through to the global block. Nested values inside `terminal.xterm` /
+ * `terminal.logging` still replace whole.
  */
 export interface EffectiveConfig extends ConfigShape {
   workspace_path?: string;
@@ -166,9 +177,17 @@ export async function getEffectiveConceptionConfig(
   }
   for (const [key, value] of Object.entries(conception)) {
     if (GLOBAL_ONLY_KEYS.has(key)) continue;
+    if (key === 'terminal' && isPlainObject(value) && isPlainObject(merged.terminal)) {
+      merged.terminal = { ...merged.terminal, ...value };
+      continue;
+    }
     merged[key] = value;
   }
   return merged as EffectiveConfig;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 async function fileExists(path: string): Promise<boolean> {

--- a/src/main/ipc/logs.test.ts
+++ b/src/main/ipc/logs.test.ts
@@ -210,3 +210,28 @@ describe('logsDeleteDay', () => {
     expect(days).toEqual([]);
   });
 });
+
+describe('logsDeleteSession', () => {
+  it('removes a single session file', async () => {
+    const file = writeLogFile('2026-05-13', '142207-t-a.jsonl', [{ kind: 'spawn' }]);
+    writeLogFile('2026-05-13', '152200-t-b.jsonl', [{ kind: 'spawn' }]);
+    const result = (await handlers.logsDeleteSession({}, file)) as { deleted: boolean };
+    expect(result.deleted).toBe(true);
+    const sessions = (await handlers.logsListSessions({}, '2026-05-13')) as { path: string }[];
+    expect(sessions.map((s) => s.path)).toEqual([
+      join(condashLogsRoot(tmp), '2026', '05', '13', '152200-t-b.jsonl'),
+    ]);
+  });
+
+  it('rejects paths outside the logs root', async () => {
+    await expect(handlers.logsDeleteSession({}, '/etc/passwd')).rejects.toThrow();
+  });
+
+  it('rejects non-jsonl files even inside the logs root', async () => {
+    const root = condashLogsRoot(tmp);
+    mkdirSync(join(root, '2026', '05', '13'), { recursive: true });
+    const txt = join(root, '2026', '05', '13', 'note.txt');
+    writeFileSync(txt, 'hello');
+    await expect(handlers.logsDeleteSession({}, txt)).rejects.toThrow();
+  });
+});

--- a/src/main/ipc/logs.ts
+++ b/src/main/ipc/logs.ts
@@ -28,6 +28,7 @@ export function registerLogsIpc(): void {
     readEvents(filePath, offset, limit),
   );
   ipcMain.handle('logsDeleteDay', async (_e, day: string) => deleteDay(day));
+  ipcMain.handle('logsDeleteSession', async (_e, filePath: string) => deleteSession(filePath));
 }
 
 interface DayEntry {
@@ -224,6 +225,24 @@ function enrichEventText(ev: TermLogEvent): void {
   if (typeof ev.data !== 'string') return;
   if (ev.kind === 'in') ev.text = canonicalizeInput(ev.data);
   else if (ev.kind === 'out') ev.text = canonicalizeOutput(ev.data);
+}
+
+async function deleteSession(filePath: string): Promise<{ deleted: boolean }> {
+  const conception = await activeConceptionPath();
+  if (!conception) return { deleted: false };
+  // Bounds-check first so a malicious renderer can't escape the logs root
+  // by passing `/etc/passwd` or `..`. `requirePathUnder` resolves symlinks
+  // and rejects anything outside the root.
+  await requirePathUnder(filePath, condashLogsRoot(conception));
+  if (!filePath.endsWith('.jsonl')) {
+    throw new Error('logsDeleteSession: only .jsonl files');
+  }
+  try {
+    await fs.rm(filePath, { force: true });
+    return { deleted: true };
+  } catch {
+    return { deleted: false };
+  }
 }
 
 async function deleteDay(day: string): Promise<{ deleted: boolean }> {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -104,6 +104,7 @@ const api: CondashApi = {
   logsReadEvents: (filePath, offset, limit) =>
     ipcRenderer.invoke('logsReadEvents', filePath, offset, limit),
   logsDeleteDay: (day) => ipcRenderer.invoke('logsDeleteDay', day),
+  logsDeleteSession: (filePath) => ipcRenderer.invoke('logsDeleteSession', filePath),
   openConceptionDirectory: () => ipcRenderer.invoke('openConceptionDirectory'),
   openExternal: (target: string) => ipcRenderer.invoke('openExternal', target),
   openPath: (target: string) => ipcRenderer.invoke('openPath', target),

--- a/src/renderer/panes/logs-pane.css
+++ b/src/renderer/panes/logs-pane.css
@@ -1,6 +1,6 @@
-/* Logs pane — split layout: toolbar on top, sessions rail on the left,
- * events on the right. Pulls colours from the renderer's CSS variables so
- * dark / light themes work without overrides. */
+/* Logs pane — two-row toolbar on top (selects + actions, then search),
+ * full-width events panel underneath. Pulls colours from the renderer's
+ * CSS variables so dark / light themes work without overrides. */
 
 .logs-pane {
   display: flex;
@@ -12,21 +12,44 @@
 
 .logs-toolbar {
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.4rem;
   padding: 0.5rem 0.75rem;
   border-bottom: 1px solid var(--surface-border, #2a2a2a);
   flex: 0 0 auto;
 }
 
-.logs-day-picker {
+.logs-toolbar-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.logs-toolbar-spacer {
+  flex: 1 1 auto;
+}
+
+.logs-picker {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
+  min-width: 0;
 }
 
-.logs-day-picker span {
-  font-size: 0.85rem;
+.logs-picker--session {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.logs-picker--session select {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.logs-picker span {
+  font-size: 0.8rem;
   color: var(--text-muted, #8a8a8a);
 }
 
@@ -42,14 +65,23 @@
 }
 
 .logs-refresh:hover,
-.logs-delete-day:hover {
+.logs-delete-day:hover:not(:disabled) {
   background: var(--surface-hover, rgba(255, 255, 255, 0.04));
 }
 
-.logs-search {
+.logs-delete-day {
+  color: #c44;
+  border-color: rgba(204, 68, 68, 0.4);
+}
+
+.logs-delete-day:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.logs-toolbar-row--search .logs-search {
   flex: 1 1 auto;
   min-width: 0;
-  max-width: 28rem;
   font-size: 0.85rem;
   padding: 0.25rem 0.6rem;
   border: 1px solid var(--surface-border, #2a2a2a);
@@ -67,88 +99,10 @@
   color: var(--text-muted, #8a8a8a);
 }
 
-.logs-delete-day {
-  color: #c44;
-  border-color: rgba(204, 68, 68, 0.4);
-}
-
-.logs-body {
-  display: grid;
-  grid-template-columns: minmax(220px, 28%) 1fr;
-  flex: 1 1 auto;
-  min-height: 0;
-  overflow: hidden;
-}
-
-.logs-sessions {
-  overflow-y: auto;
-  border-right: 1px solid var(--surface-border, #2a2a2a);
-  display: flex;
-  flex-direction: column;
-  padding: 0.25rem 0;
-}
-
-.logs-session-row {
-  text-align: left;
-  background: transparent;
-  border: 0;
-  border-bottom: 1px solid var(--surface-border, #2a2a2a);
-  padding: 0.5rem 0.75rem;
-  color: inherit;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-  font-family: inherit;
-}
-
-.logs-session-row:hover {
-  background: var(--surface-hover, rgba(255, 255, 255, 0.04));
-}
-
-.logs-session-row--selected {
-  background: var(--surface-selected, rgba(80, 140, 240, 0.12));
-}
-
-.logs-session-row--exited {
-  opacity: 0.7;
-}
-
-.logs-session-time {
-  font-variant-numeric: tabular-nums;
-  font-size: 0.85rem;
-}
-
-.logs-session-meta {
-  display: flex;
-  gap: 0.4rem;
-  font-size: 0.78rem;
-  color: var(--text-muted, #8a8a8a);
-  flex-wrap: wrap;
-}
-
-.logs-session-repo {
-  color: var(--text-default, #cfcfcf);
-  font-weight: 500;
-}
-
-.logs-session-cmd {
-  font-family: ui-monospace, Menlo, Consolas, monospace;
-}
-
-.logs-session-size {
-  font-size: 0.72rem;
-  color: var(--text-muted, #8a8a8a);
-  font-variant-numeric: tabular-nums;
-}
-
-.logs-session-exit {
-  margin-left: 0.4rem;
-}
-
 .logs-events {
   display: flex;
   flex-direction: column;
+  flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }
@@ -173,10 +127,14 @@
   padding: 0.5rem 0.75rem;
 }
 
+/* Tighter columns than the original 6rem / 4.5rem layout: the body has
+ * to compete with terminal output, and every saved column is one we
+ * don't wrap. Timestamps remain `HH:MM:SS.mmm` (12 chars, tabular-nums
+ * → fits 4.75rem). Kind chip drops to 2.75rem at 0.68rem font-size. */
 .logs-event {
   display: grid;
-  grid-template-columns: 6rem 4.5rem 1fr;
-  gap: 0.5rem;
+  grid-template-columns: 4.75rem 2.75rem 1fr;
+  gap: 0.4rem;
   align-items: baseline;
   margin-bottom: 0.15rem;
 }
@@ -184,12 +142,13 @@
 .logs-event-ts {
   color: var(--text-muted, #8a8a8a);
   font-variant-numeric: tabular-nums;
+  font-size: 0.78rem;
 }
 
 .logs-event-kind {
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   color: var(--text-muted, #8a8a8a);
 }
 

--- a/src/renderer/panes/logs.tsx
+++ b/src/renderer/panes/logs.tsx
@@ -1,4 +1,4 @@
-import { createResource, createSignal, For, Show, createMemo } from 'solid-js';
+import { createEffect, createResource, createSignal, For, Show, createMemo } from 'solid-js';
 import type { JSX } from 'solid-js';
 import type { TermLogEvent, TermLogSessionMeta } from '@shared/types';
 import { ConfirmModal } from '../confirm-modal';
@@ -8,15 +8,14 @@ import './logs-pane.css';
  * Logs pane — browse `<conception>/.condash/logs/`.
  *
  * Layout:
- *   - Top toolbar: day picker.
- *   - Left rail: one row per session-file for the chosen day.
- *   - Right panel: events from the selected session, plain-text with
- *     a `[kind]` chip per line.
+ *   - Row 1: Day select · Session select · Refresh · Delete session.
+ *   - Row 2: Search box (substring match against canonicalised event text).
+ *   - Body: events for the selected session, plain monospace text, ANSI
+ *     stripped on render.
  *
- * Scope kept tight on first ship: no search, no virtual list, no
- * embedded xterm replay. The viewer is plain monospace text — ANSI is
- * stripped on render so unprintable escape sequences don't break the
- * layout. Filtering / search / xterm-readable mode land as follow-ups.
+ * Scope kept tight: no cross-day search, no virtual list, no embedded
+ * xterm replay. The viewer is plain monospace text — ANSI is stripped on
+ * render so unprintable escape sequences don't break the layout.
  */
 export function LogsView(): JSX.Element {
   // The list of available day-dirs (newest first).
@@ -42,6 +41,19 @@ export function LogsView(): JSX.Element {
 
   const [selectedSession, setSelectedSession] = createSignal<TermLogSessionMeta | null>(null);
 
+  // Auto-select the first session whenever the session list arrives or
+  // changes. Without this, the search input + delete-session button stay
+  // disabled and the events panel reads "Pick a session" on every day
+  // change — and the new design has no session rail for the user to
+  // click on.
+  createEffect(() => {
+    const list = sessions();
+    if (!list) return;
+    const current = selectedSession();
+    if (current && list.some((s) => s.path === current.path)) return;
+    setSelectedSession(list.length > 0 ? list[0] : null);
+  });
+
   // Events for the selected session file.
   const [events, { refetch: refetchEvents }] = createResource(
     () => selectedSession(),
@@ -53,11 +65,8 @@ export function LogsView(): JSX.Element {
   );
 
   // Free-text search box. Substring match (case-insensitive) against
-  // `ev.text` (canonicalised by the IPC reader — see canonical-input.ts)
-  // with a `stripAnsi(data)` fallback for older events that lack `text`.
-  // Filtering runs in the renderer because the IPC payload is already
-  // capped at 5000 events — adding a backend grep round-trip per
-  // keystroke would feel slower than the in-memory scan.
+  // `ev.text` (canonicalised by the IPC reader) with `stripAnsi(data)`
+  // fallback for older events that lack `text`.
   const [query, setQuery] = createSignal('');
 
   const filteredEvents = createMemo<TermLogEvent[]>(() => {
@@ -67,7 +76,7 @@ export function LogsView(): JSX.Element {
     return all.filter((ev) => searchableBody(ev).toLowerCase().includes(q));
   });
 
-  const [pendingDelete, setPendingDelete] = createSignal<string | null>(null);
+  const [pendingDelete, setPendingDelete] = createSignal<TermLogSessionMeta | null>(null);
 
   const refreshAll = (): void => {
     void refetchDays();
@@ -75,8 +84,8 @@ export function LogsView(): JSX.Element {
     void refetchEvents();
   };
 
-  const confirmDelete = (day: string): void => {
-    void window.condash.logsDeleteDay(day).then(() => {
+  const confirmDeleteSession = (sess: TermLogSessionMeta): void => {
+    void window.condash.logsDeleteSession(sess.path).then(() => {
       setPendingDelete(null);
       setSelectedSession(null);
       refreshAll();
@@ -86,127 +95,113 @@ export function LogsView(): JSX.Element {
   return (
     <div class="logs-pane">
       <div class="logs-toolbar">
-        <label class="logs-day-picker">
-          <span>Day</span>
-          <select
-            value={effectiveDay() ?? ''}
-            onChange={(e) => {
-              setSelectedDay(e.currentTarget.value || null);
-              setSelectedSession(null);
+        <div class="logs-toolbar-row">
+          <label class="logs-picker">
+            <span>Day</span>
+            <select
+              value={effectiveDay() ?? ''}
+              onChange={(e) => {
+                setSelectedDay(e.currentTarget.value || null);
+                setSelectedSession(null);
+              }}
+              disabled={(days()?.length ?? 0) === 0}
+            >
+              <For each={days() ?? []}>
+                {(entry) => <option value={entry.day}>{entry.day}</option>}
+              </For>
+              <Show when={(days()?.length ?? 0) === 0}>
+                <option value="">no logs</option>
+              </Show>
+            </select>
+          </label>
+          <label class="logs-picker logs-picker--session">
+            <span>Session</span>
+            <select
+              value={selectedSession()?.path ?? ''}
+              onChange={(e) => {
+                const path = e.currentTarget.value;
+                const match = (sessions() ?? []).find((s) => s.path === path) ?? null;
+                setSelectedSession(match);
+              }}
+              disabled={(sessions()?.length ?? 0) === 0}
+            >
+              <For each={sessions() ?? []}>
+                {(meta) => <option value={meta.path}>{sessionLabel(meta)}</option>}
+              </For>
+              <Show when={(sessions()?.length ?? 0) === 0}>
+                <option value="">no sessions</option>
+              </Show>
+            </select>
+          </label>
+          <span class="logs-toolbar-spacer" />
+          <button type="button" class="logs-refresh" onClick={refreshAll}>
+            Refresh
+          </button>
+          <button
+            type="button"
+            class="logs-delete-day"
+            disabled={!selectedSession()}
+            onClick={() => {
+              const s = selectedSession();
+              if (s) setPendingDelete(s);
             }}
-            disabled={(days()?.length ?? 0) === 0}
           >
-            <For each={days() ?? []}>
-              {(entry) => <option value={entry.day}>{entry.day}</option>}
-            </For>
-            <Show when={(days()?.length ?? 0) === 0}>
-              <option value="">no logs</option>
-            </Show>
-          </select>
-        </label>
-        <button type="button" class="logs-refresh" onClick={refreshAll}>
-          Refresh
-        </button>
-        <input
-          type="search"
-          class="logs-search"
-          placeholder="Search this session…"
-          value={query()}
-          onInput={(e) => setQuery(e.currentTarget.value)}
-          disabled={!selectedSession()}
-        />
-        <Show when={effectiveDay()}>
-          {(day) => (
-            <button type="button" class="logs-delete-day" onClick={() => setPendingDelete(day())}>
-              Delete day
-            </button>
-          )}
-        </Show>
+            Delete session
+          </button>
+        </div>
+        <div class="logs-toolbar-row logs-toolbar-row--search">
+          <input
+            type="search"
+            class="logs-search"
+            placeholder="Search this session…"
+            value={query()}
+            onInput={(e) => setQuery(e.currentTarget.value)}
+            disabled={!selectedSession()}
+          />
+        </div>
       </div>
 
       <Show when={pendingDelete()}>
-        {(day) => (
+        {(sess) => (
           <ConfirmModal
-            title="Delete day's logs"
-            body={`Delete every log file from ${day()}? This cannot be undone.`}
+            title="Delete session log"
+            body={`Delete ${sess().day} ${sess().time}${sess().cmd ? ` — ${sess().cmd}` : ''}? This cannot be undone.`}
             confirmLabel="Delete"
             destructive
             onCancel={() => setPendingDelete(null)}
-            onConfirm={() => confirmDelete(day())}
+            onConfirm={() => confirmDeleteSession(sess())}
           />
         )}
       </Show>
 
-      <div class="logs-body">
-        <aside class="logs-sessions">
-          <Show
-            when={(sessions()?.length ?? 0) > 0}
-            fallback={<div class="empty">No sessions for {effectiveDay() ?? '—'}.</div>}
-          >
-            <For each={sessions() ?? []}>
-              {(meta) => (
-                <button
-                  type="button"
-                  class="logs-session-row"
-                  classList={{
-                    'logs-session-row--selected': selectedSession()?.path === meta.path,
-                    'logs-session-row--exited': meta.exitCode !== undefined,
-                  }}
-                  onClick={() => setSelectedSession(meta)}
+      <section class="logs-events">
+        <Show when={selectedSession()} fallback={<div class="empty">Pick a session above.</div>}>
+          {(sess) => (
+            <>
+              <div class="logs-events-head">
+                <span>{sess().path}</span>
+              </div>
+              <div class="logs-events-list">
+                <Show
+                  when={(events()?.length ?? 0) > 0}
+                  fallback={<div class="empty">Empty session.</div>}
                 >
-                  <div class="logs-session-time">{meta.time}</div>
-                  <div class="logs-session-meta">
-                    <Show when={meta.repo}>
-                      <span class="logs-session-repo">{meta.repo}</span>
-                    </Show>
-                    <Show when={meta.cmd}>
-                      {(cmd) => <span class="logs-session-cmd">{truncate(cmd(), 80)}</span>}
-                    </Show>
-                  </div>
-                  <div class="logs-session-size">
-                    {formatBytes(meta.bytes)}
-                    <Show when={meta.exitCode !== undefined}>
-                      <span class="logs-session-exit">· exit {meta.exitCode}</span>
-                    </Show>
-                  </div>
-                </button>
-              )}
-            </For>
-          </Show>
-        </aside>
-
-        <section class="logs-events">
-          <Show
-            when={selectedSession()}
-            fallback={<div class="empty">Pick a session on the left.</div>}
-          >
-            {(sess) => (
-              <>
-                <div class="logs-events-head">
-                  <span>{sess().path}</span>
-                </div>
-                <div class="logs-events-list">
                   <Show
-                    when={(events()?.length ?? 0) > 0}
-                    fallback={<div class="empty">Empty session.</div>}
+                    when={filteredEvents().length > 0}
+                    fallback={
+                      <div class="empty">
+                        No matches for "{query()}" ({events()?.length ?? 0} events).
+                      </div>
+                    }
                   >
-                    <Show
-                      when={filteredEvents().length > 0}
-                      fallback={
-                        <div class="empty">
-                          No matches for "{query()}" ({events()?.length ?? 0} events).
-                        </div>
-                      }
-                    >
-                      <For each={filteredEvents()}>{(ev) => <EventRow ev={ev} />}</For>
-                    </Show>
+                    <For each={filteredEvents()}>{(ev) => <EventRow ev={ev} />}</For>
                   </Show>
-                </div>
-              </>
-            )}
-          </Show>
-        </section>
-      </div>
+                </Show>
+              </div>
+            </>
+          )}
+        </Show>
+      </section>
     </div>
   );
 }
@@ -220,6 +215,14 @@ function EventRow(props: { ev: TermLogEvent }): JSX.Element {
       <span class="logs-event-body">{eventBody(ev)}</span>
     </div>
   );
+}
+
+function sessionLabel(meta: TermLogSessionMeta): string {
+  const head = meta.repo ? `${meta.time} · ${meta.repo}` : meta.time;
+  const cmd = meta.cmd ? ` · ${truncate(meta.cmd, 60)}` : '';
+  const size = ` · ${formatBytes(meta.bytes)}`;
+  const exit = meta.exitCode !== undefined ? ` · exit ${meta.exitCode}` : '';
+  return `${head}${cmd}${size}${exit}`;
 }
 
 function eventBody(ev: TermLogEvent): string {

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -87,7 +87,10 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     const prefs = deps.terminalPrefs() ?? {};
     const dir = prefs.screenshot_dir;
     if (!dir) {
-      deps.flashToast('No terminal.screenshot_dir set in condash.json', 'error');
+      deps.flashToast(
+        'No screenshot directory set — open Settings → Terminal → Screenshot directory.',
+        'error',
+      );
       return;
     }
     const latest = await window.condash.termLatestScreenshot(dir);

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -239,6 +239,10 @@ export interface CondashApi {
   logsReadEvents(filePath: string, offset?: number, limit?: number): Promise<TermLogEvent[]>;
   /** Wipe an entire day-directory. */
   logsDeleteDay(day: string): Promise<{ deleted: boolean }>;
+  /** Delete a single session file (one pty spawn). Bounded under
+   *  `<conception>/.condash/logs/`; rejects paths outside the logs root
+   *  or files that don't end in `.jsonl`. */
+  logsDeleteSession(filePath: string): Promise<{ deleted: boolean }>;
 
   /** Open the configured conception directory in the OS file manager. */
   openConceptionDirectory(): Promise<void>;


### PR DESCRIPTION
## Summary

- Restore the missing λ launcher button and screenshot-paste shortcut: a per-conception `terminal.logging` block was wiping the per-machine `terminal.launcher_command` / `screenshot_dir` thanks to top-level replace.
- Redesign the Logs pane top bar so Day + Session selects share row 1 with Refresh + Delete session, search drops to row 2, and event rows get tighter timestamp + kind columns.
- Sweep user-facing strings that still referenced the legacy `condash.json` filename.

## Changes

- `src/main/effective-config.ts`: special-case `terminal` to merge one level deep so per-conception sub-keys (e.g. `logging`) stack on top of the per-machine block instead of replacing it. Documented in `docs/reference/config.md` and `CLAUDE.md`; three new `effective-config.test.ts` cases pin the behaviour and prove non-terminal keys still replace whole.
- `src/renderer/terminal-bridge.ts`: rewrite the screenshot-paste toast to point at Settings → Terminal → Screenshot directory instead of the legacy filename.
- `src/cli/commands/worktrees.ts`: rewrite `--install` deprecation + `--env` help text to name `.condash/settings.json`.
- `src/main/ipc/logs.ts` + `src/preload/index.ts` + `src/shared/api.ts`: new `logsDeleteSession(filePath)` IPC verb — bounded under `condashLogsRoot`, `.jsonl` only. Three new `logs.test.ts` cases (happy path, path-escape, non-jsonl reject).
- `src/renderer/panes/logs.tsx` + `logs-pane.css`: two-row toolbar (Day select · Session select · Refresh · Delete session, then full-width search), sessions rail removed, auto-pick first session per day, event-row grid trimmed to `4.75rem 2.75rem 1fr` with smaller kind chip.

## Impact

- Anyone whose `.condash/settings.json` declares any `terminal.*` sub-key now keeps inherited per-machine terminal prefs instead of silently losing them. This is the doctrine's one documented exception to top-level replace.
- The Logs pane no longer surfaces a per-day wipe — deletion is per-session. Day-level deletion remains available via the `logsDeleteDay` IPC verb (kept for janitor + future surfaces) but is no longer in the UI.