### PR TITLE
Replace root AGENTS.md with .agents/agents/ source tree

### DIFF
--- a/conception-template/.agents/agents/claude.md
+++ b/conception-template/.agents/agents/claude.md
@@ -1,0 +1,3 @@
+### Claude
+
+- **Auto-memory opt-out**: this tree does not use the harness auto-memory. Durable team rules go under `## Specifics` below; durable reference material lives under [`knowledge/`](knowledge/index.md). Never write to `{{ memory_dir }}` for this tree.

--- a/conception-template/.agents/agents/common.md
+++ b/conception-template/.agents/agents/common.md
@@ -20,21 +20,6 @@ This section is shipped by condash and refreshed by `condash skills install`. Ed
 - **Autonomy**: when the next action is obvious from context, proceed — don't ask. Ask when the call is genuinely ambiguous or the action is hard to reverse. Terse prompts like "redo now", "close it", "ship" are explicit permission to run end-to-end without per-step confirmation.
 - **Keep the project README live as you work**: every project under `projects/YYYY-MM/<slug>/` is the cold-recovery contract. The moment you start, finish, partially complete, or get blocked on a `## Steps` item, flip its marker (`[ ]` `[~]` `[x]` `[!]`); append a one-line dated timeline entry on each material event (decision, PR opened, blocker found); lift inline user answers from chat into `## Notes` or `notes/NN-…md`. Goal: if this session crashes or is interrupted right now, the next reader answers "what shipped, what's left, what's blocking" from the README alone. Don't batch updates to the end of a pass.
 
-### Claude
-
-- **Auto-memory opt-out**: this tree does not use the harness auto-memory. Durable team rules go under `## Specifics` below; durable reference material lives under [`knowledge/`](knowledge/index.md). Never write to `{{ memory_dir }}` for this tree.
-
-### Kimi
-
-When operating inside this conception with Kimi Code CLI, the following are auto-approved without per-action confirmation:
-
-- Read, edit, and create any file inside the conception directory (`projects/`, `knowledge/`, `notes/`, and any other path under the conception root).
-- Run `condash` with any arguments.
-- Edit code in `<workspace_path>/<repo>/` (main app checkouts) and `<worktrees_path>/<branch>/<repo>/` (PR worktrees).
-- Run any shell command needed to test or verify app behaviour (test runners, dev servers, build commands, package installs).
-
-**Why:** Kimi Code CLI's default permission boundary treats the working directory as the only safe zone. Conception work routinely requires touching sibling repos, running the condash CLI, and executing tests. A single explicit rule removes friction that would otherwise require the user to confirm every file write or command execution.
-
 ### What `## Specifics` should contain
 
 `## Specifics` is per-conception — user-owned, never touched by `condash skills install`. Open it with the **Apps** table; everything below the table is durable team rules and workspace facts.

--- a/conception-template/.agents/agents/kimi.md
+++ b/conception-template/.agents/agents/kimi.md
@@ -1,0 +1,10 @@
+### Kimi
+
+When operating inside this conception with Kimi Code CLI, the following are auto-approved without per-action confirmation:
+
+- Read, edit, and create any file inside the conception directory (`projects/`, `knowledge/`, `notes/`, and any other path under the conception root).
+- Run `condash` with any arguments.
+- Edit code in `<workspace_path>/<repo>/` (main app checkouts) and `<worktrees_path>/<branch>/<repo>/` (PR worktrees).
+- Run any shell command needed to test or verify app behaviour (test runners, dev servers, build commands, package installs).
+
+**Why:** Kimi Code CLI's default permission boundary treats the working directory as the only safe zone. Conception work routinely requires touching sibling repos, running the condash CLI, and executing tests. A single explicit rule removes friction that would otherwise require the user to confirm every file write or command execution.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/agents-md/compile.test.ts
+++ b/src/agents-md/compile.test.ts
@@ -1,95 +1,67 @@
 import { describe, expect, it } from 'vitest';
-import { compileAgentsMd } from './compile';
+import { compileAgentConfig } from './compile';
 
