### PR TITLE
Easier drag-and-drop between project status sections

### DIFF
--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -81,9 +81,45 @@
 }
 
 .group-block.drag-over {
-  background: color-mix(in srgb, var(--col-status, var(--accent)) 8%, transparent);
-  outline: 1px dashed var(--col-status, var(--accent));
+  background: color-mix(in srgb, var(--col-status, var(--accent)) 18%, transparent);
+  outline: 2px solid var(--col-status, var(--accent));
   outline-offset: 2px;
+}
+
+/* Drag-in-progress: only EMPTY sections inflate (they have no cards to
+ * read as a drop target, so we have to give them a visible rectangle).
+ * Non-empty sections keep their resting size — their cards are already
+ * the visible drop target, the section just listens for the drop. The
+ * active hover lane gets a solid status-hue outline + tint regardless
+ * of empty-ness so the user always sees which lane is being targeted.
+ *
+ * The floating drag image is rendered in JS as our own translucent
+ * <article> clone that follows the cursor; the source card stays
+ * opaque. */
+body[data-dragging='project'] .group-block[data-empty='true'] {
+  opacity: 1;
+  min-height: 96px;
+  padding: 18px 0 28px;
+  outline: 2px dashed color-mix(in srgb, var(--col-status, var(--text-faint)) 55%, transparent);
+  outline-offset: -6px;
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--col-status, var(--accent)) 3%, transparent);
+}
+
+body[data-dragging='project'] .group-block[data-empty='true'] .group-header {
+  /* Empty headers normally shrink to a thin line — restore comfortable
+   * padding only during drag so the label sits naturally inside the
+   * inflated rectangle, then drop back when the drag ends. */
+  padding: 6px 6px 12px;
+}
+
+/* The active hover target wins regardless of empty-ness: solid 2 px in
+ * the section's status hue + 18 % background tint, so the lane the
+ * cursor is on is unambiguously the active drop target. */
+body[data-dragging='project'] .group-block.drag-over {
+  outline: 2px solid var(--col-status, var(--accent));
+  outline-offset: 2px;
+  background: color-mix(in srgb, var(--col-status, var(--accent)) 18%, transparent);
 }
 
 .group-header {

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -77,6 +77,11 @@ export function GroupBlock(props: {
     if (!isAcceptable(e)) return;
     e.preventDefault();
     if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+    // Self-heal: dragenter/dragleave can race when a fixed-position ghost
+    // hovers above the section, occasionally clearing the over state mid-
+    // hover. dragover fires continuously while the cursor is on the
+    // target, so re-asserting here keeps the highlight stable.
+    setOver(true);
   };
 
   const handleDragLeave = (e: DragEvent) => {
@@ -233,10 +238,62 @@ export function Card(props: {
     props.onOpen(props.item);
   };
 
+  // Custom ghost state — Chromium in this Electron build ignores opacity
+  // on setDragImage clones (the native snapshotter falls back to the
+  // opaque source screenshot regardless of how we position or style the
+  // element we hand to setDragImage). Instead: hide the native drag
+  // image with a 1×1 transparent png, then render our own translucent
+  // ghost div that follows the cursor via a document-level dragover
+  // listener. The ghost is removed on dragend.
+  let ghostElement: HTMLElement | null = null;
+  let ghostOffsetX = 0;
+  let ghostOffsetY = 0;
+  const onGlobalDragOver = (e: DragEvent) => {
+    if (!ghostElement) return;
+    ghostElement.style.transform = `translate(${e.clientX - ghostOffsetX}px, ${e.clientY - ghostOffsetY}px)`;
+  };
+
   const handleDragStart = (event: DragEvent) => {
     if (!event.dataTransfer) return;
     event.dataTransfer.setData(DRAG_MIME, props.item.path);
     event.dataTransfer.effectAllowed = 'move';
+
+    // Hide the native drag image — Chromium's auto-snapshot would
+    // otherwise render an opaque copy of the source card.
+    const blank = new Image();
+    blank.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+    event.dataTransfer.setDragImage(blank, 0, 0);
+
+    // Build a translucent clone to use as our own ghost. Positioned
+    // fixed so its transform follows the cursor regardless of scroll.
+    const source = event.currentTarget as HTMLElement;
+    const sourceWidth = source.offsetWidth;
+    ghostOffsetX = sourceWidth / 2;
+    ghostOffsetY = 24;
+    ghostElement = source.cloneNode(true) as HTMLElement;
+    ghostElement.style.position = 'fixed';
+    ghostElement.style.top = '0';
+    ghostElement.style.left = '0';
+    ghostElement.style.width = `${sourceWidth}px`;
+    ghostElement.style.opacity = '0.55';
+    ghostElement.style.pointerEvents = 'none';
+    ghostElement.style.zIndex = '99999';
+    ghostElement.style.transform = `translate(${event.clientX - ghostOffsetX}px, ${event.clientY - ghostOffsetY}px)`;
+    document.body.appendChild(ghostElement);
+    document.addEventListener('dragover', onGlobalDragOver);
+
+    // body flag lets every .group-block inflate its drop zone via CSS
+    // without each section having to listen for a global drag.
+    document.body.dataset.dragging = 'project';
+  };
+
+  const handleDragEnd = () => {
+    delete document.body.dataset.dragging;
+    if (ghostElement) {
+      ghostElement.remove();
+      ghostElement = null;
+    }
+    document.removeEventListener('dragover', onGlobalDragOver);
   };
 
   // Cmd/Ctrl+1..N maps to KNOWN_STATUSES[0..N-1]; ignore anything else so
@@ -271,6 +328,7 @@ export function Card(props: {
       draggable={isDraggable()}
       tabIndex={0}
       onDragStart={isDraggable() ? handleDragStart : undefined}
+      onDragEnd={isDraggable() ? handleDragEnd : undefined}
       onKeyDown={handleKeyDown}
     >
       <div class="row-head" onClick={handleHeaderClick}>


### PR DESCRIPTION
## Summary

- Dragging a project card between status sections in the Projects pane was hard to land — empty sections were a thin one-line strip, and the floating drag image was an opaque clone of the source card, hiding whatever was underneath.
- Empty status sections now inflate to a comfortable 96 px hittable rectangle with a faint dashed outline in their status hue. The dragged card renders as a custom translucent ghost following the cursor, so the destination is visible behind it. Non-empty sections are unchanged.

## Changes

- `src/renderer/panes/projects-parts/cards.tsx` — `Card`: replace the native drag-image with a translucent `<article>` clone positioned via a document-level `dragover` listener; hide the native image via a 1×1 transparent png. `GroupBlock`: self-heal `over` in `dragover` so the active drop highlight stays put under the ghost.
- `src/renderer/panes/projects-pane.css` — bump `.drag-over` to a solid 2 px status-coloured outline with 18 % background tint. Add `body[data-dragging='project'] .group-block[data-empty='true']` rules to inflate empty sections during a project drag only.

## Impact

- Empty status sections briefly grow taller while a card is being dragged. The change is scoped to the drag-in-progress state via `body[data-dragging='project']`; layout returns to normal on `dragend`.