### PR TITLE
Extract AGENTS.md style guide to docs/reference

### DIFF
--- a/conception-template/.agents/agents/common.md
+++ b/conception-template/.agents/agents/common.md
@@ -8,10 +8,6 @@ This section is shipped by condash and refreshed by `condash skills install`. Ed
 
 ### Pointers
 
-- `/projects` — items + worktrees. Canonical rules: [`projects/SKILL.md`]({{ skills_dir }}projects/SKILL.md).
-- `/knowledge` — durable reference material. Canonical rules: [`knowledge/SKILL.md`]({{ skills_dir }}knowledge/SKILL.md).
-- `/pr` — project-aware GitHub PR opener. Canonical rules: [`pr/SKILL.md`]({{ skills_dir }}pr/SKILL.md).
-- `/skills` — pull condash-shipped skill updates. Canonical rules: [`skills/SKILL.md`]({{ skills_dir }}skills/SKILL.md).
 - Tree roots: [`projects/index.md`](projects/index.md), [`knowledge/index.md`](knowledge/index.md).
 - [`condash.json`](condash.json) — per-conception overrides read by condash. Top-level keys here replace the matching keys in `~/.config/condash/settings.json`. Legacy filename `configuration.json` is still read as a fallback.
 
@@ -20,52 +16,9 @@ This section is shipped by condash and refreshed by `condash skills install`. Ed
 - **Autonomy**: when the next action is obvious from context, proceed — don't ask. Ask when the call is genuinely ambiguous or the action is hard to reverse. Terse prompts like "redo now", "close it", "ship" are explicit permission to run end-to-end without per-step confirmation.
 - **Keep the project README live as you work**: every project under `projects/YYYY-MM/<slug>/` is the cold-recovery contract. The moment you start, finish, partially complete, or get blocked on a `## Steps` item, flip its marker (`[ ]` `[~]` `[x]` `[!]`); append a one-line dated timeline entry on each material event (decision, PR opened, blocker found); lift inline user answers from chat into `## Notes` or `notes/NN-…md`. Goal: if this session crashes or is interrupted right now, the next reader answers "what shipped, what's left, what's blocking" from the README alone. Don't batch updates to the end of a pass.
 
-### What `## Specifics` should contain
-
-`## Specifics` is per-conception — user-owned, never touched by `condash skills install`. Open it with the **Apps** table; everything below the table is durable team rules and workspace facts.
-
-#### Apps table — the always-in-context list of apps
-
-One row per app this conception covers. Columns:
-
-| Column        | Meaning                                                                                                                                                                                                                                       |
-|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **App**       | Logical name prefixed with `@` (e.g. `@alicepeintures.com`). The slug used in cross-references everywhere — knowledge files, project notes, skill docs. Pick once per app, lower-case, kebab-or-dot, matching the repo basename when possible. |
-| **Purpose**   | One line in plain English — what the app *is*. Lets a reader skim "what's in this conception" without opening anything.                                                                                                                       |
-| **Repo**      | Absolute path on this host (e.g. `~/src/<workspace>/<repo>`).                                                                                                                                                                                 |
-| **Config**    | Path to the app's own agent-config file (typically `<repo>/{{ agent_config }}`). Spell it out when it lives elsewhere.                                                                                                                        |
-| **Knowledge** | Path to the per-app knowledge entry-point in this conception (e.g. `knowledge/internal/<slug>.md`). The entry point is where deep details live — Config is the navigation layer.                                                              |
-
-Keep the table tight: navigation fields only. Operational config (formatter, port, base branch, …) belongs in `condash.json`, not here.
-
-#### Submodules — subpath by default, promote when warranted
-
-A submodule (or any sub-repo / sub-package within a parent app) is reachable as `@<parent>/<submodule>/<path>` by default — one row in the table for the parent, submodules treated as internal structure. Promote a submodule to its own row when it earns the navigation cost: it has its own `{{ agent_config }}`, its own `knowledge/internal/*.md` entry, or it's worked on in independent PR cycles.
-
-Naming for promoted submodules: bare `@<sub>` when the basename is unique workspace-wide; dotted `@<parent>.<sub>` (e.g. `@PaintingManager.app`) when the bare slug would collide with another app or another submodule.
-
-`condash.json`'s `submodules:` block is orthogonal — that block lists runnable targets for the dashboard (what `make dev` to invoke, what to force-stop). The Apps table is the human / agent navigation index. They can disagree without harm; align by intent, not by mirroring.
-
-#### Cross-references via `@<app>/<path>`
-
-Knowledge entries, project notes, and rule bodies refer to source code as `@<app>/<path-in-repo>` (e.g. `@<app>/src/server.ts:42`) instead of `~/src/<workspace>/<app>/...`. The `@` prefix makes references grep-friendly and decouples prose from any one host's filesystem layout — the Apps table is the only place the absolute path appears.
-
-When in doubt: an `@<name>/...` token is *always* an app reference; a path with no leading `@` is a path inside *this* conception (`projects/...`, `knowledge/...`, `condash.json`).
-
-#### Rules
-
-After the Apps table, add durable team rules — anything an agent should always know about this workspace. Each rule:
-
-- Lives under a `### <imperative title>` heading.
-- Has body bullets describing *what to do*.
-- Carries one **Why:** sentence explaining the rationale (so an agent can judge edge cases).
-- Optionally a **How to apply:** sentence for when the rule kicks in.
-
-Group rules under `### ` topical headings (e.g. `### Repo workflow`, `### Legal / privacy`) when the file gets long. Stable by design — no verification stamps; rules either live or get deleted.
-
 ## Specifics
 
