### PR TITLE
Bump 3.0.0: scrub invalid launcher entries + drop condash-cli alias

### DIFF
--- a/build/after-pack.cjs
+++ b/build/after-pack.cjs
@@ -1,15 +1,14 @@
-// electron-builder afterPack hook — installs the `condash` launcher
-// alongside a backward-compatible `condash-cli` alias on every platform.
+// electron-builder afterPack hook — installs the `condash` launcher on Linux.
+// macOS and Windows are no-ops; their dispatch (CLI vs GUI on argv) happens
+// in src/main/index.ts since the Electron binary is invoked directly.
 //
-// From v2.24.0 condash ships as a single user-facing binary. The dispatch
-// rule (design: projects/2026-05/2026-05-13-condash-cli-reference/notes/
-// 02-unified-binary-design.md, "rule C"):
+// From v3.0.0 condash ships as a single user-facing binary. Dispatch rule:
 //   • `condash`                         → GUI (no-args is the dashboard).
 //   • `condash gui [chromium switches]` → GUI, with the rest of argv passed to Electron.
 //   • `condash <anything else>`         → CLI (re-execs the same Electron binary
 //                                          in plain-Node mode against dist-cli/condash.cjs).
-//   • `condash-cli ...`                 → CLI (deprecated alias, removed in v3.0.0).
-//                                          Prints a one-line stderr banner unless --quiet/-q.
+//
+// The v2.x `condash-cli` deprecated alias was removed in v3.0.0.
 //
 // On Linux we additionally wrap the Electron binary itself with a bash
 // launcher that exports ELECTRON_OZONE_PLATFORM_HINT=wayland on Wayland
@@ -21,49 +20,31 @@
 //
 // Linux (.deb / AppImage):
 //   /opt/condash/condash       ← dispatch bash wrapper (GUI vs CLI on argv1)
-//   /opt/condash/condash-cli   ← copy of the same wrapper (deprecated alias)
 //   /opt/condash/condash.bin   ← the real Electron binary
-//   The bash postinst (build/linux-after-install.sh) drops a second
-//   /usr/bin/condash-cli symlink alongside /usr/bin/condash.
 //
 // macOS (.app):
 //   condash.app/Contents/MacOS/condash       ← Electron binary (untouched).
 //                                              Dispatch happens in src/main/index.ts
 //                                              when CLI args are present; the
 //                                              dock / Finder paths go straight to GUI.
-//   condash.app/Contents/MacOS/condash-cli   ← deprecated alias wrapper.
 //
 // Windows (NSIS):
 //   <install>/condash.exe        ← Electron binary (untouched).
 //                                  Dispatch happens in src/main/index.ts when
 //                                  CLI args are present.
-//   <install>/condash-cli.cmd    ← deprecated alias .cmd shim.
-//   The install dir is appended to per-user PATH (HKCU\Environment\PATH)
-//   by build/installer.nsh on install, removed on uninstall.
 
 const fs = require('node:fs');
 const path = require('node:path');
 
