### PR TITLE
Format skills.ts and skills.user.test.ts

### DIFF
--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1099,21 +1099,21 @@ function userTargetRoot(target: CompileTarget): string {
 function userScriptSourceRoot(category: ScriptCategory): string {
   if (category === 'agents') {
     return (
-      process.env.CONDASH_USER_AGENTS_SCRIPTS_ROOT
-      ?? join(homedir(), '.config', 'agents', 'agents-scripts')
+      process.env.CONDASH_USER_AGENTS_SCRIPTS_ROOT ??
+      join(homedir(), '.config', 'agents', 'agents-scripts')
     );
   }
   return (
-    process.env.CONDASH_USER_CLAUDE_SCRIPTS_ROOT
-    ?? join(homedir(), '.config', 'agents', 'claude-scripts')
+    process.env.CONDASH_USER_CLAUDE_SCRIPTS_ROOT ??
+    join(homedir(), '.config', 'agents', 'claude-scripts')
   );
 }
 
 function userScriptTargetRoot(category: ScriptCategory): string {
   if (category === 'agents') {
     return (
-      process.env.CONDASH_USER_AGENTS_SCRIPTS_TARGET
-      ?? join(homedir(), '.config', 'agents', 'scripts')
+      process.env.CONDASH_USER_AGENTS_SCRIPTS_TARGET ??
+      join(homedir(), '.config', 'agents', 'scripts')
     );
   }
   return process.env.CONDASH_USER_CLAUDE_SCRIPTS_TARGET ?? join(homedir(), '.claude', 'scripts');
@@ -1310,7 +1310,9 @@ function formatUserInstallHuman(report: UserInstallReport): string {
     const parts = (['agents', 'claude'] as const)
       .filter((c) => byCategory.has(c))
       .map((c) => `${c}=${byCategory.get(c)}`);
-    lines.push(`Scripts installed → ${report.scripts.targets.agents}, ${report.scripts.targets.claude} (${parts.join(', ')})`);
+    lines.push(
+      `Scripts installed → ${report.scripts.targets.agents}, ${report.scripts.targets.claude} (${parts.join(', ')})`,
+    );
   }
   return lines.join('\n') + '\n';
 }
@@ -1328,7 +1330,10 @@ async function listUser(args: ParsedArgs, ctx: OutputContext): Promise<void> {
     allowedOnHost: hostAllowed(s, hostLabel),
   }));
   const scripts = await readUserScripts();
-  const scriptsByCategory: Record<ScriptCategory, { source: string; target: string; files: string[] }> = {
+  const scriptsByCategory: Record<
+    ScriptCategory,
+    { source: string; target: string; files: string[] }
+  > = {
     agents: {
       source: userScriptSourceRoot('agents'),
       target: userScriptTargetRoot('agents'),
@@ -1450,8 +1455,12 @@ async function userSkillsStatus(args: ParsedArgs, ctx: OutputContext): Promise<v
     (data) => {
       const d = data as { source: string; hostLabel: string | null; items: UserStatusEntry[] };
       if (d.items.length === 0) return `(nothing tracked under ${d.source})\n`;
-      const skillRows = d.items.filter((r): r is Extract<UserStatusEntry, { kind: 'skill' }> => r.kind === 'skill');
-      const scriptRows = d.items.filter((r): r is Extract<UserStatusEntry, { kind: 'script' }> => r.kind === 'script');
+      const skillRows = d.items.filter(
+        (r): r is Extract<UserStatusEntry, { kind: 'skill' }> => r.kind === 'skill',
+      );
+      const scriptRows = d.items.filter(
+        (r): r is Extract<UserStatusEntry, { kind: 'script' }> => r.kind === 'script',
+      );
       const lines: string[] = [];
       if (skillRows.length > 0) {
         const widths = {

--- a/src/cli/commands/skills.user.test.ts
+++ b/src/cli/commands/skills.user.test.ts
@@ -428,9 +428,7 @@ describe('condash skills install --user (scripts)', () => {
         ctx(),
       ),
     );
-    expect(env.data.scripts.installed).toEqual([
-      { category: 'agents', relPath: 'md_to_pdf.sh' },
-    ]);
+    expect(env.data.scripts.installed).toEqual([{ category: 'agents', relPath: 'md_to_pdf.sh' }]);
     await expect(fs.access(join(agentsScriptsTarget, 'md_to_pdf.sh'))).rejects.toThrow();
   });
 
@@ -440,7 +438,9 @@ describe('condash skills install --user (scripts)', () => {
     await install();
 
     type StatusEnv = {
-      data: { items: ({ kind: string; relPath: string; state: string } | Record<string, unknown>)[] };
+      data: {
+        items: ({ kind: string; relPath: string; state: string } | Record<string, unknown>)[];
+      };
     };
 
     // After install: both scripts should report ok.
@@ -451,9 +451,9 @@ describe('condash skills install --user (scripts)', () => {
         ctx(),
       ),
     );
-    const scriptRows = (env.data.items as { kind: string; relPath: string; state: string }[]).filter(
-      (r) => r.kind === 'script',
-    );
+    const scriptRows = (
+      env.data.items as { kind: string; relPath: string; state: string }[]
+    ).filter((r) => r.kind === 'script');
     expect(scriptRows.length).toBe(2);
     expect(scriptRows.every((r) => r.state === 'ok')).toBe(true);
 
@@ -466,8 +466,9 @@ describe('condash skills install --user (scripts)', () => {
         ctx(),
       ),
     );
-    const tamperedRow = (env.data.items as { kind: string; relPath: string; state: string }[])
-      .find((r) => r.kind === 'script' && r.relPath === 'md_to_pdf.sh');
+    const tamperedRow = (env.data.items as { kind: string; relPath: string; state: string }[]).find(
+      (r) => r.kind === 'script' && r.relPath === 'md_to_pdf.sh',
+    );
     expect(tamperedRow?.state).toBe('stale');
 
     // Remove a target: should report missing.
@@ -479,8 +480,9 @@ describe('condash skills install --user (scripts)', () => {
         ctx(),
       ),
     );
-    const missingRow = (env.data.items as { kind: string; relPath: string; state: string }[])
-      .find((r) => r.kind === 'script' && r.relPath === 'cp-hook.sh');
+    const missingRow = (env.data.items as { kind: string; relPath: string; state: string }[]).find(
+      (r) => r.kind === 'script' && r.relPath === 'cp-hook.sh',
+    );
     expect(missingRow?.state).toBe('missing');
   });
 


### PR DESCRIPTION
## Summary

- PR #176 (`Install user-scope script trees via condash skills install`) was merged with a Format-check failure in CI: my edits to `src/cli/commands/skills.ts` and `src/cli/commands/skills.user.test.ts` didn't match prettier output.
- This PR is the prettier auto-fix for those two files. Behaviour unchanged.

## Changes

- `src/cli/commands/skills.ts`: prettier-formatted (whitespace, line breaks, wrapping). 29 lines diff-stat.
- `src/cli/commands/skills.user.test.ts`: prettier-formatted. 24 lines diff-stat.

## Impact

- All 25 `skills.user.test.ts` tests still pass.
- Main typecheck clean.
- Unblocks the next `Format check` CI job.