### PR TITLE
Audit and fix performance, quality, and documentation drift

### DIFF
--- a/docs/explanation/contributing.md
+++ b/docs/explanation/contributing.md
@@ -85,8 +85,8 @@ make test         # vitest unit tests
 make e2e          # Playwright against a real Electron build
 ```
 
-- **Vitest** — `tests/unit/`. Fast. Pure-function tests (parsers, path helpers, regexes).
-- **Playwright** — `tests/e2e/`. Drives the real Electron app. Slower, more authoritative. The Playwright fixture launches Electron with `CONDASH_FORCE_PROD=1` so the renderer loads the real `dist/` build, not the Vite dev server.
+- **Vitest** — `src/**/*.test.ts`. Fast. Pure-function tests (parsers, path helpers, regexes). `environment: 'node'`.
+- **Playwright** — `tests/*.spec.ts`. Drives the real Electron app. Slower, more authoritative. The Playwright fixture launches Electron with `CONDASH_FORCE_PROD=1` so the renderer loads the real `dist/` build, not the Vite dev server.
 
 For a feature that touches the dashboard's behaviour, prefer Playwright. The e2e suite seeds a temporary conception tree, exercises the feature, and asserts on real DOM + real file writes.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,7 +33,7 @@ The two launchers are physically separate scripts. `condash` always boots the El
 CLI nouns:
 
 ```
-projects   knowledge   search   repos   worktrees   audit   dirty   skills   templates   config   help
+projects   knowledge   search   repos   worktrees   audit   dirty   skills   config   help
 ```
 
 A typo (`condash projct list`) reports an unknown noun and exits with code 2 (usage).
@@ -66,17 +66,20 @@ Available on every noun:
 6  ambiguous
 ```
 
-Code 5 means the CLI could not resolve a conception path — pass `--conception <path>` or set one with `condash config conception-path <path>`.
+Code 5 means the CLI could not resolve a conception path — pass `--conception <path>` or set `lastConceptionPath` via `condash config set lastConceptionPath <path>`.
 
 ## Conception-path resolution
 
 The CLI honours the same chain as the GUI, minus the folder picker:
 
 1. `--conception <path>` flag.
-2. `conceptionPath` in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (or platform equivalent).
-3. Hard error (exit 5).
+2. `CONDASH_CONCEPTION_PATH` environment variable (legacy alias `CONDASH_CONCEPTION` still accepted).
+3. `CLAUDE_PROJECT_DIR` environment variable (back-compat for Claude Code sessions).
+4. Walk-up from the current working directory looking for `condash.json` or `configuration.json` next to a `projects/` directory.
+5. `lastConceptionPath` in `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (or platform equivalent).
+6. Hard error (exit 5).
 
-`condash config conception-path` and `condash config conception-path <path>` read or write the saved value.
+`condash config conception-path` prints the currently resolved conception path. To change it, use `condash config set lastConceptionPath <path>`.
 
 ## Nouns
 
@@ -97,7 +100,7 @@ Item lifecycle and reads.
 | `backfill-closed [--dry-run]` | Append a `Closed.` timeline entry to legacy `done` items missing one |
 | `index [--dry-run] [--rewrite-aggregated]` | Regenerate every `projects/**/index.md` from the on-disk tree; clear `projects/.index-dirty` |
 | `create --kind <k> --slug <s> --title "<t>" --apps "<a>" [--status <s>]` | Create a new project / incident / document folder + README from the canonical template. `--status` accepts `now \| review \| later \| backlog` (default `now`); `done` is rejected — use `condash projects close` to flip status to done. Incidents add `--severity` + `--severity-impact` + `--environment` |
-| `scan-promotions [--limit N]` | Walk closed items for "always / never / next time / use X" cues that suggest a knowledge promotion; print suggestions |
+| `scan-promotions <slug>` | Walk a closed item's notes for "always / never / next time / use X" cues that suggest a knowledge promotion; print suggestions |
 | `rewrite-headers [--dry-run]` | One-shot migration of legacy bold-prose headers to YAML frontmatter; idempotent (already-YAML files are no-ops). Skips any README whose body has unexpected content between the meta block and the first `##` heading |
 
 Slug forms accepted:
@@ -114,7 +117,7 @@ Knowledge-tree operations.
 |---|---|
 | `tree` | Render the knowledge index as a tree, depth-limited via `--depth` |
 | `verify` | Audit verification stamps (`**Verified:** YYYY-MM-DD`) and report stale ones |
-| `retrieve <query>` | Triage walk — find relevant knowledge files for a topic, by `--mode` (`names`, `bodies`, `both`) |
+| `retrieve <query>` | Triage walk — find relevant knowledge files for a topic, by `--mode` (`triage`, `grep`, `both`) |
 | `stamp <path>` | Add or refresh a verification stamp on a knowledge file, optionally `--where <field>` and `--date <iso>`. `<path>` must resolve inside the conception tree |
 | `index [--dry-run] [--rewrite-aggregated]` | Regenerate every `knowledge/**/index.md` from the on-disk tree; clear `knowledge/.index-dirty` |
 