-// argv0-dispatched bash wrapper. Two physical copies share this body —
-// `/opt/condash/condash` (reachable as `/usr/bin/condash`) and
-// `/opt/condash/condash-cli` (reachable as `/usr/bin/condash-cli`). Same
-// body so the Wayland hint + Electron path resolution stay in one place;
-// behaviour switches on `basename "$0"` (or `$ARGV0` when the wrapper is
-// reached through an AppImage symlink — AppImage exports ARGV0 to the
-// basename the user invoked).
-//
-// Dispatch rule:
-//   • Invoked as `condash-cli`        → CLI (deprecation banner unless --quiet/-q).
-//   • Invoked as `condash` with no args → GUI.
-//   • Invoked as `condash gui [args]` → GUI, with `gui` stripped.
-//   • Invoked as `condash <anything>` → CLI.
+// Bash wrapper for /opt/condash/condash. Dispatches on argv:
+//   • no args            → GUI.
+//   • `condash gui …`    → GUI, with `gui` stripped.
+//   • `condash <other>`  → CLI (re-execs the Electron binary as Node against
+//                                the bundled dist-cli/condash.cjs).
 const LINUX_WRAPPER = `#!/usr/bin/env bash
 DIR="$(dirname -- "$(readlink -f -- "$0")")"
 BIN="$DIR/__BIN_NAME__"
 CLI_BUNDLE="$DIR/resources/app.asar.unpacked/dist-cli/condash.cjs"
-
-INVOKED_NAME="$(basename -- "\${ARGV0:-$0}")"
-INVOKED_NAME="\${INVOKED_NAME%.AppImage}"
 
 run_cli() {
   if [ ! -f "$CLI_BUNDLE" ]; then
@@ -81,23 +62,6 @@ run_gui() {
   exec "$BIN" "$@"
 }
 
-if [ "$INVOKED_NAME" = "condash-cli" ]; then
-  # Suppress the banner when --quiet / -q appears anywhere in argv. Match the
-  # CLI's own --quiet semantics (src/cli/parser.ts:140) — anything else falls
-  # through to the deprecation note.
-  quiet=
-  for arg in "$@"; do
-    case "$arg" in
-      --quiet|-q) quiet=1; break ;;
-    esac
-  done
-  if [ -z "$quiet" ]; then
-    echo "condash-cli: deprecated alias, use 'condash <command>' instead (alias removed in v3.0.0)." >&2
-  fi
-  run_cli "$@"
-fi
-
-# Invoked as condash. Dispatch on argv1.
 if [ $# -eq 0 ]; then
   run_gui
 fi
@@ -110,51 +74,11 @@ fi
 run_cli "$@"
 `;
 
