### PR TITLE
Surface AGENTS.md in Kimi skills tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.10.1",
+      "version": "3.10.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.10.1",
+  "version": "3.10.2",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/skills.test.ts
+++ b/src/main/skills.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { readSkillsTree } from './skills';
+import { readKimiSkillsTree, readSkillsTree } from './skills';
 
 let tmp: string;
 
@@ -124,5 +124,53 @@ describe('readSkillsTree', () => {
     const tree = (await readSkillsTree(tmp, '.claude/skills'))!;
     const claude = (tree.children ?? []).filter((c) => c.name === 'CLAUDE.md');
     expect(claude.length).toBe(0);
+  });
+});
+
+function setupKimiSkills(): void {
+  mkdirSync(join(tmp, '.kimi'));
+  mkdirSync(join(tmp, '.kimi', 'skills'));
+  mkdirSync(join(tmp, '.kimi', 'skills', 'projects'));
+  writeFileSync(
+    join(tmp, '.kimi', 'skills', 'projects', 'SKILL.md'),
+    '# Projects skill\n\nLead paragraph.\n',
+  );
+}
+
+describe('readKimiSkillsTree', () => {
+  it('returns null when the directory is missing', async () => {
+    const tree = await readKimiSkillsTree(tmp);
+    expect(tree).toBeNull();
+  });
+
+  it('injects synthetic AGENTS.md entries when present at the conception root', async () => {
+    setupKimiSkills();
+    writeFileSync(join(tmp, 'AGENTS.md'), '# Project AGENTS\n\nProject-level rules.\n');
+    writeFileSync(join(tmp, '.kimi', 'AGENTS.md'), '# Inner AGENTS\n\nKimi-dir rules.\n');
+    const tree = (await readKimiSkillsTree(tmp))!;
+    const agents = (tree.children ?? []).filter((c) => c.name === 'AGENTS.md');
+    // Both candidates surface, in stable order (root first, then `.kimi/`).
+    expect(agents.length).toBe(2);
+    expect(agents[0]?.title).toBe('Project AGENTS');
+    expect(agents[0]?.path).toContain('AGENTS.md');
+    expect(agents[0]?.relPath.startsWith('__kimi__/')).toBe(true);
+    expect(agents[1]?.title).toBe('Inner AGENTS');
+    expect(agents[1]?.relPath).toBe('__kimi__/.kimi/AGENTS.md');
+  });
+
+  it('skips AGENTS.md when neither location exists', async () => {
+    setupKimiSkills();
+    const tree = (await readKimiSkillsTree(tmp))!;
+    const agents = (tree.children ?? []).filter((c) => c.name === 'AGENTS.md');
+    expect(agents.length).toBe(0);
+  });
+
+  it('surfaces only the `.kimi/AGENTS.md` entry when the conception root lacks AGENTS.md', async () => {
+    setupKimiSkills();
+    writeFileSync(join(tmp, '.kimi', 'AGENTS.md'), '# Inner AGENTS\n\nKimi-dir rules.\n');
+    const tree = (await readKimiSkillsTree(tmp))!;
+    const agents = (tree.children ?? []).filter((c) => c.name === 'AGENTS.md');
+    expect(agents.length).toBe(1);
+    expect(agents[0]?.relPath).toBe('__kimi__/.kimi/AGENTS.md');
   });
 });

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -68,8 +68,11 @@ export async function readGenericSkillsTree(conceptionPath: string): Promise<Ski
 
 /**
  * Read the Kimi skills tree at `<conceptionPath>/.kimi/skills/`.
- * Same `.md`-only filter as `readSkillsTree`. No synthetic `CLAUDE.md`
- * injection. Uses `buildShippedLookup` on `.kimi/skills/`.
+ * Same `.md`-only filter as `readSkillsTree`. Injects synthetic
+ * root-level entries for `<conception>/AGENTS.md` and
+ * `<conception>/.kimi/AGENTS.md` when present — mirrors the
+ * `readSkillsTree` CLAUDE.md handling. Uses `buildShippedLookup` on
+ * `.kimi/skills/`.
  */
 export async function readKimiSkillsTree(conceptionPath: string): Promise<SkillNode | null> {
   const root = join(conceptionPath, '.kimi', 'skills');
@@ -79,7 +82,20 @@ export async function readKimiSkillsTree(conceptionPath: string): Promise<SkillN
     return null;
   }
   const shipped = await buildShippedLookup(root);
