### PR TITLE
Fix terminal-tab-titles test broken by v2.28.0 launchers[] rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.28.0",
+      "version": "2.28.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "2.28.0",
+  "version": "2.28.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/tests/terminal-tab-titles.spec.ts
+++ b/tests/terminal-tab-titles.spec.ts
@@ -10,15 +10,17 @@ test('terminal pane: + spawns an unpinned shell, λ spawns a pinned launcher tab
   // first token — so we expect the label "cat".
   const booted = await bootApp({
     extraConfig: {
-      terminal: { launcher_command: 'cat' },
+      terminal: { launchers: [{ symbol: 'lambda', command: 'cat' }] },
     },
   });
   try {
     const win = booted.window;
 
-    // Sanity probe: the renderer must see the launcher_command from condash.json.
+    // Sanity probe: the renderer must see the λ launcher entry from settings.
+    // Schema rename in v2.28.0 — legacy `launcher_command` migrates into this
+    // array on load; the unit suite in effective-config.test.ts covers that path.
     const prefs = await win.evaluate(() => window.condash.termGetPrefs());
-    expect(prefs.launcher_command).toBe('cat');
+    expect(prefs.launchers?.[0]?.command).toBe('cat');
 
     // The terminal pane is mounted but starts collapsed; the column header
     // (with the +/λ buttons) is rendered regardless of `open`. Click each


### PR DESCRIPTION
## Summary

- The mu-launcher work in v2.28.0 renamed `terminal.launcher_command` to a `terminal.launchers[]` array and migrates the legacy key away on first load, but `tests/terminal-tab-titles.spec.ts` was still seeding the legacy shape and asserting `prefs.launcher_command === 'cat'` — the migration drops that key, so the assertion saw `undefined` and CI failed on PR #155 (merged anyway).
- This patch updates the Playwright test to the canonical shape so CI is green again. Unit coverage of the migration path itself lives in `effective-config.test.ts` and is unaffected.

## Changes

- `tests/terminal-tab-titles.spec.ts`: seed `terminal.launchers: [{symbol: 'lambda', command: 'cat'}]` instead of the legacy scalar; assert on `prefs.launchers?.[0]?.command`.
- `package.json` + `package-lock.json`: bump 2.28.0 → 2.28.1.

## Impact

- Unblocks the Playwright suite on `main` (29/30 → 30/30 locally with `xvfb-run npx playwright test`).
- Patch release v2.28.1 — test-only change, no runtime behaviour difference.