-const MAC_CLI_WRAPPER = `#!/usr/bin/env bash
-# condash-cli (macOS) — deprecated alias. Runs the bundled Electron binary
-# in plain-Node mode against dist-cli/condash.cjs. The Electron binary lives
-# at Contents/MacOS/condash; the unpacked CLI bundle lives at
-# Contents/Resources/app.asar.unpacked/dist-cli/condash.cjs.
-DIR="$(cd -- "$(dirname -- "$0")" && pwd)"
-BIN="$DIR/condash"
-CLI_BUNDLE="$DIR/../Resources/app.asar.unpacked/dist-cli/condash.cjs"
-if [ ! -f "$CLI_BUNDLE" ]; then
-  echo "condash-cli: CLI bundle not found at $CLI_BUNDLE" >&2
-  exit 1
-fi
-
-quiet=
-for arg in "$@"; do
-  case "$arg" in
-    --quiet|-q) quiet=1; break ;;
-  esac
-done
-if [ -z "$quiet" ]; then
-  echo "condash-cli: deprecated alias, use 'condash <command>' instead (alias removed in v3.0.0)." >&2
-fi
-
-export ELECTRON_RUN_AS_NODE=1
-exec "$BIN" "$CLI_BUNDLE" "$@"
-`;
-
-// Windows .cmd shim — deprecated alias. Banner printing in batch is fragile
-// (argv iteration + redirection ordering), so emit it unconditionally; the
-// banner is one line and Windows users get the same deprecation signal as
-// every other platform. Quiet-aware suppression can be added once a user
-// reports it as noise.
-const WINDOWS_CLI_SHIM = `@echo off
-setlocal
-echo condash-cli: deprecated alias, use 'condash ^<command^>' instead (alias removed in v3.0.0). 1>&2
-set "ELECTRON_RUN_AS_NODE=1"
-"%~dp0condash.exe" "%~dp0resources\\app.asar.unpacked\\dist-cli\\condash.cjs" %*
-`;
-
 async function wrapLinux(context) {
   const appOutDir = context.appOutDir;
   const productFilename = context.packager.appInfo.productFilename;
   const realBinary = path.join(appOutDir, productFilename);
   const renamedBinary = path.join(appOutDir, `${productFilename}.bin`);
-  const cliLauncher = path.join(appOutDir, 'condash-cli');
 
   if (!fs.existsSync(realBinary)) {
     throw new Error(`afterPack: expected binary at ${realBinary} but did not find it`);
@@ -166,37 +90,9 @@ async function wrapLinux(context) {
     const script = LINUX_WRAPPER.replace('__BIN_NAME__', `${productFilename}.bin`);
     fs.writeFileSync(realBinary, script, { mode: 0o755 });
   }
-
-  // condash-cli companion (same body, different basename so argv0 dispatch
-  // routes it to CLI mode + deprecation banner). Always overwrite — cheap
-  // and idempotent.
-  const script = LINUX_WRAPPER.replace('__BIN_NAME__', `${productFilename}.bin`);
-  fs.writeFileSync(cliLauncher, script, { mode: 0o755 });
-}
-
-async function wrapMac(context) {
-  const appOutDir = context.appOutDir;
-  const productFilename = context.packager.appInfo.productFilename;
-  // appOutDir is `<release>/mac/` (or `mac-arm64/`); the .app bundle lives
-  // at `<appOutDir>/<productFilename>.app`.
-  const appBundle = path.join(appOutDir, `${productFilename}.app`);
-  const macOsDir = path.join(appBundle, 'Contents', 'MacOS');
-  if (!fs.existsSync(macOsDir)) {
-    throw new Error(`afterPack: expected MacOS dir at ${macOsDir} but did not find it`);
-  }
-  const cliLauncher = path.join(macOsDir, 'condash-cli');
-  fs.writeFileSync(cliLauncher, MAC_CLI_WRAPPER, { mode: 0o755 });
-}
-
-async function wrapWindows(context) {
-  const appOutDir = context.appOutDir;
-  const cliShim = path.join(appOutDir, 'condash-cli.cmd');
-  fs.writeFileSync(cliShim, WINDOWS_CLI_SHIM);
 }
 
 exports.default = async function afterPack(context) {
   const platform = context.electronPlatformName;
   if (platform === 'linux') return wrapLinux(context);
-  if (platform === 'darwin') return wrapMac(context);
-  if (platform === 'win32') return wrapWindows(context);
 };

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,7 +1,6 @@
 ; Custom electron-builder NSIS hook — append the install directory to
-; the per-user PATH so `condash` and `condash-cli` are reachable from any
-; shell, matching Linux's /usr/bin/condash[-cli] symlinks. See GitHub
-; issue #119.
+; the per-user PATH so `condash` is reachable from any shell, matching
+; Linux's /usr/bin/condash symlink. See GitHub issue #119.
 ;
 ; Implementation notes:
 ;

--- a/build/linux-after-install.sh
+++ b/build/linux-after-install.sh
@@ -25,12 +25,12 @@ else
     ln -sf '/opt/${sanitizedProductName}/${executable}' '/usr/bin/${executable}'
 fi
 
-# CLI companion: from v2.14.0 the GUI (condash) and the CLI (condash-cli)
-# are two separate entries on PATH. Both point at wrappers under
-# /opt/<sanitizedProductName>/ that share a body and dispatch on argv0.
-# Plain ln -sf — update-alternatives isn't useful here because no other
-# package provides condash-cli.
-ln -sf '/opt/${sanitizedProductName}/condash-cli' '/usr/bin/condash-cli'
+# Remove the deprecated `condash-cli` symlink left over from v2.x installs.
+# The /opt/<sanitizedProductName>/condash-cli wrapper file is part of the
+# .deb file set and dpkg cleans it up on upgrade; the /usr/bin/condash-cli
+# symlink was created by the previous postinst script, so dpkg does not
+# know about it and we have to remove it explicitly.
+rm -f '/usr/bin/condash-cli'
 
 chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
 

--- a/docs/help/cli.md
+++ b/docs/help/cli.md
@@ -18,10 +18,6 @@ condash <noun> <verb> [args] [--flags]
 | `condash --help`                    | Top-level CLI help.                                 |
 | `condash --version`                 | Print version.                                      |
 
-The legacy `condash-cli` binary still works as an alias for `condash`
-(CLI mode) and prints a one-line stderr deprecation note unless
-`--quiet` is set. It will be removed in v3.0.0.
-
 ## Nouns
 
 | Noun | Common verbs |

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -28,15 +28,12 @@ asarUnpack:
   - conception-template/**/*
 
 # Per-platform launcher wiring. See build/after-pack.cjs for the full why.
-# Two responsibilities:
-#   1. Linux: wrap the Electron binary with a bash launcher that exports
-#      ELECTRON_OZONE_PLATFORM_HINT=wayland on Wayland sessions before
-#      Chromium's C++ early-init reads it (otherwise the AppImage falls back
-#      to XWayland and renders blurry on fractional-scaled monitors).
-#   2. Every platform: drop a `condash-cli` deprecated alias next to the
-#      single `condash` binary. From v2.24.0 `condash` dispatches to GUI
-#      (no args) or CLI (any other invocation); the alias prints a stderr
-#      deprecation note and will be removed in v3.0.0.
+# Linux only: wrap the Electron binary with a bash launcher that exports
+# ELECTRON_OZONE_PLATFORM_HINT=wayland on Wayland sessions before
+# Chromium's C++ early-init reads it (otherwise the AppImage falls back
+# to XWayland and renders blurry on fractional-scaled monitors). The same
+# wrapper also dispatches `condash <subcommand>` → CLI (re-execs the
+# Electron binary as plain Node against dist-cli/condash.cjs).
 afterPack: build/after-pack.cjs
 
 # Publish: every tag pushes installers (and electron-builder's metadata
@@ -92,11 +89,10 @@ win:
   # click "More info" → "Run anyway".
 
 # build/installer.nsh appends $INSTDIR to per-user PATH on install (and
-# strips it on uninstall) so `condash` (and the deprecated `condash-cli`
-# alias) are reachable from any shell, matching the Linux postinst's
-# /usr/bin/condash[-cli] symlinks. electron-builder picks build/installer.nsh
-# up by default;
-# the explicit `include:` is here so the wiring isn't load-bearing on a
-# default-discovery convention. See GitHub issue #119.
+# strips it on uninstall) so `condash` is reachable from any shell,
+# matching the Linux postinst's /usr/bin/condash symlink.
+# electron-builder picks build/installer.nsh up by default; the explicit
+# `include:` is here so the wiring isn't load-bearing on a default-
+# discovery convention. See GitHub issue #119.
 nsis:
   include: build/installer.nsh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "2.30.0",
+  "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "2.30.0",
+      "version": "3.0.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -42,7 +42,7 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "condash-cli": "dist-cli/condash.cjs"
+        "condash": "dist-cli/condash.cjs"
       },
       "devDependencies": {
         "@electron/rebuild": "^3.7.2",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "condash",
-  "version": "2.30.0",
+  "version": "3.0.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",
   "bin": {
-    "condash-cli": "dist-cli/condash.cjs"
+    "condash": "dist-cli/condash.cjs"
   },
   "homepage": "https://github.com/vcoeur/condash",
   "repository": {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,11 +50,6 @@ Universal flags:
 Exit codes:
   0 ok    1 runtime    2 usage    3 validation
   4 not-found    5 no-conception    6 ambiguous
-
-Legacy alias:
-  The 'condash-cli' binary is a deprecated alias for 'condash <command>'
-  and prints a one-line stderr deprecation note unless --quiet is set. It
-  will be removed in v3.0.0.
 `;
 
 async function main(): Promise<number> {

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -159,3 +159,54 @@ describe('migrateRawSettings — dropped terminal.logging fields', () => {
     expect(parsed.terminal.logging).toEqual({ retentionDays: 28, maxDirMb: 10000 });
   });
 });
+
+describe('migrateRawSettings — invalid launcher entries', () => {
+  it('drops a launcher entry with no command (title-only), preserving valid siblings', () => {
+    // Pre-v2.28.2 the renderer could persist `{ symbol, title }` when the
+    // user typed a title without a command. The strict schema then rejects
+    // the file with `terminal.launchers.<i>.command — expected string,
+    // received undefined`, locking the Settings modal out of every save.
+    const migrated = migrateRawSettings({
+      terminal: {
+        launchers: [
+          { symbol: 'mu', title: 'Kimi' },
+          { symbol: 'lambda', command: 'claude', title: 'Claude' },
+        ],
+      },
+    }) as { terminal: { launchers: unknown[] } };
+    expect(migrated.terminal.launchers).toEqual([
+      { symbol: 'lambda', command: 'claude', title: 'Claude' },
+    ]);
+  });
+
+  it('drops a launcher entry with an empty-string command', () => {
+    const migrated = migrateRawSettings({
+      terminal: { launchers: [{ symbol: 'mu', command: '   ', title: 'Kimi' }] },
+    }) as { terminal: Record<string, unknown> };
+    expect('launchers' in migrated.terminal).toBe(false);
+  });
+
+  it('removes the launchers key entirely when every entry is invalid', () => {
+    const migrated = migrateRawSettings({
+      terminal: { launchers: [{ symbol: 'mu', title: 'Kimi' }] },
+    }) as { terminal: Record<string, unknown> };
+    expect('launchers' in migrated.terminal).toBe(false);
+  });
+
+  it('lets `validateAndCanonicaliseConceptionConfig` re-serialise a body with one bad launcher', () => {
+    // Without the scrub this throws `terminal.launchers.0.command —
+    // expected string, received undefined` (the symptom in the v2.30.0
+    // user report) and the Settings modal cannot save.
+    const json = JSON.stringify({
+      terminal: {
+        launchers: [
+          { symbol: 'mu', title: 'Kimi' },
+          { symbol: 'lambda', command: 'claude' },
+        ],
+      },
+    });
+    const canon = validateAndCanonicaliseConceptionConfig(json);
+    const parsed = JSON.parse(canon);
+    expect(parsed.terminal.launchers).toEqual([{ symbol: 'lambda', command: 'claude' }]);
+  });
+});

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -335,6 +335,14 @@ export const DEFAULT_SKILLS_PATH = '.claude/skills';
  *   were retired. Strip silently so existing `.condash/settings.json`
  *   files keep saving (otherwise every write fails with `Unrecognised
  *   key`, which also prevents the user from flipping `enabled: true`).
