### PR TITLE
Fix CLI UX: --help wins, typo-first errors, --status on create

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -96,7 +96,7 @@ Item lifecycle and reads.
 | `reopen <slug>` | Move `done` back to `now` (or `--status <s>`) and append a `Reopened.` timeline entry |
 | `backfill-closed [--dry-run]` | Append a `Closed.` timeline entry to legacy `done` items missing one |
 | `index [--dry-run] [--rewrite-aggregated]` | Regenerate every `projects/**/index.md` from the on-disk tree; clear `projects/.index-dirty` |
-| `create --kind <k> --slug <s> --title "<t>" --apps "<a>"` | Create a new project / incident / document folder + README from the canonical template. Incidents add `--severity` + `--severity-impact` + `--environment` |
+| `create --kind <k> --slug <s> --title "<t>" --apps "<a>" [--status <s>]` | Create a new project / incident / document folder + README from the canonical template. `--status` accepts `now \| review \| later \| backlog` (default `now`); `done` is rejected — use `condash projects close` to flip status to done. Incidents add `--severity` + `--severity-impact` + `--environment` |
 | `scan-promotions [--limit N]` | Walk closed items for "always / never / next time / use X" cues that suggest a knowledge promotion; print suggestions |
 | `rewrite-headers [--dry-run]` | One-shot migration of legacy bold-prose headers to YAML frontmatter; idempotent (already-YAML files are no-ops). Skips any README whose body has unexpected content between the meta block and the first `##` heading |
 
@@ -238,7 +238,13 @@ Read or change condash configuration.
 
 ### `help`
 
-`condash help` prints the top-level help. `condash help <noun>` re-dispatches to the noun's `--help` path so there's only one source of help text per noun.
+`condash help` prints the top-level help. `condash help <noun>` re-dispatches to the noun's `--help` path so there's only one source of help text per noun. `condash <noun> help <verb>` is the per-verb alias — equivalent to `condash <noun> <verb> --help`.
+
+Per-verb help is always printable: `condash <noun> <verb> --help` short-circuits before any required-flag or positional check, so you can read the usage without filling in arguments.
+
+### Unknown-flag suggestions
+
+When you mistype a flag, condash reports `Unknown flag: --foo (did you mean --bar?)` if a valid flag for the same noun is within Levenshtein distance ≤ 2. The suggestion pool is the union of every flag known to the noun (across its verbs), so a typo of a sibling-verb flag still gets surfaced. The check runs **before** required-flag validation — so `condash projects create --app foo` reports the typo of `--apps`, not "missing --apps".
 
 ## Output modes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -1,17 +1,35 @@
 import { runAudit, type AuditCheckName, type AuditReport } from '../../main/audit';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
 
 const ALL_AUDIT_CHECKS: AuditCheckName[] = ['lfs', 'binaries', 'cross-repo', 'worktrees', 'index'];
+
+const KNOWN_FLAGS_AUDIT = ['include'] as const;
+
+const NOUN_FLAGS: readonly string[] = [...new Set<string>([...KNOWN_FLAGS_AUDIT])];
 
 export async function runAuditCommand(
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  // `audit` is verbless. The two help triggers are:
+  //   - `condash audit --help`
+  //   - `condash audit help` (positional alias)
+  // Either prints the same usage block.
+  if (universalHelp || (args.positional[0] === 'help' && args.positional.length === 1)) {
+    printHelp();
+    return;
+  }
+  const includeFlag = args.flags.include;
+  delete args.flags.include;
+  assertNoExtraFlags(args, NOUN_FLAGS);
+
   const includeRaw =
-    typeof args.flags.include === 'string'
-      ? args.flags.include
+    typeof includeFlag === 'string'
+      ? includeFlag
           .split(',')
           .map((s) => s.trim())
           .filter(Boolean)
@@ -28,10 +46,29 @@ export async function runAuditCommand(
       );
     }
   }
