### PR TITLE
Bump 2.21.4: Timerless Enter-bounded terminal-log coalescer

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -198,6 +198,15 @@ The whole `.condash/` directory is gitignored by default — the auto-migrator a
 - **Events panel** on the right — chronological list of events for the selected session. Each line shows the timestamp, an event kind chip (`in` / `out` / `spawn` / `exit` / `close` / `rotate`), and the payload. ANSI escapes are stripped on render so unprintable bytes don't break the layout; the raw bytes live on disk for tools that want them.
 - **Delete day** wipes one day-directory at a time.
 
+#### Record granularity
+
+The writer treats **Enter** (or any newline on the IN side) as the transaction boundary between command-cycles:
+
+- One `in` record per command-line — the entire typed command up to `\r` / `\n`, including the trailing newline.
+- One `out` record per command-cycle — the pty's echo of the typed keystrokes, the program's response, and any prompt redraw all land in the same record. The OUT record seals when the user starts typing the next command (or at the byte cap, or on session close).
+
+This means a session that ran two commands typically lands as `spawn`, `in`, `out`, `in`, `out`, `exit`, `close` — seven records, regardless of how many keystrokes were typed. Long streams without an interactive follow-up (e.g. `tail -f`, fullscreen TUIs like vim and htop) flush in 64 KB chunks instead of one giant record, so resident memory stays bounded.
+
 ### Tuning capture
 
 The `terminal.logging` block in `.condash/settings.json` (or in the global `settings.json` for cross-conception defaults) carries the knobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.21.3",
