### PR TITLE
Bump 3.10.1: preserve user Specifics in .agents/agents/common.md

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.8.1",
+  "version": "3.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.8.1",
+      "version": "3.10.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/files.install.test.ts
+++ b/src/cli/commands/files.install.test.ts
@@ -8,7 +8,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runSkills } from './skills';
-import { SHIPPED_FILES, statusShippedFile } from './files';
+import { AGENT_CONFIG_COMMON, SHIPPED_FILES, statusShippedFile } from './files';
 import { MANIFEST_RELPATH, readManifest } from './install-shared';
 import type { OutputContext } from '../output';
 
@@ -121,6 +121,87 @@ describe('condash skills install — top-level files', () => {
     const manifest = { version: 3 as const, skills: {}, files: {} };
     const row = await statusShippedFile(file, dest, manifest);
     expect(row).toBeNull();
+  });
+
+  it('preserves a user-customised `## Specifics` in .agents/agents/common.md across reinstall', async () => {
+    // First install scaffolds the agent-config tree with the shipped common.md.
+    await install();
+    const commonPath = join(dest, '.agents/agents/common.md');
+    const initial = await fs.readFile(commonPath, 'utf8');
+    expect(initial).toContain('## General');
+    expect(initial).toContain('## Specifics');
+
+    // User customises the Specifics body (the Apps table + a team rule).
+    const customSpecifics = [
+      '## Specifics',
+      '',
+      '| App         | Purpose          | Repo                       | Config             | Knowledge   |',
+      '|-------------|------------------|----------------------------|--------------------|-------------|',
+      '| `@my-app`   | example app      | `~/src/example/my-app`     | `<repo>/CLAUDE.md` | _(none)_    |',
+      '',
+      '### Repo workflow',
+      '',
+      '- Always run `make format` after every code change.',
+      '',
+    ].join('\n');
+    // Split on the actual `## Specifics` heading (start-of-line) — there's
+    // also a backticked `## Specifics` inside the General body that we must
+    // not match.
+    const specHeading = initial.search(/^## Specifics\s*$/m);
+    expect(specHeading).toBeGreaterThan(0);
+    const beforeSpecifics = initial.slice(0, specHeading).trimEnd();
+    const customised = `${beforeSpecifics}\n\n${customSpecifics}`;
+    await fs.writeFile(commonPath, customised);
+
+    // Second install must NOT clobber Specifics. General region stays
+    // identical (no user edit there), so the install just refreshes the
+    // manifest.
+    await install();
+    const after = await fs.readFile(commonPath, 'utf8');
+    expect(after).toContain('`@my-app`');
+    expect(after).toContain('Always run `make format`');
+    expect(after).not.toContain('_(populate per-app)_');
+
+    // Compiled outputs must carry the customised Specifics rows.
+    const claude = await fs.readFile(join(dest, '.claude/CLAUDE.md'), 'utf8');
+    expect(claude).toContain('`@my-app`');
+    expect(claude).toContain('Always run `make format`');
+    const kimi = await fs.readFile(join(dest, '.kimi/AGENTS.md'), 'utf8');
+    expect(kimi).toContain('`@my-app`');
+
+    // Manifest tracks common.md alongside the user-selectable files.
+    const manifest = await readManifest(dest);
+    expect(manifest!.files![AGENT_CONFIG_COMMON.path]).toBeTruthy();
+    expect(manifest!.files![AGENT_CONFIG_COMMON.path].region).toBe('General');
+  });
+
+  it('refuses to overwrite a hand-edited `## General` in common.md without --force', async () => {
+    await install();
+    const commonPath = join(dest, '.agents/agents/common.md');
+    const shipped = await fs.readFile(commonPath, 'utf8');
+
+    // User edits the General region (between `## General` and `## Specifics`).
+    const tampered = shipped.replace('### Pointers', '### Pointers (locally edited)');
+    expect(tampered).not.toBe(shipped);
+    await fs.writeFile(commonPath, tampered);
+
+    // Re-install: General region differs from manifest hash → install exits
+    // non-zero with `refused` listed. The on-disk file must stay edited.
+    await expect(install()).rejects.toThrow(/refused/);
+    const after = await fs.readFile(commonPath, 'utf8');
+    expect(after).toContain('### Pointers (locally edited)');
+  });
+
+  it('--prune does not drop the .agents/agents/common.md manifest entry', async () => {
+    await install();
+    process.env.CONDASH_TEMPLATE_ROOT = TEMPLATE_ROOT;
+    await runSkills(
+      'install',
+      { noun: 'skills', verb: 'install', positional: [], flags: { dest, prune: true } },
+      ctx(),
+    );
+    const manifest = await readManifest(dest);
+    expect(manifest!.files![AGENT_CONFIG_COMMON.path]).toBeTruthy();
   });
 
   it('--prune drops manifest entries whose shipped source no longer exists', async () => {

--- a/src/cli/commands/files.ts
+++ b/src/cli/commands/files.ts
@@ -312,6 +312,31 @@ export async function installShippedFile(
 const AGENTS_SOURCE_RELPATH = '.agents/agents';
 
 /**
+ * `common.md` carries a `## General` region (condash-owned, refreshed on
+ * install) and a `## Specifics` region (user-owned, never touched). Treated
+ * as a region-aware shipped file, with the same hash/manifest model as
+ * `.gitignore`. The per-agent fragments (`claude.md`, `kimi.md`) ship via
+ * the same install path as the rest of the agent-config tree — they have
+ * no Specifics heading and are condash-owned in full.
+ */
+export const AGENT_CONFIG_COMMON: ShippedFile = {
+  path: `${AGENTS_SOURCE_RELPATH}/common.md`,
+  region: 'General',
+  mark: '##',
+  siblings: ['Specifics'],
+};
+
+/**
+ * Union of every file path condash knows how to (re)install — both the
+ * user-selectable `SHIPPED_FILES` entries and the always-installed
+ * agent-config sources. Used by status / prune helpers so a manifest entry
+ * for `AGENT_CONFIG_COMMON.path` isn't mistaken for a stale source.
+ */
+function knownShippedFilePaths(): Set<string> {
+  return new Set([...SHIPPED_FILES.map((f) => f.path), AGENT_CONFIG_COMMON.path]);
+}
+
+/**
  * Compile `.agents/agents/` → per-target output files (`.claude/CLAUDE.md` +
  * `.kimi/AGENTS.md`). Compiled outputs are deterministic from the source
  * and aren't tracked by the manifest — they're regenerated on every
@@ -464,7 +489,7 @@ export async function statusShippedFile(
  * top-level file.
  */
 export function sourceMissingFileRows(manifest: Manifest): FileStatusRow[] {
-  const shippedSet = new Set(SHIPPED_FILES.map((f) => f.path));
+  const shippedSet = knownShippedFilePaths();
   const rows: FileStatusRow[] = [];
   for (const [path, entry] of Object.entries(manifest.files ?? {})) {
     if (shippedSet.has(path)) continue;
@@ -497,23 +522,59 @@ export function listShippedFiles(manifest: Manifest | null): FileListRow[] {
   });
 }
 
+export interface AgentConfigInstallResult {
+  /** Per-agent fragment paths (relative to `.agents/agents/`) that were written. */
+  copied: string[];
+  /**
+   * Outcome of the region-aware install for `common.md`. `null` only when the
+   * shipped agent-config tree is missing from the bundle (returns early).
+   */
+  commonOutcome: FileInstallOutcome | null;
+}
+
 /**
- * Copy the `.agents/agents/` source tree from the shipped template to the
- * destination. Overwrites on every install (no refuse-on-edit for these
- * small source fragments; user edits should go into `## Specifics` in the
- * compiled output, not the source files).
+ * Install the `.agents/agents/` source tree from the shipped template:
  *
- * Returns the list of relative paths copied.
+ * - `common.md` ships through `installShippedFile` so the `## General` region
+ *   gets refreshed but `## Specifics` (user-owned per-conception content like
+ *   the Apps table and durable team rules) is preserved across installs.
+ *   Refused without `--force` when General has been hand-edited.
+ * - Per-agent fragments (`claude.md`, `kimi.md`) overwrite on every install —
+ *   they're small, condash-owned, and have no `## Specifics` heading to
+ *   protect.
+ *
+ * Returns the per-agent fragment paths that were (re)written plus the
+ * region-aware outcome for `common.md`.
  */
-export async function installAgentConfigSources(dest: string, dryRun: boolean): Promise<string[]> {
+export async function installAgentConfigSources(
+  params: FileInstallParams,
+): Promise<AgentConfigInstallResult> {
+  const { dest, dryRun } = params;
   const shippedDir = join(locateShippedFilesRoot(), '.agents', 'agents');
   const targetDir = join(dest, '.agents', 'agents');
   const copied: string[] = [];
 
+  try {
+    await fs.access(shippedDir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { copied: [], commonOutcome: null };
+    }
+    throw err;
+  }
+
+  if (!dryRun) await fs.mkdir(targetDir, { recursive: true });
+
+  // common.md: region-aware install via the same machinery as `.gitignore`.
+  const commonOutcome = await installShippedFile(AGENT_CONFIG_COMMON, params);
+
+  // Per-agent fragments + any future nested files: full-overwrite.
   async function walk(src: string, dst: string, prefix: string): Promise<void> {
     const entries = await fs.readdir(src, { withFileTypes: true });
     for (const entry of entries) {
       if (entry.name.startsWith('.')) continue;
+      // common.md is handled above with refuse-on-edit semantics.
+      if (prefix === '' && entry.name === 'common.md') continue;
       const srcPath = join(src, entry.name);
       const dstPath = join(dst, entry.name);
       const relPath = prefix ? `${prefix}/${entry.name}` : entry.name;
@@ -537,16 +598,8 @@ export async function installAgentConfigSources(dest: string, dryRun: boolean): 
     }
   }
 
-  try {
-    await fs.access(shippedDir);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
-    throw err;
-  }
-
-  if (!dryRun) await fs.mkdir(targetDir, { recursive: true });
   await walk(shippedDir, targetDir, '');
-  return copied;
+  return { copied, commonOutcome };
 }
 
 /**
@@ -560,7 +613,7 @@ export function pruneSourceMissingFileEntries(manifest: Manifest): {
   shippedVersion: string;
 }[] {
   if (!manifest.files) return [];
-  const shippedSet = new Set(SHIPPED_FILES.map((f) => f.path));
+  const shippedSet = knownShippedFilePaths();
   const dropped: { path: string; region: string; shippedVersion: string }[] = [];
   for (const [path, entry] of Object.entries(manifest.files)) {
     if (shippedSet.has(path)) continue;

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -478,8 +478,19 @@ async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise<void> 
     }
   }
 
-  // Pass 1c: copy agent-config sources.
-  report.agentConfigsCopied = await installAgentConfigSources(dest, dryRun);
+  // Pass 1c: copy agent-config sources. `common.md` goes through the
+  // region-aware install path so a user-customised `## Specifics` survives;
+  // the per-agent fragments (`claude.md`, `kimi.md`) overwrite in full.
+  const agentInstall = await installAgentConfigSources({
+    dest,
+    shippedVersion,
+    force,
+    showDiff,
+    dryRun,
+    manifest,
+  });
+  report.agentConfigsCopied = agentInstall.copied;
+  if (agentInstall.commonOutcome) recordFileOutcome(report, agentInstall.commonOutcome);
 
   // Pass 2b: compile .agents/agents/ → per-target outputs (no-op if source tree isn't on disk).
   report.agentsMdCompiled = await compileAgentConfigs(dest, dryRun);


### PR DESCRIPTION
## Summary

- `condash skills install` was overwriting `.agents/agents/common.md` from the shipped template on every run, silently wiping the user-owned `## Specifics` section (per-conception Apps table, durable team rules). Reproduced on two laptops.
- This PR routes `common.md` through the same region-aware install path that already protects `.gitignore`, so only the `## General` region is hash-tracked and refreshed; `## Specifics` is preserved across reinstalls. `claude.md` and `kimi.md` keep the existing full-overwrite path — they have no `## Specifics` heading.
- Patch release (3.10.1).

## Changes

- `src/cli/commands/files.ts`: export `AGENT_CONFIG_COMMON` (a `ShippedFile` describing `.agents/agents/common.md` with `region: General`, `siblings: [Specifics]`). Refactor `installAgentConfigSources` to call `installShippedFile(AGENT_CONFIG_COMMON, …)` for `common.md` and skip it in the directory walk; the walk still does `claude.md` / `kimi.md`. New `knownShippedFilePaths()` helper unions `SHIPPED_FILES` with the agent-config common entry, used by status / prune so `common.md`’s manifest entry is not mistaken for stale source.
- `src/cli/commands/skills.ts`: pass full `FileInstallParams` (shippedVersion, force, showDiff, manifest) to `installAgentConfigSources`, and feed the returned `commonOutcome` through the existing `recordFileOutcome` reporter so the install report surfaces `common.md` alongside `.gitignore`.
- `src/cli/commands/files.install.test.ts`: add three regression tests — (1) customised `## Specifics` survives a reinstall and shows up in the compiled `.claude/CLAUDE.md` / `.kimi/AGENTS.md`; (2) a hand-edited `## General` is refused without `--force`; (3) `--prune` does not drop the new `common.md` manifest entry.
- `package.json` / `package-lock.json`: 3.10.0 → 3.10.1.

## Impact

- First reinstall after this lands records a fresh manifest entry for `.agents/agents/common.md` and is a no-op when the on-disk General region matches the shipped one. Conceptions whose users had their `## Specifics` previously wiped need to restore it manually first (e.g. `git checkout <last-good-sha> -- .agents/agents/common.md`); this PR does not auto-recover lost content, it only stops the bleeding.
- If a conception has been hand-edited inside `## General`, the next `condash skills install` will refuse the file with `reason: "edited since last install"` — opt-in `--force` to overwrite, same UX as `.gitignore` today.

## Watchpoints

- After 3.10.1 ships, re-run `condash skills install` in every active conception and confirm `## Specifics` survives. If `condash skills status` reports `.agents/agents/common.md` as `edited` unexpectedly, inspect the General region for accidental host-specific drift.