### PR TITLE
Bump 2.21.3 — independent in/out coalesce buffers + widen Logs ts/kind columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.21.2",
+      "version": "2.21.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.21.2",
+  "version": "2.21.3",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/terminal-logger.test.ts
+++ b/src/main/terminal-logger.test.ts
@@ -257,7 +257,7 @@ describe('SessionLogger', () => {
     expect(outEvents[0].data).toBe('echo A');
   });
 
-  it('flushes pending in-buffer when switching to out', async () => {
+  it('keeps in / out coalesce buffers independent; close() flushes both', async () => {
     const logger = new SessionLogger(tmp, {
       sid: 't-coal-switch',
       side: 'my',
@@ -265,9 +265,10 @@ describe('SessionLogger', () => {
       spawn: { cmd: 'bash', argv: [] },
     });
     logger.spawn();
-    // Two keystrokes with no newline yet, then output arrives — the
-    // pending `in` must seal before the `out` starts so chronology is
-    // preserved.
+    // Two keystrokes (no newline yet), then a chunk of output arrives.
+    // With independent buffers neither flushes the other — both seal at
+    // close(). The `in` lands first because `flushAll()` drains `in`
+    // before `out`.
     logger.input('a');
     logger.input('b');
     logger.output('result');
@@ -281,6 +282,40 @@ describe('SessionLogger', () => {
     const outEv = events.find((e) => e.kind === 'out');
     expect(inEv?.data).toBe('ab');
     expect(outEv?.data).toBe('result');
+  });
+
+  it('collapses an interactive pty echo burst into one in + one out', async () => {
+    // Regression: v2.21.0–v2.21.2 used a single coalesce buffer that
+    // flushed on every kind switch, so the pty echoing each keystroke
+    // produced one in + one out record *per byte* — typing `ls -al<Enter>`
+    // landed 14 records on disk. The fix uses two independent buffers.
+    const logger = new SessionLogger(tmp, {
+      sid: 't-echo',
+      side: 'my',
+      cwd: '/x',
+      spawn: { cmd: 'bash', argv: [] },
+    });
+    logger.spawn();
+    // Interleave each keystroke with its pty echo, ending with Enter +
+    // the full command output. Mirrors the on-disk pattern from a real
+    // `bash` + `ls` session.
+    for (const ch of 'ls') {
+      logger.input(ch);
+      logger.output(ch);
+    }
+    logger.input('\r');
+    logger.output('\r\ntotal 0\r\n');
+    await logger.close();
+
+    const path = logger.filePath();
+    if (!path) throw new Error('no path');
+    const events = readJsonl(path);
+    const inEvents = events.filter((e) => e.kind === 'in');
+    const outEvents = events.filter((e) => e.kind === 'out');
+    expect(inEvents).toHaveLength(1);
+    expect(inEvents[0].data).toBe('ls\r');
+    expect(outEvents).toHaveLength(1);
+    expect(outEvents[0].data).toBe('ls\r\ntotal 0\r\n');
   });
 
   it('close() is idempotent', async () => {

--- a/src/main/terminal-logger.ts
+++ b/src/main/terminal-logger.ts
@@ -81,25 +81,44 @@ export function stripAnsi(s: string): string {
 /**
  * Coalesce policy. Interactive shells emit one `in` event per keystroke
  * and one `out` event echoing each character; without coalescing, typing
- * `echo A\r` yields ~14 records. The writer batches consecutive same-kind
- * payloads into one record using three rules:
+ * `echo A\r` yields ~14 records.
+ *
+ * The writer keeps **two independent buffers** — one for `in`, one for
+ * `out` — each flushing on its own rules. The earlier "switching kind
+ * flushes" rule looked sensible on paper but broke the dominant case:
+ * the pty echoes every typed byte, so the kind alternated every byte
+ * and the buffer was dumped between every keystroke and its echo. Typing
+ * `ls -al<Enter>` produced 14 records instead of two. With independent
+ * buffers, the `in` accumulates the whole command up to `\r` and the
+ * `out` accumulates the whole echo + listing — one record each. Per-byte
+ * chronology between `in` and `out` is intentionally not preserved at
+ * record granularity; the `ts` of each record (first byte of the burst)
+ * gives burst-level ordering, which is what the user actually wants.
+ *
+ * Flush rules per buffer:
  *
  *   1. **`in` flushes on line terminator** — a typed command up to Enter
- *      lands as one record (`data: "echo A\r"`), matching the user's
- *      mental model of "one line of input = one event".
+ *      lands as one record (`data: "echo A\r"`).
  *   2. **`out` flushes on idle** (`OUTPUT_IDLE_MS`) — pty echo + the
  *      shell's prompt-redraw burst collapse into one or two records per
  *      command.
- *   3. **Switching kind flushes** — preserves chronological in→out order.
+ *   3. **Either buffer flushes on cap, pause, spawn / exit / close** —
+ *      every public method that ends a turn flushes both.
  *
  * `INPUT_IDLE_MS` is a fallback for keys that never produce a newline
  * (arrow keys, raw-mode TUI input, partial pastes). `MAX_BUFFER_BYTES`
- * caps the in-memory buffer so a streaming `tail -f` or `cargo build`
+ * caps each in-memory buffer so a streaming `tail -f` or `cargo build`
  * doesn't grow unbounded if it never idles long enough to trip the timer.
  */
 const INPUT_IDLE_MS = 500;
 const OUTPUT_IDLE_MS = 100;
 const MAX_BUFFER_BYTES = 64 * 1024;
+
+interface PendingBuffer {
+  data: string;
+  ts: string;
+  timer: NodeJS.Timeout | null;
+}
 
 export class SessionLogger {
   private prefs: Required<TerminalLoggingPrefs>;
@@ -113,11 +132,12 @@ export class SessionLogger {
    * prefix so they sort together and share the same `<sid>` identity —
    * the rotation suffix differentiates them, not the timestamp. */
   private readonly spawnTime: Date;
-  /** Buffered in/out events waiting for a coalesce flush. Same-kind
-   * payloads concatenate; switching kind flushes first. Null between
-   * bursts. */
-  private pending: { kind: 'in' | 'out'; data: string; ts: string } | null = null;
-  private flushTimer: NodeJS.Timeout | null = null;
+  /** Two independent coalesce buffers — `in` and `out` accumulate
+   * separately so the pty's per-byte echo doesn't churn the buffer into
+   * single-byte records. Each carries its own idle timer; `data` empty
+   * means the buffer is idle (timer cleared, ts cleared). */
+  private pendingIn: PendingBuffer = { data: '', ts: '', timer: null };
+  private pendingOut: PendingBuffer = { data: '', ts: '', timer: null };
 
   constructor(
     private readonly conceptionPath: string,
@@ -138,13 +158,13 @@ export class SessionLogger {
     // Entering pause is a hard boundary — seal whatever was buffered so a
     // resume after the pause starts a fresh record rather than splicing
     // pre- and post-pause data together.
-    if (paused && !this.paused) this.flushPending();
+    if (paused && !this.paused) this.flushAll();
     this.paused = paused;
   }
 
   spawn(): void {
     if (!this.isEnabled()) return;
-    this.flushPending();
+    this.flushAll();
     this.write({
       kind: 'spawn',
       cmd: this.ctx.spawn.cmd,
@@ -165,7 +185,7 @@ export class SessionLogger {
 
   exit(exitCode: number): void {
     if (!this.isEnabled()) return;
-    this.flushPending();
+    this.flushAll();
     this.write({ kind: 'exit', exitCode });
   }
 
@@ -173,7 +193,7 @@ export class SessionLogger {
   close(): Promise<void> {
     if (this.closed) return Promise.resolve();
     this.closed = true;
-    this.flushPending();
+    this.flushAll();
     // Nothing was ever written → nothing to close.
     if (this.stream === null) return Promise.resolve();
     // Write the close marker explicitly — `write()` is happy to run even
@@ -190,11 +210,11 @@ export class SessionLogger {
     });
   }
 
-  /** Test hook — force the pending coalesce buffer to disk now. Production
-   * callers rely on the timer; tests use this to avoid a `setTimeout`
-   * wait. */
+  /** Test hook — force both pending coalesce buffers to disk now.
+   * Production callers rely on the timers; tests use this to avoid a
+   * `setTimeout` wait. */
   flushForTests(): void {
-    this.flushPending();
+    this.flushAll();
   }
 
   /** Absolute path of the currently-active file. Visible for tab indicator
@@ -208,47 +228,57 @@ export class SessionLogger {
   }
 
   private coalesce(kind: 'in' | 'out', data: string): void {
-    // Switching direction flushes — preserves chronology between an `in`
-    // keystroke and the matching `out` echo.
-    if (this.pending && this.pending.kind !== kind) this.flushPending();
-    if (this.pending) {
-      this.pending.data += data;
+    const buf = kind === 'in' ? this.pendingIn : this.pendingOut;
+    if (buf.data.length === 0) {
+      buf.ts = new Date().toISOString();
+      buf.data = data;
     } else {
-      this.pending = { kind, data, ts: new Date().toISOString() };
+      buf.data += data;
     }
     // Input flushes at line boundaries: one Enter press closes the
     // record. Multi-line pastes that end in newline flush in one go.
-    if (kind === 'in' && /[\r\n]$/.test(this.pending.data)) {
-      this.flushPending();
+    if (kind === 'in' && /[\r\n]$/.test(buf.data)) {
+      this.flushBuffer(kind);
       return;
     }
-    // Bound the buffer so a stream that never idles can't grow forever.
-    if (this.pending.data.length >= MAX_BUFFER_BYTES) {
-      this.flushPending();
+    // Bound each buffer so a stream that never idles can't grow forever.
+    if (buf.data.length >= MAX_BUFFER_BYTES) {
+      this.flushBuffer(kind);
       return;
     }
     // Idle-based fallback. Resetting the timer on every byte means a
     // steady stream extends the same record until idle / cap / newline /
     // close — exactly what the user expects from "one burst, one entry".
-    if (this.flushTimer !== null) clearTimeout(this.flushTimer);
+    if (buf.timer !== null) clearTimeout(buf.timer);
     const idleMs = kind === 'in' ? INPUT_IDLE_MS : OUTPUT_IDLE_MS;
-    this.flushTimer = setTimeout(() => this.flushPending(), idleMs);
+    buf.timer = setTimeout(() => this.flushBuffer(kind), idleMs);
     // Don't keep the event loop alive on the writer alone — close() and
     // exit() flush explicitly, so an orphaned timer would only delay
     // shutdown.
-    this.flushTimer.unref?.();
+    buf.timer.unref?.();
   }
 
-  private flushPending(): void {
-    if (this.flushTimer !== null) {
-      clearTimeout(this.flushTimer);
-      this.flushTimer = null;
+  private flushBuffer(kind: 'in' | 'out'): void {
+    const buf = kind === 'in' ? this.pendingIn : this.pendingOut;
+    if (buf.timer !== null) {
+      clearTimeout(buf.timer);
+      buf.timer = null;
     }
-    const p = this.pending;
-    if (p === null) return;
-    this.pending = null;
-    const encoded = this.encode(p.data);
-    this.write({ kind: p.kind, data: encoded, len: p.data.length }, p.ts);
+    if (buf.data.length === 0) return;
+    const data = buf.data;
+    const ts = buf.ts;
+    buf.data = '';
+    buf.ts = '';
+    const encoded = this.encode(data);
+    this.write({ kind, data: encoded, len: data.length }, ts);
+  }
+
+  /** Flush both buffers; used by the lifecycle methods (`spawn` / `exit`
+   * / `close` / pause). Order is `in` then `out` — same order interactive
+   * sessions naturally produce, and the test expects it. */
+  private flushAll(): void {
+    this.flushBuffer('in');
+    this.flushBuffer('out');
   }
 
   private write(event: Record<string, unknown>, ts?: string): void {

--- a/src/renderer/panes/logs-pane.css
+++ b/src/renderer/panes/logs-pane.css
@@ -127,26 +127,32 @@
   padding: 0.5rem 0.75rem;
 }
 
-/* Tighter columns than the original 6rem / 4.5rem layout: the body has
- * to compete with terminal output, and every saved column is one we
- * don't wrap. Timestamps remain `HH:MM:SS.mmm` (12 chars, tabular-nums
- * → fits 4.75rem). Kind chip drops to 2.75rem at 0.68rem font-size. */
+/* Row layout: timestamp · kind chip · body. The ts column has to fit
+ * `HH:MM:SS.mmm` (12 chars) in whatever monospace the platform picks
+ * up via the `ui-monospace, Menlo, Consolas, monospace` stack — Linux's
+ * fallback (DejaVu Sans Mono) is meaningfully wider than Menlo, so the
+ * earlier 4.75rem column overflowed straight through the 0.4rem gap
+ * into the kind chip. 5.75rem holds on every platform we ship. Kind
+ * column widens to 3.25rem so SPAWN / ROTATE / CLOSE have headroom.
+ *
+ * Font-size is unified at 0.8rem across all three cells; the earlier
+ * stagger (ts 0.78 / kind 0.68 / body 0.85) made baseline-aligned cells
+ * sit at three visibly different heights. */
 .logs-event {
   display: grid;
-  grid-template-columns: 4.75rem 2.75rem 1fr;
-  gap: 0.4rem;
+  grid-template-columns: 5.75rem 3.25rem 1fr;
+  gap: 0.5rem;
   align-items: baseline;
   margin-bottom: 0.15rem;
+  font-size: 0.8rem;
 }
 
 .logs-event-ts {
   color: var(--text-muted, #8a8a8a);
   font-variant-numeric: tabular-nums;
-  font-size: 0.78rem;
 }
 
 .logs-event-kind {
-  font-size: 0.68rem;
   text-transform: uppercase;
   letter-spacing: 0.03em;
   color: var(--text-muted, #8a8a8a);


### PR DESCRIPTION
## Summary

- Fix a regression on the v2.21.x terminal-logging feature: typing an interactive command produced one JSONL record per byte (one `in` + one `out` per echoed keystroke) instead of one record per burst — `ls -al<Enter>` landed 14 records on disk.
- Fix a Logs-pane CSS bug where the 12-char timestamp overflowed its column on Linux's default monospace fallback and butted directly against the kind chip (`17:57:06.649SPAWN`, no gap).

## Changes

- `src/main/terminal-logger.ts` — replace the single coalesce buffer with two independent buffers (`pendingIn` + `pendingOut`). Each has its own idle timer and flush rules; the earlier "switching kind flushes" rule is gone. `flushAll()` drains both at spawn / exit / close / pause.
- `src/main/terminal-logger.test.ts` — replace the "switching to out" test with "keeps in / out coalesce buffers independent; close() flushes both", and add "collapses an interactive pty echo burst into one in + one out" as the load-bearing regression test.
- `src/renderer/panes/logs-pane.css` — ts column 4.75rem → 5.75rem (the 12-char `HH:MM:SS.mmm` overflowed at the platform monospace fallback width on Linux), kind column 2.75rem → 3.25rem so SPAWN / ROTATE / CLOSE have headroom, font-size unified at 0.8rem across all three cells (removes the baseline-aligned stagger from three different cell font-sizes).
- `package.json` + `package-lock.json` — bump to 2.21.3.

## Impact

- JSONL session files shrink by roughly an order of magnitude for interactive sessions; a `bash` session that previously produced 14 records per typed command produces ~2.
- Per-byte `in` / `out` chronology is no longer preserved at record granularity — only burst-level, via the `ts` of each burst's first byte. This is the intended trade-off: the earlier "per-byte chronology" guarantee never held in practice because the buffer was dumped on every keystroke anyway.