-The general section above is shipped by condash and applies to every conception. Add rules below that are specific to this conception. Start with the **Apps** table (one row per app — see the schema in `## General`), then add durable rules grouped under `### ` headings.
+The general section above is shipped by condash and applies to every conception. Add rules below that are specific to this conception. Start with the **Apps** table, then add durable rules grouped under `### ` headings. See the condash docs for the full style guide.
 
 | App                  | Purpose                       | Repo                                | Config                       | Knowledge                          |
 |----------------------|-------------------------------|-------------------------------------|------------------------------|------------------------------------|

--- a/conception-template/.agents/agents/common.md
+++ b/conception-template/.agents/agents/common.md
@@ -18,7 +18,7 @@ This section is shipped by condash and refreshed by `condash skills install`. Ed
 
 ## Specifics
 
-The general section above is shipped by condash and applies to every conception. Add rules below that are specific to this conception. Start with the **Apps** table, then add durable rules grouped under `### ` headings. See the condash docs for the full style guide.
+The general section above is shipped by condash and applies to every conception. Add rules below that are specific to this conception. Start with the **Apps** table (one row per app: App · Purpose · Repo · Config · Knowledge), then add durable rules grouped under `### ` headings. Full style guide: <https://condash.vcoeur.com/reference/agents-md-style/>.
 
 | App                  | Purpose                       | Repo                                | Config                       | Knowledge                          |
 |----------------------|-------------------------------|-------------------------------------|------------------------------|------------------------------------|