-describe('compileAgentsMd — section stripping', () => {
-  it('keeps the matching ### Claude section for the claude target', () => {
-    const source = [
-      '# AGENTS',
-      '',
-      'Common preamble.',
-      '',
-      '### Claude',
-      '',
-      '- Claude-only rule.',
-      '',
-      '### Kimi',
-      '',
-      '- Kimi-only rule.',
-      '',
-      '## Next H2',
-      '',
-      'After.',
-      '',
-    ].join('\n');
-    const out = compileAgentsMd(source, 'claude');
-    expect(out).toContain('Claude-only rule');
-    expect(out).not.toContain('Kimi-only rule');
-    expect(out).toContain('After.');
+describe('compileAgentConfig — fragment insertion', () => {
+  it('inserts fragment before ## Specifics', () => {
+    const common = '# Title\n\n## General\n\nContent.\n\n## Specifics\n\nSpecific content.\n';
+    const fragment = '### Claude\n\n- Claude-only rule.\n';
+    const out = compileAgentConfig(common, fragment, 'claude');
+    expect(out).toContain('## General');
+    expect(out).toContain('### Claude');
+    expect(out.indexOf('### Claude')).toBeLessThan(out.indexOf('## Specifics'));
+    expect(out).toContain('Specific content.');
   });
 
-  it('keeps the matching ### Kimi section for the kimi target', () => {
-    const source = '## A\n\n### Claude\n\nC\n\n### Kimi\n\nK\n\n## B\n';
-    const out = compileAgentsMd(source, 'kimi');
-    expect(out).not.toContain('\nC\n');
-    expect(out).toContain('\nK\n');
+  it('appends fragment when ## Specifics is missing', () => {
+    const common = '# Title\n\n## General\n\nContent.\n';
+    const fragment = '### Kimi\n\n- Kimi-only rule.\n';
+    const out = compileAgentConfig(common, fragment, 'kimi');
+    expect(out).toContain('### Kimi');
+    expect(out.indexOf('Content.')).toBeLessThan(out.indexOf('### Kimi'));
   });
 
-  it('strips off-target section ending at end of file', () => {
-    const source = '## A\n\nbody\n\n### Claude\n\nclaude only\n';
-    const out = compileAgentsMd(source, 'kimi');
-    expect(out).not.toContain('claude only');
-    expect(out.trim()).toBe('## A\n\nbody'.trim());
+  it('returns common unchanged when fragment is empty', () => {
+    const common = '# Title\n\n## Specifics\n\nContent.\n';
+    const out = compileAgentConfig(common, '', 'claude');
+    expect(out).toBe('# Title\n\n## Specifics\n\nContent.\n');
   });
 
-  it('does not collapse non-target H3 headings', () => {
-    const source = '## A\n\n### Subsection\n\nBoth see this.\n\n### Claude\n\nClaude only.\n';
-    const out = compileAgentsMd(source, 'kimi');
-    expect(out).toContain('### Subsection');
-    expect(out).toContain('Both see this.');
-    expect(out).not.toContain('Claude only.');
-  });
-
-  it('strips the off-target H3 even when followed by another H3', () => {
-    const source = '## A\n\n### Kimi\n\nKimi only.\n\n### Notes\n\nShared notes.\n';
-    const out = compileAgentsMd(source, 'claude');
-    expect(out).not.toContain('Kimi only.');
-    expect(out).toContain('### Notes');
-    expect(out).toContain('Shared notes.');
-  });
-
-  it('does not leave a double-blank seam where a section was removed', () => {
-    const source = ['Line 1.', '', '### Kimi', '', 'Strip me.', '', 'Line 2.', ''].join('\n');
-    const out = compileAgentsMd(source, 'claude');
-    expect(out).not.toContain('\n\n\n');
+  it('returns common unchanged when fragment is whitespace-only', () => {
+    const common = '# Title\n\n## Specifics\n\nContent.\n';
+    const out = compileAgentConfig(common, '   \n\n  ', 'kimi');
+    expect(out).toBe('# Title\n\n## Specifics\n\nContent.\n');
   });
 });
 
-describe('compileAgentsMd — variable substitution', () => {
-  it('substitutes default per-target variables', () => {
-    const source = 'Skills live at {{ skills_dir }} and config is {{ agent_config }}.';
-    expect(compileAgentsMd(source, 'claude')).toBe(
-      'Skills live at .claude/skills/ and config is CLAUDE.md.',
-    );
-    expect(compileAgentsMd(source, 'kimi')).toBe(
-      'Skills live at .kimi/skills/ and config is AGENTS.md.',
-    );
+describe('compileAgentConfig — variable substitution', () => {
+  it('substitutes {{ skills_dir }} per target', () => {
+    const common = 'Skills at {{ skills_dir }}.';
+    const outClaude = compileAgentConfig(common, '', 'claude');
+    const outKimi = compileAgentConfig(common, '', 'kimi');
+    expect(outClaude).toBe('Skills at .claude/skills/.');
+    expect(outKimi).toBe('Skills at .kimi/skills/.');
   });
 
-  it('replaces unknown variables with the empty string', () => {
-    expect(compileAgentsMd('Hello {{ unknown }}.', 'claude')).toBe('Hello .');
+  it('substitutes {{ agent_config }} per target', () => {
+    const common = 'Config is {{ agent_config }}.';
+    expect(compileAgentConfig(common, '', 'claude')).toBe('Config is CLAUDE.md.');
+    expect(compileAgentConfig(common, '', 'kimi')).toBe('Config is AGENTS.md.');
   });
 
-  it('substitutes Kimi memory_dir with empty (no native memory)', () => {
-    expect(compileAgentsMd('Memory at {{ memory_dir }}.', 'kimi')).toBe('Memory at .');
-    expect(compileAgentsMd('Memory at {{ memory_dir }}.', 'claude')).toContain(
-      '~/.claude/projects/',
-    );
+  it('replaces unknown variables with empty string', () => {
+    expect(compileAgentConfig('Hello {{ unknown }}.', '', 'claude')).toBe('Hello .');
   });
 
-  it('honours a caller-supplied variable map override', () => {
-    const out = compileAgentsMd('{{ skills_dir }}', 'claude', {
-      variables: { skills_dir: '/tmp/override' },
+  it('substitutes {{ memory_dir }} per target', () => {
+    const common = 'Memory at {{ memory_dir }}.';
+    expect(compileAgentConfig(common, '', 'kimi')).toBe('Memory at .');
+    expect(compileAgentConfig(common, '', 'claude')).toContain('~/.claude/projects/');
+  });
+
+  it('allows variable overrides', () => {
+    const out = compileAgentConfig('{{ skills_dir }}', '', 'claude', {
+      variables: { skills_dir: 'custom/' },
     });
-    expect(out).toBe('/tmp/override');
+    expect(out).toBe('custom/');
   });
 });

--- a/src/agents-md/compile.ts
+++ b/src/agents-md/compile.ts
@@ -1,38 +1,24 @@
 /**
- * Compile a unified `AGENTS.md` source into per-agent flavours.
+ * Compile per-agent config files from a `.agents/agents/` source tree.
  *
- * The source is plain Markdown with two extensions:
+ * Source layout:
+ *   - `.agents/agents/common.md`      — shared content (must contain `## Specifics`)
+ *   - `.agents/agents/claude.md`      — Claude-only fragment
+ *   - `.agents/agents/kimi.md`        — Kimi-only fragment
  *
- *   1. **Target-tagged sections.** A heading `### Claude` (or `### Kimi`)
- *      starts a section that's kept for the matching target and stripped
- *      for the other. The section ends at the next sibling `### ` heading
- *      OR any heading of equal-or-higher level (`## `, `# `). The blank
- *      lines surrounding the heading are also collapsed so the stripped
- *      output reads cleanly.
- *
- *   2. **Variable substitution.** `{{ var }}` tokens (whitespace around the
- *      name is tolerated) are replaced from the per-target variable map.
- *      If a key isn't in the map for the current target, the token is
- *      replaced with the empty string.
- *
- * Output:
- *
- *   - Claude target → contents intended for `<conception>/.claude/CLAUDE.md`
- *   - Kimi target   → contents intended for `<conception>/.kimi/AGENTS.md`
- *
- * The compiler is intentionally minimal: no full Markdown AST, just a
- * line-based scan of `### ` and `## `/`# ` headings. This keeps it cheap
- * and predictable, and matches how authors actually structure these docs.
+ * The compile step inserts the agent-specific fragment into `common.md`
+ * immediately before the `## Specifics` heading, then applies `{{ var }}`
+ * variable substitution from the per-target map.
  */
 
 export type AgentsMdTarget = 'claude' | 'kimi';
 
 export const AGENTS_MD_TARGETS: readonly AgentsMdTarget[] = ['claude', 'kimi'] as const;
 
-/** Heading text that introduces a target-tagged H3 section. */
-const TARGET_HEADINGS: Record<AgentsMdTarget, string> = {
-  claude: 'Claude',
-  kimi: 'Kimi',
+/** Output path per target, relative to the conception root. */
+export const AGENTS_MD_OUTPUTS: Record<AgentsMdTarget, string> = {
+  claude: '.claude/CLAUDE.md',
+  kimi: '.kimi/AGENTS.md',
 };
 
 /** Default variable map per target, applied via `{{ var }}` substitution. */
@@ -56,57 +42,69 @@ export function defaultVariables(target: AgentsMdTarget): Record<string, string>
   }
 }
 
-export interface CompileAgentsMdOptions {
+export interface CompileAgentConfigOptions {
   /** Override / extend the default variable map for this target. */
   variables?: Record<string, string>;
 }
 
-export function compileAgentsMd(
-  source: string,
+/**
+ * Merge `common.md` with the per-agent fragment and substitute variables.
+ *
+ * The agent fragment is spliced in just before the first `## Specifics`
+ * heading in common.md. If common.md lacks that heading, the fragment is
+ * appended. If the agent file is empty or missing, common.md is returned
+ * unchanged (after variable substitution).
+ */
+export function compileAgentConfig(
+  common: string,
+  agentFragment: string,
   target: AgentsMdTarget,
-  opts: CompileAgentsMdOptions = {},
+  opts: CompileAgentConfigOptions = {},
 ): string {
   const variables = { ...defaultVariables(target), ...(opts.variables ?? {}) };
-  const stripped = stripOffTargetSections(source, target);
-  return substituteVariables(stripped, variables);
+  let merged: string;
+
+  if (!agentFragment.trim()) {
+    merged = common;
+  } else {
+    merged = spliceBeforeSpecifics(common, agentFragment);
+  }
+
+  return substituteVariables(merged, variables);
 }
 
 /**
- * Walk the source line by line. When a `### <off-target>` heading is hit,
- * skip every following line until the next heading of equal-or-higher level
- * (`### `, `## `, `# `) or end-of-file. Drop the surrounding blank lines
- * so the output reads cleanly.
+ * Find the first `## Specifics` heading in `common` and insert `fragment`
+ * immediately before it, separated by a single blank line.
  */
-function stripOffTargetSections(source: string, keepTarget: AgentsMdTarget): string {
-  const offTargets = AGENTS_MD_TARGETS.filter((t) => t !== keepTarget);
-  const offHeadings = new Set(offTargets.map((t) => TARGET_HEADINGS[t]));
-
-  const lines = source.split('\n');
-  const out: string[] = [];
-  let i = 0;
-  while (i < lines.length) {
-    const line = lines[i];
-    const h3 = line.match(/^### +(.+?)\s*$/);
-    if (h3 && offHeadings.has(h3[1].trim())) {
-      // Eat preceding blank lines we already pushed (so the strip leaves no
-      // double blank).
-      while (out.length > 0 && out[out.length - 1] === '') out.pop();
-      // Skip the heading and everything until the next sibling/parent heading.
-      i += 1;
-      while (i < lines.length) {
-        const probe = lines[i];
-        if (/^#{1,3} +/.test(probe)) break;
-        i += 1;
-      }
-      // Eat trailing blank lines before the next heading so we don't end up
-      // with a double-blank seam.
-      while (i < lines.length && lines[i] === '') i += 1;
-      continue;
+function spliceBeforeSpecifics(common: string, fragment: string): string {
+  const lines = common.split('\n');
+  let insertIndex = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+Specifics\s*$/.test(lines[i])) {
+      insertIndex = i;
+      break;
     }
-    out.push(line);
-    i += 1;
   }
-  return out.join('\n');
+
+  const trimmedFragment = fragment.trimEnd();
+  if (insertIndex === -1) {
+    // No ## Specifics — append with a blank line separator.
+    const sep = common.endsWith('\n') ? '' : '\n';
+    return common + sep + '\n' + trimmedFragment + '\n';
+  }
+
+  const before = lines.slice(0, insertIndex);
+  const after = lines.slice(insertIndex);
+  // Ensure a blank line between the preceding content and the fragment.
+  const result = [...before];
+  if (result.length > 0 && result[result.length - 1] !== '') {
+    result.push('');
+  }
+  result.push(trimmedFragment);
+  result.push('');
+  result.push(...after);
+  return result.join('\n') + '\n';
 }
 
 const VARIABLE_RE = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;

--- a/src/agents-md/index.ts
+++ b/src/agents-md/index.ts
@@ -1,2 +1,7 @@
-export { AGENTS_MD_TARGETS, compileAgentsMd, defaultVariables } from './compile';
-export type { AgentsMdTarget, CompileAgentsMdOptions } from './compile';
+export {
+  AGENTS_MD_TARGETS,
+  AGENTS_MD_OUTPUTS,
+  compileAgentConfig,
+  defaultVariables,
+} from './compile';
+export type { AgentsMdTarget, CompileAgentConfigOptions } from './compile';

--- a/src/cli/commands/files.install.test.ts
+++ b/src/cli/commands/files.install.test.ts
@@ -1,17 +1,14 @@
 /**
- * Install tests for the top-level file branch of `condash skills install`
- * (the artist formerly known as `condash templates install`). Verifies the
- * AGENTS.md / .gitignore region-merge pass, the AGENTS.md → per-target
- * compile pass, the legacy CLAUDE.md → AGENTS.md migration, and the v2 → v3
- * manifest namespace rename (`templates` → `files`).
+ * Install tests for the top-level file branch of `condash skills install`.
+ * Verifies the .gitignore region-merge pass, the `.agents/agents/` → per-target
+ * compile pass, and the v2 → v3 manifest namespace rename (`templates` → `files`).
  */
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runSkills } from './skills';
-import { MANIFEST_RELPATH, readManifest, sha256 } from './install-shared';
-import { extractRegion } from './regions';
+import { MANIFEST_RELPATH, readManifest } from './install-shared';
 import type { OutputContext } from '../output';
 
 const TEMPLATE_ROOT = resolve(__dirname, '..', '..', '..', 'conception-template');
@@ -40,90 +37,39 @@ async function install(positional: string[] = []): Promise<void> {
 }
 
 describe('condash skills install — top-level files', () => {
-  it('writes AGENTS.md and compiles to .claude/CLAUDE.md + .kimi/AGENTS.md', async () => {
-    await install(['AGENTS.md']);
-
-    const agents = await fs.readFile(join(dest, 'AGENTS.md'), 'utf8');
-    expect(agents).toMatch(/^# AGENTS\.md — conception/);
+  it('compiles .agents/agents/ to .claude/CLAUDE.md + .kimi/AGENTS.md', async () => {
+    await install();
 
     const claude = await fs.readFile(join(dest, '.claude/CLAUDE.md'), 'utf8');
     // Variable substitution: skills_dir → .claude/skills/
     expect(claude).toContain('.claude/skills/projects/SKILL.md');
-    // ### Kimi sections stripped, ### Claude sections kept.
+    // Claude fragment included.
     expect(claude).toContain('Auto-memory opt-out');
 
     const kimi = await fs.readFile(join(dest, '.kimi/AGENTS.md'), 'utf8');
     expect(kimi).toContain('.kimi/skills/projects/SKILL.md');
+    // Claude fragment excluded from Kimi output.
     expect(kimi).not.toContain('Auto-memory opt-out');
   });
 
-  it('migrates a legacy CLAUDE.md + v1 templates manifest to AGENTS.md', async () => {
-    // Plant a legacy CLAUDE.md with a `## General` region the user has not edited
-    // (its hash matches the manifest) and a `## Specifics` they've customised.
-    const legacy = [
-      '# CLAUDE.md — conception',
-      '',
-      '## General',
-      '',
-      'old shipped general body',
-      '',
-      '## Specifics',
-      '',
-      'My custom specifics.',
-      '',
-    ].join('\n');
-    await fs.writeFile(join(dest, 'CLAUDE.md'), legacy, 'utf8');
+  it('writes .gitignore with region replacement', async () => {
+    await install(['.gitignore']);
 
-    // Plant a v1 manifest entry tracking CLAUDE.md's General region SHA.
-    const region = extractRegion(legacy, 'General')!;
-    const manifestPath = join(dest, '.claude/skills', MANIFEST_RELPATH);
-    await fs.mkdir(join(dest, '.claude/skills'), { recursive: true });
-    await fs.writeFile(
-      manifestPath,
-      JSON.stringify(
-        {
-          version: 1,
-          skills: {},
-          templates: {
-            'CLAUDE.md': { region: 'General', sha256: sha256(region), shippedVersion: '2.28.2' },
-          },
-        },
-        null,
-        2,
-      ),
-    );
-
-    await install(['AGENTS.md']);
-
-    // CLAUDE.md is gone; AGENTS.md is present.
-    await expect(fs.access(join(dest, 'CLAUDE.md'))).rejects.toThrow();
-    const agents = await fs.readFile(join(dest, 'AGENTS.md'), 'utf8');
-    // The user's `## Specifics` survived.
-    expect(agents).toContain('My custom specifics.');
-    // The `## General` region was refreshed to the shipped content.
-    expect(agents).toContain('Pointers');
-
-    // Manifest entry migrated to AGENTS.md key, under the new `files` namespace.
-    const manifest = await readManifest(dest);
-    expect(manifest!.version).toBe(3);
-    expect(manifest!.files!['AGENTS.md']).toBeTruthy();
-    expect(manifest!.files!['CLAUDE.md']).toBeUndefined();
-
-    // Compiled outputs landed.
-    await fs.access(join(dest, '.claude/CLAUDE.md'));
-    await fs.access(join(dest, '.kimi/AGENTS.md'));
+    const gitignore = await fs.readFile(join(dest, '.gitignore'), 'utf8');
+    expect(gitignore).toContain('# General');
+    expect(gitignore).toContain('# Specifics');
   });
 
-  it('records AGENTS.md under the v3 files namespace (not templates)', async () => {
-    await install(['AGENTS.md']);
+  it('records .gitignore under the v3 files namespace (not templates)', async () => {
+    await install(['.gitignore']);
     const manifest = await readManifest(dest);
     expect(manifest!.version).toBe(3);
-    expect(manifest!.files!['AGENTS.md']).toBeTruthy();
+    expect(manifest!.files!['.gitignore']).toBeTruthy();
     expect((manifest as unknown as { templates?: unknown }).templates).toBeUndefined();
   });
 
   it('migrates a v2 manifest with `templates` to v3 `files` on first install', async () => {
-    // Plant a v2 manifest tracking CLAUDE.md (an entry condash 3.x no longer ships).
+    // Plant a v2 manifest tracking .gitignore.
     const manifestPath = join(dest, '.claude/skills', MANIFEST_RELPATH);
     await fs.mkdir(join(dest, '.claude/skills'), { recursive: true });
     await fs.writeFile(
@@ -133,7 +79,7 @@ describe('condash skills install — top-level files', () => {
           version: 2,
           skills: {},
           templates: {
-            'CLAUDE.md': { region: 'General', sha256: 'x'.repeat(64), shippedVersion: '2.26.0' },
+            '.gitignore': { region: 'General', sha256: 'x'.repeat(64), shippedVersion: '2.26.0' },
           },
         },
         null,
@@ -141,14 +87,13 @@ describe('condash skills install — top-level files', () => {
       ),
     );
 
-    await install(['AGENTS.md']);
+    await install(['.gitignore']);
 
     const manifest = await readManifest(dest);
     expect(manifest!.version).toBe(3);
-    // The stale CLAUDE.md entry survives the migration (it's still tracked in
+    // The stale entry survives the migration (it's still tracked in
     // `files` — only --prune removes it).
-    expect(manifest!.files!['CLAUDE.md']).toBeTruthy();
-    expect(manifest!.files!['AGENTS.md']).toBeTruthy();
+    expect(manifest!.files!['.gitignore']).toBeTruthy();
   });
 
   it('--prune drops manifest entries whose shipped source no longer exists', async () => {

--- a/src/cli/commands/files.ts
+++ b/src/cli/commands/files.ts
@@ -2,12 +2,10 @@
  * Top-level shipped-file install for `condash skills install`.
  *
  * Each entry in `SHIPPED_FILES` lives at the conception root and ships the
- * body of one heading-delimited region. Two entries today:
- *   - `AGENTS.md` — `## General` (markdown H2). Renamed from `CLAUDE.md`
- *     in v2.29.0; an existing `CLAUDE.md` (without an `AGENTS.md` sibling)
- *     is auto-renamed on first install so legacy installs migrate cleanly.
- *   - `.gitignore` — `# General` (gitignore-comment style; sibling
- *     `# Specifics` terminates the region).
+ * body of one heading-delimited region. Today only `.gitignore` uses this
+ * path; `AGENTS.md` was removed from shipped files in favour of a
+ * `.agents/agents/` source tree that compiles to per-agent outputs.
+ *
  * The surrounding text — anything before the General heading and the
  * user-owned `Specifics` section that follows — is never touched. Hash-based
  * safe-update model matching the agent-skill source files:
@@ -16,8 +14,7 @@
  *   - region differs from manifest → user edited → refuse without --force.
  *   - region present but file not in manifest → orphan → treat as edited.
  *   - heading absent or ambiguous → no region to write through; refuse without
- *     --force. With --force, write the entire shipped file (everything before
- *     `General` + `General` body + placeholder `Specifics` section).
+ *     --force. With --force, write the entire shipped file.
  *   - file absent entirely → fresh install path → write the shipped file.
  *   - shipped bundle no longer ships the file (a previous condash version
  *     installed it; the current one dropped it) → source-missing. Skipped
@@ -31,7 +28,12 @@
 
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
-import { AGENTS_MD_TARGETS, compileAgentsMd, type AgentsMdTarget } from '../../agents-md';
+import {
+  AGENTS_MD_TARGETS,
+  AGENTS_MD_OUTPUTS,
+  compileAgentConfig,
+  type AgentsMdTarget,
+} from '../../agents-md';
 import { CliError, ExitCodes } from '../output';
 import {
   cheapDiff,
@@ -41,12 +43,6 @@ import {
   type ManifestRegionEntry,
 } from './install-shared';
 import { DEFAULT_MARK, extractRegion, replaceRegion, type HeadingOpts } from './regions';
-
-/** Compiled-output path per target, relative to the conception root. */
-const AGENTS_MD_OUTPUTS: Record<AgentsMdTarget, string> = {
-  claude: '.claude/CLAUDE.md',
-  kimi: '.kimi/AGENTS.md',
-};
 
 export interface ShippedFile {
   /** Path relative to dest root, e.g. "AGENTS.md". */
@@ -72,7 +68,6 @@ export interface ShippedFile {
  * a one-line append plus a new entry in `conception-template/`.
  */
 export const SHIPPED_FILES: ShippedFile[] = [
-  { path: 'AGENTS.md', region: 'General' },
   { path: '.gitignore', region: 'General', mark: '#', siblings: ['Specifics'] },
 ];
 
@@ -289,27 +284,39 @@ export async function installShippedFile(
 }
 
 /**
- * Compile AGENTS.md → per-target output files (`.claude/CLAUDE.md` +
+ * Path of the agent-config source tree relative to the conception root.
+ */
+const AGENTS_SOURCE_RELPATH = '.agents/agents';
+
+/**
+ * Compile `.agents/agents/` → per-target output files (`.claude/CLAUDE.md` +
  * `.kimi/AGENTS.md`). Compiled outputs are deterministic from the source
  * and aren't tracked by the manifest — they're regenerated on every
- * install. Returns the empty array (and writes nothing) if AGENTS.md
- * doesn't exist on disk.
+ * install. Returns the empty array (and writes nothing) if the source
+ * tree doesn't exist on disk.
  */
-export async function compileAgentsMdToTargets(
+export async function compileAgentConfigs(
   dest: string,
   dryRun: boolean,
 ): Promise<{ target: AgentsMdTarget; path: string }[]> {
-  const agentsMdPath = join(dest, 'AGENTS.md');
-  let source: string | null = null;
+  const sourceDir = join(dest, AGENTS_SOURCE_RELPATH);
+  let common: string | null = null;
   try {
-    source = await fs.readFile(agentsMdPath, 'utf8');
+    common = await fs.readFile(join(sourceDir, 'common.md'), 'utf8');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
   }
-  if (source === null) return [];
+  if (common === null) return [];
+
   const written: { target: AgentsMdTarget; path: string }[] = [];
   for (const target of AGENTS_MD_TARGETS) {
-    const compiled = compileAgentsMd(source, target);
+    let fragment = '';
+    try {
+      fragment = await fs.readFile(join(sourceDir, `${target}.md`), 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    const compiled = compileAgentConfig(common, fragment, target);
     const outputPath = join(dest, AGENTS_MD_OUTPUTS[target]);
     if (!dryRun) await writeFileMkdir(outputPath, Buffer.from(compiled, 'utf8'));
     written.push({ target, path: AGENTS_MD_OUTPUTS[target] });
@@ -459,6 +466,58 @@ export function listShippedFiles(manifest: Manifest | null): FileListRow[] {
       shippedVersion: entry?.shippedVersion ?? null,
     };
   });
+}
+
+/**
+ * Copy the `.agents/agents/` source tree from the shipped template to the
+ * destination. Overwrites on every install (no refuse-on-edit for these
+ * small source fragments; user edits should go into `## Specifics` in the
+ * compiled output, not the source files).
+ *
+ * Returns the list of relative paths copied.
+ */
+export async function installAgentConfigSources(dest: string, dryRun: boolean): Promise<string[]> {
+  const shippedDir = join(locateShippedFilesRoot(), '.agents', 'agents');
+  const targetDir = join(dest, '.agents', 'agents');
+  const copied: string[] = [];
+
+  async function walk(src: string, dst: string, prefix: string): Promise<void> {
+    const entries = await fs.readdir(src, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      const srcPath = join(src, entry.name);
+      const dstPath = join(dst, entry.name);
+      const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        if (!dryRun) await fs.mkdir(dstPath, { recursive: true });
+        await walk(srcPath, dstPath, relPath);
+      } else if (entry.isFile()) {
+        const content = await fs.readFile(srcPath);
+        let shouldWrite = true;
+        try {
+          const existing = await fs.readFile(dstPath);
+          if (existing.equals(content)) shouldWrite = false;
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
+        if (shouldWrite) {
+          if (!dryRun) await writeFileMkdir(dstPath, content);
+          copied.push(relPath);
+        }
+      }
+    }
+  }
+
+  try {
+    await fs.access(shippedDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  if (!dryRun) await fs.mkdir(targetDir, { recursive: true });
+  await walk(shippedDir, targetDir, '');
+  return copied;
 }
 
 /**

--- a/src/cli/commands/project.test.ts
+++ b/src/cli/commands/project.test.ts
@@ -28,38 +28,45 @@ async function build(): Promise<void> {
 }
 
 describe('condash project build', () => {
-  it('compiles AGENTS.md to .claude/CLAUDE.md and .kimi/AGENTS.md', async () => {
-    const source = [
+  it('compiles .agents/agents/ to .claude/CLAUDE.md and .kimi/AGENTS.md', async () => {
+    const agentsDir = join(dest, '.agents', 'agents');
+    await fs.mkdir(agentsDir, { recursive: true });
+
+    const common = [
       '# AGENTS.md — test',
       '',
       '## General',
       '',
       'Skills at {{ skills_dir }}.',
       '',
-      '### Claude',
-      '',
-      '- Memory at {{ memory_dir }}.',
-      '',
-      '### Kimi',
-      '',
-      '- No memory.',
+      '## Specifics',
       '',
     ].join('\n');
-    await fs.writeFile(join(dest, 'AGENTS.md'), source, 'utf8');
+    await fs.writeFile(join(agentsDir, 'common.md'), common, 'utf8');
+
+    const claudeFragment = ['### Claude', '', '- Memory at {{ memory_dir }}.', ''].join('\n');
+    await fs.writeFile(join(agentsDir, 'claude.md'), claudeFragment, 'utf8');
+
+    const kimiFragment = ['### Kimi', '', '- No memory.', ''].join('\n');
+    await fs.writeFile(join(agentsDir, 'kimi.md'), kimiFragment, 'utf8');
+
     await build();
 
     const claude = await fs.readFile(join(dest, '.claude/CLAUDE.md'), 'utf8');
     expect(claude).toContain('Skills at .claude/skills/.');
     expect(claude).toContain('Memory at ~/.claude/projects/');
     expect(claude).not.toContain('No memory.');
+    // Fragment inserted before ## Specifics
+    expect(claude.indexOf('### Claude')).toBeLessThan(claude.indexOf('## Specifics'));
 
     const kimi = await fs.readFile(join(dest, '.kimi/AGENTS.md'), 'utf8');
     expect(kimi).toContain('Skills at .kimi/skills/.');
     expect(kimi).toContain('No memory.');
-    expect(kimi).not.toContain('Memory at');
+    expect(kimi).not.toContain('Memory at ~/.claude/projects/');
+    expect(kimi.indexOf('### Kimi')).toBeLessThan(kimi.indexOf('## Specifics'));
   });
 
-  it('errors with NOT_FOUND when AGENTS.md is missing', async () => {
-    await expect(build()).rejects.toThrow(/No AGENTS\.md found/);
+  it('errors with NOT_FOUND when .agents/agents/ is missing', async () => {
+    await expect(build()).rejects.toThrow(/No agent-config source found/);
   });
 });

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -1,14 +1,10 @@
 /**
  * `condash project build`
  *
- * Compile the conception's `AGENTS.md` source-of-truth into per-agent output
- * files (`.claude/CLAUDE.md` and `.kimi/AGENTS.md`). This is what the user
- * runs after editing `AGENTS.md` directly to refresh the compiled flavours
- * without going through `condash templates install` (which also re-syncs
- * shipped regions from condash itself).
- *
- * Same compile path as the one chained by `templates install` — this verb
- * just exposes it standalone for fast author iteration.
+ * Compile the conception's `.agents/agents/` source tree into per-agent
+ * output files (`.claude/CLAUDE.md` and `.kimi/AGENTS.md`). This is what
+ * the user runs after editing the agent-config sources directly to refresh
+ * the compiled flavours without going through `condash skills install`.
  */
 
 import { promises as fs } from 'node:fs';
@@ -16,16 +12,16 @@ import { isAbsolute, join, resolve } from 'node:path';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { resolveConception } from '../conception';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
-import { AGENTS_MD_TARGETS, compileAgentsMd, type AgentsMdTarget } from '../../agents-md';
+import {
+  AGENTS_MD_TARGETS,
+  AGENTS_MD_OUTPUTS,
+  compileAgentConfig,
+  type AgentsMdTarget,
+} from '../../agents-md';
 import { writeFileMkdir } from './install-shared';
 
-const AGENTS_MD_OUTPUTS: Record<AgentsMdTarget, string> = {
-  claude: '.claude/CLAUDE.md',
-  kimi: '.kimi/AGENTS.md',
-};
-
 interface BuildReport {
-  source: string;
+  sourceDir: string;
   /** One entry per target, listing the absolute path written. */
   outputs: { target: AgentsMdTarget; path: string }[];
 }
@@ -49,23 +45,30 @@ async function buildProject(args: ParsedArgs, ctx: OutputContext): Promise<void>
   for (const k of ['dest', 'dry-run']) delete args.flags[k];
   assertNoExtraFlags(args);
 
-  const sourcePath = join(dest, 'AGENTS.md');
-  let source: string;
+  const sourceDir = join(dest, '.agents', 'agents');
+  const commonPath = join(sourceDir, 'common.md');
+  let common: string;
   try {
-    source = await fs.readFile(sourcePath, 'utf8');
+    common = await fs.readFile(commonPath, 'utf8');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
       throw new CliError(
         ExitCodes.NOT_FOUND,
-        `No AGENTS.md found at ${sourcePath}. Run \`condash templates install\` to seed it from the shipped template.`,
+        `No agent-config source found at ${sourceDir}. Run \`condash skills install\` to seed it from the shipped template.`,
       );
     }
     throw err;
   }
 
-  const report: BuildReport = { source: sourcePath, outputs: [] };
+  const report: BuildReport = { sourceDir, outputs: [] };
   for (const target of AGENTS_MD_TARGETS) {
-    const compiled = compileAgentsMd(source, target);
+    let fragment = '';
+    try {
+      fragment = await fs.readFile(join(sourceDir, `${target}.md`), 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    const compiled = compileAgentConfig(common, fragment, target);
     const outputPath = join(dest, AGENTS_MD_OUTPUTS[target]);
     if (!dryRun) await writeFileMkdir(outputPath, Buffer.from(compiled, 'utf8'));
     report.outputs.push({ target, path: outputPath });
@@ -73,7 +76,7 @@ async function buildProject(args: ParsedArgs, ctx: OutputContext): Promise<void>
 
   emit(ctx, report, (data) => {
     const d = data as BuildReport;
-    const lines = [`Source: ${d.source}`];
+    const lines = [`Source: ${d.sourceDir}`];
     for (const o of d.outputs) lines.push(`  → ${o.path}  (${o.target})`);
     return lines.join('\n') + '\n';
   });

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -78,12 +78,11 @@ import {
 } from './install-shared';
 import {
   SHIPPED_FILES,
-  compileAgentsMdToTargets,
+  compileAgentConfigs,
+  installAgentConfigSources,
   installShippedFile,
   listShippedFiles,
   locateShippedFilesRoot,
-  maybeRenameClaudeMdToAgentsMd,
-  migrateClaudeMdManifestEntry,
   pruneSourceMissingFileEntries,
   sourceMissingFileRows,
   statusShippedFile,
@@ -212,7 +211,7 @@ interface InstallReport {
     sourceMissing: { path: string; region: string; shippedVersion: string }[];
   };
   agentsMdCompiled: { target: AgentsMdTarget; path: string }[];
-  renamedFromClaudeMd: boolean;
+  agentConfigsCopied: string[];
   pruned?: {
     skills: { skill: string; relPath: string; shippedVersion: string }[];
     files: { path: string; region: string; shippedVersion: string }[];
@@ -268,11 +267,6 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
     skills: {},
   };
 
-  // v2.29.0 migration: rename CLAUDE.md → AGENTS.md (and its manifest entry)
-  // when the user has an existing legacy install but no AGENTS.md yet.
-  const renamedFromClaudeMd = !dryRun ? await maybeRenameClaudeMdToAgentsMd(dest) : false;
-  if (renamedFromClaudeMd) migrateClaudeMdManifestEntry(manifest);
-
   const report: InstallReport = {
     destination: sourceRoot,
     conceptionRoot: dest,
@@ -296,7 +290,7 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
       sourceMissing: [],
     },
     agentsMdCompiled: [],
-    renamedFromClaudeMd,
+    agentConfigsCopied: [],
     diffs: showDiff ? [] : undefined,
   };
 
@@ -428,8 +422,11 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
     }
   }
 
-  // Pass 2b: compile AGENTS.md → per-target outputs (no-op if AGENTS.md isn't on disk).
-  report.agentsMdCompiled = await compileAgentsMdToTargets(dest, dryRun);
+  // Pass 1c: copy agent-config sources.
+  report.agentConfigsCopied = await installAgentConfigSources(dest, dryRun);
+
+  // Pass 2b: compile .agents/agents/ → per-target outputs (no-op if source tree isn't on disk).
+  report.agentsMdCompiled = await compileAgentConfigs(dest, dryRun);
 
   // --prune: drop manifest entries whose shipped source is gone.
   if (prune) {
@@ -565,9 +562,6 @@ function formatInstallHuman(report: InstallReport): string {
   lines.push(`Source-of-truth: ${report.destination}`);
   lines.push(`Compiled → ${report.outputs.claude}`);
   lines.push(`Compiled → ${report.outputs.kimi}`);
-  if (report.renamedFromClaudeMd) {
-    lines.push(`Renamed: CLAUDE.md → AGENTS.md (legacy install migration)`);
-  }
   if (report.copied.length > 0) {
     lines.push(`Sources copied (${report.copied.length}):`);
     for (const f of report.copied) lines.push(`  + ${f.skill}/${f.relPath}`);
@@ -642,8 +636,12 @@ function formatInstallHuman(report: InstallReport): string {
     );
     lines.push(`Compiled outputs: ${parts.join(', ')}`);
   }
+  if (report.agentConfigsCopied.length > 0) {
+    lines.push(`Agent configs copied (${report.agentConfigsCopied.length}):`);
+    for (const p of report.agentConfigsCopied) lines.push(`  + ${p}`);
+  }
   if (report.agentsMdCompiled.length > 0) {
-    lines.push(`Compiled from AGENTS.md (${report.agentsMdCompiled.length}):`);
+    lines.push(`Compiled agent configs (${report.agentsMdCompiled.length}):`);
     for (const c of report.agentsMdCompiled) lines.push(`  → ${c.path}  (${c.target})`);
   }
   if (report.diffs && report.diffs.length > 0) {


### PR DESCRIPTION
## Summary

- The root  was loaded by every agent, leaking Claude-specific sections into Kimi's context.
- Replace the single-file model with  that compiles to per-agent outputs.
- On Source-of-truth: /home/alice/src/vcoeur/conception/.agents/skills
Compiled → /home/alice/src/vcoeur/conception/.claude/skills
Compiled → /home/alice/src/vcoeur/conception/.kimi/skills
Sources unchanged: 23
Files unchanged: 1
Compiled outputs: claude=15, kimi=15
Compiled from AGENTS.md (2):
  → .claude/CLAUDE.md  (claude)
  → .kimi/AGENTS.md  (kimi), condash copies the source tree and compiles  +  into  and .

## Changes

-  — new source tree
-  — deleted (no longer shipped)
-  —  replaces ; inserts agent fragment before 
-  — remove  from ; add  and 
-  — wire new compile/copy passes; remove legacy  →  migration
-  — Source: /home/alice/src/vcoeur/conception/AGENTS.md
  → /home/alice/src/vcoeur/conception/.claude/CLAUDE.md  (claude)
  → /home/alice/src/vcoeur/conception/.kimi/AGENTS.md  (kimi) reads from  instead of root 
- , ,  — updated for new behaviour

## Impact

- Root  is no longer shipped. Existing user-owned  files become fully user-managed (condash stops touching them).
- Old manifest entries for  surface as  and can be cleaned up with .
- Source: /home/alice/src/vcoeur/conception/AGENTS.md
  → /home/alice/src/vcoeur/conception/.claude/CLAUDE.md  (claude)
  → /home/alice/src/vcoeur/conception/.kimi/AGENTS.md  (kimi) now errors if  is absent, directing users to run Source-of-truth: /home/alice/src/vcoeur/conception/.agents/skills
Compiled → /home/alice/src/vcoeur/conception/.claude/skills
Compiled → /home/alice/src/vcoeur/conception/.kimi/skills
Sources unchanged: 23
Files unchanged: 1
Compiled outputs: claude=15, kimi=15
Compiled from AGENTS.md (2):
  → .claude/CLAUDE.md  (claude)
  → .kimi/AGENTS.md  (kimi) first.

## Watchpoints

- After upgrade, conceptions that still relied on root  for  updates will see stale content until they migrate to  or manage the file manually.