+      "version": "2.21.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.21.3",
+  "version": "2.21.4",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/terminal-logger.test.ts
+++ b/src/main/terminal-logger.test.ts
@@ -285,10 +285,10 @@ describe('SessionLogger', () => {
   });
 
   it('collapses an interactive pty echo burst into one in + one out', async () => {
-    // Regression: v2.21.0–v2.21.2 used a single coalesce buffer that
-    // flushed on every kind switch, so the pty echoing each keystroke
-    // produced one in + one out record *per byte* — typing `ls -al<Enter>`
-    // landed 14 records on disk. The fix uses two independent buffers.
+    // Happy path for the timerless Enter-bounded model. Typing `ls<Enter>`
+    // and receiving the listing should produce one IN record (`ls\r`) and
+    // one OUT record (echo + listing + any prompt redraw), regardless of
+    // how the bytes are interleaved between input() and output() calls.
     const logger = new SessionLogger(tmp, {
       sid: 't-echo',
       side: 'my',
@@ -296,9 +296,6 @@ describe('SessionLogger', () => {
       spawn: { cmd: 'bash', argv: [] },
     });
     logger.spawn();
-    // Interleave each keystroke with its pty echo, ending with Enter +
-    // the full command output. Mirrors the on-disk pattern from a real
-    // `bash` + `ls` session.
     for (const ch of 'ls') {
       logger.input(ch);
       logger.output(ch);
@@ -316,6 +313,109 @@ describe('SessionLogger', () => {
     expect(inEvents[0].data).toBe('ls\r');
     expect(outEvents).toHaveLength(1);
     expect(outEvents[0].data).toBe('ls\r\ntotal 0\r\n');
+  });
+
+  it('does not fragment under delayed keystroke dispatch', async () => {
+    // Regression target: v2.21.0–v2.21.3 used idle timers. Under real
+    // human typing (~200ms between keys, longer than OUTPUT_IDLE_MS=100ms
+    // in v2.21.3), each echoed byte flushed before the next arrived,
+    // producing one OUT record per character — the v2.21.3 unit test
+    // missed it because it dispatched keystrokes synchronously. The new
+    // model has no timers; this test interleaves input/output with a
+    // delay larger than any prior idle threshold and asserts the same
+    // outcome as the synchronous happy-path test.
+    const logger = new SessionLogger(tmp, {
+      sid: 't-slow',
+      side: 'my',
+      cwd: '/x',
+      spawn: { cmd: 'bash', argv: [] },
+    });
+    logger.spawn();
+    for (const ch of 'ls') {
+      logger.input(ch);
+      logger.output(ch);
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    logger.input('\r');
+    logger.output('\r\ntotal 0\r\n');
+    await logger.close();
+
+    const path = logger.filePath();
+    if (!path) throw new Error('no path');
+    const events = readJsonl(path);
+    const inEvents = events.filter((e) => e.kind === 'in');
+    const outEvents = events.filter((e) => e.kind === 'out');
+    expect(inEvents).toHaveLength(1);
+    expect(inEvents[0].data).toBe('ls\r');
+    expect(outEvents).toHaveLength(1);
+    expect(outEvents[0].data).toBe('ls\r\ntotal 0\r\n');
+  });
+
+  it('seals each OUT record at the start of the next IN burst', async () => {
+    // Defining behaviour of the transaction-boundary model: the OUT
+    // record for cycle N closes when the user starts typing cycle N+1,
+    // so each OUT carries echoes + program output + prompt redraw of
+    // exactly one command-cycle.
+    const logger = new SessionLogger(tmp, {
+      sid: 't-cycle',
+      side: 'my',
+      cwd: '/x',
+      spawn: { cmd: 'bash', argv: [] },
+    });
+    logger.spawn();
+    // Cycle 1: type 'ls', see echo + listing + new prompt
+    for (const ch of 'ls') {
+      logger.input(ch);
+      logger.output(ch);
+    }
+    logger.input('\r');
+    logger.output('\r\ntotal 0\r\n$ ');
+    // Cycle 2: start typing 'pwd' — first keystroke seals cycle 1's OUT
+    for (const ch of 'pwd') {
+      logger.input(ch);
+      logger.output(ch);
+    }
+    logger.input('\r');
+    logger.output('\r\n/home/x\r\n$ ');
+    await logger.close();
+
+    const path = logger.filePath();
+    if (!path) throw new Error('no path');
+    const events = readJsonl(path).filter((e) => e.kind === 'in' || e.kind === 'out');
+    expect(events).toHaveLength(4);
+    expect(events[0]).toMatchObject({ kind: 'in', data: 'ls\r' });
+    expect(events[1]).toMatchObject({ kind: 'out', data: 'ls\r\ntotal 0\r\n$ ' });
+    expect(events[2]).toMatchObject({ kind: 'in', data: 'pwd\r' });
+    expect(events[3]).toMatchObject({ kind: 'out', data: 'pwd\r\n/home/x\r\n$ ' });
+  });
+
+  it('caps OUT records at the byte limit for streams without Enter', async () => {
+    // Long streams (`tail -f`) and fullscreen TUIs never see a typed
+    // newline, so the byte cap is the only thing keeping resident
+    // memory bounded. Push >2x the cap through OUT and confirm the
+    // buffer flushes in chunks instead of accumulating one record.
+    const logger = new SessionLogger(tmp, {
+      sid: 't-cap',
+      side: 'my',
+      cwd: '/x',
+      spawn: { cmd: 'bash', argv: [] },
+    });
+    logger.spawn();
+    const chunk = 'x'.repeat(8 * 1024); // 8 KB
+    const chunks = 20; // 160 KB total — exceeds the 64 KB cap ~2.5x
+    for (let i = 0; i < chunks; i++) logger.output(chunk);
+    await logger.close();
+    const path = logger.filePath();
+    if (!path) throw new Error('no path');
+    const outEvents = readJsonl(path).filter((e) => e.kind === 'out');
+    expect(outEvents.length).toBeGreaterThanOrEqual(2);
+    const total = outEvents.reduce((acc, e) => acc + ((e.data as string) ?? '').length, 0);
+    expect(total).toBe(chunks * chunk.length);
+    for (const ev of outEvents) {
+      // Each flushed record fits within the cap plus the chunk-width
+      // overrun (we flush after the cap is hit, not pre-emptively).
+      expect((ev.data as string).length).toBeLessThanOrEqual(64 * 1024 + chunk.length);
+    }
   });
 
   it('close() is idempotent', async () => {

--- a/src/main/terminal-logger.ts
+++ b/src/main/terminal-logger.ts
@@ -83,41 +83,38 @@ export function stripAnsi(s: string): string {
  * and one `out` event echoing each character; without coalescing, typing
  * `echo A\r` yields ~14 records.
  *
- * The writer keeps **two independent buffers** — one for `in`, one for
- * `out` — each flushing on its own rules. The earlier "switching kind
- * flushes" rule looked sensible on paper but broke the dominant case:
- * the pty echoes every typed byte, so the kind alternated every byte
- * and the buffer was dumped between every keystroke and its echo. Typing
- * `ls -al<Enter>` produced 14 records instead of two. With independent
- * buffers, the `in` accumulates the whole command up to `\r` and the
- * `out` accumulates the whole echo + listing — one record each. Per-byte
- * chronology between `in` and `out` is intentionally not preserved at
- * record granularity; the `ts` of each record (first byte of the burst)
- * gives burst-level ordering, which is what the user actually wants.
+ * The writer treats **Enter as the natural transaction boundary**. There
+ * are no timers — earlier idle-based heuristics fragmented per-byte under
+ * real human typing (a 100ms OUT idle is shorter than the ~200ms gap
+ * between keystrokes, so each echoed byte flushed before the next
+ * arrived).
  *
- * Flush rules per buffer:
+ * Flush rules:
  *
- *   1. **`in` flushes on line terminator** — a typed command up to Enter
- *      lands as one record (`data: "echo A\r"`).
- *   2. **`out` flushes on idle** (`OUTPUT_IDLE_MS`) — pty echo + the
- *      shell's prompt-redraw burst collapse into one or two records per
- *      command.
- *   3. **Either buffer flushes on cap, pause, spawn / exit / close** —
- *      every public method that ends a turn flushes both.
+ *   - **`in`** buffer flushes when its data ends in `\r` or `\n`. One
+ *     command-line → one record.
+ *   - **`out`** buffer flushes when a **fresh `in` burst starts** —
+ *     i.e., when the IN buffer transitions from empty to non-empty,
+ *     signalling that the user is starting the next command. That makes
+ *     one OUT record per command-cycle: pty echo of the previous
+ *     command's keystrokes + program output + prompt redraw all land
+ *     together, anchored at the timestamp of the echo's first byte.
+ *   - Both buffers flush on `MAX_BUFFER_BYTES` (memory safety) and on
+ *     lifecycle events (spawn / exit / close / pause).
  *
- * `INPUT_IDLE_MS` is a fallback for keys that never produce a newline
- * (arrow keys, raw-mode TUI input, partial pastes). `MAX_BUFFER_BYTES`
- * caps each in-memory buffer so a streaming `tail -f` or `cargo build`
- * doesn't grow unbounded if it never idles long enough to trip the timer.
+ * The byte cap is the only safety net for sessions that never see a
+ * newline on the IN side — long-running streams (`tail -f`), fullscreen
+ * TUIs (vim, htop), or commands that exit without an interactive
+ * follow-up. Those flush in 64 KB chunks. Per-byte chronology between
+ * `in` and `out` is intentionally not preserved at record granularity;
+ * each record's `ts` is the first byte of that record's burst, which
+ * gives transaction-level ordering — what a reader of the JSONL wants.
  */
-const INPUT_IDLE_MS = 500;
-const OUTPUT_IDLE_MS = 100;
 const MAX_BUFFER_BYTES = 64 * 1024;
 
 interface PendingBuffer {
   data: string;
   ts: string;
-  timer: NodeJS.Timeout | null;
 }
 
 export class SessionLogger {
@@ -133,11 +130,11 @@ export class SessionLogger {
    * the rotation suffix differentiates them, not the timestamp. */
   private readonly spawnTime: Date;
   /** Two independent coalesce buffers — `in` and `out` accumulate
-   * separately so the pty's per-byte echo doesn't churn the buffer into
-   * single-byte records. Each carries its own idle timer; `data` empty
-   * means the buffer is idle (timer cleared, ts cleared). */
-  private pendingIn: PendingBuffer = { data: '', ts: '', timer: null };
-  private pendingOut: PendingBuffer = { data: '', ts: '', timer: null };
+   * separately. The IN side flushes on `\r`/`\n`; the OUT side flushes
+   * whenever IN does. Both also flush on byte cap and lifecycle events.
+   * `data` empty means the buffer is idle. */
+  private pendingIn: PendingBuffer = { data: '', ts: '' };
+  private pendingOut: PendingBuffer = { data: '', ts: '' };
 
   constructor(
     private readonly conceptionPath: string,
@@ -210,9 +207,9 @@ export class SessionLogger {
     });
   }
 
-  /** Test hook — force both pending coalesce buffers to disk now.
-   * Production callers rely on the timers; tests use this to avoid a
-   * `setTimeout` wait. */
+  /** Test hook — force both pending coalesce buffers to disk now. Kept
+   * for tests that want to assert on partial buffers without ending the
+   * session (the production path flushes on Enter / cap / lifecycle). */
   flushForTests(): void {
     this.flushAll();
   }
@@ -229,41 +226,39 @@ export class SessionLogger {
 
   private coalesce(kind: 'in' | 'out', data: string): void {
     const buf = kind === 'in' ? this.pendingIn : this.pendingOut;
+    // First byte of a fresh IN burst — the user is starting the next
+    // command-cycle. Flush whatever OUT had accumulated (echoes +
+    // program output + prompt redraw of the previous cycle) before
+    // opening a new IN record. This is what makes one OUT record per
+    // command-cycle.
+    if (kind === 'in' && buf.data.length === 0) {
+      this.flushBuffer('out');
+    }
     if (buf.data.length === 0) {
       buf.ts = new Date().toISOString();
       buf.data = data;
     } else {
       buf.data += data;
     }
-    // Input flushes at line boundaries: one Enter press closes the
-    // record. Multi-line pastes that end in newline flush in one go.
+    // IN flushes at line boundaries: one Enter press (or a multi-line
+    // paste ending in a newline) closes the IN record. OUT stays
+    // buffered — it'll seal at the next IN-burst-start, the cap, or
+    // close.
     if (kind === 'in' && /[\r\n]$/.test(buf.data)) {
-      this.flushBuffer(kind);
+      this.flushBuffer('in');
       return;
     }
-    // Bound each buffer so a stream that never idles can't grow forever.
+    // Memory-safety cap. Long streams (`tail -f`) and fullscreen TUIs
+    // (vim, htop) never see a typed newline, so without this the buffer
+    // would grow unbounded. 64 KB is large enough to hold a typical
+    // command-cycle but small enough to bound resident memory.
     if (buf.data.length >= MAX_BUFFER_BYTES) {
       this.flushBuffer(kind);
-      return;
     }
-    // Idle-based fallback. Resetting the timer on every byte means a
-    // steady stream extends the same record until idle / cap / newline /
-    // close — exactly what the user expects from "one burst, one entry".
-    if (buf.timer !== null) clearTimeout(buf.timer);
-    const idleMs = kind === 'in' ? INPUT_IDLE_MS : OUTPUT_IDLE_MS;
-    buf.timer = setTimeout(() => this.flushBuffer(kind), idleMs);
-    // Don't keep the event loop alive on the writer alone — close() and
-    // exit() flush explicitly, so an orphaned timer would only delay
-    // shutdown.
-    buf.timer.unref?.();
   }
 
   private flushBuffer(kind: 'in' | 'out'): void {
     const buf = kind === 'in' ? this.pendingIn : this.pendingOut;
-    if (buf.timer !== null) {
-      clearTimeout(buf.timer);
-      buf.timer = null;
-    }
     if (buf.data.length === 0) return;
     const data = buf.data;
     const ts = buf.ts;
@@ -274,8 +269,8 @@ export class SessionLogger {
   }
 
   /** Flush both buffers; used by the lifecycle methods (`spawn` / `exit`
-   * / `close` / pause). Order is `in` then `out` — same order interactive
-   * sessions naturally produce, and the test expects it. */
+   * / `close` / pause) and by the IN-side Enter flush. Order is `in`
+   * then `out` — same order interactive sessions naturally produce. */
   private flushAll(): void {
     this.flushBuffer('in');
     this.flushBuffer('out');


### PR DESCRIPTION
## Summary

- v2.21.3 still fragmented OUT records per-byte under real human typing: each echoed character flushed before the next arrived, because the 100 ms OUT idle threshold was shorter than the inter-keystroke interval. The shipped regression test missed it — keystrokes were dispatched synchronously, so no `setTimeout` callback could fire mid-loop.
- This rewrites the coalescer with no timers. The IN buffer flushes on `\r`/`\n`; the OUT buffer seals at the start of the next IN burst, treating Enter as the natural transaction boundary. Result: one IN record + one OUT record per command-cycle, where the OUT carries echoes + program output + prompt redraw together.
- Memory safety preserved via the existing 64 KB byte cap and lifecycle flushes. Long streams (`tail -f`) and fullscreen TUIs (vim, htop) flush in cap-sized chunks instead of accumulating one giant record.

## Changes

- `src/main/terminal-logger.ts`: drop `INPUT_IDLE_MS`, `OUTPUT_IDLE_MS`, the `PendingBuffer.timer` field, and all `setTimeout` / `clearTimeout` calls. Rewrite `coalesce` to flush OUT on the IN-buffer empty → non-empty transition. Docstring rewritten.
- `src/main/terminal-logger.test.ts`: keep the existing happy-path test (passes under the new model with the same expected payloads). Add three new tests: delayed-dispatch with 250 ms inter-keystroke pauses (proves the policy is timing-independent), transaction-boundary across two consecutive command-cycles, and the byte cap firing on a stream without newlines.
- `docs/guides/terminal.md`: new "Record granularity" subsection describing the Enter-as-transaction-boundary model.
- `package.json` + `package-lock.json`: 2.21.3 → 2.21.4.

## Impact

- On-disk record counts drop dramatically for interactive sessions — a typical `ls -la` cycle now lands two records (one IN + one OUT) instead of ~30. The JSONL schema is unchanged.
- The writer has no time-dependent code paths, so unit tests are deterministic.

## Watchpoints

- Playwright e2e was skipped locally (chrome-sandbox SUID environment issue, pre-existing and orthogonal to this change). Verify the e2e suite is unaffected in CI.