-  delete args.flags.include;
-  assertNoExtraFlags(args);
   const report = await runAudit(conceptionPath, include as AuditCheckName[]);
   emit(ctx, report, formatAuditPretty, [], { streamField: 'issues' });
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'condash audit [--include <checks>]',
+      '',
+      'Run umbrella audits across the conception tree.',
+      '',
+      'Optional:',
+      `  --include    Comma-separated subset of {${ALL_AUDIT_CHECKS.join(', ')}}, or 'all' (default).`,
+      '',
+      'Examples:',
+      '  condash audit',
+      '  condash audit --include lfs,binaries --json',
+      '  condash audit --include all',
+      '',
+      UNIVERSAL_FOOTER,
+      '',
+    ].join('\n'),
+  );
 }
 
 function formatAuditPretty(report: AuditReport): string {

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -12,15 +12,43 @@ import { atomicWrite } from '../../main/atomic-write';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { resolveConception } from '../conception';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
+
+const KNOWN_FLAGS_CONCEPTION_PATH: readonly string[] = [];
+const KNOWN_FLAGS_PATH: readonly string[] = [];
+const KNOWN_FLAGS_LIST = ['effective', 'global'] as const;
+const KNOWN_FLAGS_GET = ['effective', 'global'] as const;
+const KNOWN_FLAGS_SET = ['global'] as const;
+const KNOWN_FLAGS_MIGRATE: readonly string[] = [];
+
+const NOUN_FLAGS: readonly string[] = [
+  ...new Set<string>([
+    ...KNOWN_FLAGS_CONCEPTION_PATH,
+    ...KNOWN_FLAGS_PATH,
+    ...KNOWN_FLAGS_LIST,
+    ...KNOWN_FLAGS_GET,
+    ...KNOWN_FLAGS_SET,
+    ...KNOWN_FLAGS_MIGRATE,
+  ]),
+];
 
 export async function runConfig(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   if (verb === 'conception-path') {
-    assertNoExtraFlags(args);
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const resolved = await resolveConception(undefined);
     emit(
       ctx,
@@ -30,7 +58,7 @@ export async function runConfig(
     return;
   }
   if (verb === 'path') {
-    assertNoExtraFlags(args);
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const conception = await resolveConceptionConfigPath(conceptionPath);
     const data = { global: settingsPath(), conception };
     emit(ctx, data, () => `global:    ${data.global}\nconception: ${data.conception}\n`);
@@ -39,10 +67,10 @@ export async function runConfig(
   if (verb === null || verb === 'list') {
     const useEffective = consumeFlag(args, '--effective');
     const useGlobal = consumeFlag(args, '--global');
+    assertNoExtraFlags(args, NOUN_FLAGS);
     if (useEffective && useGlobal) {
       throw new CliError(ExitCodes.USAGE, '--effective and --global are mutually exclusive');
     }
-    assertNoExtraFlags(args);
     let config: unknown;
     if (useGlobal) {
       const raw = await fs.readFile(settingsPath(), 'utf8').catch((err) => {
@@ -60,15 +88,15 @@ export async function runConfig(
     return;
   }
   if (verb === 'get') {
+    const useEffective = consumeFlag(args, '--effective');
+    const useGlobal = consumeFlag(args, '--global');
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const key = args.positional[0];
     if (!key)
       throw new CliError(ExitCodes.USAGE, 'Usage: condash config get <key> [--effective|--global]');
-    const useEffective = consumeFlag(args, '--effective');
-    const useGlobal = consumeFlag(args, '--global');
     if (useEffective && useGlobal) {
       throw new CliError(ExitCodes.USAGE, '--effective and --global are mutually exclusive');
     }
-    assertNoExtraFlags(args);
     let config: unknown;
     let source: string;
     if (useGlobal) {
@@ -93,13 +121,13 @@ export async function runConfig(
     return;
   }
   if (verb === 'set') {
+    const writeGlobal = consumeFlag(args, '--global');
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const key = args.positional[0];
     const value = args.positional[1];
     if (!key || value === undefined) {
       throw new CliError(ExitCodes.USAGE, 'Usage: condash config set <key> <value> [--global]');
     }
-    const writeGlobal = consumeFlag(args, '--global');
-    assertNoExtraFlags(args);
     // Parse value as JSON when it looks like a primitive / object / array;
     // otherwise treat as a literal string (the common case).
     let parsedValue: unknown = value;
@@ -137,7 +165,7 @@ export async function runConfig(
     return;
   }
   if (verb === 'migrate') {
-    assertNoExtraFlags(args);
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const result = await migrateLegacyConfig(conceptionPath);
     emit(ctx, result, (d) => {
       const r = d as Awaited<ReturnType<typeof migrateLegacyConfig>>;
@@ -204,6 +232,136 @@ async function mutateJsonFile(
   // mkdir -p before writing.
   await fs.mkdir(dirname(path), { recursive: true });
   await atomicWrite(path, JSON.stringify(current, null, 2) + '\n');
+}
+
+function printHelp(verb: string | null): void {
+  switch (verb) {
+    case 'conception-path':
+      process.stdout.write(
+        [
+          'condash config conception-path',
+          '',
+          'Print the resolved conception path + how it was resolved.',
+          '',
+          'Examples:',
+          '  condash config conception-path',
+          '  condash config conception-path --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'path':
+      process.stdout.write(
+        [
+          'condash config path',
+          '',
+          'Print the on-disk path of the global + conception settings files.',
+          '',
+          'Examples:',
+          '  condash config path',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'list':
+    case null:
+      process.stdout.write(
+        [
+          'condash config list [--effective|--global]',
+          '',
+          'Print the merged config. Default: per-conception view.',
+          '',
+          'Optional:',
+          '  --effective   Show the merged effective config (global + conception).',
+          '  --global      Show the global ~/.config/condash/settings.json only.',
+          '',
+          'Examples:',
+          '  condash config list',
+          '  condash config list --effective --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'get':
+      process.stdout.write(
+        [
+          'condash config get <key> [--effective|--global]',
+          '',
+          'Read one config key (dotted path).',
+          '',
+          'Examples:',
+          '  condash config get repos[0].path',
+          '  condash config get audit.thresholds.binary --effective',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'set':
+      process.stdout.write(
+        [
+          'condash config set <key> <value> [--global]',
+          '',
+          'Write one config key. Value is parsed as JSON when it looks like one,',
+          'otherwise treated as a literal string. Default target: .condash/settings.json.',
+          '',
+          'Optional:',
+          '  --global   Write to ~/.config/condash/settings.json instead.',
+          '',
+          'Examples:',
+          '  condash config set repos[0].path /home/me/src/foo',
+          '  condash config set audit.thresholds.binary 5242880 --global',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'migrate':
+      process.stdout.write(
+        [
+          'condash config migrate',
+          '',
+          'One-shot: copy legacy condash.json / configuration.json to .condash/settings.json',
+          'and add .condash/ to .gitignore (if needed).',
+          '',
+          'Examples:',
+          '  condash config migrate',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    default:
+      printSubHelp();
+  }
+}
+
+function printSubHelp(): void {
+  process.stdout.write(
+    [
+      'condash config <verb> [args]',
+      '',
+      'Verbs:',
+      '  conception-path   Print the resolved conception path.',
+      '  path              Print the on-disk paths of the settings files.',
+      '  list              Print merged config (default: per-conception view).',
+      '  get <key>         Read one config key (dotted path).',
+      '  set <key> <val>   Write one config key.',
+      '  migrate           Copy legacy condash.json / configuration.json to .condash/settings.json.',
+      '',
+      UNIVERSAL_FOOTER,
+      '',
+    ].join('\n'),
+  );
 }
 
 function pickByDottedPath(obj: unknown, dotted: string): unknown {

--- a/src/cli/commands/dirty.ts
+++ b/src/cli/commands/dirty.ts
@@ -3,15 +3,30 @@ import { join } from 'node:path';
 import { touchDirtyMarker } from '../../main/dirty';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
+
+// `dirty` verbs take only positional args today — the suggestion pool is
+// empty but `assertNoExtraFlags(args, NOUN_FLAGS)` still rejects any flag
+// the user invents.
+const NOUN_FLAGS: readonly string[] = [];
 
 export async function runDirty(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   if (verb === null || verb === 'list') {
-    assertNoExtraFlags(args);
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const data = {
       projects: await readMarker(join(conceptionPath, 'projects', '.index-dirty')),
       knowledge: await readMarker(join(conceptionPath, 'knowledge', '.index-dirty')),
@@ -30,22 +45,22 @@ export async function runDirty(
     return;
   }
   if (verb === 'touch') {
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const tree = args.positional[0];
     if (tree !== 'projects' && tree !== 'knowledge') {
       throw new CliError(ExitCodes.USAGE, 'Usage: condash dirty touch <projects|knowledge>');
     }
-    assertNoExtraFlags(args);
     await touchDirtyMarker(conceptionPath, tree);
     const path = join(conceptionPath, tree, '.index-dirty');
     emit(ctx, { tree, path, present: true }, (d) => `touched ${(d as { path: string }).path}\n`);
     return;
   }
   if (verb === 'clear') {
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const which = args.positional[0];
     if (which !== 'projects' && which !== 'knowledge' && which !== 'all') {
       throw new CliError(ExitCodes.USAGE, 'Usage: condash dirty clear <projects|knowledge|all>');
     }
-    assertNoExtraFlags(args);
     const targets = which === 'all' ? ['projects', 'knowledge'] : [which];
     const cleared: string[] = [];
     for (const t of targets) {
@@ -89,4 +104,75 @@ async function readMarker(path: string): Promise<MarkerInfo> {
     }
     throw err;
   }
+}
+
+function printHelp(verb: string | null): void {
+  switch (verb) {
+    case 'list':
+    case null:
+      process.stdout.write(
+        [
+          'condash dirty list',
+          '',
+          'Show the per-tree dirty marker state (which trees need re-indexing).',
+          '',
+          'Examples:',
+          '  condash dirty list',
+          '  condash dirty list --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'touch':
+      process.stdout.write(
+        [
+          'condash dirty touch <projects|knowledge>',
+          '',
+          "Force the named tree's dirty marker on so the next index regeneration runs.",
+          '',
+          'Examples:',
+          '  condash dirty touch projects',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'clear':
+      process.stdout.write(
+        [
+          'condash dirty clear <projects|knowledge|all>',
+          '',
+          "Remove the named tree's dirty marker (or both with `all`).",
+          '',
+          'Examples:',
+          '  condash dirty clear knowledge',
+          '  condash dirty clear all',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    default:
+      printSubHelp();
+  }
+}
+
+function printSubHelp(): void {
+  process.stdout.write(
+    [
+      'condash dirty <verb> [args]',
+      '',
+      'Verbs:',
+      '  list    Show per-tree dirty marker state.',
+      "  touch   Force a tree's dirty marker on.",
+      "  clear   Remove a tree's dirty marker (or both with `all`).",
+      '',
+      UNIVERSAL_FOOTER,
+      '',
+    ].join('\n'),
+  );
 }

--- a/src/cli/commands/knowledge.ts
+++ b/src/cli/commands/knowledge.ts
@@ -8,18 +8,44 @@ import { isoToday } from '../../shared/iso-today';
 import type { KnowledgeNode } from '../../shared/types';
 import { CliError, ExitCodes, emit, validation, type OutputContext } from '../output';
 import { assertNoExtraFlags, parseIntFlag, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
 
 const DEFAULT_MAX_AGE_DAYS = 30;
+
+const KNOWN_FLAGS_TREE = ['depth'] as const;
+const KNOWN_FLAGS_VERIFY = ['max-age'] as const;
+const KNOWN_FLAGS_RETRIEVE = ['mode'] as const;
+const KNOWN_FLAGS_STAMP = ['where', 'date', 'insert-after'] as const;
+const KNOWN_FLAGS_INDEX = ['dry-run', 'rewrite-aggregated'] as const;
+
+const NOUN_FLAGS: readonly string[] = [
+  ...new Set<string>([
+    ...KNOWN_FLAGS_TREE,
+    ...KNOWN_FLAGS_VERIFY,
+    ...KNOWN_FLAGS_RETRIEVE,
+    ...KNOWN_FLAGS_STAMP,
+    ...KNOWN_FLAGS_INDEX,
+  ]),
+];
 
 export async function runKnowledge(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   switch (verb) {
     case null:
-      printSubHelp();
+      printHelp(null);
       return;
     case 'tree':
       return await treeCommand(args, ctx, conceptionPath);
@@ -45,7 +71,7 @@ async function indexCommand(
   const rewriteAggregated = args.flags['rewrite-aggregated'] === true;
   delete args.flags['dry-run'];
   delete args.flags['rewrite-aggregated'];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const report = await regenerateIndex(conceptionPath, knowledgeStrategy, {
     dryRun,
     rewriteAggregated,
@@ -99,7 +125,7 @@ async function treeCommand(
 ): Promise<void> {
   const depth = parseIntFlag(args.flags.depth, Infinity);
   delete args.flags.depth;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const root = await readKnowledgeTree(conceptionPath);
   if (!root) throw new CliError(ExitCodes.NOT_FOUND, 'No knowledge/ tree found');
   const trimmed = trimDepth(root, depth);
@@ -156,7 +182,7 @@ async function verifyCommand(
 ): Promise<void> {
   const maxAge = parseIntFlag(args.flags['max-age'], DEFAULT_MAX_AGE_DAYS);
   delete args.flags['max-age'];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const knowledgeRoot = join(conceptionPath, 'knowledge');
   const files = await collectKnowledgeFiles(knowledgeRoot);
 
@@ -266,16 +292,17 @@ async function retrieveCommand(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const modeFlag = args.flags.mode;
+  delete args.flags.mode;
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const query = args.positional.join(' ').trim();
   if (!query) {
     throw new CliError(ExitCodes.USAGE, 'Usage: condash knowledge retrieve <query>');
   }
-  const mode = (args.flags.mode as string | undefined) ?? 'both';
+  const mode = (modeFlag as string | undefined) ?? 'both';
   if (!['triage', 'grep', 'both'].includes(mode)) {
     throw new CliError(ExitCodes.USAGE, `--mode must be triage|grep|both`);
   }
-  delete args.flags.mode;
-  assertNoExtraFlags(args);
 
   const knowledgeRoot = join(conceptionPath, 'knowledge');
   const triage: TriageMatch[] = [];
@@ -426,6 +453,12 @@ async function stampCommand(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const where = args.flags.where;
+  const dateFlag = args.flags.date;
+  const insertAfter =
+    typeof args.flags['insert-after'] === 'string' ? (args.flags['insert-after'] as string) : null;
+  for (const k of ['where', 'date', 'insert-after']) delete args.flags[k];
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const target = args.positional[0];
   if (!target) {
     throw new CliError(
@@ -433,18 +466,13 @@ async function stampCommand(
       'Usage: condash knowledge stamp <path> --where <where> [--date YYYY-MM-DD]',
     );
   }
-  const where = args.flags.where;
   if (typeof where !== 'string' || !where.trim()) {
     throw new CliError(ExitCodes.USAGE, '--where is required (e.g. "<app>@<sha> on <branch>")');
   }
-  const date = typeof args.flags.date === 'string' ? args.flags.date : isoToday();
+  const date = typeof dateFlag === 'string' ? dateFlag : isoToday();
   if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
     validation(`--date must be YYYY-MM-DD; got '${date}'`);
   }
-  const insertAfter =
-    typeof args.flags['insert-after'] === 'string' ? (args.flags['insert-after'] as string) : null;
-  for (const k of ['where', 'date', 'insert-after']) delete args.flags[k];
-  assertNoExtraFlags(args);
   const targetPath = isAbsoluteLike(target) ? target : join(conceptionPath, target);
   // The stamp writes a body file — refuse anywhere outside the conception
   // tree so a `--target ../../etc/passwd` argument can't prepend a Verified
@@ -535,6 +563,113 @@ function isAbsoluteLike(p: string): boolean {
   return p.startsWith('/') || /^[A-Za-z]:\\/.test(p);
 }
 
+function printHelp(verb: string | null): void {
+  switch (verb) {
+    case 'tree':
+      process.stdout.write(
+        [
+          'condash knowledge tree [--depth N]',
+          '',
+          'Hierarchical view of knowledge/.',
+          '',
+          'Optional:',
+          '  --depth   Cap recursion at N levels (default: unlimited).',
+          '',
+          'Examples:',
+          '  condash knowledge tree',
+          '  condash knowledge tree --depth 2 --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'verify':
+      process.stdout.write(
+        [
+          'condash knowledge verify [--max-age N]',
+          '',
+          'Audit **Verified:** stamps; report any older than --max-age days.',
+          '',
+          'Optional:',
+          `  --max-age   Threshold in days (default: ${DEFAULT_MAX_AGE_DAYS}).`,
+          '',
+          'Examples:',
+          '  condash knowledge verify',
+          '  condash knowledge verify --max-age 60 --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'retrieve':
+      process.stdout.write(
+        [
+          'condash knowledge retrieve <query> [--mode <mode>]',
+          '',
+          'Match a query against index.md keywords; falls back to grep.',
+          '',
+          'Optional:',
+          '  --mode    triage | grep | both   (default: both)',
+          '',
+          'Examples:',
+          '  condash knowledge retrieve "session cookie"',
+          '  condash knowledge retrieve gdpr --mode triage --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'stamp':
+      process.stdout.write(
+        [
+          'condash knowledge stamp <path> --where <where> [--date YYYY-MM-DD] [--insert-after <heading>]',
+          '',
+          'Idempotently write a **Verified:** line into a file.',
+          '',
+          'Required:',
+          '  --where         Provenance string (e.g. "condash@abc1234 on main").',
+          '',
+          'Optional:',
+          '  --date          Stamp date (default: today).',
+          '  --insert-after  Heading after which to insert when no stamp exists yet.',
+          '',
+          'Examples:',
+          '  condash knowledge stamp knowledge/internal/condash.md --where "condash@abc1234 on main"',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'index':
+      process.stdout.write(
+        [
+          'condash knowledge index [--dry-run] [--rewrite-aggregated]',
+          '',
+          'Regenerate every knowledge/**/index.md.',
+          '',
+          'Optional:',
+          '  --dry-run                Preview without writing.',
+          '  --rewrite-aggregated     One-shot migration: re-derive every subdir bullet',
+          '                           from descendants and mark drafted.',
+          '',
+          'Examples:',
+          '  condash knowledge index',
+          '  condash knowledge index --dry-run --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    default:
+      printSubHelp();
+  }
+}
+
 function printSubHelp(): void {
   process.stdout.write(
     [
@@ -546,8 +681,8 @@ function printSubHelp(): void {
       '  retrieve    Match a query against index.md keywords; falls back to grep.',
       '  stamp       Idempotently write a **Verified:** line into a file.',
       '  index       Regenerate every knowledge/**/index.md.',
-      '              Flags: --dry-run, --rewrite-aggregated (one-shot migration:',
-      '              re-derive every subdir bullet from descendants, mark drafted).',
+      '',
+      UNIVERSAL_FOOTER,
       '',
     ].join('\n'),
   );

--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -12,6 +12,7 @@ import { isAbsolute, join, resolve } from 'node:path';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { resolveConception } from '../conception';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
 import {
   AGENTS_MD_TARGETS,
   AGENTS_MD_OUTPUTS,
@@ -19,6 +20,10 @@ import {
   type AgentsMdTarget,
 } from '../../agents-md';
 import { writeFileMkdir } from './install-shared';
+
+const KNOWN_FLAGS_BUILD = ['dest', 'dry-run'] as const;
+
+const NOUN_FLAGS: readonly string[] = [...new Set<string>([...KNOWN_FLAGS_BUILD])];
 
 interface BuildReport {
   sourceDir: string;
@@ -30,7 +35,16 @@ export async function runProject(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   switch (verb) {
     case 'build':
       return await buildProject(args, ctx);
@@ -40,10 +54,12 @@ export async function runProject(
 }
 
 async function buildProject(args: ParsedArgs, ctx: OutputContext): Promise<void> {
-  const dest = await resolveDest(args);
   const dryRun = args.flags['dry-run'] === true;
+  // `dest` is read inside resolveDest; stash + clear before assertNoExtraFlags.
+  const destFlag = args.flags.dest;
   for (const k of ['dest', 'dry-run']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
+  const dest = await resolveDest(destFlag);
 
   const sourceDir = join(dest, '.agents', 'agents');
   const commonPath = join(sourceDir, 'common.md');
@@ -82,8 +98,7 @@ async function buildProject(args: ParsedArgs, ctx: OutputContext): Promise<void>
   });
 }
 
-async function resolveDest(args: ParsedArgs): Promise<string> {
-  const explicit = args.flags.dest;
+async function resolveDest(explicit: string | boolean | undefined): Promise<string> {
   if (typeof explicit === 'string') {
     return isAbsolute(explicit) ? explicit : resolve(process.cwd(), explicit);
   }
@@ -93,4 +108,44 @@ async function resolveDest(args: ParsedArgs): Promise<string> {
   } catch {
     return process.cwd();
   }
+}
+
+function printHelp(verb: string | null): void {
+  if (verb === 'build' || verb === null) {
+    process.stdout.write(
+      [
+        'condash project build [--dest <path>] [--dry-run]',
+        '',
+        "Compile the conception's `.agents/agents/` source tree into per-agent",
+        'output files (`.claude/CLAUDE.md` and `.kimi/AGENTS.md`).',
+        '',
+        'Optional:',
+        '  --dest      Conception root to build (default: resolved conception or cwd).',
+        '  --dry-run   Show what would be written without modifying anything.',
+        '',
+        'Examples:',
+        '  condash project build',
+        '  condash project build --dest ~/src/vcoeur/conception --dry-run',
+        '',
+        UNIVERSAL_FOOTER,
+        '',
+      ].join('\n'),
+    );
+    return;
+  }
+  printSubHelp();
+}
+
+function printSubHelp(): void {
+  process.stdout.write(
+    [
+      'condash project <verb> [args]',
+      '',
+      'Verbs:',
+      '  build   Compile .agents/agents/ → .claude/CLAUDE.md + .kimi/AGENTS.md.',
+      '',
+      UNIVERSAL_FOOTER,
+      '',
+    ].join('\n'),
+  );
 }

--- a/src/cli/commands/projects-create.test.ts
+++ b/src/cli/commands/projects-create.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Behavioural coverage for the three sharp edges fixed by 2026-05-16-condash-
+ * cli-ux-fixes:
+ *
+ *   B1 — `condash projects <verb> --help` always wins over required-arg checks.
+ *   B2 — Unknown flags surface BEFORE missing-required errors, with a
+ *        `(did you mean --X?)` suggestion drawn from the noun-wide flag pool.
+ *   B3 — `condash projects create --status <s>` accepted; `done` rejected.
+ *
+ * Tests run against `runProjects` (B1) and `createCommand` (B2/B3) directly.
+ */
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runProjects } from './projects';
+import { createCommand } from './projects-maintenance';
+import type { OutputContext } from '../output';
+import { CliError } from '../output';
+
+let conceptionPath: string;
+
+beforeEach(async () => {
+  conceptionPath = await fs.mkdtemp(join(tmpdir(), 'projects-create-'));
+  // Minimal scaffolding — projects/ tree is created lazily by createCommand.
+});
+
+afterEach(async () => {
+  await fs.rm(conceptionPath, { recursive: true, force: true });
+});
+
+function ctx(): OutputContext {
+  return { json: false, ndjson: false, quiet: true, noColor: true };
+}
+
+function captureStdout(
+  fn: () => Promise<void> | void,
+): Promise<{ stdout: string; threw: unknown }> {
+  return new Promise((resolve) => {
+    const chunks: string[] = [];
+    const orig = process.stdout.write.bind(process.stdout);
+    process.stdout.write = ((data: string | Uint8Array) => {
+      chunks.push(typeof data === 'string' ? data : Buffer.from(data).toString('utf8'));
+      return true;
+    }) as typeof process.stdout.write;
+    Promise.resolve()
+      .then(fn)
+      .then(
+        () => {
+          process.stdout.write = orig;
+          resolve({ stdout: chunks.join(''), threw: undefined });
+        },
+        (err) => {
+          process.stdout.write = orig;
+          resolve({ stdout: chunks.join(''), threw: err });
+        },
+      );
+  });
+}
+
+describe('B1 — `--help` always wins', () => {
+  it('prints create-help instead of complaining about missing --apps', async () => {
+    const { stdout, threw } = await captureStdout(async () => {
+      await runProjects(
+        'create',
+        { noun: 'projects', verb: 'create', positional: [], flags: {} },
+        ctx(),
+        conceptionPath,
+        true, // universalHelp
+      );
+    });
+    expect(threw).toBeUndefined();
+    expect(stdout).toMatch(/condash projects create/);
+    expect(stdout).toMatch(/--apps/);
+    expect(stdout).not.toMatch(/--apps is required/);
+  });
+
+  it('prints help when --help is combined with a typo', async () => {
+    const { stdout, threw } = await captureStdout(async () => {
+      await runProjects(
+        'create',
+        { noun: 'projects', verb: 'create', positional: [], flags: { app: 'foo' } },
+        ctx(),
+        conceptionPath,
+        true,
+      );
+    });
+    expect(threw).toBeUndefined();
+    expect(stdout).toMatch(/condash projects create/);
+  });
+
+  it('routes `condash projects help create` (positional alias) to create-help', async () => {
+    const { stdout, threw } = await captureStdout(async () => {
+      await runProjects(
+        'help',
+        { noun: 'projects', verb: 'help', positional: ['create'], flags: {} },
+        ctx(),
+        conceptionPath,
+        false,
+      );
+    });
+    expect(threw).toBeUndefined();
+    expect(stdout).toMatch(/condash projects create/);
+    expect(stdout).toMatch(/--apps/);
+  });
+
+  it('--help on `read` (which requires a slug positional) prints help', async () => {
+    const { stdout, threw } = await captureStdout(async () => {
+      await runProjects(
+        'read',
+        { noun: 'projects', verb: 'read', positional: [], flags: {} },
+        ctx(),
+        conceptionPath,
+        true,
+      );
+    });
+    expect(threw).toBeUndefined();
+    expect(stdout).toMatch(/condash projects read/);
+    expect(stdout).not.toMatch(/Usage: condash projects read/);
+  });
+});
+
+describe('B2 — typo-first validation', () => {
+  it('rejects --app (typo of --apps) with a suggestion BEFORE missing-required', async () => {
+    let caught: unknown;
+    try {
+      await createCommand(
+        {
+          noun: 'projects',
+          verb: 'create',
+          positional: [],
+          flags: { app: 'condash', kind: 'project', slug: 'x', title: 't' },
+        },
+        ctx(),
+        conceptionPath,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as Error).message).toMatch(/Unknown flag: --app \(did you mean --apps\?\)/);
+    expect((caught as Error).message).not.toMatch(/--apps is required/);
+  });
+
+  it('reports unknown flag without a suggestion when nothing is close', async () => {
+    let caught: unknown;
+    try {
+      await createCommand(
+        {
+          noun: 'projects',
+          verb: 'create',
+          positional: [],
+          flags: { xyzzy: 'foo', apps: 'a', kind: 'project', slug: 'x', title: 't' },
+        },
+        ctx(),
+        conceptionPath,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as Error).message).toMatch(/Unknown flag: --xyzzy$/);
+  });
+
+  it('typo wins over missing-required (no --apps, no --kind, plus a typo)', async () => {
+    let caught: unknown;
+    try {
+      await createCommand(
+        { noun: 'projects', verb: 'create', positional: [], flags: { app: 'condash' } },
+        ctx(),
+        conceptionPath,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as Error).message).toMatch(/Unknown flag: --app/);
+    expect((caught as Error).message).toMatch(/did you mean --apps/);
+  });
+});
+
+describe('B3 — --status on create', () => {
+  it('writes `status: review` to README when --status review is passed', async () => {
+    await createCommand(
+      {
+        noun: 'projects',
+        verb: 'create',
+        positional: [],
+        flags: {
+          apps: 'condash',
+          kind: 'project',
+          slug: 'b3-review-test',
+          title: 'B3 review',
+          status: 'review',
+        },
+      },
+      ctx(),
+      conceptionPath,
+    );
+    // createCommand wrote under projects/<YYYY-MM>/<YYYY-MM-DD>-b3-review-test/
+    const months = await fs.readdir(join(conceptionPath, 'projects'));
+    const month = months.find((m) => /^\d{4}-\d{2}$/.test(m));
+    expect(month).toBeDefined();
+    const dir = (await fs.readdir(join(conceptionPath, 'projects', month!))).find((d) =>
+      d.endsWith('-b3-review-test'),
+    );
+    expect(dir).toBeDefined();
+    const readme = await fs.readFile(
+      join(conceptionPath, 'projects', month!, dir!, 'README.md'),
+      'utf8',
+    );
+    expect(readme).toMatch(/status: review/);
+  });
+
+  it('defaults to `status: now` when --status is omitted', async () => {
+    await createCommand(
+      {
+        noun: 'projects',
+        verb: 'create',
+        positional: [],
+        flags: {
+          apps: 'condash',
+          kind: 'project',
+          slug: 'b3-default-test',
+          title: 'B3 default',
+        },
+      },
+      ctx(),
+      conceptionPath,
+    );
+    const months = await fs.readdir(join(conceptionPath, 'projects'));
+    const month = months.find((m) => /^\d{4}-\d{2}$/.test(m))!;
+    const dir = (await fs.readdir(join(conceptionPath, 'projects', month))).find((d) =>
+      d.endsWith('-b3-default-test'),
+    )!;
+    const readme = await fs.readFile(
+      join(conceptionPath, 'projects', month, dir, 'README.md'),
+      'utf8',
+    );
+    expect(readme).toMatch(/status: now/);
+  });
+
+  it('rejects --status done with a pointer to `condash projects close`', async () => {
+    let caught: unknown;
+    try {
+      await createCommand(
+        {
+          noun: 'projects',
+          verb: 'create',
+          positional: [],
+          flags: {
+            apps: 'condash',
+            kind: 'project',
+            slug: 'b3-done-test',
+            title: 'B3 done',
+            status: 'done',
+          },
+        },
+        ctx(),
+        conceptionPath,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect(caught).toBeInstanceOf(CliError);
+    expect((caught as CliError).exitCode).toBe(3);
+    expect((caught as Error).message).toMatch(/--status done is not allowed at create time/);
+    expect((caught as Error).message).toMatch(/condash projects close/);
+  });
+
+  it('rejects --status invalid with the standard enum-error shape', async () => {
+    let caught: unknown;
+    try {
+      await createCommand(
+        {
+          noun: 'projects',
+          verb: 'create',
+          positional: [],
+          flags: {
+            apps: 'condash',
+            kind: 'project',
+            slug: 'b3-invalid-test',
+            title: 'B3 invalid',
+            status: 'banana',
+          },
+        },
+        ctx(),
+        conceptionPath,
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as Error).message).toMatch(/--status must be one of/);
+    expect((caught as Error).message).toMatch(/banana/);
+  });
+});

--- a/src/cli/commands/projects-maintenance.ts
+++ b/src/cli/commands/projects-maintenance.ts
@@ -17,6 +17,7 @@ import { isValidSlugTail } from '../../shared/slug';
 import { resolveSlug } from '../slug-resolver';
 import { CliError, ExitCodes, emit, validation, type OutputContext } from '../output';
 import { assertNoExtraFlags, parseCsvFlag, type ParsedArgs } from '../parser';
+import { NOUN_FLAGS } from './projects';
 
 // createProjectCore + CreateProjectInput + CreateProjectResult moved to
 // src/main/create-project.ts in pass-10 — re-exported here so external
@@ -37,7 +38,7 @@ export async function indexCommand(
   const rewriteAggregated = args.flags['rewrite-aggregated'] === true;
   delete args.flags['dry-run'];
   delete args.flags['rewrite-aggregated'];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const report = await regenerateIndex(conceptionPath, projectsStrategy, {
     dryRun,
     rewriteAggregated,
@@ -100,14 +101,22 @@ function relativeIfPossible(path: string, rootPath: string): string {
   return relative(conceptionRoot, path) || path;
 }
 
+// Statuses accepted at create time. `done` is intentionally excluded — it
+// requires a Closed Timeline entry that only `condash projects close` writes.
+const CREATE_STATUSES = ['now', 'review', 'later', 'backlog'] as const;
+
 export async function createCommand(
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  // Pull every known flag into a local first, then delete the keys from
+  // args.flags, so assertNoExtraFlags can fire on typos *before* the
+  // required-arg validation below. Without this ordering, `--app foo`
+  // gets reported as "missing --apps" rather than "did you mean --apps?".
   const apps = parseCsvFlag(args.flags.apps) ?? [];
-  if (apps.length === 0) validation(`--apps is required (comma-separated, may be backticked)`);
-  const input = {
+  const rawStatus = typeof args.flags.status === 'string' ? args.flags.status.toLowerCase() : '';
+  const input: CreateProjectInput = {
     kind: String(args.flags.kind ?? '').toLowerCase(),
     slug: String(args.flags.slug ?? '').trim(),
     title: String(args.flags.title ?? '').trim(),
@@ -115,6 +124,7 @@ export async function createCommand(
     branch: typeof args.flags.branch === 'string' ? args.flags.branch.trim() || null : null,
     base: typeof args.flags.base === 'string' ? args.flags.base.trim() || null : null,
     date: typeof args.flags.date === 'string' ? args.flags.date.trim() : undefined,
+    status: rawStatus || 'now',
     severity:
       typeof args.flags.severity === 'string' ? args.flags.severity.toLowerCase() || null : null,
     severityImpact:
@@ -134,13 +144,31 @@ export async function createCommand(
     'branch',
     'base',
     'date',
+    'status',
     'severity',
     'severity-impact',
     'environment',
   ]) {
     delete args.flags[k];
   }
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
+
+  // `--status done` rejected with a pointer: closing an item requires the
+  // close-side Timeline entry + leftover-branch probe, neither of which
+  // create runs. (See lifecycle rule in conception/.claude/CLAUDE.md.)
+  if (rawStatus === 'done') {
+    validation(
+      `--status done is not allowed at create time; create with status=now, then \`condash projects close ${input.slug || '<slug>'}\`.`,
+    );
+  }
+  if (rawStatus && !(CREATE_STATUSES as readonly string[]).includes(rawStatus)) {
+    validation(
+      `--status must be one of {${CREATE_STATUSES.join(', ')}}; got '${rawStatus}'. ` +
+        `(Use \`condash projects close\` for done.)`,
+    );
+  }
+  if (apps.length === 0) validation(`--apps is required (comma-separated, may be backticked)`);
+
   const result = await createProjectCore(conceptionPath, input);
   emit(ctx, result, (data) => {
     const d = data as { relPath: string; readme: string };
@@ -153,11 +181,11 @@ export async function scanPromotionsCommand(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const slug = args.positional[0];
   if (!slug) {
     throw new CliError(ExitCodes.USAGE, 'Usage: condash projects scan-promotions <slug>');
   }
-  assertNoExtraFlags(args);
   const candidate = await resolveSlug(conceptionPath, slug);
   const notesDir = join(candidate.itemDir, 'notes');
   let entries: string[];
@@ -222,7 +250,7 @@ export async function rewriteHeadersCommand(
 ): Promise<void> {
   const dryRun = args.flags['dry-run'] === true;
   delete args.flags['dry-run'];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const report = await rewriteHeadersInTree(conceptionPath, { dryRun });
   emit(ctx, { ...report, dryRun }, (data) => {
     const d = data as RewriteHeadersReport & { dryRun: boolean };
@@ -270,7 +298,7 @@ export async function backfillClosed(
 ): Promise<void> {
   const dryRun = args.flags['dry-run'] === true;
   delete args.flags['dry-run'];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const readmes = await findProjectReadmes(conceptionPath);
   const candidates: BackfillEntry[] = [];
   const skipped: { slug: string; reason: string }[] = [];

--- a/src/cli/commands/projects-mutate.ts
+++ b/src/cli/commands/projects-mutate.ts
@@ -6,17 +6,20 @@ import { resolveSlug } from '../slug-resolver';
 import { CliError, ExitCodes, emit, validation, type OutputContext } from '../output';
 import { readHeader } from '../../main/header-io';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { NOUN_FLAGS } from './projects';
 
 export async function statusCommand(
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const summary = typeof args.flags.summary === 'string' ? args.flags.summary.trim() : undefined;
+  delete args.flags.summary;
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const sub = args.positional[0];
   if (sub === 'get') {
     const slug = args.positional[1];
     if (!slug) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects status get <slug>');
-    assertNoExtraFlags(args);
     const candidate = await resolveSlug(conceptionPath, slug);
     const header = await readHeader(candidate.readmePath);
     emit(
@@ -35,9 +38,6 @@ export async function statusCommand(
     if (!(KNOWN_STATUSES as readonly string[]).includes(value)) {
       validation(`Status '${value}' not in {${KNOWN_STATUSES.join(', ')}}`);
     }
-    const summary = typeof args.flags.summary === 'string' ? args.flags.summary.trim() : undefined;
-    delete args.flags.summary;
-    assertNoExtraFlags(args);
     const candidate = await resolveSlug(conceptionPath, slug);
     const transition = await transitionStatus(candidate.readmePath, value, { summary });
     const dirtyMarker = await touchDirtyMarker(conceptionPath, 'projects');
@@ -66,16 +66,16 @@ export async function closeProject(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
-  const slug = args.positional[0];
-  if (!slug) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects close <slug>');
   const newStatus = (args.flags.status as string | undefined) ?? 'done';
-  if (!(KNOWN_STATUSES as readonly string[]).includes(newStatus)) {
-    validation(`Status '${newStatus}' not in {${KNOWN_STATUSES.join(', ')}}`);
-  }
   const summary = (args.flags.summary as string | undefined)?.trim();
   const noTouchDirty = args.flags['no-touch-dirty'] === true;
   for (const k of ['status', 'summary', 'no-touch-dirty']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
+  const slug = args.positional[0];
+  if (!slug) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects close <slug>');
+  if (!(KNOWN_STATUSES as readonly string[]).includes(newStatus)) {
+    validation(`Status '${newStatus}' not in {${KNOWN_STATUSES.join(', ')}}`);
+  }
 
   const candidate = await resolveSlug(conceptionPath, slug);
   const header = await readHeader(candidate.readmePath);
@@ -108,17 +108,17 @@ export async function reopenProject(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const target = (args.flags.status as string | undefined) ?? 'now';
+  delete args.flags.status;
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const slug = args.positional[0];
   if (!slug) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects reopen <slug>');
-  const target = (args.flags.status as string | undefined) ?? 'now';
   if (!(KNOWN_STATUSES as readonly string[]).includes(target)) {
     validation(`Status '${target}' not in {${KNOWN_STATUSES.join(', ')}}`);
   }
   if (target === 'done') {
     validation(`reopen target cannot be 'done' — use \`condash projects close\` instead`);
   }
-  delete args.flags.status;
-  assertNoExtraFlags(args);
   const candidate = await resolveSlug(conceptionPath, slug);
   const header = await readHeader(candidate.readmePath);
   const previous = (header.status ?? '').toLowerCase();

--- a/src/cli/commands/projects-read.ts
+++ b/src/cli/commands/projects-read.ts
@@ -10,6 +10,7 @@ import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { parseHeader, validateHeader, validateBody, type HeaderFields } from '../../shared/header';
 import { readHeader } from '../../main/header-io';
 import { assertNoExtraFlags, parseCsvFlag, parseIntFlag, type ParsedArgs } from '../parser';
+import { NOUN_FLAGS } from './projects';
 
 interface ProjectListRow {
   slug: string;
@@ -39,7 +40,7 @@ export async function listProjects(
   const branchFilter = typeof args.flags.branch === 'string' ? args.flags.branch : null;
   const sort = (args.flags.sort as string | undefined) ?? 'status';
   for (const k of ['status', 'kind', 'apps', 'branch', 'sort']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
 
   const readmes = await findProjectReadmes(conceptionPath);
   const rows: ProjectListRow[] = [];
@@ -114,6 +115,9 @@ export async function readProject(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const withNotes = args.flags['with-notes'] === true;
+  delete args.flags['with-notes'];
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const slug = args.positional[0];
   if (!slug) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects read <slug>');
   const candidate = await resolveSlug(conceptionPath, slug);
@@ -138,9 +142,6 @@ export async function readProject(
     deliverableCount: project.deliverableCount,
     extra: header.extra,
   };
-  const withNotes = args.flags['with-notes'] === true;
-  delete args.flags['with-notes'];
-  assertNoExtraFlags(args);
   if (withNotes) {
     const notesDir = join(candidate.itemDir, 'notes');
     data.notes = await readNotesDir(notesDir);
@@ -191,9 +192,9 @@ export async function resolveCommand(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const slug = args.positional[0];
   if (!slug) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects resolve <slug>');
-  assertNoExtraFlags(args);
   const candidate = await resolveSlug(conceptionPath, slug);
   emit(
     ctx,
@@ -212,13 +213,13 @@ export async function searchProjects(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
-  const query = args.positional.join(' ');
-  if (!query) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects search <query>');
   const limit = parseIntFlag(args.flags.limit, 50);
   const statusFilter = parseCsvFlag(args.flags.status);
   const kindFilter = parseCsvFlag(args.flags.kind);
   for (const k of ['limit', 'status', 'kind']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
+  const query = args.positional.join(' ');
+  if (!query) throw new CliError(ExitCodes.USAGE, 'Usage: condash projects search <query>');
 
   const results = await searchAll(conceptionPath, query);
   const projectHits = results.hits.filter((h) => h.source === 'project');
@@ -292,7 +293,7 @@ export async function validateCommand(
   const explicitPath = typeof args.flags.path === 'string' ? args.flags.path : null;
   const slug = args.positional[0];
   for (const k of ['all', 'path']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
 
   let readmes: string[];
   if (all) {

--- a/src/cli/commands/projects.ts
+++ b/src/cli/commands/projects.ts
@@ -1,5 +1,6 @@
 import { CliError, ExitCodes, type OutputContext } from '../output';
 import { type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
 import {
   listProjects,
   readProject,
@@ -25,16 +26,75 @@ import type { CreateProjectInput, CreateProjectResult } from './projects-mainten
 export { createProjectCore, isValidSlugTail };
 export type { CreateProjectInput, CreateProjectResult };
 
+// Per-verb known flags. Used both to (a) reorder validation so unknown-flag
+// errors come before missing-required, and (b) build NOUN_FLAGS — the
+// suggestion pool used by `assertNoExtraFlags(args, NOUN_FLAGS)` so a typo
+// of a sibling-verb flag still gets a `(did you mean --X?)` hint.
+export const KNOWN_FLAGS_LIST = ['status', 'kind', 'apps', 'branch', 'sort'] as const;
+export const KNOWN_FLAGS_READ = ['with-notes'] as const;
+export const KNOWN_FLAGS_RESOLVE: readonly string[] = [];
+export const KNOWN_FLAGS_SEARCH = ['limit', 'status', 'kind'] as const;
+export const KNOWN_FLAGS_VALIDATE = ['all', 'path'] as const;
+export const KNOWN_FLAGS_STATUS = ['summary'] as const;
+export const KNOWN_FLAGS_CLOSE = ['status', 'summary', 'no-touch-dirty'] as const;
+export const KNOWN_FLAGS_REOPEN = ['status'] as const;
+export const KNOWN_FLAGS_BACKFILL_CLOSED = ['dry-run'] as const;
+export const KNOWN_FLAGS_INDEX = ['dry-run', 'rewrite-aggregated'] as const;
+export const KNOWN_FLAGS_CREATE = [
+  'apps',
+  'kind',
+  'slug',
+  'title',
+  'branch',
+  'base',
+  'date',
+  'status',
+  'severity',
+  'severity-impact',
+  'environment',
+] as const;
+export const KNOWN_FLAGS_SCAN_PROMOTIONS: readonly string[] = [];
+export const KNOWN_FLAGS_REWRITE_HEADERS = ['dry-run'] as const;
+
+export const NOUN_FLAGS: readonly string[] = [
+  ...new Set<string>([
+    ...KNOWN_FLAGS_LIST,
+    ...KNOWN_FLAGS_READ,
+    ...KNOWN_FLAGS_RESOLVE,
+    ...KNOWN_FLAGS_SEARCH,
+    ...KNOWN_FLAGS_VALIDATE,
+    ...KNOWN_FLAGS_STATUS,
+    ...KNOWN_FLAGS_CLOSE,
+    ...KNOWN_FLAGS_REOPEN,
+    ...KNOWN_FLAGS_BACKFILL_CLOSED,
+    ...KNOWN_FLAGS_INDEX,
+    ...KNOWN_FLAGS_CREATE,
+    ...KNOWN_FLAGS_SCAN_PROMOTIONS,
+    ...KNOWN_FLAGS_REWRITE_HEADERS,
+  ]),
+];
+
 export async function runProjects(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   switch (verb) {
     case null:
+      printHelp(null);
+      return;
     case 'list':
-      return verb === null ? printSubHelp() : await listProjects(args, ctx, conceptionPath);
+      return await listProjects(args, ctx, conceptionPath);
     case 'read':
       return await readProject(args, ctx, conceptionPath);
     case 'resolve':
@@ -64,6 +124,214 @@ export async function runProjects(
   }
 }
 
+function printHelp(verb: string | null): void {
+  switch (verb) {
+    case 'list':
+      writeBlock([
+        'condash projects list [--status <s>] [--kind <k>] [--apps <a,b>] [--branch <br>] [--sort <s>]',
+        '',
+        'List projects, filtered + sorted.',
+        '',
+        'Optional:',
+        '  --status   CSV of {now, review, later, backlog, done}.',
+        '  --kind     CSV of {project, incident, document}.',
+        '  --apps     CSV of app names; matches if any overlap.',
+        '  --branch   Exact branch match.',
+        '  --sort     status (default) | slug | date',
+        '',
+        'Examples:',
+        '  condash projects list',
+        '  condash projects list --status now,review --sort date',
+      ]);
+      return;
+    case 'read':
+      writeBlock([
+        'condash projects read <slug> [--with-notes]',
+        '',
+        'Read a project README + parsed metadata.',
+        '',
+        'Optional:',
+        '  --with-notes   Also include the contents of notes/*.md.',
+        '',
+        'Examples:',
+        '  condash projects read condash-cli-ux-fixes',
+        '  condash projects read condash-cli-ux-fixes --with-notes --json',
+      ]);
+      return;
+    case 'resolve':
+      writeBlock([
+        'condash projects resolve <slug>',
+        '',
+        'Resolve a slug to its absolute item path.',
+        '',
+        'Examples:',
+        '  condash projects resolve condash-cli-ux-fixes',
+      ]);
+      return;
+    case 'search':
+      writeBlock([
+        'condash projects search <query> [--status <s>] [--kind <k>] [--limit <n>]',
+        '',
+        'Full-text search restricted to project READMEs/notes.',
+        '',
+        'Optional:',
+        '  --status   CSV of statuses to filter by.',
+        '  --kind     CSV of kinds to filter by.',
+        '  --limit    Maximum hits to return (default: 50).',
+        '',
+        'Examples:',
+        '  condash projects search "dirty marker"',
+        '  condash projects search retention --status now,review --limit 20',
+      ]);
+      return;
+    case 'validate':
+      writeBlock([
+        'condash projects validate [<slug> | --all | --path <readme>]',
+        '',
+        'Validate one or many project READMEs against the canonical header schema.',
+        '',
+        'Optional:',
+        '  --all          Validate every project README.',
+        '  --path <p>     Validate one specific README (must resolve inside the conception).',
+        '',
+        'Examples:',
+        '  condash projects validate condash-cli-ux-fixes',
+        '  condash projects validate --all --json',
+      ]);
+      return;
+    case 'status':
+      writeBlock([
+        'condash projects status <get|set> <slug> [<value>] [--summary <text>]',
+        '',
+        'Get or set the **Status** field. On set, --summary appends a Timeline entry on done-edges.',
+        '',
+        'Optional:',
+        '  --summary   Annotate the Timeline entry written on done-edges.',
+        '',
+        'Examples:',
+        '  condash projects status get condash-cli-ux-fixes',
+        '  condash projects status set condash-cli-ux-fixes review',
+        '  condash projects status set condash-cli-ux-fixes done --summary "shipped via PR #42"',
+      ]);
+      return;
+    case 'close':
+      writeBlock([
+        'condash projects close <slug> [--status <s>] [--summary <text>] [--no-touch-dirty]',
+        '',
+        'Flip status to done + append a closing Timeline entry; warn on leftover branch/worktree.',
+        '',
+        'Optional:',
+        '  --status           Override target status (default: done).',
+        '  --summary          Annotate the Timeline entry.',
+        '  --no-touch-dirty   Skip touching the projects dirty marker.',
+        '',
+        'Examples:',
+        '  condash projects close condash-cli-ux-fixes',
+        '  condash projects close condash-cli-ux-fixes --summary "shipped"',
+      ]);
+      return;
+    case 'reopen':
+      writeBlock([
+        'condash projects reopen <slug> [--status <s>]',
+        '',
+        'Flip status from done back to --status (default: now) + append a reopen Timeline entry.',
+        '',
+        'Optional:',
+        '  --status   Target status (default: now). `done` is rejected.',
+        '',
+        'Examples:',
+        '  condash projects reopen condash-cli-ux-fixes',
+        '  condash projects reopen condash-cli-ux-fixes --status review',
+      ]);
+      return;
+    case 'backfill-closed':
+      writeBlock([
+        'condash projects backfill-closed [--dry-run]',
+        '',
+        'One-shot: append `Closed.` Timeline entries to legacy done items missing one.',
+        'Date is taken from `git log -1` on the README, falling back to mtime.',
+        '',
+        'Optional:',
+        '  --dry-run   Preview without writing.',
+        '',
+        'Examples:',
+        '  condash projects backfill-closed --dry-run',
+        '  condash projects backfill-closed',
+      ]);
+      return;
+    case 'index':
+      writeBlock([
+        'condash projects index [--dry-run] [--rewrite-aggregated]',
+        '',
+        'Regenerate projects/index.md + month indexes.',
+        '',
+        'Optional:',
+        '  --dry-run                Preview without writing.',
+        '  --rewrite-aggregated     One-shot: re-derive every aggregated bullet.',
+        '',
+        'Examples:',
+        '  condash projects index',
+        '  condash projects index --dry-run --json',
+      ]);
+      return;
+    case 'create':
+      writeBlock([
+        'condash projects create --kind <kind> --slug <slug> --title <text> --apps <a,b> [flags]',
+        '',
+        'Create a new item under projects/YYYY-MM/<slug>/.',
+        '',
+        'Required:',
+        '  --kind     project | incident | document',
+        '  --slug     lowercase letters, digits, hyphens',
+        '  --title    free text',
+        '  --apps     comma-separated app list (e.g. condash,knoten)',
+        '',
+        'Optional:',
+        '  --branch              git branch name',
+        '  --base                base branch for PRs (default: main)',
+        '  --status              now | review | later | backlog  (default: now)',
+        '  --date                YYYY-MM-DD (default: today)',
+        '  --severity            low | medium | high           (incidents only)',
+        '  --severity-impact     free text                     (incidents only)',
+        '  --environment         PROD | STAGING | DEV          (incidents only)',
+        '',
+        'Examples:',
+        '  condash projects create --kind project --slug fix-x --title "Fix X" --apps condash',
+        '  condash projects create --kind project --slug y --title "Y" --apps a,b --status later',
+      ]);
+      return;
+    case 'scan-promotions':
+      writeBlock([
+        'condash projects scan-promotions <slug>',
+        '',
+        "Surface durable-finding candidates inside an item's notes/ for /knowledge promotion.",
+        '',
+        'Examples:',
+        '  condash projects scan-promotions condash-cli-ux-fixes',
+      ]);
+      return;
+    case 'rewrite-headers':
+      writeBlock([
+        'condash projects rewrite-headers [--dry-run]',
+        '',
+        'One-shot migration: convert legacy bold-prose headers to YAML frontmatter.',
+        '',
+        'Optional:',
+        '  --dry-run   Preview without writing.',
+        '',
+        'Examples:',
+        '  condash projects rewrite-headers --dry-run',
+      ]);
+      return;
+    default:
+      printSubHelp();
+  }
+}
+
+function writeBlock(lines: string[]): void {
+  process.stdout.write([...lines, '', UNIVERSAL_FOOTER, ''].join('\n'));
+}
+
 function printSubHelp(): void {
   process.stdout.write(
     [
@@ -75,14 +343,16 @@ function printSubHelp(): void {
       '  resolve          Resolve a slug to its absolute path.',
       '  search           Search project READMEs and notes.',
       '  validate         Validate header(s) against canonical enums.',
-      '  status           get|set the **Status** field. set: --summary appends to ## Timeline on done-edges.',
-      '  close            Flip status to done + append closing timeline entry. --summary "..." annotates the entry.',
-      '  reopen           Flip status from done back to --status (default now) + append reopen entry.',
-      '  backfill-closed  One-shot: append `Closed.` timeline entries to legacy done items missing one. --dry-run previews.',
+      '  status           get|set the **Status** field.',
+      '  close            Flip status to done + append closing Timeline entry.',
+      '  reopen           Flip status from done back to --status (default: now).',
+      '  backfill-closed  One-shot: append `Closed.` to legacy done items.',
       '  index            Regenerate projects/index.md + month indexes.',
-      '  create           Create a new item: --kind --slug --apps --title [--branch …].',
-      "  scan-promotions  Surface durable-finding candidates inside an item's notes/.",
-      '  rewrite-headers  One-shot: convert legacy bold-prose headers to YAML frontmatter. --dry-run previews.',
+      '  create           Create a new item.',
+      '  scan-promotions  Surface durable-finding candidates inside notes/.',
+      '  rewrite-headers  One-shot: convert legacy bold-prose headers to YAML.',
+      '',
+      UNIVERSAL_FOOTER,
       '',
     ].join('\n'),
   );

--- a/src/cli/commands/repos.ts
+++ b/src/cli/commands/repos.ts
@@ -1,17 +1,31 @@
 import { listRepos } from '../../main/repos';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
+
+const KNOWN_FLAGS_LIST = ['include-worktrees'] as const;
+
+const NOUN_FLAGS: readonly string[] = [...new Set<string>([...KNOWN_FLAGS_LIST])];
 
 export async function runRepos(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   if (verb === null || verb === 'list') {
     const includeWorktrees = args.flags['include-worktrees'] === true;
     delete args.flags['include-worktrees'];
-    assertNoExtraFlags(args);
+    assertNoExtraFlags(args, NOUN_FLAGS);
     const repos = await listRepos(conceptionPath);
     if (!includeWorktrees) {
       // Strip worktrees to match the documented default (faster, no per-repo
@@ -29,4 +43,38 @@ export async function runRepos(
     return;
   }
   throw new CliError(ExitCodes.USAGE, `Unknown repos verb: ${verb}`);
+}
+
+function printHelp(verb: string | null): void {
+  if (verb === 'list' || verb === null) {
+    process.stdout.write(
+      [
+        'condash repos list [--include-worktrees]',
+        '',
+        'List configured repositories from condash.json.',
+        '',
+        'Optional:',
+        "  --include-worktrees   Also report each repo's worktrees (slower).",
+        '',
+        'Examples:',
+        '  condash repos list',
+        '  condash repos list --include-worktrees --json',
+        UNIVERSAL_FOOTER,
+      ].join('\n'),
+    );
+    return;
+  }
+  printSubHelp();
+}
+
+function printSubHelp(): void {
+  process.stdout.write(
+    [
+      'condash repos <verb> [args]',
+      '',
+      'Verbs:',
+      '  list   List configured repositories.',
+      UNIVERSAL_FOOTER,
+    ].join('\n'),
+  );
 }

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -1,21 +1,37 @@
 import { search as searchAll } from '../../main/search';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { assertNoExtraFlags, parseIntFlag, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
+
+const KNOWN_FLAGS_SEARCH = ['scope', 'limit'] as const;
+
+const NOUN_FLAGS: readonly string[] = [...new Set<string>([...KNOWN_FLAGS_SEARCH])];
 
 export async function runSearch(
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  // `search` is verbless; the help triggers are `search --help` and the
+  // `search help` positional alias (which means: query is exactly `help`
+  // with no other words → ambiguous, lean toward help).
+  if (universalHelp || (args.positional[0] === 'help' && args.positional.length === 1)) {
+    printHelp();
+    return;
+  }
+  const scopeFlag = args.flags.scope;
+  const limitFlag = args.flags.limit;
+  for (const k of ['scope', 'limit']) delete args.flags[k];
+  assertNoExtraFlags(args, NOUN_FLAGS);
+
   const query = args.positional.join(' ').trim();
   if (!query) throw new CliError(ExitCodes.USAGE, 'Usage: condash search <query>');
-  const scope = (args.flags.scope as string | undefined) ?? 'all';
+  const scope = (scopeFlag as string | undefined) ?? 'all';
   if (!['all', 'projects', 'knowledge'].includes(scope)) {
     throw new CliError(ExitCodes.USAGE, '--scope must be all|projects|knowledge');
   }
-  const limit = parseIntFlag(args.flags.limit, 50);
-  for (const k of ['scope', 'limit']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  const limit = parseIntFlag(limitFlag, 50);
 
   const results = await searchAll(conceptionPath, query);
   const filtered = scope === 'all' ? results.hits : results.hits.filter((h) => h.source === scope);
@@ -41,5 +57,26 @@ export async function runSearch(
     },
     [],
     { streamField: 'hits' },
+  );
+}
+
+function printHelp(): void {
+  process.stdout.write(
+    [
+      'condash search <query> [--scope <scope>] [--limit <n>]',
+      '',
+      'Cross-tree search across project READMEs/notes and knowledge files.',
+      '',
+      'Optional:',
+      '  --scope    all | projects | knowledge   (default: all)',
+      '  --limit    Maximum hits to return       (default: 50)',
+      '',
+      'Examples:',
+      '  condash search "dirty marker"',
+      '  condash search retention --scope knowledge --limit 10',
+      '',
+      UNIVERSAL_FOOTER,
+      '',
+    ].join('\n'),
   );
 }

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -59,6 +59,7 @@ import { isAbsolute, join, resolve } from 'node:path';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { resolveConception } from '../conception';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
 import { type AgentsMdTarget } from '../../agents-md';
 import {
   COMPILE_TARGETS,
@@ -92,6 +93,20 @@ import {
   type ShippedFile,
 } from './files';
 
+const KNOWN_FLAGS_LIST = ['dest', 'user'] as const;
+const KNOWN_FLAGS_INSTALL = ['dest', 'user', 'force', 'diff', 'dry-run', 'prune'] as const;
+const KNOWN_FLAGS_STATUS = ['dest', 'user'] as const;
+const KNOWN_FLAGS_VALIDATE = ['dest', 'user'] as const;
+
+const NOUN_FLAGS: readonly string[] = [
+  ...new Set<string>([
+    ...KNOWN_FLAGS_LIST,
+    ...KNOWN_FLAGS_INSTALL,
+    ...KNOWN_FLAGS_STATUS,
+    ...KNOWN_FLAGS_VALIDATE,
+  ]),
+];
+
 /** Path of the skillspec source tree relative to the conception root. */
 const SOURCE_RELPATH = '.agents/skills';
 
@@ -115,7 +130,16 @@ export async function runSkills(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   const userScope = args.flags.user === true;
   if (userScope && args.flags.dest !== undefined) {
     throw new CliError(ExitCodes.USAGE, '`--user` is incompatible with `--dest`');
@@ -150,7 +174,7 @@ async function listRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> {
   const shipped = await readShippedSkills();
   const dest = await resolveDest(args).catch(() => null);
   delete args.flags.dest;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const manifest = dest ? await readManifest(dest) : null;
   const skillsRows = shipped.map((s) => {
     const installedFiles = manifest?.skills[s.name]?.source;
@@ -259,7 +283,7 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
   const dryRun = args.flags['dry-run'] === true;
   const prune = args.flags.prune === true;
   for (const k of ['dest', 'force', 'diff', 'dry-run', 'prune']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const shippedVersion = process.env.CONDASH_CLI_VERSION ?? 'dev';
 
   const manifest: Manifest = (await readManifest(dest)) ?? {
@@ -672,7 +696,7 @@ interface RepoStatusReport {
 async function repoStatus(args: ParsedArgs, ctx: OutputContext): Promise<void> {
   const dest = await resolveDest(args);
   delete args.flags.dest;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const sourceRoot = join(dest, SOURCE_RELPATH);
   const shipped = await readShippedSkills();
   const manifest: Manifest = (await readManifest(dest)) ?? {
@@ -826,7 +850,7 @@ interface ValidateReport {
 async function validateSkills(args: ParsedArgs, ctx: OutputContext): Promise<void> {
   const requestedNames = args.positional.length > 0 ? args.positional : null;
   delete args.flags.dest;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
 
   const shipped = await readShippedSkills();
   const selected = requestedNames
@@ -1111,7 +1135,7 @@ async function installUserSkills(args: ParsedArgs, ctx: OutputContext): Promise<
 
   const dryRun = args.flags['dry-run'] === true;
   for (const k of ['user', 'dry-run']) delete args.flags[k];
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
 
   const hostLabel = await readHostLabel();
   const report: UserInstallReport = {
@@ -1167,7 +1191,7 @@ function formatUserInstallHuman(report: UserInstallReport): string {
 
 async function listUser(args: ParsedArgs, ctx: OutputContext): Promise<void> {
   delete args.flags.user;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const all = await readUserSkills();
   const hostLabel = await readHostLabel();
   const rows = all.map((s) => ({
@@ -1213,7 +1237,7 @@ interface UserStatusEntry {
 
 async function userSkillsStatus(args: ParsedArgs, ctx: OutputContext): Promise<void> {
   delete args.flags.user;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const all = await readUserSkills();
   const hostLabel = await readHostLabel();
   const items: UserStatusEntry[] = [];
@@ -1272,7 +1296,7 @@ async function userSkillsStatus(args: ParsedArgs, ctx: OutputContext): Promise<v
 async function validateUserSkills(args: ParsedArgs, ctx: OutputContext): Promise<void> {
   const requestedNames = args.positional.length > 0 ? args.positional : null;
   delete args.flags.user;
-  assertNoExtraFlags(args);
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const all = await readUserSkills();
   const selected = requestedNames ? all.filter((s) => requestedNames.includes(s.name)) : all;
   if (requestedNames) {
@@ -1327,3 +1351,109 @@ async function validateUserSkills(args: ParsedArgs, ctx: OutputContext): Promise
 // Re-export utility for tests that previously imported from templates.ts.
 // New code should import directly from `./regions` and `./files`.
 export { locateShippedFilesRoot };
+
+function printHelp(verb: string | null): void {
+  switch (verb) {
+    case 'list':
+    case null:
+      process.stdout.write(
+        [
+          'condash skills list [--user] [--dest <path>]',
+          '',
+          'List shipped skills + top-level files (and their install status).',
+          '',
+          'Optional:',
+          '  --user        Switch to user scope (~/.config/agents/skills).',
+          '  --dest <path> Override repo-scope destination (default: resolved conception).',
+          '',
+          'Examples:',
+          '  condash skills list',
+          '  condash skills list --user',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'install':
+      process.stdout.write(
+        [
+          'condash skills install [<skill-or-file>...] [--user] [--dest <path>]',
+          '                       [--force] [--diff] [--dry-run] [--prune]',
+          '',
+          'Install (or refresh) shipped skills + top-level files into the conception.',
+          'Refuses to overwrite user-edited sources unless --force.',
+          '',
+          'Optional:',
+          '  --user        User scope (~/.config/agents/skills → ~/.claude/, ~/.kimi/).',
+          '  --dest <path> Override repo-scope destination.',
+          '  --force       Override refuse-on-edit (repo scope only).',
+          '  --diff        Show a unified diff per refused item.',
+          '  --dry-run     Report what would change; touch nothing.',
+          '  --prune       Drop manifest entries whose shipped source has been removed.',
+          '',
+          'Examples:',
+          '  condash skills install',
+          '  condash skills install pr knowledge --diff',
+          '  condash skills install --user --dry-run',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'status':
+      process.stdout.write(
+        [
+          'condash skills status [--user] [--dest <path>]',
+          '',
+          'Per-skill / per-file install state (tracked, edited, missing on source).',
+          '',
+          'Examples:',
+          '  condash skills status',
+          '  condash skills status --user --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'validate':
+      process.stdout.write(
+        [
+          'condash skills validate [--user] [--dest <path>]',
+          '',
+          'Lint shipped skill specs + top-level file regions.',
+          '',
+          'Examples:',
+          '  condash skills validate',
+          '  condash skills validate --user',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    default:
+      printSubHelp();
+  }
+}
+
+function printSubHelp(): void {
+  process.stdout.write(
+    [
+      'condash skills <verb> [args]',
+      '',
+      'Verbs:',
+      '  list       List shipped skills + top-level files.',
+      '  install    Install (or refresh) shipped artefacts.',
+      '  status     Per-skill / per-file install state.',
+      '  validate   Lint shipped skill specs + top-level file regions.',
+      '',
+      'Scopes: pass --user for user-scope (~/.config/agents/skills); default is repo scope.',
+      '',
+      UNIVERSAL_FOOTER,
+      '',
+    ].join('\n'),
+  );
+}

--- a/src/cli/commands/worktrees.ts
+++ b/src/cli/commands/worktrees.ts
@@ -9,17 +9,43 @@ import {
 } from '../../main/worktree-ops';
 import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { assertNoExtraFlags, parseCsvFlag, type ParsedArgs } from '../parser';
+import { UNIVERSAL_FOOTER } from '../help';
 import { runRepos } from './repos';
+
+const KNOWN_FLAGS_LIST = ['include-worktrees'] as const;
+const KNOWN_FLAGS_CHECK: readonly string[] = [];
+const KNOWN_FLAGS_MISMATCH: readonly string[] = [];
+const KNOWN_FLAGS_SETUP = ['repo', 'copy-env', 'no-env', 'no-install', 'install', 'base'] as const;
+const KNOWN_FLAGS_REMOVE = ['repo', 'force', 'force-rm'] as const;
+
+const NOUN_FLAGS: readonly string[] = [
+  ...new Set<string>([
+    ...KNOWN_FLAGS_LIST,
+    ...KNOWN_FLAGS_CHECK,
+    ...KNOWN_FLAGS_MISMATCH,
+    ...KNOWN_FLAGS_SETUP,
+    ...KNOWN_FLAGS_REMOVE,
+  ]),
+];
 
 export async function runWorktrees(
   verb: string | null,
   args: ParsedArgs,
   ctx: OutputContext,
   conceptionPath: string,
+  universalHelp = false,
 ): Promise<void> {
+  if (verb === 'help') {
+    printHelp(args.positional[0] ?? null);
+    return;
+  }
+  if (universalHelp) {
+    printHelp(verb);
+    return;
+  }
   switch (verb) {
     case null:
-      printWorktreesHelp();
+      printHelp(null);
       return;
     case 'list':
       // Full repo list with worktrees included — same payload `repos list
@@ -30,7 +56,7 @@ export async function runWorktrees(
     case 'check':
       return await worktreeCheck(args, ctx, conceptionPath);
     case 'mismatch':
-      return await worktreeMismatch(ctx, conceptionPath);
+      return await worktreeMismatch(args, ctx, conceptionPath);
     case 'setup':
       return await worktreeSetup(args, ctx, conceptionPath);
     case 'remove':
@@ -45,11 +71,11 @@ async function worktreeCheck(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const branch = args.positional[0];
   if (!branch) {
     throw new CliError(ExitCodes.USAGE, 'Usage: condash worktrees check <branch>');
   }
-  assertNoExtraFlags(args);
   const result = await checkBranchState(conceptionPath, branch);
   emit(ctx, result, formatBranchCheck);
 }
@@ -87,7 +113,12 @@ function formatBranchCheck(result: BranchCheckResult): string {
   return lines.join('\n') + '\n';
 }
 
-async function worktreeMismatch(ctx: OutputContext, conceptionPath: string): Promise<void> {
+async function worktreeMismatch(
+  args: ParsedArgs,
+  ctx: OutputContext,
+  conceptionPath: string,
+): Promise<void> {
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const report = await runAudit(conceptionPath, ['worktrees']);
   emit(
     ctx,
@@ -109,6 +140,22 @@ async function worktreeSetup(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const repos = parseCsvFlag(args.flags.repo) ?? undefined;
+  const copyEnv = args.flags['copy-env'] === true;
+  const skipEnv = args.flags['no-env'] === true;
+  const skipInstall = args.flags['no-install'] === true;
+  const installDeprecated = args.flags.install === true;
+  const baseFlag = args.flags.base;
+  const base = typeof baseFlag === 'string' && baseFlag.length > 0 ? baseFlag : undefined;
+  for (const k of ['repo', 'copy-env', 'no-env', 'no-install', 'install', 'base']) {
+    delete args.flags[k];
+  }
+  assertNoExtraFlags(args, NOUN_FLAGS);
+  if (installDeprecated) {
+    process.stderr.write(
+      '[deprecated] --install is now the default for repos that declare install: in .condash/settings.json. Use --no-install to skip.\n',
+    );
+  }
   const branch = args.positional[0];
   if (!branch) {
     throw new CliError(
@@ -116,21 +163,6 @@ async function worktreeSetup(
       'Usage: condash worktrees setup <branch> [--repo <r>...] [--no-env] [--no-install] [--copy-env] [--base <ref>]',
     );
   }
-  const repos = parseCsvFlag(args.flags.repo) ?? undefined;
-  const copyEnv = args.flags['copy-env'] === true;
-  const skipEnv = args.flags['no-env'] === true;
-  const skipInstall = args.flags['no-install'] === true;
-  if (args.flags.install === true) {
-    process.stderr.write(
-      '[deprecated] --install is now the default for repos that declare install: in .condash/settings.json. Use --no-install to skip.\n',
-    );
-  }
-  const baseFlag = args.flags.base;
-  const base = typeof baseFlag === 'string' && baseFlag.length > 0 ? baseFlag : undefined;
-  for (const k of ['repo', 'copy-env', 'no-env', 'no-install', 'install', 'base']) {
-    delete args.flags[k];
-  }
-  assertNoExtraFlags(args);
   const result = await setupBranchWorktrees(conceptionPath, branch, {
     repos,
     copyEnv,
@@ -175,6 +207,11 @@ async function worktreeRemove(
   ctx: OutputContext,
   conceptionPath: string,
 ): Promise<void> {
+  const repos = parseCsvFlag(args.flags.repo) ?? undefined;
+  const force = args.flags.force === true;
+  const forceRm = args.flags['force-rm'] === true;
+  for (const k of ['repo', 'force', 'force-rm']) delete args.flags[k];
+  assertNoExtraFlags(args, NOUN_FLAGS);
   const branch = args.positional[0];
   if (!branch) {
     throw new CliError(
@@ -182,11 +219,6 @@ async function worktreeRemove(
       'Usage: condash worktrees remove <branch> [--repo <r>...] [--force] [--force-rm]',
     );
   }
-  const repos = parseCsvFlag(args.flags.repo) ?? undefined;
-  const force = args.flags.force === true;
-  const forceRm = args.flags['force-rm'] === true;
-  for (const k of ['repo', 'force', 'force-rm']) delete args.flags[k];
-  assertNoExtraFlags(args);
   const result = await removeBranchWorktrees(conceptionPath, branch, { repos, force, forceRm });
   emit(ctx, result, formatRemoveResult);
 }
@@ -217,28 +249,117 @@ function formatRemoveResult(result: RemoveResult): string {
   return lines.join('\n') + '\n';
 }
 
-function printWorktreesHelp(): void {
+function printHelp(verb: string | null): void {
+  switch (verb) {
+    case 'list':
+      process.stdout.write(
+        [
+          'condash worktrees list',
+          '',
+          'List configured repos with their worktrees (alias of `repos list --include-worktrees`).',
+          '',
+          'Examples:',
+          '  condash worktrees list',
+          '  condash worktrees list --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'check':
+      process.stdout.write(
+        [
+          'condash worktrees check <branch>',
+          '',
+          'Per-repo state for one branch: declaring items, on-disk worktrees, local branches.',
+          '',
+          'Examples:',
+          '  condash worktrees check condash-cli-ux-fixes',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'mismatch':
+      process.stdout.write(
+        [
+          'condash worktrees mismatch',
+          '',
+          'List items declaring **Branch** but missing on-disk worktrees.',
+          '',
+          'Examples:',
+          '  condash worktrees mismatch',
+          '  condash worktrees mismatch --json',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'setup':
+      process.stdout.write(
+        [
+          'condash worktrees setup <branch> [--repo <r>...] [--no-env] [--no-install] [--copy-env] [--base <ref>]',
+          '',
+          'Create worktrees for every repo in the union of **Apps** declaring this branch.',
+          '',
+          'Optional:',
+          '  --repo         Restrict to specific repos (comma-separated).',
+          '  --no-env       Skip the per-repo env-file copy declared in .condash/settings.json.',
+          '  --no-install   Skip the per-repo install command declared in .condash/settings.json.',
+          '  --copy-env     Legacy: opportunistic .env / .env.local copy for repos without `env:`.',
+          '  --base         Base ref. Defaults to **Base** from declaring item READMEs (must agree).',
+          '',
+          'Examples:',
+          '  condash worktrees setup condash-cli-ux-fixes',
+          '  condash worktrees setup feature-x --repo condash --no-install',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    case 'remove':
+      process.stdout.write(
+        [
+          'condash worktrees remove <branch> [--repo <r>...] [--force] [--force-rm]',
+          '',
+          'Remove worktrees for this branch, protected-set aware.',
+          '',
+          'Optional:',
+          '  --repo       Restrict to specific repos (comma-separated).',
+          '  --force      Pass through to `git worktree remove --force` (deletes even if dirty).',
+          '  --force-rm   Implies --force; if git deregisters but leaves files behind, `rm -rf` them.',
+          '',
+          'Examples:',
+          '  condash worktrees remove condash-cli-ux-fixes',
+          '  condash worktrees remove feature-x --force-rm',
+          '',
+          UNIVERSAL_FOOTER,
+          '',
+        ].join('\n'),
+      );
+      return;
+    default:
+      printSubHelp();
+  }
+}
+
+function printSubHelp(): void {
   process.stdout.write(
     [
       'condash worktrees <verb> [args]',
       '',
       'Verbs:',
-      '  list             Repos with their worktrees (alias of repos list --include-worktrees).',
-      '  check <branch>   Per-repo state for one branch (declaring items, on-disk worktrees, local branches).',
+      '  list             Repos with their worktrees (alias of `repos list --include-worktrees`).',
+      '  check <branch>   Per-repo state for one branch.',
       '  mismatch         Items declaring **Branch** but missing on-disk worktrees.',
-      '  setup <branch>   Create worktrees for every repo in the union of **Apps** declaring this branch.',
-      '                   Flags: --repo <r>... (override) --no-env --no-install --copy-env --base <ref>',
-      '                   Base ref defaults to the **Base** field on declaring item READMEs (must agree).',
-      '                   Repos with `env: [...]` in .condash/settings.json have those files copied by default;',
-      '                   --no-env opts out. Repos with `install: <cmd>` have it run by default; --no-install',
-      '                   opts out. --copy-env is the legacy opportunistic .env / .env.local copy for repos',
-      '                   without `env:` declared.',
+      '  setup <branch>   Create worktrees for every repo declaring this branch.',
       '  remove <branch>  Remove worktrees for this branch, protected-set aware.',
-      '                   Flags: --repo <r>... (override) --force --force-rm.',
-      '                   --force passes through to `git worktree remove --force` (deletes even if dirty).',
-      '                   --force-rm implies --force; if git deregisters but leaves files behind',
-      '                   (e.g. node_modules), `rm -rf` the leftover dir to finish the job.',
-      '                   Without --force-rm, half-removed entries land in `partiallyRemoved[]`.',
+      '',
+      UNIVERSAL_FOOTER,
       '',
     ].join('\n'),
   );

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared bits for the per-noun help text. Each `runNoun` declares its own
+ * `printHelp(verb)` and per-verb help blocks; the universal-flag footer is
+ * the only piece worth centralising — it changes when a new universal flag
+ * lands and we don't want to grep 38 help blocks to update it.
+ */
+export const UNIVERSAL_FOOTER =
+  'Universal: --json, --ndjson, --quiet, --no-color, --conception <path>';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -102,16 +102,20 @@ async function main(): Promise<number> {
 
   if (!parsed.noun || parsed.noun === 'help') {
     if (parsed.noun === 'help' && parsed.verb) {
-      // Re-dispatch into the noun's --help path so we don't keep two help strings.
+      // Re-dispatch into the noun's --help path so we don't keep two help
+      // strings. `condash help <noun>` → noun-level help; `condash help
+      // <noun> <verb>` → verb-level help (forwards the third token as the
+      // verb so the runNoun's per-verb printHelp picks it up).
+      const subVerb = parsed.positional[0] ?? null;
       const subArgs = {
         ...parsed,
         noun: parsed.verb,
-        verb: null,
-        positional: [],
-        flags: { help: true },
+        verb: subVerb,
+        positional: parsed.positional.slice(1),
+        flags: {},
       };
       try {
-        return await dispatch(subArgs, ctx, universal);
+        return await dispatch(subArgs, ctx, { ...universal, help: true });
       } catch (err) {
         return reportError(ctx, err);
       }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -134,43 +134,47 @@ async function dispatch(
 ): Promise<number> {
   // Commands that don't need conception path resolution.
   if (args.noun === 'config' && args.verb === 'conception-path') {
-    await runConfig(args.verb, args, ctx, '');
+    await runConfig(args.verb, args, ctx, '', universal.help);
     return ExitCodes.OK;
   }
 
   const resolved = await resolveConception(universal.conceptionPath);
   const conceptionPath = resolved.path;
 
+  // `--help` always wins. Each runNoun honours `universalHelp` by short-
+  // circuiting to per-verb help text before any required-arg check.
+  const help = universal.help;
+
   switch (args.noun) {
     case 'project':
-      await runProject(args.verb, args, ctx);
+      await runProject(args.verb, args, ctx, help);
       return ExitCodes.OK;
     case 'projects':
-      await runProjects(args.verb, args, ctx, conceptionPath);
+      await runProjects(args.verb, args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'knowledge':
-      await runKnowledge(args.verb, args, ctx, conceptionPath);
+      await runKnowledge(args.verb, args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'search':
-      await runSearch(args, ctx, conceptionPath);
+      await runSearch(args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'repos':
-      await runRepos(args.verb, args, ctx, conceptionPath);
+      await runRepos(args.verb, args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'worktrees':
-      await runWorktrees(args.verb, args, ctx, conceptionPath);
+      await runWorktrees(args.verb, args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'audit':
-      await runAuditCommand(args, ctx, conceptionPath);
+      await runAuditCommand(args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'dirty':
-      await runDirty(args.verb, args, ctx, conceptionPath);
+      await runDirty(args.verb, args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     case 'skills':
-      await runSkills(args.verb, args, ctx);
+      await runSkills(args.verb, args, ctx, help);
       return ExitCodes.OK;
     case 'config':
-      await runConfig(args.verb, args, ctx, conceptionPath);
+      await runConfig(args.verb, args, ctx, conceptionPath, help);
       return ExitCodes.OK;
     default:
       throw new CliError(ExitCodes.USAGE, `Unknown noun: ${args.noun}`);

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -175,6 +175,13 @@ function emitNdjson<T>(data: T, shape: NdjsonShape): void {
 }
 
 export function reportError(ctx: OutputContext, err: unknown): ExitCode {
+  // Promote UsageError (parser-level, e.g. unknown-flag rejections from
+  // `assertNoExtraFlags`) to a USAGE CliError so consumers see exit code 2
+  // instead of the generic RUNTIME (1). Without this, every typo a verb's
+  // assertNoExtraFlags catches surfaces as exit 1.
+  if (err && typeof err === 'object' && (err as { name?: string }).name === 'UsageError') {
+    err = new CliError(ExitCodes.USAGE, (err as Error).message);
+  }
   if (err instanceof CliError) {
     if (ctx.json || ctx.ndjson) {
       const envelope: JsonEnvelope<never> = {

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,3 +1,5 @@
+import { UsageError } from './parser';
+
 /**
  * Output + exit-code helpers shared by every command.
  *
@@ -179,8 +181,8 @@ export function reportError(ctx: OutputContext, err: unknown): ExitCode {
   // `assertNoExtraFlags`) to a USAGE CliError so consumers see exit code 2
   // instead of the generic RUNTIME (1). Without this, every typo a verb's
   // assertNoExtraFlags catches surfaces as exit 1.
-  if (err && typeof err === 'object' && (err as { name?: string }).name === 'UsageError') {
-    err = new CliError(ExitCodes.USAGE, (err as Error).message);
+  if (err instanceof UsageError) {
+    err = new CliError(ExitCodes.USAGE, err.message);
   }
   if (err instanceof CliError) {
     if (ctx.json || ctx.ndjson) {

--- a/src/cli/parser.test.ts
+++ b/src/cli/parser.test.ts
@@ -4,6 +4,7 @@ import {
   parseArgs,
   parseCsvFlag,
   parseIntFlag,
+  suggestFlag,
   takeUniversalFlags,
   UsageError,
 } from './parser';
@@ -136,6 +137,37 @@ describe('assertNoExtraFlags', () => {
       expect(msg).toMatch(/--bar/);
       expect(msg).toMatch(/Unknown flags/);
     }
+  });
+
+  it('appends a `(did you mean --X?)` hint when a sibling pool is supplied', () => {
+    const args = parseArgs(['x', 'y', '--app', 'foo']);
+    expect(() => assertNoExtraFlags(args, ['apps', 'kind', 'slug', 'title'])).toThrow(
+      /Unknown flag: --app \(did you mean --apps\?\)/,
+    );
+  });
+
+  it('emits no hint when nothing is within distance 2', () => {
+    const args = parseArgs(['x', 'y', '--xyzzy', 'foo']);
+    expect(() => assertNoExtraFlags(args, ['apps', 'kind', 'slug', 'title'])).toThrow(
+      /^Unknown flag: --xyzzy$/,
+    );
+  });
+});
+
+describe('suggestFlag', () => {
+  it('returns the closest valid flag at distance ≤ 2', () => {
+    expect(suggestFlag('app', ['apps', 'kind', 'slug'])).toBe('apps');
+    expect(suggestFlag('aps', ['apps', 'kind'])).toBe('apps');
+    expect(suggestFlag('bracnh', ['branch', 'base'])).toBe('branch');
+  });
+
+  it('returns null when nothing is within distance 2', () => {
+    expect(suggestFlag('xyzzy', ['apps', 'kind', 'slug'])).toBeNull();
+  });
+
+  it('returns null when two candidates tie', () => {
+    // 'aps' is distance 1 from both 'apps' and 'ape' — a tie.
+    expect(suggestFlag('aps', ['apps', 'ape'])).toBeNull();
   });
 });
 

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -207,12 +207,70 @@ export function takeUniversalFlags(args: ParsedArgs): UniversalFlags {
  * but every command was silently dropping unknown flags. Call this at
  * the END of a command's flag extraction (after pulling each known key
  * into a local) to catch typos like `--sortx status`.
+ *
+ * When `siblingPool` is supplied, each unknown flag is matched against it
+ * via Levenshtein distance ≤ 2; the closest unique match is appended as
+ * `(did you mean --X?)`. Pass the union of every flag valid on the noun
+ * (across its verbs), not just the current verb's set, so a typo of a
+ * sibling-verb flag is suggested even when this verb wouldn't accept it.
+ * Pre-2026-05-16 callers of `assertNoExtraFlags(args)` keep working
+ * unchanged (no suggestion, same single-flag error).
  */
-export function assertNoExtraFlags(args: ParsedArgs): void {
+export function assertNoExtraFlags(args: ParsedArgs, siblingPool?: readonly string[]): void {
   const extras = Object.keys(args.flags);
   if (extras.length === 0) return;
   const word = extras.length === 1 ? 'flag' : 'flags';
-  throw new UsageError(`Unknown ${word}: ${extras.map((k) => `--${k}`).join(', ')}`);
+  const tagged = extras.map((k) => {
+    if (!siblingPool) return `--${k}`;
+    const hint = suggestFlag(k, siblingPool);
+    return hint ? `--${k} (did you mean --${hint}?)` : `--${k}`;
+  });
+  throw new UsageError(`Unknown ${word}: ${tagged.join(', ')}`);
+}
+
+/**
+ * Closest match for `typo` within Levenshtein distance ≤ 2; returns null
+ * when nothing is close enough or when two candidates tie. Used by
+ * `assertNoExtraFlags` to attach a `(did you mean --X?)` hint to unknown
+ * flag errors.
+ */
+export function suggestFlag(typo: string, candidates: readonly string[]): string | null {
+  let best: { name: string; dist: number } | null = null;
+  for (const cand of candidates) {
+    if (cand === typo) continue; // shouldn't happen — typo by definition isn't valid
+    const d = levenshtein(typo, cand);
+    if (d > 2) continue;
+    if (!best || d < best.dist) {
+      best = { name: cand, dist: d };
+    } else if (d === best.dist && cand !== best.name) {
+      // Two candidates at the same distance — prefer no suggestion over a
+      // coin-flip.
+      return null;
+    }
+  }
+  return best?.name ?? null;
+}
+
+/**
+ * Iterative Levenshtein with a single rolling row. ~12 lines instead of a
+ * dependency; runs once per unknown flag against ~20-flag pools.
+ */
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = new Array<number>(b.length + 1);
+  let curr = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length];
 }
 
 /**

--- a/src/main/create-project.ts
+++ b/src/main/create-project.ts
@@ -34,6 +34,8 @@ export interface CreateProjectInput {
   base: string | null;
   /** ISO YYYY-MM-DD; defaults to today. */
   date?: string;
+  /** Initial status; defaults to 'now'. The CLI rejects 'done' here — see createCommand. */
+  status?: string;
   severity: string | null;
   severityImpact: string | null;
   environment: string | null;
@@ -47,6 +49,7 @@ export interface CreateProjectResult {
   kind: string;
   title: string;
   date: string;
+  status: string;
   apps: string[];
   branch: string | null;
   base: string | null;
@@ -105,10 +108,16 @@ export async function createProjectCore(
     );
   }
 
+  // Default to 'now' for callers (e.g. the GUI's quick-create form) that
+  // omit the field. The CLI's createCommand has already validated against
+  // the 4-status enum and rejected 'done'.
+  const status = (input.status ?? '').trim() || 'now';
+
   const readmeBody = renderTemplate({
     kind: kind as (typeof ITEM_KINDS)[number],
     title,
     date,
+    status,
     apps,
     branch,
     base,
@@ -145,6 +154,7 @@ export async function createProjectCore(
     kind,
     title,
     date,
+    status,
     apps,
     branch,
     base,
@@ -155,6 +165,7 @@ interface TemplateInputs {
   kind: (typeof ITEM_KINDS)[number];
   title: string;
   date: string;
+  status: string;
   apps: string[];
   branch: string | null;
   base: string | null;
@@ -167,7 +178,7 @@ function renderTemplate(input: TemplateInputs): string {
   const fmLines: string[] = ['---'];
   fmLines.push(`date: ${input.date}`);
   fmLines.push(`kind: ${input.kind}`);
-  fmLines.push(`status: now`);
+  fmLines.push(`status: ${input.status}`);
   if (input.apps.length === 0) {
     fmLines.push('apps: []');
   } else {

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -183,17 +183,15 @@ export function registerProjectsIpc(): void {
         apps: [],
         branch: null,
         base: null,
+        // The renderer asked for status `now | review | later | backlog`.
+        // createProjectCore writes it into the YAML directly — no post-flip
+        // via transitionStatus needed, since none of the four edges
+        // transitionStatus's done-edge logic.
+        status: input.status,
         severity: input.severity ?? null,
         severityImpact: input.severityImpact ?? null,
         environment: input.environment ?? null,
       });
-      // The renderer asked for status `now | review | later | backlog`, but
-      // createProjectCore always renders `Status: now`. If the user picked
-      // anything else, flip it now via the same transitionStatus primitive
-      // — that keeps the status-write path single-source.
-      if (input.status !== 'now') {
-        await transitionStatus(result.readme, input.status);
-      }
       return {
         slug: result.slug,
         path: result.path,


### PR DESCRIPTION
## Summary

- Three sharp edges across every `condash <noun> <verb>` were eroding trust in the tool: broken `--help` on subcommands with required args, misleading errors on flag typos, and rejected natural flags like `--status` at create time.
- This PR fixes all three uniformly across all 10 nouns (`project`, `projects`, `knowledge`, `search`, `repos`, `worktrees`, `audit`, `dirty`, `skills`, `config`) and ~38 verbs.
- Bumps `3.6.0` → `3.7.0`.

## Changes

- **B1 — `--help` always wins.** Each `runNoun` now plumbs `universalHelp` from the dispatcher and short-circuits to per-verb help text before any required-arg or positional check. Adds the `condash <noun> help <verb>` positional alias (mirrors `condash <noun> <verb> --help`). Per-verb help text added for every verb, with at least one example.
- **B2 — Typo-first validation with suggestions.** `assertNoExtraFlags` now takes an optional `siblingPool` arg and computes Levenshtein distance against it; closest match within distance ≤ 2 surfaces as `(did you mean --X?)`. Each verb declares a local `KNOWN_FLAGS` const; the noun aggregates them into `NOUN_FLAGS` (the suggestion pool). Validation order across every verb: pull known flags → `assertNoExtraFlags(args, NOUN_FLAGS)` → required-arg check → value-enum check. So `condash projects create --app foo` reports the typo of `--apps` instead of "missing --apps".
- **B3 — `--status` on create.** `condash projects create --status <s>` accepts `now | review | later | backlog` (default `now`); `done` is rejected with a pointer to `condash projects close` (preserves the lifecycle invariant that closing writes a `Closed.` Timeline entry). `status` is added to `CreateProjectInput` + `CreateProjectResult`; `renderTemplate` uses it instead of the hardcoded `now`. The IPC `createProject` handler is unchanged — it continues to default `status` and post-flip via `transitionStatus`.
- **Exit-code fix.** `UsageError` (parser-level, e.g. unknown-flag rejections) is now mapped to exit code `2` (USAGE) by `reportError`, matching the documented exit-code table. Previously it leaked through as `1` (RUNTIME).
- **Tests.** 11 new behavioural tests in `projects-create.test.ts` cover B1/B2/B3 acceptance cases against `runProjects` + `createCommand`. 4 new parser tests cover the suggestion engine + opt-in pool. All 395 existing tests still pass; `make typecheck` clean.
- **Docs.** `docs/reference/cli.md`: `--status` documented on `projects create`; new sections describe per-verb `--help` and the unknown-flag suggestion engine. New shared `src/cli/help.ts` exports `UNIVERSAL_FOOTER` so the universal-flag list lives in one place.

## Impact

- **CLI consumers / skills.** Existing `condash …` invocations are unchanged in behaviour. New affordances (`--help` on every verb, typo hints, `--status` on create) are additive. The exit-code change for `UsageError` (1 → 2) is a fix, but skills that grep on exit code may need to re-check.
- **Bundle size.** CLI grows by ~3 KB (per-verb help strings + Levenshtein) — `654.5 KB` total.
- **Help-text drift.** ~38 per-verb help blocks now live inline in each `runNoun` file. New verbs / new flags must be added in three places: the verb's `KNOWN_FLAGS` const, the verb's help block, and the verb's value-extraction code.

## Watchpoints

- **Suggestion-engine false positives.** Levenshtein ≤ 2 with the union pool may suggest sibling-verb flags that aren't valid on the current verb (intentional — see project notes for the design rationale). If user reports get noisy, consider tightening to per-verb pool with a sibling-verb fallback annotation.
- **`condash projects create --status review` adoption.** The new flag respects the project-lifecycle rule that `now` is the default for newly-created items; `review` is meant for items whose first blocking step is already external. Watch `/projects list status=review` shortly after merge for cases where `review` was set inappropriately.
