### PR TITLE
Skills pane: Generic / Claude / Kimi agent tabs

### DIFF
--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -1,25 +1,60 @@
 # The Skills pane
 
-The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the right working-surface slot (`Ctrl+L` to switch in). It reads the project-local `.claude/skills/` tree (or whatever you point `skills_path` at) and lets you view and edit skill markdown without leaving the dashboard.
+The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the right working-surface slot (`Ctrl+L` to switch in). It surfaces three trees through a single tab bar at the top of the pane — **Generic** (agent-neutral source skillspecs), **Claude** (compiled output for Claude Code), and **Kimi** (compiled output for Kimi CLI).
 
 ![Skills pane — skill sections with SKILL.md indices and body-file cards](../assets/screenshots/skills-pane-light.png#only-light)
 ![Skills pane — skill sections with SKILL.md indices and body-file cards](../assets/screenshots/skills-pane-dark.png#only-dark)
 
-## What it shows
+## The three tabs
 
-By default the pane reads from `<conception>/.claude/skills/`. Each directory under the root is treated as a skill — its `SKILL.md` is rendered as a badged callout at the top of the directory's expanded body (just below the directory header), and its body files (`create.md`, `update.md`, `index.md`, …) render as cards underneath. The walker recurses to any depth, so nested helper directories render as their own sections.
+| Tab | Reads from | Editable? | Notes |
+|---|---|---|---|
+| **Generic** | `<conception>/.agents/skills/` | Yes | Agent-neutral source — `.md` body files and `.yaml` spec / target overlays. |
+| **Claude** | `<conception>/<skills_path>` (default `.claude/skills/`) | Yes (but see warning) | Compiled output. Edits here are overwritten on the next `condash skills install`. |
+| **Kimi** | `<conception>/.kimi/skills/` | No | Compiled output. Always regenerated from source — buttons are hidden. |
 
-The pane also surfaces the conception's `CLAUDE.md` files — `<conception>/CLAUDE.md` and `<conception>/.claude/CLAUDE.md` — as top-level entries with a `CLAUDE` badge, alongside the regular skill directories. They open in the same note modal as everything else.
+The currently-selected tab is remembered per-machine in `settings.json` (`skillsActiveTab`), so the next launch reopens the same view. The first launch after the tabs ship defaults to **Claude** to match the pre-tabs behaviour.
 
-Only `.md` files are surfaced — non-markdown files in a skill directory are ignored.
+Each tab maintains its own directory expansion state and scroll position. Switching tabs is paint-only — all three trees are loaded eagerly when a conception is opened.
+
+## What each tab shows
+
+### Generic (source skillspecs)
+
+The Generic tab walks `.agents/skills/` and surfaces both `.md` and `.yaml` files:
+
+- `body.md` and sibling markdown files (`index.md`, `retrieve.md`, …) render as standard cards. Title is pulled from the first H1.
+- `spec.yaml` and `targets/<agent>.yaml` render as cards with a `YAML` badge — title falls back to the filename when no H1 is present (YAML has none).
+
+The Generic tab does **not** inject the synthetic `CLAUDE.md` callout — that entry only makes sense in the Claude tab.
+
+### Claude (compiled)
+
+Identical to the pre-tabs Skills pane:
+
+- Each subdirectory under `<skills_path>` is treated as a skill — its `SKILL.md` renders as a badged callout at the top of the expanded body.
+- Body files render as cards underneath. The walker recurses to any depth.
+- The conception's `<conception>/CLAUDE.md` and `<conception>/.claude/CLAUDE.md` are surfaced at the root with a `CLAUDE` badge.
+
+### Kimi (compiled)
+
+Same layout as Claude, but rooted at `.kimi/skills/` and without the synthetic `CLAUDE.md` injection (Kimi uses `AGENTS.md`, not `CLAUDE.md`). The tab is read-only: tree-mutation buttons are suppressed and the main-process resolver refuses to write under `.kimi/skills/`. Edit the matching source skillspec under `.agents/skills/` and re-run `condash skills install` to regenerate.
 
 ## Editing skills
 
 Click any card to open the file in the note modal — the same editor used elsewhere in condash, with atomic-write save through `writeNote`. Wikilinks and relative markdown links route through the in-modal navigator just like Knowledge files.
 
+The Generic tab is the right place to edit. Edits made through the Claude tab persist until the next `condash skills install`, at which point the compiled output is rebuilt from the matching source skillspec.
+
 ## Shipped-skill tracking
 
-Skills installed by `condash skills install` are tracked in `<skills_path>/.condash-skills.json`. The pane uses this manifest to flag two states:
+Each tree carries its own `.condash-skills.json` manifest, populated by `condash skills install`:
+
+- `<conception>/.agents/.condash-skills.json` — source refuse-on-edit tracking (CLI internal).
+- `<conception>/<skills_path>/.condash-skills.json` — Claude compiled tracking.
+- `<conception>/.kimi/skills/.condash-skills.json` — Kimi compiled tracking.
+
+The pane uses each manifest to flag two states on the matching tab:
 
 - **shipped** — the on-disk content matches the version condash shipped. Cards display a `shipped` chip; the `SKILL` callout carries the same flag.
 - **shipped · diverged** — the file is shipped but locally edited. Cards display an amber `shipped · diverged` chip; the `SKILL` callout switches to amber. Opening the file shows a banner: *"Shipped by condash, but locally edited. Running `condash skills install` will flag this divergence."*
@@ -28,7 +63,9 @@ The flags are informational only — local edits are never blocked. They exist s
 
 ## Configuration
 
-Set the directory by editing `condash.json` at the conception root (per-tree, versioned with the conception), or via **Settings → Workspace → Skills directory**. The value is **not** in `settings.json` — it's tree-side so teammates see the same skills tree.
+`skills_path` controls only the **Claude** tab's root directory. The Generic and Kimi tabs always read from `.agents/skills/` and `.kimi/skills/` respectively — those paths are not user-configurable.
+
+Set the Claude tab's directory by editing `condash.json` at the conception root (per-tree, versioned with the conception), or via **Settings → Workspace → Skills directory**. The value is **not** in `settings.json` — it's tree-side so teammates see the same skills tree.
 
 ```json
 {

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -105,7 +105,7 @@ Legacy formats — JSONL event streams from condash ≤ 2.22, compressed `.txt.g
 | `workspace_path` | Directory condash resolves relative repo paths against. Every direct subdirectory containing a `.git/` shows up in the **Code** pane. If unset, the pane is hidden. Repos with an explicit `path` may live outside this root.                                                    |
 | `worktrees_path` | Additional sandbox for the "open in IDE" buttons. Paths outside `workspace_path` and `worktrees_path` are rejected before the shell sees them.                                                                                                                                   |
 | `resources_path` | Directory backing the **Resources** pane. Relative paths are resolved against `<conception_path>`; default `"resources"`. Every file under this tree (any extension) shows up as a card. Unset = same as default. See [Resources pane guide](../guides/resources-pane.md).       |
-| `skills_path`    | Directory backing the **Skills** pane. Relative paths are resolved against `<conception_path>`; default `".claude/skills"`. Markdown only. Each skill renders as a section with its `SKILL.md` body. Unset = same as default. See [Skills pane guide](../guides/skills-pane.md). |
+| `skills_path`    | Directory backing the **Skills** pane's **Claude** tab. Relative paths are resolved against `<conception_path>`; default `".claude/skills"`. Markdown only. Each skill renders as a section with its `SKILL.md` body. Unset = same as default. The pane's other two tabs (**Generic**, **Kimi**) read from fixed paths — `.agents/skills/` and `.kimi/skills/` respectively — and are not user-configurable. See [Skills pane guide](../guides/skills-pane.md). |
 
 ### `repositories`
 
@@ -308,10 +308,13 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
   "treeExpansion": {
     "knowledge": ["topics", "topics/security"],
     "resources": [],
-    "skills": ["pr"]
+    "skillsGeneric": [],
+    "skillsClaude": ["pr"],
+    "skillsKimi": []
   },
   "selectedBranches": ["feature-foo", "release-2026-05"],
-  "branchFilterStickyAll": false
+  "branchFilterStickyAll": false,
+  "skillsActiveTab": "claude"
 }
 ```
 
@@ -324,9 +327,10 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
 | `layout`                | Composite-layout state. See [LayoutState](#layoutstate) below.                                                                                                                                                                                             |
 | `welcome`               | First-launch state. `welcome.dismissed: true` hides the Welcome screen even when both Projects and Knowledge are empty.                                                                                                                                    |
 | `cardMinWidth`          | Per-pane card grid min-width. See [CardMinWidth](#cardminwidth) below.                                                                                                                                                                                     |
-| `treeExpansion`         | Per-pane set of expanded directory `relPath`s for the Knowledge / Resources / Skills tree panes. Empty (or missing) means everything is collapsed — the on-purpose first-load state per #89.                                                               |
+| `treeExpansion`         | Per-pane set of expanded directory `relPath`s for the Knowledge / Resources / Skills tree panes. Skills carries three independent sets — `skillsGeneric`, `skillsClaude`, `skillsKimi` — one per tab. Empty (or missing) means everything is collapsed — the on-purpose first-load state per #89. The legacy `skills` key is migrated into `skillsClaude` on first read and never written back. |
 | `selectedBranches`      | Branches pinned by the Code-pane top-of-pane filter. The primary worktree row is always rendered; this set is additive on top of it. Honoured only when `branchFilterStickyAll` is false.                                                                  |
 | `branchFilterStickyAll` | True ⇒ Code-pane filter is in **All (sticky)** mode: every branch is shown and new ones auto-pin. False ⇒ honour `selectedBranches` exactly (empty = main only). Defaults to true on first read when no explicit selection was ever made, false otherwise. |
+| `skillsActiveTab`       | Active tab in the Skills pane — `generic`, `claude`, or `kimi`. Defaults to `claude` (preserves pre-tabs behaviour for users without an explicit selection). Persisted on every tab switch.                                                                |
 
 Workspace-shape keys (`workspace_path`, `worktrees_path`, `resources_path`, `skills_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal`) are also valid in `settings.json` — they act as global defaults that any conception's `.condash/settings.json` may override. The reverse direction is forbidden: a conception's `settings.json` cannot set `lastConceptionPath` or `recentConceptionPaths`, since those describe the tree's own location and the user's machine-local recents list.
 

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -74,7 +74,15 @@ Install or refresh the shipped skills. Use it after upgrading condash to pull up
 | `status` | `/skills status` | `condash skills status` (compare local vs shipped via SHA256) |
 | `install` | `/skills install` | `condash skills install` (per-file diff + confirmation walk) |
 
-The manifest at `<conception>/.claude/skills/.condash-skills.json` tracks the shipped version + SHA256 per file so updates can detect local edits.
+`condash skills install` writes three independent manifests so each tree gets its own shipped/diverged tracking:
+
+| Manifest path | Purpose | Schema |
+|---|---|---|
+| `<conception>/.agents/.condash-skills.json` | Source refuse-on-edit (CLI internal) | `skills.<name>.source` |
+| `<conception>/.claude/skills/.condash-skills.json` | Claude compiled tracking | `skills.<name>.files` |
+| `<conception>/.kimi/skills/.condash-skills.json` | Kimi compiled tracking | `skills.<name>.files` |
+
+The source manifest moved from `.claude/skills/.condash-skills.json` to `.agents/.condash-skills.json` when the skillspec compiler shipped. `readManifest` migrates the legacy path on first read (one-shot, transparent — the legacy file is moved, not copied).
 
 ## `/pr`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/install-shared.test.ts
+++ b/src/cli/commands/install-shared.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Focused tests for `readManifest` / `writeManifest` — exercises the
+ * one-shot migration from the legacy `.claude/skills/.condash-skills.json`
+ * path to the new `.agents/.condash-skills.json` path without going through
+ * `runSkills` (which would overwrite the file as a side-effect).
+ */
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { MANIFEST_RELPATH, MANIFEST_VERSION, readManifest, writeManifest } from './install-shared';
+
+let dest: string;
+
+beforeEach(async () => {
+  dest = await fs.mkdtemp(join(tmpdir(), 'install-shared-'));
+});
+
+afterEach(async () => {
+  await fs.rm(dest, { recursive: true, force: true });
+});
+
+const legacyPath = (root: string): string => join(root, '.claude', 'skills', MANIFEST_RELPATH);
+const newPath = (root: string): string => join(root, '.agents', MANIFEST_RELPATH);
+
+describe('readManifest source-manifest migration', () => {
+  it('returns null when neither location has a manifest', async () => {
+    const manifest = await readManifest(dest);
+    expect(manifest).toBeNull();
+  });
+
+  it('reads from .agents/ when present and leaves the legacy path untouched', async () => {
+    const fixture = {
+      version: MANIFEST_VERSION,
+      skills: {
+        foo: { source: { 'spec.yaml': { sha256: 'a'.repeat(64), shippedVersion: '3.7.0' } } },
+      },
+    };
+    await fs.mkdir(join(dest, '.agents'), { recursive: true });
+    await fs.writeFile(newPath(dest), JSON.stringify(fixture));
+    // Plant a stale legacy file too — it should not be read or moved.
+    await fs.mkdir(join(dest, '.claude', 'skills'), { recursive: true });
+    await fs.writeFile(legacyPath(dest), JSON.stringify({ version: MANIFEST_VERSION, skills: {} }));
+
+    const manifest = await readManifest(dest);
+    expect(manifest?.version).toBe(MANIFEST_VERSION);
+    expect(manifest?.skills.foo).toBeTruthy();
+    // Legacy path still exists — we only migrate when .agents/ is missing.
+    await expect(fs.access(legacyPath(dest))).resolves.toBeUndefined();
+  });
+
+  it('migrates the legacy file to .agents/ on first read and returns the parsed manifest', async () => {
+    const fixture = {
+      version: MANIFEST_VERSION,
+      skills: {
+        pr: { source: { 'spec.yaml': { sha256: 'b'.repeat(64), shippedVersion: '3.7.0' } } },
+      },
+    };
+    await fs.mkdir(join(dest, '.claude', 'skills'), { recursive: true });
+    await fs.writeFile(legacyPath(dest), JSON.stringify(fixture, null, 2));
+
+    const manifest = await readManifest(dest);
+    expect(manifest?.version).toBe(MANIFEST_VERSION);
+    expect(manifest?.skills.pr).toBeTruthy();
+
+    // Legacy file is gone …
+    await expect(fs.access(legacyPath(dest))).rejects.toThrow();
+    // … and the new file is in place.
+    await expect(fs.access(newPath(dest))).resolves.toBeUndefined();
+  });
+
+  it('is idempotent — a second readManifest after a migration is a no-op', async () => {
+    const fixture = { version: MANIFEST_VERSION, skills: {} };
+    await fs.mkdir(join(dest, '.claude', 'skills'), { recursive: true });
+    await fs.writeFile(legacyPath(dest), JSON.stringify(fixture));
+
+    const first = await readManifest(dest);
+    expect(first).not.toBeNull();
+    const newPathStat = await fs.stat(newPath(dest));
+
+    const second = await readManifest(dest);
+    expect(second).not.toBeNull();
+    const newPathStatAgain = await fs.stat(newPath(dest));
+    // mtime unchanged — the second read did not rewrite the file.
+    expect(newPathStatAgain.mtimeMs).toBe(newPathStat.mtimeMs);
+  });
+
+  it('migrates v1 schemas in memory before persisting them at the new path', async () => {
+    await fs.mkdir(join(dest, '.claude', 'skills'), { recursive: true });
+    await fs.writeFile(
+      legacyPath(dest),
+      JSON.stringify({
+        version: 1,
+        skills: {},
+        templates: {
+          'AGENTS.md': { region: 'General', sha256: 'c'.repeat(64), shippedVersion: '2.27.0' },
+        },
+      }),
+    );
+
+    const manifest = await readManifest(dest);
+    expect(manifest?.version).toBe(MANIFEST_VERSION);
+    expect(manifest?.files?.['AGENTS.md']).toBeTruthy();
+    // The legacy file has been moved; the on-disk content at the new
+    // location is the raw v1 bytes (`writeManifest` later in `installRepo`
+    // upgrades them) — but the in-memory return is v3.
+    await expect(fs.access(legacyPath(dest))).rejects.toThrow();
+  });
+
+  it('refuses to migrate a corrupt legacy file', async () => {
+    await fs.mkdir(join(dest, '.claude', 'skills'), { recursive: true });
+    await fs.writeFile(legacyPath(dest), '{not-json');
+
+    await expect(readManifest(dest)).rejects.toThrow(/parse manifest/);
+    // Legacy file is still in place — migration short-circuits on parse failure.
+    await expect(fs.access(legacyPath(dest))).resolves.toBeUndefined();
+    await expect(fs.access(newPath(dest))).rejects.toThrow();
+  });
+});
+
+describe('writeManifest', () => {
+  it('always writes to .agents/.condash-skills.json regardless of legacy presence', async () => {
+    await fs.mkdir(join(dest, '.claude', 'skills'), { recursive: true });
+    await fs.writeFile(legacyPath(dest), JSON.stringify({ version: MANIFEST_VERSION, skills: {} }));
+
+    await writeManifest(dest, { version: MANIFEST_VERSION, skills: {} });
+    await expect(fs.access(newPath(dest))).resolves.toBeUndefined();
+    // Pre-existing legacy file is untouched by writeManifest — only readManifest moves it.
+    await expect(fs.access(legacyPath(dest))).resolves.toBeUndefined();
+  });
+});

--- a/src/cli/commands/install-shared.ts
+++ b/src/cli/commands/install-shared.ts
@@ -8,10 +8,17 @@
  *   - **Top-level files** at the conception root (e.g. AGENTS.md, .gitignore)
  *     — heading-delimited regions, hash-tracked per file by region body.
  *
- * Both kinds write to the same manifest at
- * `<dest>/.claude/skills/.condash-skills.json`. The file lives under
- * `.claude/skills/` for historical reasons; top-level files are written
- * elsewhere but reusing the path avoids two manifests that can drift.
+ * The CLI writes three independent manifests on each install:
+ *   - `<dest>/.agents/.condash-skills.json` — source refuse-on-edit. Tracks
+ *     each shipped source file under `.agents/skills/`. Used by the
+ *     skills walker to flag local edits before re-installing.
+ *   - `<dest>/.claude/skills/.condash-skills.json` — Claude compiled output.
+ *   - `<dest>/.kimi/skills/.condash-skills.json` — Kimi compiled output.
+ *
+ * The source manifest moved from `.claude/skills/.condash-skills.json` to
+ * `.agents/.condash-skills.json` when the skillspec compiler shipped.
+ * `readManifest` migrates the legacy file on first read (one-shot, the
+ * legacy file is moved rather than copied).
  */
 
 import { createHash } from 'node:crypto';
@@ -79,7 +86,11 @@ export interface Manifest {
   files?: Record<string, ManifestRegionEntry>;
 }
 
-/** Read the manifest at `<dest>/.claude/skills/.condash-skills.json`.
+/** Read the source manifest at `<dest>/.agents/.condash-skills.json`.
+ *
+ * If the new location doesn't exist, falls back to the legacy path
+ * `<dest>/.claude/skills/.condash-skills.json` and **moves** it to
+ * `.agents/` transparently. This is a one-time migration.
  *
  * Migrates older schemas in-memory on read:
  *
@@ -94,45 +105,75 @@ export interface Manifest {
  * `writeManifest` call.
  */
 export async function readManifest(dest: string): Promise<Manifest | null> {
-  const path = join(dest, '.claude', 'skills', MANIFEST_RELPATH);
+  const newPath = join(dest, '.agents', MANIFEST_RELPATH);
+  const legacyPath = join(dest, '.claude', 'skills', MANIFEST_RELPATH);
   type LegacyManifest = Manifest & { templates?: Record<string, ManifestRegionEntry> };
+
+  let path = newPath;
+  let raw: string;
   try {
-    const raw = await fs.readFile(path, 'utf8');
-    const parsed = JSON.parse(raw) as LegacyManifest;
-    if (parsed.version === 1) {
-      return {
-        version: MANIFEST_VERSION,
-        skills: {},
-        files: parsed.templates,
-      };
-    }
-    if (parsed.version === 2) {
-      return {
-        version: MANIFEST_VERSION,
-        skills: parsed.skills ?? {},
-        files: parsed.templates,
-      };
-    }
-    if (parsed.version !== MANIFEST_VERSION) {
+    raw = await fs.readFile(newPath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       throw new CliError(
         ExitCodes.RUNTIME,
-        `Manifest at ${path} has unknown version ${parsed.version} (expected ${MANIFEST_VERSION})`,
+        `Could not read manifest at ${newPath}: ${(err as Error).message}`,
       );
     }
-    if (!parsed.skills) parsed.skills = {};
-    return parsed;
+    // Fall back to legacy path and migrate if present.
+    try {
+      raw = await fs.readFile(legacyPath, 'utf8');
+      path = legacyPath;
+    } catch (err2) {
+      if ((err2 as NodeJS.ErrnoException).code === 'ENOENT') return null;
+      throw new CliError(
+        ExitCodes.RUNTIME,
+        `Could not read manifest at ${legacyPath}: ${(err2 as Error).message}`,
+      );
+    }
+  }
+
+  let parsed: LegacyManifest;
+  try {
+    parsed = JSON.parse(raw) as LegacyManifest;
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
-    if (err instanceof CliError) throw err;
     throw new CliError(
       ExitCodes.RUNTIME,
-      `Could not read manifest at ${path}: ${(err as Error).message}`,
+      `Could not parse manifest at ${path}: ${(err as Error).message}`,
     );
   }
+
+  if (parsed.version === 1) {
+    parsed = {
+      version: MANIFEST_VERSION,
+      skills: {},
+      files: parsed.templates,
+    };
+  } else if (parsed.version === 2) {
+    parsed = {
+      version: MANIFEST_VERSION,
+      skills: parsed.skills ?? {},
+      files: parsed.templates,
+    };
+  } else if (parsed.version !== MANIFEST_VERSION) {
+    throw new CliError(
+      ExitCodes.RUNTIME,
+      `Manifest at ${path} has unknown version ${parsed.version} (expected ${MANIFEST_VERSION})`,
+    );
+  }
+  if (!parsed.skills) parsed.skills = {};
+
+  // One-time transparent migration: legacy path → new path.
+  if (path === legacyPath) {
+    await fs.mkdir(dirname(newPath), { recursive: true });
+    await fs.rename(legacyPath, newPath);
+  }
+
+  return parsed;
 }
 
 export async function writeManifest(dest: string, manifest: Manifest): Promise<void> {
-  const path = join(dest, '.claude', 'skills', MANIFEST_RELPATH);
+  const path = join(dest, '.agents', MANIFEST_RELPATH);
   await writeFileMkdir(path, Buffer.from(JSON.stringify(manifest, null, 2) + '\n', 'utf8'));
 }
 

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -68,6 +68,7 @@ import {
   type CompileTarget,
 } from '../../skillspec';
 import {
+  MANIFEST_RELPATH,
   MANIFEST_VERSION,
   cheapDiff,
   readManifest,
@@ -395,6 +396,16 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
   // propagates to the target trees — that's the install/compile decoupling
   // promise.
   const compileTargets = await collectInstalledSkillNames(sourceRoot, shipped);
+
+  // Per-target compiled manifest builders: skillName -> { files: { relPath -> entry } }
+  const compiledManifests: Record<
+    CompileTarget,
+    Record<string, { files: Record<string, { sha256: string; shippedVersion: string }> }>
+  > = {
+    claude: {},
+    kimi: {},
+  };
+
   for (const skillName of compileTargets) {
     const skill = shipped.find((s) => s.name === skillName);
     const compileFromDir = dryRun && skill ? skill.sourceDir : join(sourceRoot, skillName);
@@ -415,10 +426,30 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
       // Wipe stale outputs so previously-shipped-but-now-deleted assets
       // don't linger. Skipped on dry-run.
       if (!dryRun) await rmTreeIfPresent(outputRoot);
+      compiledManifests[target][skillName] = { files: {} };
       for (const [relPath, content] of Object.entries(compiled.files)) {
         if (!dryRun) await writeFileMkdir(join(outputRoot, relPath), content);
         report.compiled.push({ skill: skillName, target, relPath });
+        compiledManifests[target][skillName].files[relPath] = {
+          sha256: sha256(content),
+          shippedVersion,
+        };
       }
+    }
+  }
+
+  // Write compiled manifests for each target.
+  for (const target of COMPILE_TARGETS) {
+    const compiledManifest = {
+      version: MANIFEST_VERSION,
+      skills: compiledManifests[target],
+    };
+    const manifestPath = join(dest, TARGET_RELPATHS[target], MANIFEST_RELPATH);
+    if (!dryRun) {
+      await writeFileMkdir(
+        manifestPath,
+        Buffer.from(JSON.stringify(compiledManifest, null, 2) + '\n', 'utf8'),
+      );
     }
   }
 

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -2,11 +2,28 @@ import { ipcMain } from 'electron';
 import { toPosix } from '../../shared/path';
 import { getEffectiveConceptionConfig } from '../effective-config';
 import { DEFAULT_LAYOUT, readSettings, settingsPath, updateSettings } from '../settings';
-import type { CardMinWidthPrefs, LayoutState, Theme, TreeExpansionPrefs } from '../../shared/types';
-import { DEFAULT_CARD_MIN_WIDTH } from '../../shared/types';
+import type {
+  CardMinWidthPrefs,
+  LayoutState,
+  SkillTab,
+  Theme,
+  TreeExpansionPrefs,
+} from '../../shared/types';
+import { DEFAULT_CARD_MIN_WIDTH, SKILL_TABS } from '../../shared/types';
 
-const TREE_EXPANSION_KEYS = ['knowledge', 'resources', 'skills'] as const;
+// Note: the legacy `skills` key is accepted on read (migrated to
+// `skillsClaude`) but never written back. New writers emit the three
+// per-tab keys.
+const TREE_EXPANSION_KEYS = [
+  'knowledge',
+  'resources',
+  'skillsGeneric',
+  'skillsClaude',
+  'skillsKimi',
+] as const;
 type TreeExpansionKey = (typeof TREE_EXPANSION_KEYS)[number];
+
+const SKILL_TAB_SET: ReadonlySet<SkillTab> = new Set(SKILL_TABS);
 
 const THEMES: ReadonlySet<Theme> = new Set(['light', 'dark', 'system']);
 
@@ -115,11 +132,23 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
 
   ipcMain.handle('getTreeExpansion', async () => {
     const { treeExpansion } = await readSettings();
-    const out: Required<TreeExpansionPrefs> = {
+    const out: Required<Pick<TreeExpansionPrefs, TreeExpansionKey>> = {
       knowledge: [],
       resources: [],
-      skills: [],
+      skillsGeneric: [],
+      skillsClaude: [],
+      skillsKimi: [],
     };
+    // Legacy `skills` key migrates into `skillsClaude` so users keep their
+    // existing expansion state when the tabs ship for the first time.
+    const legacySkills = Array.isArray(treeExpansion?.skills) ? treeExpansion.skills : null;
+    if (legacySkills) {
+      const seen = new Set<string>();
+      for (const entry of legacySkills) {
+        if (typeof entry === 'string') seen.add(entry);
+      }
+      out.skillsClaude = Array.from(seen);
+    }
     for (const key of TREE_EXPANSION_KEYS) {
       const v = treeExpansion?.[key];
       if (Array.isArray(v)) {
@@ -146,7 +175,7 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
     const sanitised: TreeExpansionPrefs = {};
     let nonEmpty = false;
     for (const key of TREE_EXPANSION_KEYS) {
-      const v = input[key as TreeExpansionKey];
+      const v = input[key];
       if (!Array.isArray(v)) continue;
       const seen = new Set<string>();
       for (const entry of v) {
@@ -157,6 +186,8 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
         nonEmpty = true;
       }
     }
+    // Always drop the legacy `skills` key on write — the read path has
+    // already migrated it to `skillsClaude`.
     await updateSettings((cur) => ({
       ...cur,
       treeExpansion: nonEmpty ? sanitised : undefined,
@@ -208,6 +239,23 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
       throw new Error('setBranchFilterStickyAll: expected boolean');
     }
     await updateSettings((cur) => ({ ...cur, branchFilterStickyAll: raw }));
+  });
+
+  // Skills-pane active tab (per-machine). Default is `claude` — preserves
+  // the pre-tabs behaviour for existing users.
+  ipcMain.handle('getSkillsActiveTab', async (): Promise<SkillTab> => {
+    const { skillsActiveTab } = await readSettings();
+    if (typeof skillsActiveTab === 'string' && SKILL_TAB_SET.has(skillsActiveTab as SkillTab)) {
+      return skillsActiveTab as SkillTab;
+    }
+    return 'claude';
+  });
+
+  ipcMain.handle('setSkillsActiveTab', async (_, raw: unknown) => {
+    if (typeof raw !== 'string' || !SKILL_TAB_SET.has(raw as SkillTab)) {
+      throw new Error('setSkillsActiveTab: expected generic | claude | kimi');
+    }
+    await updateSettings((cur) => ({ ...cur, skillsActiveTab: raw as SkillTab }));
   });
 
   ipcMain.handle('setCardMinWidth', async (_, raw: unknown) => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -161,6 +161,19 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
         out[key] = Array.from(seen);
       }
     }
+    // Opportunistically rewrite settings.json without the legacy `skills`
+    // key so it doesn't linger indefinitely for users who never trigger a
+    // tree-expansion mutation. Fire-and-forget — failure here is non-fatal
+    // and the next read will simply re-migrate.
+    if (legacySkills && treeExpansion) {
+      const { skills: _drop, ...rest } = treeExpansion;
+      void _drop;
+      const rewritten: TreeExpansionPrefs = {
+        ...rest,
+        skillsClaude: out.skillsClaude.length > 0 ? out.skillsClaude : rest.skillsClaude,
+      };
+      void updateSettings((cur) => ({ ...cur, treeExpansion: rewritten })).catch(() => undefined);
+    }
     return out;
   });
 

--- a/src/main/ipc/trees.ts
+++ b/src/main/ipc/trees.ts
@@ -2,11 +2,11 @@ import { ipcMain } from 'electron';
 import { resolveConceptionPaths } from '../conception-paths';
 import { readKnowledgeTree } from '../knowledge';
 import { readResourcesTree } from '../resources';
-import { readSkillsTree } from '../skills';
+import { readSkillsTreeForTab } from '../skills';
 import { search } from '../search';
 import { readSettings } from '../settings';
 import { treeCreateMd, treeImportFile, treeMkdir } from '../tree-mutations';
-import type { TreeRoot } from '../../shared/types';
+import type { SkillTab, TreeRoot } from '../../shared/types';
 import { withConception } from './utils';
 
 /**
@@ -27,23 +27,27 @@ export function registerTreesIpc(): void {
     }, null),
   );
 
-  ipcMain.handle('readSkillsTree', () =>
+  ipcMain.handle('readSkillsTree', (_, tab: SkillTab) =>
     withConception(async (conceptionPath) => {
       const { skills } = await resolveConceptionPaths(conceptionPath);
-      return readSkillsTree(conceptionPath, skills);
+      return readSkillsTreeForTab(conceptionPath, tab, skills);
     }, null),
   );
 
-  ipcMain.handle('treeCreateMd', (_, root: TreeRoot, dirRelPath: string, filename: string) =>
-    treeCreateMd(root, dirRelPath, filename),
+  ipcMain.handle(
+    'treeCreateMd',
+    (_, root: TreeRoot, dirRelPath: string, filename: string, skillTab?: SkillTab) =>
+      treeCreateMd(root, dirRelPath, filename, skillTab),
   );
 
-  ipcMain.handle('treeMkdir', (_, root: TreeRoot, dirRelPath: string, name: string) =>
-    treeMkdir(root, dirRelPath, name),
+  ipcMain.handle(
+    'treeMkdir',
+    (_, root: TreeRoot, dirRelPath: string, name: string, skillTab?: SkillTab) =>
+      treeMkdir(root, dirRelPath, name, skillTab),
   );
 
-  ipcMain.handle('treeImportFile', (_, root: TreeRoot, dirRelPath: string) =>
-    treeImportFile(root, dirRelPath),
+  ipcMain.handle('treeImportFile', (_, root: TreeRoot, dirRelPath: string, skillTab?: SkillTab) =>
+    treeImportFile(root, dirRelPath, skillTab),
   );
 
   // The original handler returned `[]` when no conception path was set;

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -37,13 +37,28 @@ export async function search(conceptionPath: string, query: string): Promise<Sea
 
   const { resources, skills } = await resolveConceptionPaths(conceptionPath);
 
-  const [projectFiles, knowledgeFiles, resourceFiles, skillFiles, logFiles] = await Promise.all([
+  // Skills search covers all three trees (Generic / Claude / Kimi). The
+  // source label stays `skills` for every hit; the relPath shown to the
+  // user (e.g. `.agents/skills/...` vs `.claude/skills/...`) is what
+  // distinguishes them in the result list.
+  const [
+    projectFiles,
+    knowledgeFiles,
+    resourceFiles,
+    skillFilesClaude,
+    skillFilesGeneric,
+    skillFilesKimi,
+    logFiles,
+  ] = await Promise.all([
     collectProjectFiles(join(conceptionPath, 'projects')),
     collectKnowledgeFiles(join(conceptionPath, 'knowledge')),
     collectResourceFiles(join(conceptionPath, resources)),
     collectSkillFiles(join(conceptionPath, skills)),
+    collectSkillFiles(join(conceptionPath, '.agents', 'skills')),
+    collectSkillFiles(join(conceptionPath, '.kimi', 'skills')),
     collectLogFiles(condashLogsRoot(conceptionPath)),
   ]);
+  const skillFiles = [...skillFilesClaude, ...skillFilesGeneric, ...skillFilesKimi];
 
   const matchPromises: Promise<MatchOutput | null>[] = [];
 

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -1,6 +1,6 @@
 import { promises as fs } from 'node:fs';
 import { basename, join } from 'node:path';
-import type { SkillNode } from '../shared/types';
+import type { SkillNode, SkillTab } from '../shared/types';
 import { toPosix } from '../shared/path';
 import { parseHead } from './knowledge';
 import { readFileHead } from './read-file-head';
@@ -41,12 +41,58 @@ export async function readSkillsTree(
     new Set<string>(),
     shipped,
     root,
+    /* acceptYaml */ false,
   );
   const claudeEntries = await readConceptionClaudeMd(conceptionPath);
   if (claudeEntries.length > 0) {
     tree.children = [...claudeEntries, ...(tree.children ?? [])];
   }
   return tree;
+}
+
+/**
+ * Read the generic skills tree at `<conceptionPath>/.agents/skills/`.
+ * Accepts both `.md` and `.yaml` files. No synthetic `CLAUDE.md` entries.
+ * Uses `buildShippedLookup` on the root `.agents/skills/`.
+ */
+export async function readGenericSkillsTree(conceptionPath: string): Promise<SkillNode | null> {
+  const root = join(conceptionPath, '.agents', 'skills');
+  try {
+    await fs.access(root);
+  } catch {
+    return null;
+  }
+  const shipped = await buildShippedLookup(root);
+  return walk(root, '', 'skills', new Set<string>(), shipped, root, /* acceptYaml */ true);
+}
+
+/**
+ * Read the Kimi skills tree at `<conceptionPath>/.kimi/skills/`.
+ * Same `.md`-only filter as `readSkillsTree`. No synthetic `CLAUDE.md`
+ * injection. Uses `buildShippedLookup` on `.kimi/skills/`.
+ */
+export async function readKimiSkillsTree(conceptionPath: string): Promise<SkillNode | null> {
+  const root = join(conceptionPath, '.kimi', 'skills');
+  try {
+    await fs.access(root);
+  } catch {
+    return null;
+  }
+  const shipped = await buildShippedLookup(root);
+  return walk(root, '', 'skills', new Set<string>(), shipped, root, /* acceptYaml */ false);
+}
+
+/**
+ * Router that delegates to the tab-specific reader.
+ */
+export async function readSkillsTreeForTab(
+  conceptionPath: string,
+  tab: SkillTab,
+  skillsRelPath: string,
+): Promise<SkillNode | null> {
+  if (tab === 'generic') return readGenericSkillsTree(conceptionPath);
+  if (tab === 'kimi') return readKimiSkillsTree(conceptionPath);
+  return readSkillsTree(conceptionPath, skillsRelPath);
 }
 
 /** Probe `<conceptionPath>/CLAUDE.md` and `<conceptionPath>/.claude/CLAUDE.md`
@@ -86,6 +132,7 @@ async function walk(
   visitedDirs: Set<string>,
   shipped: ShippedLookup,
   root: string,
+  acceptYaml: boolean,
 ): Promise<SkillNode> {
   const stat = await fs.stat(absPath);
   if (stat.isFile()) {
@@ -125,14 +172,18 @@ async function walk(
   const accepted = entries.filter((e) => {
     if (HIDDEN_PREFIX.test(e.name)) return false;
     if (e.isDirectory()) return true;
-    return e.isFile() && e.name.toLowerCase().endsWith('.md');
+    if (!e.isFile()) return false;
+    const lower = e.name.toLowerCase();
+    if (lower.endsWith('.md')) return true;
+    if (acceptYaml && (lower.endsWith('.yaml') || lower.endsWith('.yml'))) return true;
+    return false;
   });
 
   const children = await Promise.all(
     accepted.map(async (entry) => {
       const childAbs = join(absPath, entry.name);
       const childRel = relPath ? `${relPath}/${entry.name}` : entry.name;
-      return walk(childAbs, childRel, entry.name, nextVisited, shipped, root);
+      return walk(childAbs, childRel, entry.name, nextVisited, shipped, root, acceptYaml);
     }),
   );
 

--- a/src/main/tree-mutations.ts
+++ b/src/main/tree-mutations.ts
@@ -1,7 +1,7 @@
 import { constants as fsConstants, promises as fs } from 'node:fs';
 import { basename, extname, join, normalize } from 'node:path';
 import { dialog } from 'electron';
-import type { TreeRoot } from '../shared/types';
+import type { SkillTab, TreeRoot } from '../shared/types';
 import { toPosix } from '../shared/path';
 import { readSettings } from './settings';
 import { resolveConceptionPaths } from './conception-paths';
@@ -20,14 +20,21 @@ import { requirePathUnder } from './path-bounds';
 
 /** Resolve a tree root to its absolute on-disk path. Knowledge is hardcoded
  * to `<conception>/knowledge/`; resources + skills come from
- * `condash.json`. */
-async function resolveRoot(root: TreeRoot): Promise<string> {
+ * `condash.json`. When `root === 'skills'`, `skillTab` selects the
+ * per-tab directory (generic / claude / kimi). */
+async function resolveRoot(root: TreeRoot, skillTab?: SkillTab): Promise<string> {
   const { lastConceptionPath: conceptionPath } = await readSettings();
   if (!conceptionPath) throw new Error('no conception path is set');
   if (root === 'knowledge') return join(conceptionPath, 'knowledge');
   const { resources, skills } = await resolveConceptionPaths(conceptionPath);
   if (root === 'resources') return join(conceptionPath, resources);
-  if (root === 'skills') return join(conceptionPath, skills);
+  if (root === 'skills') {
+    const tab = skillTab ?? 'claude';
+    if (tab === 'generic') return join(conceptionPath, '.agents', 'skills');
+    if (tab === 'claude') return join(conceptionPath, skills);
+    if (tab === 'kimi') throw new Error('Kimi skills tree is read-only');
+    throw new Error(`unknown skill tab: ${tab}`);
+  }
   throw new Error(`unknown tree root: ${root as string}`);
 }
 
@@ -64,8 +71,9 @@ async function resolveChildBounded(
   root: TreeRoot,
   dirRelPath: string,
   childName: string,
+  skillTab?: SkillTab,
 ): Promise<{ rootAbs: string; targetAbs: string }> {
-  const rootAbs = await resolveRoot(root);
+  const rootAbs = await resolveRoot(root, skillTab);
   if (typeof dirRelPath !== 'string') {
     throw new Error('dirRelPath must be a string');
   }
@@ -97,27 +105,37 @@ export async function treeCreateMd(
   root: TreeRoot,
   dirRelPath: string,
   filename: string,
+  skillTab?: SkillTab,
 ): Promise<string> {
   const sanitised = buildFilename(root, filename);
-  const { targetAbs } = await resolveChildBounded(root, dirRelPath, sanitised);
+  const { targetAbs } = await resolveChildBounded(root, dirRelPath, sanitised, skillTab);
   // `wx` flag refuses to overwrite — surfaces a clear error to the
   // renderer when the user picks a name that's already taken.
   await fs.writeFile(targetAbs, '', { encoding: 'utf8', flag: 'wx' });
   return toPosix(targetAbs);
 }
 
-export async function treeMkdir(root: TreeRoot, dirRelPath: string, name: string): Promise<string> {
+export async function treeMkdir(
+  root: TreeRoot,
+  dirRelPath: string,
+  name: string,
+  skillTab?: SkillTab,
+): Promise<string> {
   const sanitised = sanitiseSegment(name, '').replace(/\.+/g, '-');
   if (sanitised.length === 0) throw new Error('directory name is empty after sanitisation');
-  const { targetAbs } = await resolveChildBounded(root, dirRelPath, sanitised);
+  const { targetAbs } = await resolveChildBounded(root, dirRelPath, sanitised, skillTab);
   await fs.mkdir(targetAbs, { recursive: true });
   return toPosix(targetAbs);
 }
 
-export async function treeImportFile(root: TreeRoot, dirRelPath: string): Promise<string | null> {
+export async function treeImportFile(
+  root: TreeRoot,
+  dirRelPath: string,
+  skillTab?: SkillTab,
+): Promise<string | null> {
   // Resolve + bounds-check the destination before opening the dialog so
   // we never copy a file just to throw away on a bad target.
-  const rootAbs = await resolveRoot(root);
+  const rootAbs = await resolveRoot(root, skillTab);
   const cleanedDir = normalize(dirRelPath ?? '');
   const dirAbs = cleanedDir === '' || cleanedDir === '.' ? rootAbs : join(rootAbs, cleanedDir);
   await requirePathUnder(dirAbs, rootAbs);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -13,7 +13,7 @@ const api: CondashApi = {
   getProject: (path) => ipcRenderer.invoke('getProject', path),
   readKnowledgeTree: () => ipcRenderer.invoke('readKnowledgeTree'),
   readResourcesTree: () => ipcRenderer.invoke('readResourcesTree'),
-  readSkillsTree: () => ipcRenderer.invoke('readSkillsTree'),
+  readSkillsTree: (tab) => ipcRenderer.invoke('readSkillsTree', tab),
   search: (query) => ipcRenderer.invoke('search', query),
   listRepos: () => ipcRenderer.invoke('listRepos'),
   listReposForPrimary: (primaryName) => ipcRenderer.invoke('listReposForPrimary', primaryName),
@@ -46,6 +46,8 @@ const api: CondashApi = {
   setSelectedBranches: (list) => ipcRenderer.invoke('setSelectedBranches', list),
   getBranchFilterStickyAll: () => ipcRenderer.invoke('getBranchFilterStickyAll'),
   setBranchFilterStickyAll: (value) => ipcRenderer.invoke('setBranchFilterStickyAll', value),
+  getSkillsActiveTab: () => ipcRenderer.invoke('getSkillsActiveTab'),
+  setSkillsActiveTab: (tab) => ipcRenderer.invoke('setSkillsActiveTab', tab),
   getSettingsPath: () => ipcRenderer.invoke('getSettingsPath'),
   getGlobalSettingsRaw: () => ipcRenderer.invoke('getGlobalSettingsRaw'),
   writeGlobalSettings: (expectedContent, newContent) =>
@@ -111,10 +113,12 @@ const api: CondashApi = {
   openPath: (target: string) => ipcRenderer.invoke('openPath', target),
   createProjectNote: (projectPath: string, slug: string) =>
     ipcRenderer.invoke('createProjectNote', projectPath, slug),
-  treeCreateMd: (root, dirRelPath, filename) =>
-    ipcRenderer.invoke('treeCreateMd', root, dirRelPath, filename),
-  treeMkdir: (root, dirRelPath, name) => ipcRenderer.invoke('treeMkdir', root, dirRelPath, name),
-  treeImportFile: (root, dirRelPath) => ipcRenderer.invoke('treeImportFile', root, dirRelPath),
+  treeCreateMd: (root, dirRelPath, filename, skillTab) =>
+    ipcRenderer.invoke('treeCreateMd', root, dirRelPath, filename, skillTab),
+  treeMkdir: (root, dirRelPath, name, skillTab) =>
+    ipcRenderer.invoke('treeMkdir', root, dirRelPath, name, skillTab),
+  treeImportFile: (root, dirRelPath, skillTab) =>
+    ipcRenderer.invoke('treeImportFile', root, dirRelPath, skillTab),
   quitApp: () => ipcRenderer.invoke('quitApp'),
   getAppInfo: () => ipcRenderer.invoke('getAppInfo'),
   pdfToFileUrl: (path: string) => ipcRenderer.invoke('pdfToFileUrl', path),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -12,6 +12,7 @@ import type {
   RepoEntry,
   ResourceNode,
   SkillNode,
+  SkillTab,
   Step,
   TerminalPrefs,
   Theme,
@@ -220,8 +221,13 @@ function App() {
   };
 
   const treeExpansion = createTreeExpansion({ flashToast });
-  const { knowledgeExpanded, resourcesExpanded, skillsExpanded, toggleTreeExpand, expandTreeDir } =
-    treeExpansion;
+  const {
+    knowledgeExpanded,
+    resourcesExpanded,
+    skillsExpandedByTab,
+    toggleTreeExpand,
+    expandTreeDir,
+  } = treeExpansion;
 
   const branchFilter = createBranchFilterStore({ flashToast });
 
@@ -230,6 +236,18 @@ function App() {
       window.condash.treeCreateMd(root, dirRelPath, filename),
     mkdir: (root, dirRelPath, name) => window.condash.treeMkdir(root, dirRelPath, name),
     importFile: (root, dirRelPath) => window.condash.treeImportFile(root, dirRelPath),
+  };
+  // Skills mutations pre-bind the currently-active Skills tab so source
+  // edits land in `.agents/skills/` and Claude edits in `<skills_path>`.
+  // The Kimi tab uses the affordance allowlist to suppress the buttons
+  // entirely; the main-process resolver enforces the rule as a backstop.
+  const skillsMutations: TreeViewMutationApi = {
+    createMd: (root, dirRelPath, filename) =>
+      window.condash.treeCreateMd(root, dirRelPath, filename, skillsActiveTab()),
+    mkdir: (root, dirRelPath, name) =>
+      window.condash.treeMkdir(root, dirRelPath, name, skillsActiveTab()),
+    importFile: (root, dirRelPath) =>
+      window.condash.treeImportFile(root, dirRelPath, skillsActiveTab()),
   };
   const treePrompts: TreeViewPromptApi = {
     prompt: openPrompt,
@@ -257,7 +275,16 @@ function App() {
       reloadProjects: reloadProjects,
       reloadKnowledge: knowledgeStore.reload,
       reloadResources: resourcesStore.reload,
-      reloadSkills: skillsStore.reload,
+      reloadSkills: () =>
+        // The renderer can't know which tab(s) a tree event affects without
+        // duplicating the path-routing logic that lives in the main
+        // process. Reload all three; each fetcher is cheap and operates
+        // against a small tree (~10–50 files).
+        Promise.all([
+          skillsStores.generic.reload(),
+          skillsStores.claude.reload(),
+          skillsStores.kimi.reload(),
+        ]).then(() => undefined),
       reloadConfig: reloadConfig,
       // Repos do not subscribe to tree events directly — repo-events
       // covers scalar / structural updates; `config` is the only path
@@ -323,12 +350,41 @@ function App() {
   });
   const resources = resourcesStore.root;
 
-  const skillsStore = createTreeStore<SkillNode>({
-    conceptionPath,
-    fetcher: () => window.condash.readSkillsTree(),
-    key: 'relPath',
-  });
-  const skills = skillsStore.root;
+  // One tree store per Skills tab. The trees back independent on-disk roots
+  // (`.agents/skills/`, `<skills_path>`, `.kimi/skills/`), so each gets its
+  // own fetcher, store, and reload trigger. All three are eagerly loaded
+  // when the conception path is set so tab switching is paint-only.
+  const skillsStores: Record<SkillTab, ReturnType<typeof createTreeStore<SkillNode>>> = {
+    generic: createTreeStore<SkillNode>({
+      conceptionPath,
+      fetcher: () => window.condash.readSkillsTree('generic'),
+      key: 'relPath',
+    }),
+    claude: createTreeStore<SkillNode>({
+      conceptionPath,
+      fetcher: () => window.condash.readSkillsTree('claude'),
+      key: 'relPath',
+    }),
+    kimi: createTreeStore<SkillNode>({
+      conceptionPath,
+      fetcher: () => window.condash.readSkillsTree('kimi'),
+      key: 'relPath',
+    }),
+  };
+  // Active tab (defaults to `claude` to preserve pre-tabs behaviour; the
+  // hydrate-from-IPC `then` below replaces it with the persisted value).
+  const [skillsActiveTab, setSkillsActiveTabSig] = createSignal<SkillTab>('claude');
+  void window.condash.getSkillsActiveTab().then((tab) => setSkillsActiveTabSig(tab));
+  const persistSkillsActiveTab = (tab: SkillTab): void => {
+    void window.condash.setSkillsActiveTab(tab).catch((err) => {
+      flashToast(`Could not persist Skills tab: ${(err as Error).message}`, 'error');
+    });
+  };
+  const handleSkillsTabSelect = (tab: SkillTab): void => {
+    setSkillsActiveTabSig(tab);
+    persistSkillsActiveTab(tab);
+  };
+  const activeSkillsRoot = createMemo(() => skillsStores[skillsActiveTab()].root());
 
   // Code-pane repos store. Owns the scalar/set-membership split and the
   // structural-event debouncer; see `./repos-store.ts` for the contract.
@@ -514,7 +570,9 @@ function App() {
       reloadProjects(),
       knowledgeStore.reload(),
       resourcesStore.reload(),
-      skillsStore.reload(),
+      skillsStores.generic.reload(),
+      skillsStores.claude.reload(),
+      skillsStores.kimi.reload(),
       reloadConfig(),
       reloadRepos(),
     ]);
@@ -648,6 +706,7 @@ function App() {
     newPath: string,
     kind: TreeAffordance,
     sourceDirRelPath: string,
+    skillTab?: SkillTab,
   ): void => {
     // Reload the affected tree explicitly — the chokidar watcher does
     // fire on the new file, but the open-the-newly-created-file branch
@@ -655,8 +714,11 @@ function App() {
     // the new entry on the same frame.
     if (treeKey === 'knowledge') void knowledgeStore.reload();
     else if (treeKey === 'resources') void resourcesStore.reload();
-    else void skillsStore.reload();
-    expandTreeDir(treeKey, sourceDirRelPath);
+    else {
+      const tab = skillTab ?? skillsActiveTab();
+      void skillsStores[tab].reload();
+    }
+    expandTreeDir(treeKey, sourceDirRelPath, skillTab);
     if (kind === 'mkdir') return;
     if (treeKey === 'knowledge') {
       handleOpenKnowledgeFile(newPath);
@@ -1049,7 +1111,9 @@ function App() {
                 <Show when={layout().working === 'skills'}>
                   <section class="pane pane-working">
                     <SkillsView
-                      root={skills() ?? null}
+                      tab={skillsActiveTab()}
+                      onSelectTab={handleSkillsTabSelect}
+                      root={activeSkillsRoot() ?? null}
                       onOpen={handleOpenSkillFile}
                       onOpenSettings={() => setSettingsOpen(true)}
                       onCopyInstallCommand={() => {
@@ -1060,12 +1124,12 @@ function App() {
                             flashToast(`Copy failed: ${(err as Error).message}`, 'error'),
                           );
                       }}
-                      expanded={skillsExpanded}
-                      onToggleExpand={(rel) => toggleTreeExpand('skills', rel)}
-                      mutations={treeMutations}
+                      expanded={() => skillsExpandedByTab(skillsActiveTab())()}
+                      onToggleExpand={(rel) => toggleTreeExpand('skills', rel, skillsActiveTab())}
+                      mutations={skillsMutations}
                       prompts={treePrompts}
                       onAfterMutation={(newPath, kind, source) =>
-                        handleAfterTreeMutation('skills', newPath, kind, source)
+                        handleAfterTreeMutation('skills', newPath, kind, source, skillsActiveTab())
                       }
                       onError={treeError}
                     />

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -237,18 +237,6 @@ function App() {
     mkdir: (root, dirRelPath, name) => window.condash.treeMkdir(root, dirRelPath, name),
     importFile: (root, dirRelPath) => window.condash.treeImportFile(root, dirRelPath),
   };
-  // Skills mutations pre-bind the currently-active Skills tab so source
-  // edits land in `.agents/skills/` and Claude edits in `<skills_path>`.
-  // The Kimi tab uses the affordance allowlist to suppress the buttons
-  // entirely; the main-process resolver enforces the rule as a backstop.
-  const skillsMutations: TreeViewMutationApi = {
-    createMd: (root, dirRelPath, filename) =>
-      window.condash.treeCreateMd(root, dirRelPath, filename, skillsActiveTab()),
-    mkdir: (root, dirRelPath, name) =>
-      window.condash.treeMkdir(root, dirRelPath, name, skillsActiveTab()),
-    importFile: (root, dirRelPath) =>
-      window.condash.treeImportFile(root, dirRelPath, skillsActiveTab()),
-  };
   const treePrompts: TreeViewPromptApi = {
     prompt: openPrompt,
   };
@@ -385,6 +373,20 @@ function App() {
     persistSkillsActiveTab(tab);
   };
   const activeSkillsRoot = createMemo(() => skillsStores[skillsActiveTab()].root());
+  // Skills mutations pre-bind the currently-active Skills tab so source
+  // edits land in `.agents/skills/` and Claude edits in `<skills_path>`.
+  // The Kimi tab uses the affordance allowlist to suppress the buttons
+  // entirely; the main-process resolver enforces the rule as a backstop.
+  // Declared after `skillsActiveTab` so the closures don't carry forward
+  // references to a not-yet-initialised signal.
+  const skillsMutations: TreeViewMutationApi = {
+    createMd: (root, dirRelPath, filename) =>
+      window.condash.treeCreateMd(root, dirRelPath, filename, skillsActiveTab()),
+    mkdir: (root, dirRelPath, name) =>
+      window.condash.treeMkdir(root, dirRelPath, name, skillsActiveTab()),
+    importFile: (root, dirRelPath) =>
+      window.condash.treeImportFile(root, dirRelPath, skillsActiveTab()),
+  };
 
   // Code-pane repos store. Owns the scalar/set-membership split and the
   // structural-event debouncer; see `./repos-store.ts` for the contract.

--- a/src/renderer/panes/pane-scroll-memory.ts
+++ b/src/renderer/panes/pane-scroll-memory.ts
@@ -1,4 +1,4 @@
-import { onCleanup } from 'solid-js';
+import { createEffect, onCleanup } from 'solid-js';
 
 /**
  * Per-pane in-session scroll-position memory.
@@ -12,21 +12,28 @@ import { onCleanup } from 'solid-js';
  * Module-level Map: lives for the lifetime of the renderer process. Not
  * persisted across launches — saving scroll positions to settings.json
  * would carry too much per-session noise.
+ *
+ * The `paneId` argument may be a plain string or a getter. A getter lets
+ * callers thread a reactive sub-id (e.g. the active Skills tab) so the
+ * hook saves the current scrollTop under the previous id and restores
+ * the next id's position in the same scroller — no remount required.
  */
 const positions = new Map<string, number>();
 
-/**
- * Solid hook: returns a ref callback. Pass it to the pane's scroll
- * container. On mount, restores the saved scrollTop (if any). On
- * unmount, captures the current scrollTop into the module-level Map.
- */
-export function usePaneScrollMemory(paneId: string): (el: HTMLElement | undefined) => void {
+export function usePaneScrollMemory(
+  paneId: string | (() => string),
+): (el: HTMLElement | undefined) => void {
   let scroller: HTMLElement | undefined;
+  let lastId: string | undefined;
+
+  const resolveId = (): string => (typeof paneId === 'string' ? paneId : paneId());
 
   const ref = (el: HTMLElement | undefined): void => {
     scroller = el;
     if (!el) return;
-    const saved = positions.get(paneId);
+    const id = resolveId();
+    lastId = id;
+    const saved = positions.get(id);
     if (saved !== undefined) {
       // queueMicrotask so the restore happens after the pane's children
       // have laid out — otherwise scrollTop assignment hits an empty
@@ -37,8 +44,29 @@ export function usePaneScrollMemory(paneId: string): (el: HTMLElement | undefine
     }
   };
 
+  // Reactively follow `paneId` changes when a getter is passed: save the
+  // current scrollTop under the *previous* id, then restore the new id's
+  // position. The first invocation only records the initial id.
+  if (typeof paneId !== 'string') {
+    createEffect(() => {
+      const nextId = paneId();
+      if (!scroller) {
+        lastId = nextId;
+        return;
+      }
+      if (lastId !== undefined && lastId !== nextId) {
+        positions.set(lastId, scroller.scrollTop);
+      }
+      lastId = nextId;
+      const saved = positions.get(nextId);
+      queueMicrotask(() => {
+        if (scroller) scroller.scrollTop = saved ?? 0;
+      });
+    });
+  }
+
   onCleanup(() => {
-    if (scroller) positions.set(paneId, scroller.scrollTop);
+    if (scroller && lastId !== undefined) positions.set(lastId, scroller.scrollTop);
   });
 
   return ref;

--- a/src/renderer/panes/skills-pane.css
+++ b/src/renderer/panes/skills-pane.css
@@ -1,8 +1,53 @@
 .skills-pane {
   flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-base);
+}
+
+.skills-tabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 12px;
+  flex-shrink: 0;
+}
+
+.skills-tab {
+  background: none;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  letter-spacing: 0.04em;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  transition:
+    color 120ms,
+    border-bottom-color 120ms;
+}
+
+.skills-tab:hover {
+  color: var(--text-primary);
+}
+
+.skills-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent);
+}
+
+.skills-tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.skills-tree {
+  flex: 1;
   overflow-y: auto;
   padding: 12px 14px 24px;
-  background: var(--bg-base);
+  min-height: 0;
 }
 
 .skills-group {
@@ -85,6 +130,23 @@
 
 .skills-card[data-shipped='diverged'] {
   border-left: 2px solid var(--warn);
+}
+
+/* YAML spec cards (Generic tab only) — same chrome as a markdown card,
+ * with a slim accent stripe on the left so the eye separates skill
+ * bodies from skillspec metadata in a glance. */
+.skills-card[data-kind='yaml'] {
+  border-left: 2px solid var(--accent);
+}
+
+.skills-card-kind {
+  font-size: var(--text-2xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
 }
 
 .skills-card-head {

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -1,5 +1,6 @@
-import { Show } from 'solid-js';
-import type { SkillNode } from '@shared/types';
+import { For, Show } from 'solid-js';
+import type { SkillNode, SkillTab } from '@shared/types';
+import { SKILL_TABS } from '@shared/types';
 import { usePaneScrollMemory } from './pane-scroll-memory';
 import {
   TreeView,
@@ -9,7 +10,18 @@ import {
 } from './tree-view';
 import './skills-pane.css';
 
-const SKILLS_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
+// Compiled tabs (Claude / Kimi) accept the same SKILL_AFFORDANCES as before;
+// the Generic tab also accepts source-edit mutations. The Kimi tab is
+// read-only because its content is regenerated on every `condash skills
+// install` — see notes/02-design.md §Q1.
+const EDITABLE_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
+const READONLY_AFFORDANCES: ReadonlyArray<TreeAffordance> = [];
+
+const TAB_LABELS: Record<SkillTab, string> = {
+  generic: 'Generic',
+  claude: 'Claude',
+  kimi: 'Kimi',
+};
 
 function isSkillIndex(node: SkillNode): boolean {
   // Case-sensitive — that's how the manifest stores it and how
@@ -24,7 +36,15 @@ function isClaudeMd(node: SkillNode): boolean {
   return node.kind === 'file' && node.name === 'CLAUDE.md';
 }
 
+function isYamlSpec(node: SkillNode): boolean {
+  if (node.kind !== 'file') return false;
+  const lower = node.name.toLowerCase();
+  return lower.endsWith('.yaml') || lower.endsWith('.yml');
+}
+
 export function SkillsView(props: {
+  tab: SkillTab;
+  onSelectTab: (tab: SkillTab) => void;
   root: SkillNode | null;
   onOpen: (path: string, title: string, shipped?: SkillNode['shipped']) => void;
   /** Open Settings (so the user can adjust `skills_path`). */
@@ -39,122 +59,189 @@ export function SkillsView(props: {
   onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
   onError: (message: string) => void;
 }) {
-  const scrollRef = usePaneScrollMemory('skills');
+  // Per-tab scroll memory so flipping tabs restores the prior position.
+  const scrollRef = usePaneScrollMemory(() => `skills-${props.tab}`);
+
+  const affordances = (): ReadonlyArray<TreeAffordance> =>
+    props.tab === 'kimi' ? READONLY_AFFORDANCES : EDITABLE_AFFORDANCES;
+
+  const emptyState = () => {
+    if (props.tab === 'generic') {
+      return (
+        <div class="empty">
+          <p>No source skills.</p>
+          <p>
+            Run <code>condash skills install</code> to lay down bundled skillspecs under{' '}
+            <code>.agents/skills/</code>.
+          </p>
+          <div class="empty-actions">
+            <Show when={props.onCopyInstallCommand}>
+              <button
+                type="button"
+                class="empty-cta"
+                onClick={() => props.onCopyInstallCommand?.()}
+              >
+                Copy install command
+              </button>
+            </Show>
+          </div>
+        </div>
+      );
+    }
+    if (props.tab === 'kimi') {
+      return (
+        <div class="empty">
+          <p>No Kimi skills installed.</p>
+          <p>
+            Run <code>condash skills install</code> to compile bundled skills for Kimi under{' '}
+            <code>.kimi/skills/</code>.
+          </p>
+          <div class="empty-actions">
+            <Show when={props.onCopyInstallCommand}>
+              <button
+                type="button"
+                class="empty-cta"
+                onClick={() => props.onCopyInstallCommand?.()}
+              >
+                Copy install command
+              </button>
+            </Show>
+          </div>
+        </div>
+      );
+    }
+    return (
+      <div class="empty">
+        <p>No skills installed.</p>
+        <p>
+          Run <code>condash skills install</code> to lay down the bundled skills, or change{' '}
+          <code>skills_path</code> in Settings.
+        </p>
+        <div class="empty-actions">
+          <Show when={props.onCopyInstallCommand}>
+            <button type="button" class="empty-cta" onClick={() => props.onCopyInstallCommand?.()}>
+              Copy install command
+            </button>
+          </Show>
+          <Show when={props.onOpenSettings}>
+            <button type="button" class="empty-cta" onClick={() => props.onOpenSettings?.()}>
+              Edit settings
+            </button>
+          </Show>
+        </div>
+      </div>
+    );
+  };
 
   return (
-    <div class="skills-pane" ref={scrollRef}>
-      <Show
-        when={props.root}
-        fallback={
-          <div class="empty">
-            <p>No skills installed.</p>
-            <p>
-              Run <code>condash skills install</code> to lay down the bundled skills, or change{' '}
-              <code>skills_path</code> in Settings.
-            </p>
-            <div class="empty-actions">
-              <Show when={props.onCopyInstallCommand}>
-                <button
-                  type="button"
-                  class="empty-cta"
-                  onClick={() => props.onCopyInstallCommand?.()}
-                >
-                  Copy install command
-                </button>
-              </Show>
-              <Show when={props.onOpenSettings}>
-                <button type="button" class="empty-cta" onClick={() => props.onOpenSettings?.()}>
-                  Edit settings
-                </button>
-              </Show>
-            </div>
-          </div>
-        }
-      >
-        {(root) => (
-          <TreeView<SkillNode>
-            treeKey="skills"
-            root={root()}
-            expanded={props.expanded}
-            onToggleExpand={props.onToggleExpand}
-            affordances={SKILLS_AFFORDANCES}
-            mutations={props.mutations}
-            prompts={props.prompts}
-            onAfterMutation={props.onAfterMutation}
-            onError={props.onError}
-            specialFile={(file, dir) => {
-              // Sub-directories surface their SKILL.md; the synthetic
-              // CLAUDE.md entries surface only at the root level.
-              if (dir.relPath === '') return isClaudeMd(file);
-              return isSkillIndex(file);
-            }}
-            renderSpecialFile={(file, dir) => {
-              if (isClaudeMd(file)) {
+    <div class="skills-pane">
+      <div class="skills-tabs" role="tablist" aria-label="Skills source">
+        <For each={SKILL_TABS}>
+          {(tab) => (
+            <button
+              type="button"
+              role="tab"
+              class="skills-tab"
+              classList={{ active: props.tab === tab }}
+              aria-selected={props.tab === tab}
+              onClick={() => props.onSelectTab(tab)}
+            >
+              {TAB_LABELS[tab]}
+            </button>
+          )}
+        </For>
+      </div>
+      <div class="skills-tree" ref={scrollRef}>
+        <Show when={props.root} fallback={emptyState()}>
+          {(root) => (
+            <TreeView<SkillNode>
+              treeKey="skills"
+              root={root()}
+              expanded={props.expanded}
+              onToggleExpand={props.onToggleExpand}
+              affordances={affordances()}
+              mutations={props.mutations}
+              prompts={props.prompts}
+              onAfterMutation={props.onAfterMutation}
+              onError={props.onError}
+              specialFile={(file, dir) => {
+                // CLAUDE.md only surfaces in the Claude tab at the root level
+                // (Generic and Kimi readers do not inject the synthetic entry).
+                if (dir.relPath === '' && props.tab === 'claude' && isClaudeMd(file)) return true;
+                // Compiled tabs surface SKILL.md inside skill subdirs.
+                if (props.tab !== 'generic' && dir.relPath !== '' && isSkillIndex(file))
+                  return true;
+                return false;
+              }}
+              renderSpecialFile={(file, dir) => {
+                if (isClaudeMd(file)) {
+                  return (
+                    <button
+                      type="button"
+                      class="tree-special-file claude-special-file"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        props.onOpen(file.path, file.title, file.shipped);
+                      }}
+                      title={`Open ${file.path}`}
+                      aria-label={`Open ${file.path}`}
+                    >
+                      <span class="tree-special-badge">CLAUDE</span>
+                      <span class="tree-special-title">{file.title}</span>
+                      <span class="tree-special-meta">{file.relPath}</span>
+                    </button>
+                  );
+                }
+                const shipped = file.shipped;
                 return (
                   <button
                     type="button"
-                    class="tree-special-file claude-special-file"
+                    class="tree-special-file skill-special-file"
+                    classList={{
+                      shipped: !!shipped,
+                      diverged: !!shipped?.diverged,
+                    }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      props.onOpen(file.path, file.title, file.shipped);
+                      props.onOpen(file.path, file.title, shipped);
                     }}
-                    title={`Open ${file.path}`}
-                    aria-label={`Open ${file.path}`}
+                    aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
+                      shipped?.diverged ? ' (shipped, locally edited)' : shipped ? ' (shipped)' : ''
+                    }`}
+                    title={
+                      shipped?.diverged
+                        ? 'SKILL.md (shipped, locally edited)'
+                        : shipped
+                          ? 'SKILL.md (shipped)'
+                          : 'SKILL.md'
+                    }
                   >
-                    <span class="tree-special-badge">CLAUDE</span>
+                    <span class="tree-special-badge">SKILL</span>
                     <span class="tree-special-title">{file.title}</span>
-                    <span class="tree-special-meta">{file.relPath}</span>
+                    <Show when={shipped}>
+                      <span class="tree-special-meta">
+                        {shipped?.diverged ? 'diverged' : 'shipped'}
+                      </span>
+                    </Show>
                   </button>
                 );
-              }
-              const shipped = file.shipped;
-              return (
-                <button
-                  type="button"
-                  class="tree-special-file skill-special-file"
-                  classList={{
-                    shipped: !!shipped,
-                    diverged: !!shipped?.diverged,
-                  }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    props.onOpen(file.path, file.title, shipped);
-                  }}
-                  aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
-                    shipped?.diverged ? ' (shipped, locally edited)' : shipped ? ' (shipped)' : ''
-                  }`}
-                  title={
-                    shipped?.diverged
-                      ? 'SKILL.md (shipped, locally edited)'
-                      : shipped
-                        ? 'SKILL.md (shipped)'
-                        : 'SKILL.md'
-                  }
-                >
-                  <span class="tree-special-badge">SKILL</span>
-                  <span class="tree-special-title">{file.title}</span>
-                  <Show when={shipped}>
-                    <span class="tree-special-meta">
-                      {shipped?.diverged ? 'diverged' : 'shipped'}
-                    </span>
-                  </Show>
-                </button>
-              );
-            }}
-            renderFile={(file) => (
-              <SkillCard
-                node={file}
-                onOpen={() => props.onOpen(file.path, file.title, file.shipped)}
-              />
-            )}
-          />
-        )}
-      </Show>
+              }}
+              renderFile={(file) => (
+                <SkillCard
+                  node={file}
+                  isYaml={isYamlSpec(file)}
+                  onOpen={() => props.onOpen(file.path, file.title, file.shipped)}
+                />
+              )}
+            />
+          )}
+        </Show>
+      </div>
     </div>
   );
 }
 
