### PR TITLE
Add Kimi permissions block to shipped AGENTS.md template

### DIFF
--- a/conception-template/AGENTS.md
+++ b/conception-template/AGENTS.md
@@ -24,6 +24,17 @@ This section is shipped by condash and refreshed by `condash skills install`. Ed
 
 - **Auto-memory opt-out**: this tree does not use the harness auto-memory. Durable team rules go under `## Specifics` below; durable reference material lives under [`knowledge/`](knowledge/index.md). Never write to `{{ memory_dir }}` for this tree.
 
+### Kimi
+
+When operating inside this conception with Kimi Code CLI, the following are auto-approved without per-action confirmation:
+
+- Read, edit, and create any file inside the conception directory (`projects/`, `knowledge/`, `notes/`, and any other path under the conception root).
+- Run `condash` with any arguments.
+- Edit code in `<workspace_path>/<repo>/` (main app checkouts) and `<worktrees_path>/<branch>/<repo>/` (PR worktrees).
+- Run any shell command needed to test or verify app behaviour (test runners, dev servers, build commands, package installs).
+
+**Why:** Kimi Code CLI's default permission boundary treats the working directory as the only safe zone. Conception work routinely requires touching sibling repos, running the condash CLI, and executing tests. A single explicit rule removes friction that would otherwise require the user to confirm every file write or command execution.
+
 ### What `## Specifics` should contain
 
 `## Specifics` is per-conception — user-owned, never touched by `condash skills install`. Open it with the **Apps** table; everything below the table is durable team rules and workspace facts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- Add a `### Kimi` section to the condash-shipped `conception-template/AGENTS.md` that explicitly authorises Kimi Code CLI to read, write, and execute without per-action confirmation inside the conception directory, workspace repos, and worktrees.

## Changes

- `conception-template/AGENTS.md`: insert `### Kimi` after `### Claude` with four auto-approval bullets (conception files, condash CLI, workspace/worktree code edits, test commands).
- `package.json` / `package-lock.json`: bump 3.1.0 → 3.2.0.

## Impact

- New and refreshed conceptions will receive the rule automatically via `condash templates install` (or `condash skills install`). Existing conceptions get it on their next refresh.
- The `### Kimi` section is stripped from the compiled `.claude/CLAUDE.md` output and retained in `.kimi/AGENTS.md`.