-  return walk(root, '', 'skills', new Set<string>(), shipped, root, /* acceptYaml */ false);
+  const tree = await walk(
+    root,
+    '',
+    'skills',
+    new Set<string>(),
+    shipped,
+    root,
+    /* acceptYaml */ false,
+  );
+  const agentsEntries = await readConceptionAgentsMd(conceptionPath);
+  if (agentsEntries.length > 0) {
+    tree.children = [...agentsEntries, ...(tree.children ?? [])];
+  }
+  return tree;
 }
 
 /**
@@ -100,10 +116,28 @@ export async function readSkillsTreeForTab(
  *  `relPath` is sentinel-prefixed (`__claude__/...`) so it can't collide with
  *  any real path inside the skills tree. */
 async function readConceptionClaudeMd(conceptionPath: string): Promise<SkillNode[]> {
-  const candidates: Array<{ rel: string; abs: string }> = [
+  return readConceptionAgentConfig(conceptionPath, [
     { rel: '__claude__/CLAUDE.md', abs: join(conceptionPath, 'CLAUDE.md') },
     { rel: '__claude__/.claude/CLAUDE.md', abs: join(conceptionPath, '.claude', 'CLAUDE.md') },
-  ];
+  ]);
+}
+
+/** Probe `<conceptionPath>/AGENTS.md` and `<conceptionPath>/.kimi/AGENTS.md`
+ *  and return synthetic SkillNode entries for whichever exist. The synthetic
+ *  `relPath` is sentinel-prefixed (`__kimi__/...`) so it can't collide with
+ *  any real path inside the skills tree. Mirrors `readConceptionClaudeMd`
+ *  for the Kimi tab. */
+async function readConceptionAgentsMd(conceptionPath: string): Promise<SkillNode[]> {
+  return readConceptionAgentConfig(conceptionPath, [
+    { rel: '__kimi__/AGENTS.md', abs: join(conceptionPath, 'AGENTS.md') },
+    { rel: '__kimi__/.kimi/AGENTS.md', abs: join(conceptionPath, '.kimi', 'AGENTS.md') },
+  ]);
+}
+
+async function readConceptionAgentConfig(
+  _conceptionPath: string,
+  candidates: ReadonlyArray<{ rel: string; abs: string }>,
+): Promise<SkillNode[]> {
   const found: SkillNode[] = [];
   for (const { rel, abs } of candidates) {
     try {
@@ -112,11 +146,12 @@ async function readConceptionClaudeMd(conceptionPath: string): Promise<SkillNode
     } catch {
       continue;
     }
-    const meta = await readMarkdownMeta(abs, 'CLAUDE.md');
+    const name = basename(abs);
+    const meta = await readMarkdownMeta(abs, name);
     found.push({
       relPath: rel,
       path: toPosix(abs),
-      name: 'CLAUDE.md',
+      name,
       title: meta.title,
       kind: 'file',
       summary: meta.summary,

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -14,6 +14,10 @@ import './skills-pane.css';
 // the Generic tab also accepts source-edit mutations. The Kimi tab is
 // read-only because its content is regenerated on every `condash skills
 // install` — see notes/02-design.md §Q1.
+//
+// Each compiled tab also surfaces the conception's agent-config file as a
+// synthetic root-level entry: CLAUDE.md on the Claude tab, AGENTS.md on
+// the Kimi tab (injected in src/main/skills.ts).
 const EDITABLE_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
 const READONLY_AFFORDANCES: ReadonlyArray<TreeAffordance> = [];
 
@@ -34,6 +38,14 @@ function isSkillIndex(node: SkillNode): boolean {
  *  skills root (`relPath` starts with the `__claude__/` sentinel). */
 function isClaudeMd(node: SkillNode): boolean {
   return node.kind === 'file' && node.name === 'CLAUDE.md';
+}
+
+/** Recognise a synthetic AGENTS.md entry injected by the main-process
+ *  skills walker for the Kimi tab. Carries `name === 'AGENTS.md'` and
+ *  lives only at the skills root (`relPath` starts with the `__kimi__/`
+ *  sentinel). */
+function isAgentsMd(node: SkillNode): boolean {
+  return node.kind === 'file' && node.name === 'AGENTS.md';
 }
 
 function isYamlSpec(node: SkillNode): boolean {
@@ -201,13 +213,16 @@ export function SkillsView(props: {
                 // CLAUDE.md only surfaces in the Claude tab at the root level
                 // (Generic and Kimi readers do not inject the synthetic entry).
                 if (dir.relPath === '' && props.tab === 'claude' && isClaudeMd(file)) return true;
+                // AGENTS.md mirrors CLAUDE.md but for the Kimi tab.
+                if (dir.relPath === '' && props.tab === 'kimi' && isAgentsMd(file)) return true;
                 // Compiled tabs surface SKILL.md inside skill subdirs.
                 if (props.tab !== 'generic' && dir.relPath !== '' && isSkillIndex(file))
                   return true;
                 return false;
               }}
               renderSpecialFile={(file, dir) => {
-                if (isClaudeMd(file)) {
+                if (isClaudeMd(file) || isAgentsMd(file)) {
+                  const badge = isClaudeMd(file) ? 'CLAUDE' : 'AGENTS';
                   return (
                     <button
                       type="button"
@@ -219,7 +234,7 @@ export function SkillsView(props: {
                       title={`Open ${file.path}`}
                       aria-label={`Open ${file.path}`}
                     >
-                      <span class="tree-special-badge">CLAUDE</span>
+                      <span class="tree-special-badge">{badge}</span>
                       <span class="tree-special-title">{file.title}</span>
                       <span class="tree-special-meta">{file.relPath}</span>
                     </button>


### PR DESCRIPTION
## Summary

- Skills pane injected synthetic CLAUDE.md root entries on the Claude tab but had no analogue on the Kimi tab, so the conception's AGENTS.md was unreachable from the pane.
- Mirror the Claude behaviour for AGENTS.md so both tabs surface their respective agent-config files at the root.
- Patch bump to 3.10.2.

## Changes

- `src/main/skills.ts`: `readKimiSkillsTree` now injects synthetic root entries for `<conception>/AGENTS.md` and `<conception>/.kimi/AGENTS.md` with the `__kimi__/` sentinel relPath. Extracted a shared `readConceptionAgentConfig` helper so the Claude and Kimi probes share one loop.
- `src/renderer/panes/skills.tsx`: `isAgentsMd` helper; `specialFile` predicate also accepts AGENTS.md at the Kimi tab root; `renderSpecialFile` renders an AGENTS badge identical in shape to the CLAUDE one.
- `src/main/skills.test.ts`: new `readKimiSkillsTree` describe block covering both-present, neither-present, and inner-only AGENTS.md cases.
- `package.json` / `package-lock.json`: version 3.10.1 → 3.10.2.

## Impact

- The Kimi tab now shows an AGENTS card at the root level when the conception ships an AGENTS.md (either at the root or under `.kimi/`). Existing Kimi installs without AGENTS.md are unaffected — the empty-state path still triggers.

## Watchpoints

- The synthetic relPath sentinel (`__kimi__/`) is excluded from real-file collisions the same way `__claude__/` is. If a user ever creates a real file under those sentinel names inside the skills tree, the renderer would render it with the special-file path; the existing CLAUDE.md handling carries the same constraint, so no new regression surface.