--- a/docs/reference/agents-md-style.md
+++ b/docs/reference/agents-md-style.md
@@ -1,0 +1,51 @@
+---
+title: AGENTS.md style guide · condash reference
+description: How to write the per-conception ## Specifics section and durable team rules in an AGENTS.md file.
+---
+
+# AGENTS.md style guide
+
+> **Audience.** Conception maintainers — anyone who edits the `AGENTS.md` at the root of a conception tree.
+
+Every conception has an `AGENTS.md` file. The `## General` section is shipped by condash and overwritten on every `condash skills install`. Everything under `## Specifics` is yours — it describes the apps, repositories, and team rules for this workspace.
+
+This guide covers the shape of `## Specifics`.
+
+## Apps table
+
+Open `## Specifics` with the **Apps** table — one row per app the conception covers.
+
+| Column | Meaning |
+|---|---|
+| **App** | Logical name prefixed with `@` (e.g. `@alicepeintures.com`). Lower-case, kebab-or-dot, matching the repo basename when possible. The slug used in cross-references everywhere. |
+| **Purpose** | One line in plain English — what the app *is*. Lets a reader skim "what's in this conception" without opening anything. |
+| **Repo** | Absolute path on this host (e.g. `~/src/<workspace>/<repo>`). |
+| **Config** | Path to the app's own agent-config file (typically `<repo>/AGENTS.md`). Spell it out when it lives elsewhere. |
+| **Knowledge** | Path to the per-app knowledge entry-point in this conception (e.g. `knowledge/internal/<slug>.md`). The entry point is where deep details live — Config is the navigation layer. |
+
+Keep the table tight: navigation fields only. Operational config (formatter, port, base branch, …) belongs in `condash.json`, not here.
+
+### Submodules
+
+A submodule (or any sub-repo / sub-package within a parent app) is reachable as `@<parent>/<submodule>/<path>` by default — one row in the table for the parent, submodules treated as internal structure. Promote a submodule to its own row when it earns the navigation cost: it has its own `AGENTS.md`, its own `knowledge/internal/*.md` entry, or it's worked on in independent PR cycles.
+
+Naming for promoted submodules: bare `@<sub>` when the basename is unique workspace-wide; dotted `@<parent>.<sub>` (e.g. `@PaintingManager.app`) when the bare slug would collide with another app or another submodule.
+
+`condash.json`'s `submodules:` block is orthogonal — that block lists runnable targets for the dashboard (what `make dev` to invoke, what to force-stop). The Apps table is the human / agent navigation index. They can disagree without harm; align by intent, not by mirroring.
+
+### Cross-references via `@<app>/<path>`
+
+Knowledge entries, project notes, and rule bodies refer to source code as `@<app>/<path-in-repo>` (e.g. `@<app>/src/server.ts:42`) instead of `~/src/<workspace>/<app>/...`. The `@` prefix makes references grep-friendly and decouples prose from any one host's filesystem layout — the Apps table is the only place the absolute path appears.
+
+When in doubt: an `@<name>/...` token is *always* an app reference; a path with no leading `@` is a path inside *this* conception (`projects/...`, `knowledge/...`, `condash.json`).
+
+## Rules
+
+After the Apps table, add durable team rules — anything an agent should always know about this workspace. Each rule:
+
+- Lives under a `### <imperative title>` heading.
+- Has body bullets describing *what to do*.
+- Carries one **Why:** sentence explaining the rationale (so an agent can judge edge cases).
+- Optionally a **How to apply:** sentence for when the rule kicks in.
+
+Group rules under `### ` topical headings (e.g. `### Repo workflow`, `### Legal / privacy`) when the file gets long. Stable by design — no verification stamps; rules either live or get deleted.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -16,6 +16,7 @@ Short pages, one per surface. Look things up here; learn them in **[Get started]
 - [Keyboard shortcuts](shortcuts.md) — dashboard and terminal.
 - [README format](readme-format.md) — header fields and rules.
 - [Status, steps, deliverables](conception-convention.md) — the content-level conventions.
+- [AGENTS.md style guide](agents-md-style.md) — how to write the per-conception `## Specifics` section.
 
 **Advanced**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.10.2",
+      "version": "3.10.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.10.2",
+  "version": "3.10.3",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- The `## General` section of every conception's `AGENTS.md` is regenerated from a condash template on every `condash skills install`. Every byte in that template is repeated in every agent prompt.
- The `### What ## Specifics should contain` subsection and the per-skill `### Pointers` entries are reference material that agents don't need at runtime (skills self-describe, and the style guide is for humans maintaining the file).

## Changes

- Remove `### What ## Specifics should contain` from `conception-template/.agents/agents/common.md`.
- Trim `### Pointers` to non-obvious entries only: tree roots and `condash.json`. Drop the per-skill listings.
- Add `docs/reference/agents-md-style.md` with the relocated style guide: Apps table schema, submodules guidance, cross-reference conventions, and rule format.
- Link the new doc from `docs/reference/index.md`.
- Update the `## Specifics` intro in the template to point to the docs instead of embedding the schema.
- Bump version to 3.10.3.

## Impact

- Every conception's agent prompt shrinks by ~40 lines after the next `condash skills install`.
- Human editors can still look up the full style guide in the condash docs.