+ * - `terminal.launchers[]` entries missing a non-empty string `command`
+ *   are dropped. The renderer-side guard (`applyLauncherEdit`, v2.28.2)
+ *   already prevents writing `{ symbol, title }` entries, but a file
+ *   that ended up shaped that way through a pre-v2.28.2 session or an
+ *   external editor would otherwise fail every subsequent save with
+ *   `terminal.launchers.<i>.command — expected string, received
+ *   undefined` and lock the user out of the Settings modal. Scrub here
+ *   so the next write removes the bad entry from disk.
  */
 export function migrateRawSettings(parsed: unknown): unknown {
   if (!parsed || typeof parsed !== 'object') return parsed;
@@ -350,6 +358,18 @@ export function migrateRawSettings(parsed: unknown): unknown {
     delete term.launcher_command;
   } else if ('launcher_command' in term) {
     delete term.launcher_command;
+  }
+  if (Array.isArray(term.launchers)) {
+    const scrubbed = term.launchers.filter((entry) => {
+      if (!entry || typeof entry !== 'object') return false;
+      const command = (entry as { command?: unknown }).command;
+      return typeof command === 'string' && command.trim().length > 0;
+    });
+    if (scrubbed.length === 0) {
+      delete term.launchers;
+    } else {
+      term.launchers = scrubbed;
+    }
   }
   const logging = term.logging;
   if (logging && typeof logging === 'object') {

--- a/tests/help-loader.spec.ts
+++ b/tests/help-loader.spec.ts
@@ -37,15 +37,15 @@ test.describe('Help loader', () => {
     });
   }
 
-  test("cli body mentions the legacy 'condash-cli' alias", async () => {
+  test('cli body shows the `condash gui [chromium-switch ...]` invocation row', async () => {
     const booted = await bootApp();
     try {
       const body = await booted.window.evaluate(() => window.condash.readHelpDoc('cli'));
       // Asserts on a string the live `docs/help/cli.md` body must contain so
       // the help loader is verified to be reading the *current* file, not a
-      // stale bundled copy. Picks the legacy-alias mention because it's the
-      // most stable token in the file post-unification (v2.24.0).
-      expect(body).toMatch(/condash-cli/);
+      // stale bundled copy. Picks the `condash gui` row because it documents
+      // the single-binary dispatch rule and is unlikely to change shape.
+      expect(body).toMatch(/condash gui \[chromium-switch \.\.\.\]/);
     } finally {
       await booted.cleanup();
     }


### PR DESCRIPTION
## Summary

- Re-fix for the v2.28.0 launcher-save error that resurfaced on v2.30.0 (`condash.json: terminal.launchers.0.command — Invalid input: expected string, received undefined`): the renderer-side guard alone cannot repair an invalid entry that already lives on disk from a pre-v2.28.2 session or an external editor.
- Removes the deprecated `condash-cli` alias binary advertised for removal in v3.0.0 since the unified-binary release (v2.24.0); ships one `condash` binary that dispatches on argv.
- Re-cuts the release from current main so `dist-cli/condash.cjs` has the v2.29.1 fix back (v2.30.0 was tagged on a branch that predated it; the installed CLI crashes with `Cannot find module 'electron'`).

## Changes

- `src/main/config-schema.ts`: extend `migrateRawSettings` to drop any `terminal.launchers[]` entry whose `command` is missing, non-string, or empty after trim; remove the `launchers` key entirely when every entry is invalid. 4 new tests in `config-schema.test.ts` cover title-only, whitespace-only, all-invalid, and the full round-trip through `validateAndCanonicaliseConceptionConfig`.
- `build/after-pack.cjs`: rewrite to install the single `condash` Linux dispatch wrapper only (Wayland hint + GUI/CLI on argv); drop the macOS `MAC_CLI_WRAPPER`, the Windows `WINDOWS_CLI_SHIM`, and the dual-launcher Linux companion script. macOS and Windows are now no-ops in afterPack — their dispatch already happens in `src/main/index.ts`.
- `build/linux-after-install.sh`: drop the `/usr/bin/condash-cli` symlink creation; actively `rm -f /usr/bin/condash-cli` so upgrades from v2.x clean up the symlink the previous postinst owned.
- `electron-builder.yml`: update the `afterPack` and `nsis` comment blocks to describe the single-binary world.
- `build/installer.nsh`: comment-only update describing the single-binary PATH append.
- `package.json` / `package-lock.json`: rename the `bin` key `condash-cli` → `condash`; bump version `2.30.0` → `3.0.0`.
- `src/cli/index.ts`: remove the `Legacy alias:` paragraph from `TOP_HELP`.
- `docs/help/cli.md`: drop the legacy-alias note from the top-level section.
- `tests/help-loader.spec.ts`: replace the `condash-cli` mention assertion with one anchored on the `condash gui [chromium-switch ...]` invocation row.

## Impact

- Breaking change for any user / script invoking `condash-cli` directly — they must switch to `condash <subcommand>`. The deprecation banner has shipped this notice since v2.24.0.
- The `bin` rename `condash-cli` → `condash` is cosmetic for end users (the package is private, never published to npm) but tooling that resolves the binary via `npm bin` or workspace symlinks now finds `condash` instead.
- The `.deb` postinst now removes a `/usr/bin/condash-cli` left behind by a v2.x install. Stale `/opt/condash/condash-cli` wrapper files are tracked by dpkg and removed automatically on upgrade.

## Watchpoints

- After tagging `v3.0.0`: verify the published `.deb` postinst cleans up `/usr/bin/condash-cli` on an upgrade from a v2.x install and that `condash --version` round-trips (no top-level `require('electron')` in `dist-cli/condash.cjs`).
- Settings modal on a conception whose `.condash/settings.json` carries a `{ symbol, title }` launcher entry should now save successfully; the bad entry is dropped on the first write.