-function SkillCard(props: { node: SkillNode; onOpen: () => void }) {
+function SkillCard(props: { node: SkillNode; isYaml: boolean; onOpen: () => void }) {
   const shippedStatus = (): 'none' | 'clean' | 'diverged' => {
     const s = props.node.shipped;
     if (!s) return 'none';
@@ -165,10 +252,11 @@ function SkillCard(props: { node: SkillNode; onOpen: () => void }) {
     <article
       class="skills-card"
       data-shipped={shippedStatus()}
+      data-kind={props.isYaml ? 'yaml' : 'md'}
       title={props.node.path}
       tabIndex={0}
       role="button"
-      aria-label={`Open skill ${props.node.title}`}
+      aria-label={`Open ${props.isYaml ? 'spec' : 'skill'} ${props.node.title}`}
       onClick={() => props.onOpen()}
       onKeyDown={(e) => {
         if (e.key === 'Enter' || e.key === ' ') {
@@ -180,6 +268,9 @@ function SkillCard(props: { node: SkillNode; onOpen: () => void }) {
     >
       <header class="skills-card-head">
         <h3 class="skills-card-title">{props.node.title}</h3>
+        <Show when={props.isYaml}>
+          <span class="skills-card-kind">YAML</span>
+        </Show>
         <Show when={props.node.shipped}>
           {(stamp) => (
             <span

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -65,6 +65,34 @@ export function SkillsView(props: {
   const affordances = (): ReadonlyArray<TreeAffordance> =>
     props.tab === 'kimi' ? READONLY_AFFORDANCES : EDITABLE_AFFORDANCES;
 
+  // Per-tab button refs so the ARIA keyboard handler below can move focus
+  // to the next/previous tab without a global DOM query.
+  const tabRefs: Partial<Record<SkillTab, HTMLButtonElement>> = {};
+
+  // ARIA tab pattern: Left/Right (and Home/End) cycle the tab strip when
+  // a tab button has focus. We focus the next tab so screen readers
+  // re-announce and the visible focus ring follows. Wraps end-to-end.
+  const handleTabKeyDown = (event: KeyboardEvent, tab: SkillTab): void => {
+    const current = SKILL_TABS.indexOf(tab);
+    if (current < 0) return;
+    let nextIndex: number;
+    if (event.key === 'ArrowLeft') {
+      nextIndex = (current - 1 + SKILL_TABS.length) % SKILL_TABS.length;
+    } else if (event.key === 'ArrowRight') {
+      nextIndex = (current + 1) % SKILL_TABS.length;
+    } else if (event.key === 'Home') {
+      nextIndex = 0;
+    } else if (event.key === 'End') {
+      nextIndex = SKILL_TABS.length - 1;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    const nextTab = SKILL_TABS[nextIndex];
+    props.onSelectTab(nextTab);
+    tabRefs[nextTab]?.focus();
+  };
+
   const emptyState = () => {
     if (props.tab === 'generic') {
       return (
@@ -135,7 +163,7 @@ export function SkillsView(props: {
 
   return (
     <div class="skills-pane">
-      <div class="skills-tabs" role="tablist" aria-label="Skills source">
+      <div class="skills-tabs" role="tablist" aria-label="Skill tree source">
         <For each={SKILL_TABS}>
           {(tab) => (
             <button
@@ -144,7 +172,12 @@ export function SkillsView(props: {
               class="skills-tab"
               classList={{ active: props.tab === tab }}
               aria-selected={props.tab === tab}
+              tabIndex={props.tab === tab ? 0 : -1}
+              ref={(el) => {
+                tabRefs[tab] = el;
+              }}
               onClick={() => props.onSelectTab(tab)}
+              onKeyDown={(e) => handleTabKeyDown(e, tab)}
             >
               {TAB_LABELS[tab]}
             </button>

--- a/src/renderer/tree-expansion.ts
+++ b/src/renderer/tree-expansion.ts
@@ -1,6 +1,6 @@
 import { createSignal } from 'solid-js';
 import type { Accessor } from 'solid-js';
-import type { TreeRoot } from '@shared/types';
+import type { SkillTab, TreeRoot } from '@shared/types';
 
 export interface TreeExpansionDeps {
   /** Surface a transient toast in the renderer (used for persist failures). */
@@ -10,12 +10,16 @@ export interface TreeExpansionDeps {
 export interface TreeExpansion {
   knowledgeExpanded: Accessor<ReadonlySet<string>>;
   resourcesExpanded: Accessor<ReadonlySet<string>>;
-  skillsExpanded: Accessor<ReadonlySet<string>>;
-  /** Toggle a directory's expanded state in the given pane and persist. */
-  toggleTreeExpand: (treeKey: TreeRoot, relPath: string) => void;
+  /** Per-tab expanded set for the Skills pane. Pass `'claude'` to get the
+   *  set previously keyed on `skills`; the legacy key was migrated by the
+   *  main-process IPC handler on first read. */
+  skillsExpandedByTab: (tab: SkillTab) => Accessor<ReadonlySet<string>>;
+  /** Toggle a directory's expanded state in the given pane and persist.
+   *  When `treeKey === 'skills'`, `skillTab` is required. */
+  toggleTreeExpand: (treeKey: TreeRoot, relPath: string, skillTab?: SkillTab) => void;
   /** Force a directory into the expanded set without toggling — used after
    *  a successful tree mutation so the user can see the new file. */
-  expandTreeDir: (treeKey: TreeRoot, relPath: string) => void;
+  expandTreeDir: (treeKey: TreeRoot, relPath: string, skillTab?: SkillTab) => void;
 }
 
 /**
@@ -24,73 +28,112 @@ export interface TreeExpansion {
  * currently expanded; an empty set means the pane is fully collapsed
  * (the on-purpose first-load state). The hydrate-from-IPC then-callback
  * overrides the empty defaults when the user has prior state on disk.
+ *
+ * The Skills pane carries three independent sets — one per agent tab
+ * (Generic / Claude / Kimi). The on-disk schema migrates the legacy
+ * `skills` key into `skillsClaude` on first read.
  */
 export function createTreeExpansion(deps: TreeExpansionDeps): TreeExpansion {
   const [knowledgeExpanded, setKnowledgeExpanded] = createSignal<ReadonlySet<string>>(new Set());
   const [resourcesExpanded, setResourcesExpanded] = createSignal<ReadonlySet<string>>(new Set());
-  const [skillsExpanded, setSkillsExpanded] = createSignal<ReadonlySet<string>>(new Set());
+  const [skillsGenericExpanded, setSkillsGenericExpanded] = createSignal<ReadonlySet<string>>(
+    new Set(),
+  );
+  const [skillsClaudeExpanded, setSkillsClaudeExpanded] = createSignal<ReadonlySet<string>>(
+    new Set(),
+  );
+  const [skillsKimiExpanded, setSkillsKimiExpanded] = createSignal<ReadonlySet<string>>(new Set());
+
   void window.condash.getTreeExpansion().then((prefs) => {
     setKnowledgeExpanded(new Set(prefs.knowledge));
     setResourcesExpanded(new Set(prefs.resources));
-    setSkillsExpanded(new Set(prefs.skills));
+    setSkillsGenericExpanded(new Set(prefs.skillsGeneric));
+    setSkillsClaudeExpanded(new Set(prefs.skillsClaude));
+    setSkillsKimiExpanded(new Set(prefs.skillsKimi));
   });
 
-  /** Persist the union of the three pane sets to settings.json.
+  const skillsGetter = (tab: SkillTab): Accessor<ReadonlySet<string>> =>
+    tab === 'generic'
+      ? skillsGenericExpanded
+      : tab === 'kimi'
+        ? skillsKimiExpanded
+        : skillsClaudeExpanded;
+  const skillsSetter = (tab: SkillTab) =>
+    tab === 'generic'
+      ? setSkillsGenericExpanded
+      : tab === 'kimi'
+        ? setSkillsKimiExpanded
+        : setSkillsClaudeExpanded;
+
+  /** Persist the union of every pane / tab set to settings.json.
    *  Fire-and-forget — a write failure surfaces as a toast but the
    *  in-memory state stays authoritative for the session. */
   const persistTreeExpansion = (): void => {
     const prefs = {
       knowledge: Array.from(knowledgeExpanded()),
       resources: Array.from(resourcesExpanded()),
-      skills: Array.from(skillsExpanded()),
+      skillsGeneric: Array.from(skillsGenericExpanded()),
+      skillsClaude: Array.from(skillsClaudeExpanded()),
+      skillsKimi: Array.from(skillsKimiExpanded()),
     };
     void window.condash.setTreeExpansion(prefs).catch((err) => {
       deps.flashToast(`Could not persist tree expansion: ${(err as Error).message}`, 'error');
     });
   };
 
-  const toggleTreeExpand = (treeKey: TreeRoot, relPath: string): void => {
-    const setterByKey = {
-      knowledge: setKnowledgeExpanded,
-      resources: setResourcesExpanded,
-      skills: setSkillsExpanded,
-    } as const;
-    const getterByKey = {
-      knowledge: knowledgeExpanded,
-      resources: resourcesExpanded,
-      skills: skillsExpanded,
-    } as const;
-    const next = new Set(getterByKey[treeKey]());
-    if (next.has(relPath)) next.delete(relPath);
-    else next.add(relPath);
-    setterByKey[treeKey](next);
+  const resolveSkillsTab = (skillTab: SkillTab | undefined): SkillTab => skillTab ?? 'claude';
+
+  const toggleTreeExpand = (treeKey: TreeRoot, relPath: string, skillTab?: SkillTab): void => {
+    if (treeKey === 'knowledge') {
+      const next = new Set(knowledgeExpanded());
+      if (next.has(relPath)) next.delete(relPath);
+      else next.add(relPath);
+      setKnowledgeExpanded(next);
+    } else if (treeKey === 'resources') {
+      const next = new Set(resourcesExpanded());
+      if (next.has(relPath)) next.delete(relPath);
+      else next.add(relPath);
+      setResourcesExpanded(next);
+    } else {
+      const tab = resolveSkillsTab(skillTab);
+      const cur = skillsGetter(tab)();
+      const next = new Set(cur);
+      if (next.has(relPath)) next.delete(relPath);
+      else next.add(relPath);
+      skillsSetter(tab)(next);
+    }
     persistTreeExpansion();
   };
 
-  const expandTreeDir = (treeKey: TreeRoot, relPath: string): void => {
+  const expandTreeDir = (treeKey: TreeRoot, relPath: string, skillTab?: SkillTab): void => {
     if (relPath === '') return; // root is always expanded; no need to track
-    const setterByKey = {
-      knowledge: setKnowledgeExpanded,
-      resources: setResourcesExpanded,
-      skills: setSkillsExpanded,
-    } as const;
-    const getterByKey = {
-      knowledge: knowledgeExpanded,
-      resources: resourcesExpanded,
-      skills: skillsExpanded,
-    } as const;
-    const cur = getterByKey[treeKey]();
-    if (cur.has(relPath)) return;
-    const next = new Set(cur);
-    next.add(relPath);
-    setterByKey[treeKey](next);
+    if (treeKey === 'knowledge') {
+      const cur = knowledgeExpanded();
+      if (cur.has(relPath)) return;
+      const next = new Set(cur);
+      next.add(relPath);
+      setKnowledgeExpanded(next);
+    } else if (treeKey === 'resources') {
+      const cur = resourcesExpanded();
+      if (cur.has(relPath)) return;
+      const next = new Set(cur);
+      next.add(relPath);
+      setResourcesExpanded(next);
+    } else {
+      const tab = resolveSkillsTab(skillTab);
+      const cur = skillsGetter(tab)();
+      if (cur.has(relPath)) return;
+      const next = new Set(cur);
+      next.add(relPath);
+      skillsSetter(tab)(next);
+    }
     persistTreeExpansion();
   };
 
   return {
     knowledgeExpanded,
     resourcesExpanded,
-    skillsExpanded,
+    skillsExpandedByTab: skillsGetter,
     toggleTreeExpand,
     expandTreeDir,
   };

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -17,6 +17,7 @@ import type {
   ResourceNode,
   SearchResults,
   SkillNode,
+  SkillTab,
   StepMarker,
   TermDataMessage,
   TermExitMessage,
@@ -40,10 +41,13 @@ export interface CondashApi {
    * carrying mime + coarse category for the renderer's icon picker.
    * Resolves to null when the directory is missing. */
   readResourcesTree(): Promise<ResourceNode | null>;
-  /** Tree under <conception>/<skills_path> — `.md` files only, with
-   * shipped-SHA stamps populated from `.condash-skills.json` when present.
+  /** Tree under the active skills tab's root:
+   *  - generic → `.agents/skills/` (`.md` and `.yaml` files)
+   *  - claude  → `<conception>/<skills_path>` (`.md` only)
+   *  - kimi    → `.kimi/skills/` (`.md` only)
+   * Shipped-SHA stamps are populated from `.condash-skills.json` when present.
    * Resolves to null when the directory is missing. */
-  readSkillsTree(): Promise<SkillNode | null>;
+  readSkillsTree(tab: SkillTab): Promise<SkillNode | null>;
   search(query: string): Promise<SearchResults>;
   listRepos(): Promise<RepoEntry[]>;
   /** Per-primary partial reload — returns the primary's `RepoEntry` plus
@@ -128,6 +132,9 @@ export interface CondashApi {
   getBranchFilterStickyAll(): Promise<boolean>;
   /** Persist the All-sticky mode flag. */
   setBranchFilterStickyAll(value: boolean): Promise<void>;
+  /** Active tab in the Skills pane. Persisted per-machine in settings.json. */
+  getSkillsActiveTab(): Promise<SkillTab>;
+  setSkillsActiveTab(tab: SkillTab): Promise<void>;
   /** Absolute path to `~/.config/condash/settings.json` (or platform equivalent),
    * for the settings modal's "Open externally" button. */
   getSettingsPath(): Promise<string>;
@@ -271,17 +278,28 @@ export interface CondashApi {
    *  `.md` extension is appended when missing. Resources accept any
    *  extension; knowledge / skills always force `.md`. Refuses to overwrite
    *  an existing file. Returns the new file's absolute path so the caller
-   *  can re-fetch the tree and open the file in the editor. */
-  treeCreateMd(root: TreeRoot, dirRelPath: string, filename: string): Promise<string>;
+   *  can re-fetch the tree and open the file in the editor.
+   *  When `root === 'skills'`, `skillTab` selects which tab's directory is
+   *  the target (generic / claude / kimi). Kimi rejects with an error. */
+  treeCreateMd(
+    root: TreeRoot,
+    dirRelPath: string,
+    filename: string,
+    skillTab?: SkillTab,
+  ): Promise<string>;
   /** Create a new subdirectory under one of the three tree panes'
    *  directories. Same `dirRelPath` semantics as `treeCreateMd`. `name` is
    *  sanitised to lowercase-hyphen. Idempotent: a no-op if the directory
-   *  already exists, but always returns its absolute path. */
-  treeMkdir(root: TreeRoot, dirRelPath: string, name: string): Promise<string>;
+   *  already exists, but always returns its absolute path.
+   *  When `root === 'skills'`, `skillTab` selects which tab's directory is
+   *  the target (generic / claude / kimi). Kimi rejects with an error. */
+  treeMkdir(root: TreeRoot, dirRelPath: string, name: string, skillTab?: SkillTab): Promise<string>;
   /** Pop an OS file picker, then copy the chosen file into the target tree
    *  directory. Resolves to the destination's absolute path, or `null` when
-   *  the user cancels. Refuses to overwrite an existing file. */
-  treeImportFile(root: TreeRoot, dirRelPath: string): Promise<string | null>;
+   *  the user cancels. Refuses to overwrite an existing file.
+   *  When `root === 'skills'`, `skillTab` selects which tab's directory is
+   *  the target (generic / claude / kimi). Kimi rejects with an error. */
+  treeImportFile(root: TreeRoot, dirRelPath: string, skillTab?: SkillTab): Promise<string | null>;
   /** Trigger app quit. Renderer is responsible for any user confirmation. */
   quitApp(): Promise<void>;
   /** App version + bundled release metadata used by the About modal.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -158,6 +158,11 @@ export interface LogsOpenRequest {
  * All four are mutually exclusive: showing one swaps the others out. */
 export type WorkingSurface = 'code' | 'knowledge' | 'resources' | 'skills' | 'logs' | null;
 
+/** Active tab in the Skills pane. */
+export type SkillTab = 'generic' | 'claude' | 'kimi';
+
+export const SKILL_TABS: readonly SkillTab[] = ['generic', 'claude', 'kimi'] as const;
+
 /** Composite-layout state. The unified window has a top band (Projects on
  * the left, working surface on the right) and a bottom band (Terminal).
  * Each band can be hidden independently; the working surface is also
@@ -220,6 +225,10 @@ export interface Settings {
    *  is empty/undefined, false otherwise — preserves existing behaviour
    *  for users with an explicit selection. Issue #169. */
   branchFilterStickyAll?: boolean;
+  /** Active tab in the Skills pane. Persisted per-machine so the next
+   *  launch reopens whichever tab the user last looked at. Defaults to
+   *  `claude` (preserves pre-tabs behaviour for existing users). */
+  skillsActiveTab?: SkillTab;
 }
 
 /** Sets of expanded directory `relPath`s for the three tree panes. The
@@ -227,7 +236,13 @@ export interface Settings {
 export interface TreeExpansionPrefs {
   knowledge?: string[];
   resources?: string[];
+  /** Legacy key — migrated to `skillsClaude` on first read. Kept for
+   *  backwards compatibility during load; writers always emit the three
+   *  per-tab keys below. */
   skills?: string[];
+  skillsGeneric?: string[];
+  skillsClaude?: string[];
+  skillsKimi?: string[];
 }
 
 /** Discriminator for the three tree panes. Used by the `tree.*` IPC verbs


### PR DESCRIPTION
## Summary

- Replace the single-tree Skills pane with three tabs — Generic (agent-neutral source skillspecs), Claude (compiled output), Kimi (compiled output) — so source and per-agent outputs are all reachable in the dashboard without changing `skills_path` or browsing externally.
- All three trees are eager-loaded; tab switching is paint-only. Per-tab expansion and scroll state are persisted; the active tab itself is per-machine.
- CLI gains separate compiled manifests under each target's `skills/.condash-skills.json` so shipped/diverged tracking now actually works for Claude (broken since 2026-05-14) and is also wired up for Kimi.

## Changes

- `shared/types.ts` — `SkillTab` enum + `SKILL_TABS`; new `treeExpansion` sub-keys; `skillsActiveTab` on `Settings`.
- `main/skills.ts` — `readGenericSkillsTree` (accepts `.yaml`, no synthetic `CLAUDE.md`), `readKimiSkillsTree`, `readSkillsTreeForTab` router.
- `main/ipc/trees.ts` — `readSkillsTree` routes through the tab router; mutation IPCs pass through `skillTab`.
- `main/ipc/settings.ts` — `getTreeExpansion` migrates legacy `skills` into `skillsClaude`; new `get/setSkillsActiveTab` handlers.
- `main/tree-mutations.ts` — skills root resolved per tab; Kimi rejects writes.
- `main/search/index.ts` — walks all three skill roots in parallel; source label stays `skills`.
- `cli/commands/install-shared.ts` — `readManifest` tries `.agents/.condash-skills.json` first; one-shot `mv` from the legacy `.claude/skills` location; `writeManifest` always targets `.agents/`.
- `cli/commands/skills.ts` — post-compile, writes a per-target manifest under `.claude/skills/.condash-skills.json` and `.kimi/skills/.condash-skills.json`.
- `preload/index.ts` — `readSkillsTree(tab)`, `get/setSkillsActiveTab`, `skillTab?` threaded into tree mutations.
- `renderer/main.tsx` — three `TreeStore`s eager-loaded, `skillsActiveTab` signal, `skillsMutations` wrapper, post-mutation routes to the right tab's reload.
- `renderer/tree-expansion.ts` — three skills signals, `skillsExpandedByTab(tab)` accessor, toggle/expand accept `skillTab`.
- `renderer/panes/skills.tsx` — tab bar, per-tab affordances and empty states, YAML card kind.
- `renderer/panes/pane-scroll-memory.ts` — `paneId` may be a getter so tab switches save/restore per tab without remount.
- `renderer/panes/skills-pane.css` — tab bar styles, YAML card stripe.
- `docs/guides/skills-pane.md`, `docs/reference/config.md`, `docs/reference/skill.md` — three-tab UX, new `treeExpansion` sub-keys, three-manifest layout.
- `package.json` / `package-lock.json` — 3.7.0.

## Impact

- `treeExpansion.skills` (if any) migrates into `skillsClaude` on first read and never writes back; users keep their Claude-tab expansion state.
- The CLI source manifest moves from `.claude/skills/.condash-skills.json` to `.agents/.condash-skills.json` — one-shot `mv` on the next install, transparent.
- The shipped/diverged badge on Claude SKILL cards has been broken since the skillspec compiler shipped (manifest sat in the wrong place with the wrong schema). It comes back with this release.
- `skillsActiveTab` defaults to `claude` so existing users see no behaviour change on first open.

## Watchpoints

- No in-browser dev-build verification was performed. `typecheck`, prettier, `build:main`, `build:renderer`, `build:cli`, and the 368-test vitest suite are all green; the rendered UI of the tab bar / YAML cards is not yet eyeballed on a running dashboard.