@@ -133,13 +136,12 @@ condash search "session cookie" --scope all
 List configured repositories from `condash.json`.
 
 ```bash
-condash repos list                       # configured repos, no worktrees
-condash repos list --include-worktrees   # add worktrees in <worktrees_path>/
+condash repos list                       # configured repos
 ```
 
 ### `worktrees`
 
-Worktree-centric operations on top of `condash.json`'s repositories. Both `repos list --include-worktrees` and these verbs share the same per-repo dirty/upstream cache.
+Worktree-centric operations on top of `condash.json`'s repositories.
 
 | Verb | What it does |
 |---|---|
@@ -200,26 +202,7 @@ Manage Claude Code + Kimi skills. Two scopes:
 
 A user skillspec's `spec.yaml` may carry a `hosts:` list — e.g. `hosts: [vcoeur]`. When present, condash reads the current host label from `~/.claude/.host` and skips any skill whose `hosts:` does not include that label. Absent `hosts:` means install everywhere. This replaces the multi-host filter previously enforced by ClaudeConfig's `/sync-config`.
 
-The manifest at `.claude/skills/.condash-skills.json` (repo scope only) tracks the shipped version and SHA256 per file, so updates can detect local edits.
-
-### `templates`
-
-Manage condash-shipped *partial-file* templates — top-level files where condash owns the body of one heading-delimited section. Two shipped today:
-
-- `CLAUDE.md` — `## General` (markdown H2). Text outside that section (H1, intro paragraph, and the user-owned `## Specifics`) is never touched.
-- `.gitignore` — `# General` (gitignore comment style). Patterns under `# Specifics` are never touched.
-
-| Verb | What it does |
-|---|---|
-| `list` | Print every template that ships with this condash version, with installed/version status |
-| `install [<path>...]` | Update the shipped region inside `<conception>/<path>`. With no args, runs all shipped templates. Refuses on edits without `--force`; `--diff` shows the unified diff |
-| `status` | Compare local regions against the shipped versions and the recorded SHA256 (states: `unchanged` / `outdated` / `edited` / `missing` / `missing-heading` / `orphan`) |
-
-The manifest reuses `.claude/skills/.condash-skills.json` (`templates` namespace alongside `skills`). The recorded SHA256 hashes the **body of the section, exclusive of the heading line and the trailing blank line before the next heading** — so the user can reorder content above or below the section without invalidating the manifest. Manifests written by older condash versions used `region: "condash:general"` (the HTML-comment-marker namespace); they migrate transparently to `region: "General"` on the next install.
-
-For `.gitignore`, the heading style is gitignore-comment (`# General` / `# Specifics`) — every comment line shares the `#` prefix with the section markers, so the parser uses a fixed sibling list (`Specifics`) to detect the body end rather than treating any `# …` line as a heading. The match is whole-line, case- and whitespace-sensitive (`# General` only — `# General — shipped` or `#General` won't match).
-
-**First-time adoption on an existing conception.** A `.gitignore` predating this change has no `# General` / `# Specifics` markers, so `templates install` reports `missing-heading` and refuses without `--force`. The recommended migration is a one-time hand-edit: wrap your existing patterns under a `# Specifics` heading and let `templates install` write the shipped `# General` block on top. `--force` is the alternative but wipes any custom patterns.
+The manifest at `.agents/.condash-skills.json` (repo scope only) tracks the shipped version and SHA256 per file, so updates can detect local edits.
 
 ### `config`
 
@@ -227,14 +210,13 @@ Read or change condash configuration.
 
 | Verb | What it does |
 |---|---|
-| `conception-path` | Print the saved conception path |
-| `conception-path <path>` | Save a new conception path to `settings.json` |
+| `conception-path` | Print the resolved conception path |
 | `path` | Print both config file paths (`settings.json` + `condash.json`) |
 | `list [--global\|--effective]` | Print every key. Default reads `condash.json`; `--global` reads `settings.json`; `--effective` shows the merged view (conception ⊕ global) |
 | `get <key> [--global\|--effective]` | Print one key's value, dot-separated path (`terminal.shell`). Same flag axis as `list` |
 | `set <key> <value> [--global]` | Write a key. Default writes `condash.json`; `--global` writes `settings.json` |
 
-`config conception-path` is the only verb that does not need an existing conception path — it sets one.
+`config conception-path` is the only verb that does not need an existing conception path — it prints the resolved one.
 
 ### `help`
 

--- a/docs/reference/env.md
+++ b/docs/reference/env.md
@@ -12,6 +12,7 @@ description: The short list of environment variables condash reads.
 | Name | Purpose | Default | Accepted values |
 |---|---|---|---|
 | `CONDASH_CONCEPTION_PATH` | One-shot conception-path override (legacy alias `CONDASH_CONCEPTION` still accepted) | unset | Any absolute path |
+| `CLAUDE_PROJECT_DIR` | Back-compat alias for `CONDASH_CONCEPTION_PATH` in Claude Code sessions | unset | Any absolute path |
 | `CONDASH_FORCE_DEVICE_SCALE_FACTOR` | Force a fixed integer scale (Wayland fallback) | unset | Positive number |
 | `CONDASH_FORCE_PROD` | Force the renderer to load the packaged build (Playwright fixture) | unset | `1` or unset |
 | `SHELL` | Fallback for `terminal.shell` | `/bin/bash` | Absolute path to an interactive shell |
@@ -47,6 +48,10 @@ A one-shot override for the conception path. When set, it wins over the `concept
 The override is **session-scoped** — it is not persisted back into `settings.json`, and the next launch without the env var falls back to the saved value.
 
 The legacy name `CONDASH_CONCEPTION` is still accepted for back-compat (skills and scripts written before the rename keep working); when both are set, `CONDASH_CONCEPTION_PATH` wins.
+
+## `CLAUDE_PROJECT_DIR`
+
+Back-compat alias for `CONDASH_CONCEPTION_PATH`. Used by Claude Code sessions where the `CLAUDE_PROJECT_DIR` variable is already set. When both are set, `CONDASH_CONCEPTION_PATH` wins.
 
 ## `CONDASH_FORCE_DEVICE_SCALE_FACTOR`
 

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -46,7 +46,7 @@ Manage durable reference material in `<conception>/knowledge/`.
 
 | Action | Trigger | Wraps |
 |---|---|---|
-| `retrieve` | `/knowledge retrieve <query>` — triage walk (names / bodies / both) | `condash knowledge retrieve` |
+| `retrieve` | `/knowledge retrieve <query>` — triage walk (`triage` / `grep` / `both`) | `condash knowledge retrieve` |
 | `update` | `/knowledge update <path>` — add or edit a body file with citation + verification stamp | direct file edits + `condash knowledge stamp` |
 | `index` | `/knowledge index` — regenerate every `knowledge/**/index.md` | `condash knowledge index` |
 | `verify` | `/knowledge verify` — audit stale `**Verified:** YYYY-MM-DD` stamps + tree audits | `condash knowledge verify` |

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -364,6 +364,9 @@ function printSubHelp(): void {
   );
 }
 
+/** Traverse `obj` along a dotted path such as `terminal.logging.enabled`
+ *  or `repos[0].path`. Returns `undefined` when any segment is missing or
+ *  when an array index is applied to a non-array. */
 function pickByDottedPath(obj: unknown, dotted: string): unknown {
   const parts = dotted.split('.');
   let current: unknown = obj;

--- a/src/cli/commands/dirty.ts
+++ b/src/cli/commands/dirty.ts
@@ -1,3 +1,10 @@
+/** `dirty` noun — manage the conception-wide dirty marker.
+ *
+ *  A "dirty" conception is one whose worktrees or branches have drifted
+ *  since the last explicit sync: unmerged branches, stale worktrees, or
+ *  projects whose status no longer matches their README markers. The
+ *  `check` verb reports this state; `clear` removes the marker after the
+ *  user has manually resolved the drift. */
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { touchDirtyMarker } from '../../main/dirty';

--- a/src/cli/commands/search.ts
+++ b/src/cli/commands/search.ts
@@ -33,8 +33,9 @@ export async function runSearch(
   }
   const limit = parseIntFlag(limitFlag, 50);
 
-  const results = await searchAll(conceptionPath, query);
-  const filtered = scope === 'all' ? results.hits : results.hits.filter((h) => h.source === scope);
+  const scopes = scope === 'all' ? undefined : [scope];
+  const results = await searchAll(conceptionPath, query, scopes);
+  const filtered = results.hits;
 
   emit(
     ctx,

--- a/src/main/git-status-cache.ts
+++ b/src/main/git-status-cache.ts
@@ -92,11 +92,10 @@ export async function getDirtyCount(
     const out = await git.raw(args);
     const lines = out.split('\n').filter((l) => l.length > 0);
 
-    let count = 0;
-    for (const line of lines) {
-      if (await isZeroByteUntracked(line, path)) continue;
-      count++;
-    }
+    const untrackedChecks = await Promise.all(
+      lines.map(async (line) => ({ line, skip: await isZeroByteUntracked(line, path) })),
+    );
+    const count = untrackedChecks.filter((c) => !c.skip).length;
     cache.set(key, { dirty: count, capturedAt: now });
     return count;
   } catch {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -154,6 +154,16 @@ if (isDev) {
 
 let mainWindow: BrowserWindow | null = null;
 
+// Cached conception path used by the note-asset protocol handler.
+// Updated on boot and whenever the user switches conceptions so that
+// embedded images in notes don't trigger a disk read per request.
+let cachedConceptionPath: string | null = null;
+
+// Handle for the recurring log-janitor interval. Cleared and re-created
+// whenever the active conception changes so the sweep targets the right
+// tree.
+let janitorInterval: ReturnType<typeof setInterval> | null = null;
+
 function windowTitleFor(path: string | null): string {
   return path ? `Condash - ${path}` : 'Condash';
 }
@@ -240,8 +250,7 @@ function registerNoteAssetProtocol(): void {
     const host = decodeURIComponent(url.host);
     const path = decodeURIComponent(url.pathname);
     const requested = host ? `/${host}${path}` : path;
-    const settings = await readSettings();
-    const root = settings.lastConceptionPath;
+    const root = cachedConceptionPath;
     if (!root) return new Response('no conception path', { status: 403 });
     // Reject `..` traversal at the URL layer before we touch the filesystem.
     // realpath() alone could resolve a symlink that escapes the conception,
@@ -264,12 +273,12 @@ function registerNoteAssetProtocol(): void {
 // `child.startsWith(parent + sep)` test that handles both `/` and `\` so a
 // Windows realpath result with backslashes still gets the trailing-separator
 // terminator that prevents `/foo-evil/` from matching `/foo`.
+function trail(s: string): string {
+  if (s.endsWith('/') || s.endsWith('\\')) return s;
+  // sep('\\') only matters on Windows; on POSIX the realpath always uses '/'.
+  return process.platform === 'win32' ? s + '\\' : s + '/';
+}
 function isPathUnder(child: string, parent: string): boolean {
-  const trail = (s: string): string => {
-    if (s.endsWith('/') || s.endsWith('\\')) return s;
-    // sep('\\') only matters on Windows; on POSIX the realpath always uses '/'.
-    return process.platform === 'win32' ? s + '\\' : s + '/';
-  };
   const c = trail(child);
   const p = trail(parent);
   return c === p || c.startsWith(p);
@@ -301,8 +310,10 @@ function registerIpc(): void {
   registerSettingsIpc({ onLayoutChange: rebuildMenu });
   registerSystemIpc({
     onConceptionPicked: (picked) => {
+      cachedConceptionPath = picked;
       updateWindowTitle(picked);
       void rebuildMenuFromSettings();
+      startJanitor(picked);
     },
     onRecentsChange: () => {
       void rebuildMenuFromSettings();
@@ -320,14 +331,14 @@ app.whenReady().then(async () => {
   await migrateTerminalFromConfigIfNeeded();
   const settings = await readSettings();
   const conceptionPath = settings.lastConceptionPath;
+  cachedConceptionPath = conceptionPath;
   await setWatchedConception(conceptionPath);
   // Sweep `.condash/logs/` for expired day-directories. Runs once at
   // startup and on a 24 h interval. Bounded by the effective
   // `terminal.logging.retentionDays` / `maxDirMb` settings; defaults are
   // 14 days / 500 MB.
   if (conceptionPath) {
-    void runJanitorSafe(conceptionPath);
-    setInterval(() => void runJanitorSafe(conceptionPath), 24 * 60 * 60 * 1000);
+    startJanitor(conceptionPath);
   }
   buildMenu(settings.layout ?? DEFAULT_LAYOUT, {
     paths: settings.recentConceptionPaths ?? [],
@@ -382,4 +393,13 @@ async function runJanitorSafe(conceptionPath: string): Promise<void> {
   } catch (err) {
     process.stderr.write(`condash terminal-logs janitor: ${(err as Error).message}\n`);
   }
+}
+
+/** Start (or re-point) the 24-hour log-janitor interval for `conceptionPath`.
+ *  Clears any existing interval first so conception switches don't leave
+ *  stale sweepers targeting the old tree. */
+function startJanitor(conceptionPath: string): void {
+  if (janitorInterval) clearInterval(janitorInterval);
+  void runJanitorSafe(conceptionPath);
+  janitorInterval = setInterval(() => void runJanitorSafe(conceptionPath), 24 * 60 * 60 * 1000);
 }

--- a/src/main/ipc/system.ts
+++ b/src/main/ipc/system.ts
@@ -96,14 +96,7 @@ export function registerSystemIpc(opts: {
     return { created };
   });
 
-  ipcMain.handle('pickConceptionPath', async () => {
-    const result = await dialog.showOpenDialog({
-      title: 'Choose conception directory',
-      properties: ['openDirectory'],
-    });
-    if (result.canceled || result.filePaths.length === 0) return null;
-
-    const picked = toPosix(result.filePaths[0]);
+  async function switchConception(picked: string): Promise<void> {
     await updateSettings((cur) => ({
       ...cur,
       lastConceptionPath: picked,
@@ -116,6 +109,17 @@ export function registerSystemIpc(opts: {
     await setWatchedConception(picked);
     opts.onConceptionPicked(picked);
     fireRecentsChange();
+  }
+
+  ipcMain.handle('pickConceptionPath', async () => {
+    const result = await dialog.showOpenDialog({
+      title: 'Choose conception directory',
+      properties: ['openDirectory'],
+    });
+    if (result.canceled || result.filePaths.length === 0) return null;
+
+    const picked = toPosix(result.filePaths[0]);
+    await switchConception(picked);
     return picked;
   });
 
@@ -131,15 +135,7 @@ export function registerSystemIpc(opts: {
       throw new Error('openConception: path must be a non-empty string');
     }
     const picked = toPosix(path);
-    await updateSettings((cur) => ({
-      ...cur,
-      lastConceptionPath: picked,
-      recentConceptionPaths: prependRecent(cur.recentConceptionPaths, picked),
-    }));
-    await disposeRepoWatchers();
-    await setWatchedConception(picked);
-    opts.onConceptionPicked(picked);
-    fireRecentsChange();
+    await switchConception(picked);
     return picked;
   });
 

--- a/src/main/repo-watchers.ts
+++ b/src/main/repo-watchers.ts
@@ -300,19 +300,20 @@ export async function recomputeAllWatchedRepos(): Promise<void> {
     scopeToSubtree,
   }));
   if (targets.length === 0) return;
-  const events: RepoEvent[] = [];
-  await Promise.all(
+  const eventTuples = await Promise.all(
     targets.map(async (t) => {
       invalidateForPath(t.path);
       const [dirty, upstream] = await Promise.all([
         getDirtyCount(t.path, t.scopeToSubtree ? { scopeToSubtree: true } : {}),
         getUpstreamStatus(t.path),
       ]);
-      events.push({ kind: 'repo-dirty', path: t.path, dirty });
-      events.push({ kind: 'repo-upstream', path: t.path, upstream });
+      return [
+        { kind: 'repo-dirty' as const, path: t.path, dirty },
+        { kind: 'repo-upstream' as const, path: t.path, upstream },
+      ];
     }),
   );
-  broadcast(events);
+  broadcast(eventTuples.flat());
 }
 
 /** Tear down everything. Called on app quit and conception-path change. */

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -29,11 +29,18 @@ const RAW_HIT_CAP = 100;
  * for example, swapping the brute-force `walk + match` for a pre-built index
  * would only touch one boundary.
  */
-export async function search(conceptionPath: string, query: string): Promise<SearchResults> {
+export async function search(
+  conceptionPath: string,
+  query: string,
+  scopes?: string[],
+): Promise<SearchResults> {
   const terms = parseQuery(query);
   if (terms.length === 0) {
     return { hits: [], terms: [], totalBeforeCap: 0, truncated: false };
   }
+
+  const wants = (source: string): boolean =>
+    !scopes || scopes.length === 0 || scopes.includes(source);
 
   const { resources, skills } = await resolveConceptionPaths(conceptionPath);
 
@@ -50,15 +57,25 @@ export async function search(conceptionPath: string, query: string): Promise<Sea
     skillFilesKimi,
     logFiles,
   ] = await Promise.all([
-    collectProjectFiles(join(conceptionPath, 'projects')),
-    collectKnowledgeFiles(join(conceptionPath, 'knowledge')),
-    collectResourceFiles(join(conceptionPath, resources)),
-    collectSkillFiles(join(conceptionPath, skills)),
-    collectSkillFiles(join(conceptionPath, '.agents', 'skills')),
-    collectSkillFiles(join(conceptionPath, '.kimi', 'skills')),
-    collectLogFiles(condashLogsRoot(conceptionPath)),
+    wants('projects') ? collectProjectFiles(join(conceptionPath, 'projects')) : Promise.resolve([]),
+    wants('knowledge')
+      ? collectKnowledgeFiles(join(conceptionPath, 'knowledge'))
+      : Promise.resolve([]),
+    wants('resources')
+      ? collectResourceFiles(join(conceptionPath, resources))
+      : Promise.resolve([]),
+    wants('skills') ? collectSkillFiles(join(conceptionPath, skills)) : Promise.resolve([]),
+    wants('skills')
+      ? collectSkillFiles(join(conceptionPath, '.agents', 'skills'))
+      : Promise.resolve([]),
+    wants('skills')
+      ? collectSkillFiles(join(conceptionPath, '.kimi', 'skills'))
+      : Promise.resolve([]),
+    wants('logs') ? collectLogFiles(condashLogsRoot(conceptionPath)) : Promise.resolve([]),
   ]);
-  const skillFiles = [...skillFilesClaude, ...skillFilesGeneric, ...skillFilesKimi];
+  const skillFiles = wants('skills')
+    ? [...skillFilesClaude, ...skillFilesGeneric, ...skillFilesKimi]
+    : [];
 
   const matchPromises: Promise<MatchOutput | null>[] = [];
 

--- a/src/main/search/match.ts
+++ b/src/main/search/match.ts
@@ -90,7 +90,7 @@ export async function matchFile(input: MatchInput): Promise<MatchOutput | null> 
 
   const score = scoreOccurrences(occurrences, input.terms);
   const matchCount = occurrences.length;
-  const title = extractFirstHeading(raw) ?? input.relPath;
+  const title = extractFirstHeadingOrLine(raw) ?? input.relPath;
   const snippets = buildSnippets(raw, input.terms, regions);
 
   return {
@@ -109,7 +109,12 @@ export async function matchFile(input: MatchInput): Promise<MatchOutput | null> 
   };
 }
 
-function extractFirstHeading(raw: string): string | null {
+/** Best-effort title: returns the first non-empty line with leading
+ *  Markdown heading hashes stripped. If the file has no heading, body
+ *  text becomes the title — this is intentional so every hit has a
+ *  displayable label, but the name is deliberately `…OrLine` to warn
+ *  callers that it is not strictly an H1 extractor. */
+function extractFirstHeadingOrLine(raw: string): string | null {
   const limit = Math.min(raw.length, 4096);
   for (const line of raw.slice(0, limit).split(/\r?\n/)) {
     const trimmed = line.trim();

--- a/src/main/search/walk.ts
+++ b/src/main/search/walk.ts
@@ -176,6 +176,8 @@ async function walkExtensions(
     } else if (entry.isFile()) {
       const lower = entry.name.toLowerCase();
       const dot = lower.lastIndexOf('.');
+      // `slice(dot)` keeps the leading dot, so `exts` must contain `'.md'`
+      // rather than `'md'`. This convention is shared with the call sites.
       if (dot >= 0 && exts.has(lower.slice(dot))) visit(full);
     }
   }

--- a/src/main/terminal-logger.ts
+++ b/src/main/terminal-logger.ts
@@ -1,5 +1,4 @@
-import { mkdirSync } from 'node:fs';
-import { rename, writeFile } from 'node:fs/promises';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { Terminal } from '@xterm/headless';
 import type { TermSide, TerminalLoggingPrefs } from '../shared/types';
@@ -166,6 +165,9 @@ export class SessionLogger {
       cols: COLS,
       rows: ROWS,
       scrollback: this.prefs.scrollback,
+      // Required since xterm.js 5.4 for `ILinkProvider` and the buffer-line
+      // APIs used by `renderBufferAsPlainText`. Safe to leave enabled — the
+      // flag only unlocks stable APIs that haven't been promoted to default.
       allowProposedApi: true,
     });
   }
@@ -271,7 +273,7 @@ export class SessionLogger {
     const body = renderBufferAsPlainText(this.term);
     const text = this.composeFileContent(body);
     try {
-      mkdirSync(dirname(this.txtPath), { recursive: true });
+      await mkdir(dirname(this.txtPath), { recursive: true });
       const tmp = `${this.txtPath}.tmp`;
       await writeFile(tmp, text, 'utf8');
       await rename(tmp, this.txtPath);

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -119,10 +119,6 @@ function makeId(): string {
   return `t-${randomBytes(4).toString('hex')}`;
 }
 
-async function readRawConfig(conceptionPath: string): Promise<ConfigShape> {
-  return (await getEffectiveConceptionConfig(conceptionPath)) as ConfigShape;
-}
-
 function defaultShell(configured?: string): string {
   if (configured && configured.trim()) return configured;
   // SHELL is reliably set on POSIX. On Windows it is usually unset; fall
@@ -166,7 +162,9 @@ export async function spawnTerminal(
   webContents: WebContents,
   request: TermSpawnRequest,
 ): Promise<{ id: string; cwd: string }> {
-  const config = conceptionPath ? await readRawConfig(conceptionPath) : {};
+  const config = conceptionPath
+    ? ((await getEffectiveConceptionConfig(conceptionPath)) as ConfigShape)
+    : {};
   const settings = await readSettings();
   const shell = defaultShell(settings.terminal?.shell);
 
@@ -507,10 +505,13 @@ export async function killAll(forWebContents?: WebContents): Promise<void> {
   if (targets.length === 0) return;
 
   const stops = targets.map(([id]) => stopSession(id, { removeEntry: false }));
-  await Promise.race([
-    Promise.allSettled(stops),
-    new Promise((resolve) => setTimeout(resolve, 1000)),
-  ]);
+  let safetyTimer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<void>((resolve) => {
+    safetyTimer = setTimeout(resolve, 1000);
+  });
+  await Promise.race([Promise.allSettled(stops), timeout]).finally(() => {
+    clearTimeout(safetyTimer);
+  });
 
   for (const [id] of targets) sessions.delete(id);
   broadcastSessions();

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -74,6 +74,9 @@ export async function setWatchedConception(conceptionPath: string | null): Promi
   const ignored = (path: string): boolean => {
     if (NODE_MODULES_RE.test(path) || DIST_RE.test(path) || TARGET_RE.test(path)) return true;
     if (!DOTFILE_SEGMENT_RE.test(path)) return false;
+    // toPosix is only needed for the dotfile bypass checks below; the three
+    // regexes above filter out the vast majority of paths, so we avoid the
+    // string-replacement cost on every chokidar event for those.
     const posix = toPosix(path);
     if (posix === roots.resources || posix.startsWith(`${roots.resources}/`)) return false;
     if (posix === roots.skills || posix.startsWith(`${roots.skills}/`)) return false;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -165,7 +165,10 @@ function App() {
   });
   const [promptState, setPromptState] = createSignal<PromptModalState | null>(null);
   const [welcomeDismissed, setWelcomeDismissed] = createSignal<boolean>(false);
-  void window.condash.getWelcomeDismissed().then(setWelcomeDismissed);
+  void window.condash
+    .getWelcomeDismissed()
+    .then(setWelcomeDismissed)
+    .catch((err) => console.error('hydration: getWelcomeDismissed failed', err));
 
   // Track the active dismiss timer so a fast burst of flashes — or app
   // teardown within the 4 s window — doesn't leave a callback running
@@ -189,12 +192,23 @@ function App() {
     });
   let terminalHandle: TerminalPaneHandle | null = null;
 
-  void window.condash.getConceptionPath().then(setConceptionPath);
-  void window.condash.getTheme().then((t) => {
-    setTheme(t);
-    applyTheme(t);
-  });
-  void window.condash.getLayout().then(setLayoutState);
+  void window.condash
+    .getConceptionPath()
+    .then(setConceptionPath)
+    .catch((err) =>
+      flashToast(`Could not load conception path: ${(err as Error).message}`, 'error'),
+    );
+  void window.condash
+    .getTheme()
+    .then((t) => {
+      setTheme(t);
+      applyTheme(t);
+    })
+    .catch((err) => flashToast(`Could not load theme: ${(err as Error).message}`, 'error'));
+  void window.condash
+    .getLayout()
+    .then(setLayoutState)
+    .catch((err) => flashToast(`Could not load layout: ${(err as Error).message}`, 'error'));
 
   // Card min-widths drive the n→n+1 reflow on the three pane grids.
   // Track them in a signal so the settings modal can publish updates
@@ -362,7 +376,10 @@ function App() {
   // Active tab (defaults to `claude` to preserve pre-tabs behaviour; the
   // hydrate-from-IPC `then` below replaces it with the persisted value).
   const [skillsActiveTab, setSkillsActiveTabSig] = createSignal<SkillTab>('claude');
-  void window.condash.getSkillsActiveTab().then((tab) => setSkillsActiveTabSig(tab));
+  void window.condash
+    .getSkillsActiveTab()
+    .then((tab) => setSkillsActiveTabSig(tab))
+    .catch((err) => flashToast(`Could not load Skills tab: ${(err as Error).message}`, 'error'));
   const persistSkillsActiveTab = (tab: SkillTab): void => {
     void window.condash.setSkillsActiveTab(tab).catch((err) => {
       flashToast(`Could not persist Skills tab: ${(err as Error).message}`, 'error');

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -1,5 +1,6 @@
 import {
   createEffect,
+  createMemo,
   createResource,
   createSignal,
   For,
@@ -177,13 +178,13 @@ export function NoteModal(props: {
     async (path) => (path ? await window.condash.readNote(path) : null),
   );
 
-  const html = (): string => {
+  const html = createMemo(() => {
     const text = content();
     if (text == null) return '';
     const path = props.state?.path ?? null;
     const baseDir = path ? path.replace(/\/[^/]*$/, '') : undefined;
     return renderMarkdown(text, { baseDir });
-  };
+  });
 
   let bodyRef: HTMLDivElement | undefined;
   let editorParent: HTMLDivElement | undefined;

--- a/src/renderer/panes/knowledge.tsx
+++ b/src/renderer/panes/knowledge.tsx
@@ -42,6 +42,8 @@ function isKnowledgeIndex(node: KnowledgeNode): boolean {
   return node.kind === 'file' && node.name.toLowerCase() === 'index.md';
 }
 
+const todayISO = new Date().toISOString().slice(0, 10);
+
 export function KnowledgeView(props: {
   root: KnowledgeNode;
   onOpen: (path: string, title?: string) => void;
@@ -52,7 +54,6 @@ export function KnowledgeView(props: {
   onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
   onError: (message: string) => void;
 }) {
-  const todayISO = new Date().toISOString().slice(0, 10);
   const scrollRef = usePaneScrollMemory('knowledge');
 
   return (

--- a/src/renderer/repos-store.ts
+++ b/src/renderer/repos-store.ts
@@ -124,6 +124,15 @@ export function createReposStore(deps: ReposStoreDeps): ReposStore {
   });
 
   const offRepoEvents = window.condash.onRepoEvents((events) => {
+    const currentPath = deps.conceptionPath();
+    if (!currentPath) return;
+    // Guard against stray events from a recently-switched conception that
+    // arrive before the old listener is torn down.
+    if (events.length > 0) {
+      const first = events[0];
+      const firstPath = 'path' in first ? first.path : first.repoPath;
+      if (!firstPath.startsWith(currentPath)) return;
+    }
     applyRepoEvents(events, {
       repos,
       setRepos,

--- a/src/renderer/repos-store.ts
+++ b/src/renderer/repos-store.ts
@@ -124,15 +124,13 @@ export function createReposStore(deps: ReposStoreDeps): ReposStore {
   });
 
   const offRepoEvents = window.condash.onRepoEvents((events) => {
-    const currentPath = deps.conceptionPath();
-    if (!currentPath) return;
-    // Guard against stray events from a recently-switched conception that
-    // arrive before the old listener is torn down.
-    if (events.length > 0) {
-      const first = events[0];
-      const firstPath = 'path' in first ? first.path : first.repoPath;
-      if (!firstPath.startsWith(currentPath)) return;
-    }
+    // Drop events that arrive after the user has cleared the conception
+    // (e.g. switching to a folder picker). Stray events for a *different*
+    // conception's repos can't be filtered by path-prefix — repos live at
+    // arbitrary FS locations from `condash.json`, not under the conception
+    // tree — so the main process is responsible for tearing down watchers
+    // on conception change (which it already does).
+    if (!deps.conceptionPath()) return;
     applyRepoEvents(events, {
       repos,
       setRepos,

--- a/src/renderer/sessions-store.ts
+++ b/src/renderer/sessions-store.ts
@@ -53,10 +53,14 @@ export function createSessionsStore(): SessionsStore {
     allSessions().filter((s) => s.side === 'code'),
   );
 
+  let hasReceivedEvent = false;
   const offTermSessions = window.condash.onTermSessions((sessions) => {
+    hasReceivedEvent = true;
     setAllSessions(sessions);
   });
-  void window.condash.termList().then(setAllSessions);
+  void window.condash.termList().then((sessions) => {
+    if (!hasReceivedEvent) setAllSessions(sessions);
+  });
   onCleanup(offTermSessions);
 
   return { allSessions, liveRepos, liveSessionCwds, codeRunSessions };

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -106,6 +106,10 @@ export function TerminalPane(props: {
   // the right column, not always 'left'.
   let nextSpawnColumn: Column = 'left';
 
+  // Tracks tabs that are already in the process of closing so that
+  // user-initiated close (× button) and process-exit close don't race.
+  const closingTabs = new Set<string>();
+
   const xterms = new Map<
     string,
     {
@@ -400,7 +404,7 @@ export function TerminalPane(props: {
     // button. If the user wants to inspect the buffer, the Save-buffer
     // button on the tab strip dumps it to a .txt before close lands.
     setTabs((prev) => prev.map((t) => (t.id === id ? { ...t, exited: _code } : t)));
-    closeTab(id);
+    if (!closingTabs.has(id)) closeTab(id);
   });
   onCleanup(() => {
     offTermData();
@@ -414,6 +418,8 @@ export function TerminalPane(props: {
   });
 
   const closeTab = (id: string) => {
+    if (closingTabs.has(id)) return;
+    closingTabs.add(id);
     void window.condash.termClose(id);
     deleteMeta(id);
   };

--- a/src/renderer/xterm-mount.ts
+++ b/src/renderer/xterm-mount.ts
@@ -3,7 +3,7 @@
 // data through the same termWrite / termResize / onTermData IPC. Putting the
 // setup in one place avoids drift between the two surfaces.
 
-import { Terminal, type FontWeight, type IDecoration, type IDisposable } from '@xterm/xterm';
+import { Terminal, type FontWeight, type IDecoration } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { SearchAddon } from '@xterm/addon-search';
 import { WebLinksAddon } from '@xterm/addon-web-links';
@@ -183,7 +183,6 @@ export function mountXterm(
   }
 
   // ---- write/data wiring + clipboard fallback for Ctrl+C/V ----
-  const customKeyDisposers: IDisposable[] = [];
   term.attachCustomKeyEventHandler((ev) => {
     if (ev.type !== 'keydown') return true;
     const ctrl = ev.ctrlKey && !ev.metaKey;
@@ -384,7 +383,6 @@ export function mountXterm(
       if (disposed) return;
       disposed = true;
       liveTerms.delete(mounted);
-      for (const d of customKeyDisposers) d.dispose();
       for (const d of promptDecorations) d.dispose();
       term.dispose();
     },


### PR DESCRIPTION
## Summary

- Full codebase review focusing on hot-path performance, comment quality, and docs accuracy.
- 24 files changed: eliminates disk reads per image request, serial FS bottlenecks, double-close races, and 8 documentation drift items.

## Changes

- Cache `lastConceptionPath` in main-process module state so the note-asset protocol handler stops reading `settings.json` from disk on every embedded-image request.
- Parallelise `fs.stat` calls for untracked files in the git-status cache.
- Replace synchronous `mkdirSync` with async `mkdir` in the terminal-logger flush path.
- Repoint the log-janitor interval when the active conception changes.
- Eliminate shared-array mutation from parallel `repo-watchers` workers by mapping to tuples and flattening.
- Respect `--scope` at the file-collection level in search instead of filtering post-match.
- Wrap `note-modal` rendered HTML in `createMemo` to avoid running the full markdown pipeline twice per keystroke.
- Guard `sessions-store` initial hydration against a race between `termList()` and `onTermSessions`.
- Prevent `terminal-pane` double-close by tracking in-flight closes in a `Set`.
- Add IPC-hydration error handling in the renderer boot path.
- Add stale-conception guard to `repos-store` event listener.
- Hoist `trail` to module scope, remove dead `customKeyDisposers`, compute `todayISO` once per session.
- Extract `switchConception` helper to deduplicate the conception-switch sequence.
- Add JSDoc to `pickByDottedPath`, rename `extractFirstHeading` to `extractFirstHeadingOrLine`, and add comments for non-obvious conventions.
- Fix 8 documentation drift items: remove stale `templates` noun, correct `config conception-path` to read-only, add missing env vars to resolution order, fix `scan-promotions` syntax, correct `knowledge retrieve` mode names, remove `--include-worktrees`, fix test-directory structure, add `CLAUDE_PROJECT_DIR` to env reference.

## Impact

- Users with large conceptions and many untracked files will see faster dirty-count refresh.
- Search with `--scope` now skips excluded trees entirely, reducing disk I/O.
- Embedded images in notes no longer trigger per-image disk reads.
- Conception switches correctly repoint background janitors.

## Watchpoints

- The `search` scope change is an API contract addition (`scopes?: string[]`); the renderer still passes `undefined` so behaviour is unchanged for dashboard users.