### PR TITLE
Fix race in getTreeExpansion opportunistic legacy-key rewrite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/ipc/settings-tree-expansion.test.ts
+++ b/src/main/ipc/settings-tree-expansion.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Settings-IPC tests focused on the legacy `treeExpansion.skills` migration
+ * path that lives inside `getTreeExpansion`. The handler under test fires
+ * an opportunistic write to drop the legacy key; we verify that the write
+ * survives a concurrent `setTreeExpansion` (the race surfaced in PR #173
+ * re-review).
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: () => '/tmp/electron-app' },
+}));
+
+let tmp: string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
+let settingsPathValue: string;
+
+async function writeSettings(content: object): Promise<void> {
+  await fs.writeFile(settingsPathValue, JSON.stringify(content));
+}
+
+async function readSettingsFile(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(settingsPathValue, 'utf8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+/** The opportunistic legacy-key rewrite is fire-and-forget — it's queued
+ *  through `withSettingsQueue` and runs after the handler returns. Poll
+ *  the on-disk file until the predicate is satisfied (or time out). */
+async function waitForFile(
+  predicate: (settings: Record<string, unknown>) => boolean,
+  timeoutMs = 3000,
+): Promise<Record<string, unknown>> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const onDisk = await readSettingsFile();
+    if (predicate(onDisk)) return onDisk;
+    if (Date.now() > deadline) {
+      throw new Error(`waitForFile timed out — last contents: ${JSON.stringify(onDisk, null, 2)}`);
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  tmp = mkdtempSync(join(tmpdir(), 'condash-settings-ipc-'));
+  settingsPathValue = join(tmp, 'settings.json');
+  // Override the user-data dir so `settingsPath()` lands in the temp dir.
+  vi.doMock('../user-data-dir', () => ({ userDataDir: () => tmp }));
+
+  handlers = {};
+  const { ipcMain } = await import('electron');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ipcMain.handle as any).mockImplementation(
+    (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
+      handlers[channel] = fn;
+    },
+  );
+  const { registerSettingsIpc } = await import('./settings');
+  registerSettingsIpc({ onLayoutChange: () => undefined });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  vi.doUnmock('../user-data-dir');
+});
+
+describe('getTreeExpansion legacy-skills migration', () => {
+  it('migrates `skills` → `skillsClaude` in the returned shape', async () => {
+    await writeSettings({
+      lastConceptionPath: null,
+      recentConceptionPaths: [],
+      theme: 'system',
+      terminal: {},
+      treeExpansion: { skills: ['pr', 'projects'] },
+    });
+    const result = (await handlers.getTreeExpansion()) as Record<string, string[]>;
+    expect(result.skillsClaude.sort()).toEqual(['pr', 'projects']);
+    expect(result.skillsGeneric).toEqual([]);
+    expect(result.skillsKimi).toEqual([]);
+  });
+
+  it('explicit `skillsClaude` wins over the legacy `skills` array', async () => {
+    await writeSettings({
+      lastConceptionPath: null,
+      recentConceptionPaths: [],
+      theme: 'system',
+      terminal: {},
+      treeExpansion: {
+        skills: ['legacy-only'],
+        skillsClaude: ['explicit'],
+      },
+    });
+    const result = (await handlers.getTreeExpansion()) as Record<string, string[]>;
+    expect(result.skillsClaude).toEqual(['explicit']);
+  });
+
+  it('opportunistically rewrites settings.json to drop the legacy `skills` key', async () => {
+    await writeSettings({
+      lastConceptionPath: null,
+      recentConceptionPaths: [],
+      theme: 'system',
+      terminal: {},
+      treeExpansion: { skills: ['pr'] },
+    });
+    await handlers.getTreeExpansion();
+    const onDisk = await waitForFile((s) => {
+      const te = s.treeExpansion as Record<string, unknown> | undefined;
+      return te !== undefined && te.skills === undefined && Array.isArray(te.skillsClaude);
+    });
+    const te = onDisk.treeExpansion as Record<string, unknown>;
+    expect(te.skills).toBeUndefined();
+    expect(te.skillsClaude).toEqual(['pr']);
+  });
+
+  it('does not clobber a concurrent setTreeExpansion update', async () => {
+    // Start: legacy-only on disk.
+    await writeSettings({
+      lastConceptionPath: null,
+      recentConceptionPaths: [],
+      theme: 'system',
+      terminal: {},
+      treeExpansion: { skills: ['old-claude'] },
+    });
+    // Fire getTreeExpansion (queues an opportunistic rewrite) AND
+    // setTreeExpansion in the same microtask. `updateSettings` runs both
+    // under `withSettingsQueue`; we assert the resulting on-disk state
+    // reflects the explicit setTreeExpansion call, not the stale-snapshot
+    // migration.
+    await Promise.all([
+      handlers.getTreeExpansion(),
+      // IPC handlers' first arg is the (unused) event; payload is second.
+      handlers.setTreeExpansion(null, {
+        skillsClaude: ['fresh-explicit'],
+        skillsGeneric: ['gen'],
+      }),
+    ]);
+    // The settings queue serializes both writes; wait for the post-state.
+    const onDisk = await waitForFile((s) => {
+      const te = s.treeExpansion as Record<string, unknown> | undefined;
+      return te !== undefined && te.skills === undefined && Array.isArray(te.skillsClaude);
+    });
+    const te = onDisk.treeExpansion as Record<string, unknown>;
+    expect(te.skills).toBeUndefined();
+    expect(te.skillsClaude).toEqual(['fresh-explicit']);
+    expect(te.skillsGeneric).toEqual(['gen']);
+  });
+
+  it('is a no-op when no legacy `skills` key exists', async () => {
+    await writeSettings({
+      lastConceptionPath: null,
+      recentConceptionPaths: [],
+      theme: 'system',
+      terminal: {},
+      treeExpansion: { skillsClaude: ['pr'] },
+    });
+    const mtimeBefore = (await fs.stat(settingsPathValue)).mtimeMs;
+    await handlers.getTreeExpansion();
+    await new Promise((r) => setImmediate(r));
+    const mtimeAfter = (await fs.stat(settingsPathValue)).mtimeMs;
+    expect(mtimeAfter).toBe(mtimeBefore);
+  });
+});

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -165,14 +165,28 @@ export function registerSettingsIpc(opts: { onLayoutChange: (layout: LayoutState
     // key so it doesn't linger indefinitely for users who never trigger a
     // tree-expansion mutation. Fire-and-forget — failure here is non-fatal
     // and the next read will simply re-migrate.
-    if (legacySkills && treeExpansion) {
-      const { skills: _drop, ...rest } = treeExpansion;
-      void _drop;
-      const rewritten: TreeExpansionPrefs = {
-        ...rest,
-        skillsClaude: out.skillsClaude.length > 0 ? out.skillsClaude : rest.skillsClaude,
-      };
-      void updateSettings((cur) => ({ ...cur, treeExpansion: rewritten })).catch(() => undefined);
+    //
+    // The mutator re-reads `cur.treeExpansion` under `withSettingsQueue`
+    // rather than reusing the outer snapshot, so a parallel
+    // `setTreeExpansion` that landed between our read and this mutator
+    // running is preserved instead of being clobbered with stale state.
+    if (legacySkills) {
+      void updateSettings((cur) => {
+        const curTreeExpansion = cur.treeExpansion;
+        // Another mutator already dropped the legacy key — nothing to do.
+        if (!curTreeExpansion?.skills) return cur;
+        const { skills: legacyOnDisk, ...rest } = curTreeExpansion;
+        const migrated = new Set<string>();
+        for (const entry of Array.isArray(legacyOnDisk) ? legacyOnDisk : []) {
+          if (typeof entry === 'string') migrated.add(entry);
+        }
+        // Explicit `skillsClaude` (if any) wins; legacy only fills the gap.
+        const skillsClaude =
+          rest.skillsClaude ?? (migrated.size > 0 ? Array.from(migrated) : undefined);
+        const merged: TreeExpansionPrefs = { ...rest };
+        if (skillsClaude !== undefined) merged.skillsClaude = skillsClaude;
+        return { ...cur, treeExpansion: merged };
+      }).catch(() => undefined);
     }
     return out;
   });


### PR DESCRIPTION
## Summary

- Fix the race in `getTreeExpansion`'s opportunistic legacy-`skills` key drop. v3.7.0 built the rewrite from the outer `readSettings` snapshot; if a parallel `setTreeExpansion` landed between the read and the queued mutator, the legacy-drop write could clobber the fresher state.
- Move the drop inside the mutator so it reads `cur.treeExpansion` under `withSettingsQueue`, preserving any parallel update.

## Changes

- `src/main/ipc/settings.ts` — the opportunistic mutator now re-reads `cur.treeExpansion`, drops the legacy `skills` key, and merges in the migrated `skillsClaude` only when no explicit `skillsClaude` is already on disk. Early-returns when another mutator already dropped the key.
- `src/main/ipc/settings-tree-expansion.test.ts` — new test file (5 cases): basic migration, explicit-wins-over-legacy, opportunistic rewrite landing on disk, race against parallel `setTreeExpansion`, and a no-op when no legacy key is present.
- `package.json` / `package-lock.json` — 3.7.1.

## Impact

- Users whose `settings.json` still carries the legacy `treeExpansion.skills` key see the same migration behaviour from a renderer-facing perspective; the difference is only that the queued write now composes safely with any other write in flight.
- No schema change. No on-disk format change beyond the legacy-key drop that v3.7.0 already wired up.
