### PR TITLE
Cut renderer tree-pane cascading re-computes; 4 audit-tail fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.10.3",
+      "version": "3.10.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/code-runs.tsx
+++ b/src/renderer/code-runs.tsx
@@ -15,7 +15,29 @@ interface CodeRunRowsProps {
   onClose: (id: string) => void;
 }
 
+/** Single parent listener fans out term events into per-row handlers.
+ *  Previously each row registered its own `onTermData` / `onTermExit`
+ *  subscription — N rows meant N main↔renderer bridge listeners and N
+ *  per-event no-op id checks. Rows now claim/release a slot in these
+ *  Maps on mount/cleanup. */
+type DataHandler = (data: string) => void;
+type ExitHandler = (code: number) => void;
+
 export function CodeRunRows(props: CodeRunRowsProps) {
+  const dataHandlers = new Map<string, DataHandler>();
+  const exitHandlers = new Map<string, ExitHandler>();
+
+  const offData = window.condash.onTermData(({ id, data }) => {
+    dataHandlers.get(id)?.(data);
+  });
+  const offExit = window.condash.onTermExit(({ id, code }) => {
+    exitHandlers.get(id)?.(code);
+  });
+  onCleanup(() => {
+    offData();
+    offExit();
+  });
+
   return (
     <Show when={props.sessions.length > 0}>
       <section class="code-runs">
@@ -30,6 +52,8 @@ export function CodeRunRows(props: CodeRunRowsProps) {
                 session={session}
                 repos={props.repos}
                 xtermPrefs={props.xtermPrefs}
+                dataHandlers={dataHandlers}
+                exitHandlers={exitHandlers}
                 onClose={() => props.onClose(session.id)}
               />
             )}
@@ -73,6 +97,8 @@ function CodeRunRow(props: {
   session: TermSession;
   repos: readonly RepoEntry[];
   xtermPrefs?: TerminalXtermPrefs;
+  dataHandlers: Map<string, DataHandler>;
+  exitHandlers: Map<string, ExitHandler>;
   onClose: () => void;
 }) {
   // Active-run rows start collapsed — the user may have many running, and an
@@ -123,19 +149,20 @@ function CodeRunRow(props: {
   });
 
   // Stream live data into the local xterm. Buffered output is in main; the
-  // live stream goes through onTermData regardless of expand state.
-  const offData = window.condash.onTermData(({ id, data }) => {
-    if (id !== props.session.id) return;
+  // live stream goes through the parent's onTermData regardless of expand
+  // state. The parent fans events out via the shared Map keyed on session
+  // id so there is one main↔renderer bridge listener total, not one per
+  // row.
+  props.dataHandlers.set(props.session.id, (data) => {
     mounted?.term.write(data);
   });
-  const offExit = window.condash.onTermExit(({ id, code }) => {
-    if (id !== props.session.id) return;
+  props.exitHandlers.set(props.session.id, (code) => {
     mounted?.term.write(`\r\n\x1b[33m[process exited ${code}]\x1b[0m\r\n`);
   });
 
   onCleanup(() => {
-    offData();
-    offExit();
+    props.dataHandlers.delete(props.session.id);
+    props.exitHandlers.delete(props.session.id);
     mounted?.dispose();
     mounted = null;
     xtermElement.remove();

--- a/src/renderer/logs-modal.tsx
+++ b/src/renderer/logs-modal.tsx
@@ -75,19 +75,24 @@ export function LogsViewerModal(props: {
     setActiveHit(0);
   });
 
-  const ROW_HEIGHT = 19.04; // matches `--logs-row-height` in logs-modal.css
+  // Row height is the single source of truth in CSS (`--logs-row-height`)
+  // — read it from the mounted transcript so a future stylesheet change
+  // can't silently drift this virtualiser. Falls back to the published
+  // CSS default while the element is still measuring.
+  const DEFAULT_ROW_HEIGHT = 19.04;
+  const [rowHeight, setRowHeight] = createSignal(DEFAULT_ROW_HEIGHT);
   const OVERSCAN = 12;
   const [scrollTop, setScrollTop] = createSignal(0);
   const [viewportHeight, setViewportHeight] = createSignal(600);
 
-  const totalHeight = createMemo(() => lines().length * ROW_HEIGHT);
+  const totalHeight = createMemo(() => lines().length * rowHeight());
 
   const visible = createMemo<{ idx: number; text: string }[]>(() => {
     const arr = lines();
     if (arr.length === 0) return [];
     const vh = Math.max(viewportHeight(), 1);
-    const first = Math.max(0, Math.floor(scrollTop() / ROW_HEIGHT) - OVERSCAN);
-    const last = Math.min(arr.length, Math.ceil((scrollTop() + vh) / ROW_HEIGHT) + OVERSCAN);
+    const first = Math.max(0, Math.floor(scrollTop() / rowHeight()) - OVERSCAN);
+    const last = Math.min(arr.length, Math.ceil((scrollTop() + vh) / rowHeight()) + OVERSCAN);
     const out: { idx: number; text: string }[] = [];
     for (let i = first; i < last; i++) {
       out.push({ idx: i, text: arr[i] });
@@ -112,6 +117,11 @@ export function LogsViewerModal(props: {
     transcriptEl = el;
     setViewportHeight(el.clientHeight);
     setScrollTop(el.scrollTop);
+    // Resolve `--logs-row-height` from the rendered element so CSS
+    // remains the single source of truth. parseFloat strips the `px`.
+    const cssValue = getComputedStyle(el).getPropertyValue('--logs-row-height').trim();
+    const parsed = Number.parseFloat(cssValue);
+    if (Number.isFinite(parsed) && parsed > 0) setRowHeight(parsed);
     resizeObserver?.disconnect();
     resizeObserver = new ResizeObserver(() => {
       setViewportHeight(el.clientHeight);
@@ -136,7 +146,7 @@ export function LogsViewerModal(props: {
     if (!transcriptEl) return;
     const target = all[activeHit() % all.length];
     if (!target) return;
-    const desired = target.lineIdx * ROW_HEIGHT - transcriptEl.clientHeight / 2;
+    const desired = target.lineIdx * rowHeight() - transcriptEl.clientHeight / 2;
     transcriptEl.scrollTop = Math.max(0, desired);
   });
 
@@ -251,7 +261,7 @@ export function LogsViewerModal(props: {
               <div class="logs-transcript-spacer" style={{ height: `${totalHeight()}px` }}>
                 <For each={visible()}>
                   {(row) => (
-                    <div class="logs-line" style={{ top: `${row.idx * ROW_HEIGHT}px` }}>
+                    <div class="logs-line" style={{ top: `${row.idx * rowHeight()}px` }}>
                       <LineContents
                         text={row.text}
                         hits={hitsByLine().get(row.idx) ?? []}

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -3,6 +3,7 @@ import {
   createResource,
   createSignal,
   For,
+  on,
   onCleanup,
   onMount,
   Show,
@@ -89,14 +90,28 @@ export function NoteModal(props: {
     props.state?.readOnly ? 'view' : (props.state?.initialMode ?? 'view'),
   );
 
-  createEffect(() => {
-    if (props.state?.readOnly) {
-      setMode('view');
-      return;
-    }
-    if (props.state?.initialMode) setMode(props.state.initialMode);
-    else if (props.state && !isMarkdown(props.state.path)) setMode('edit');
-  });
+  // Key the mode-reset on the specific state fields that drive it. Without
+  // `on`, this effect tracks every property read on `props.state` and
+  // re-fires whenever the host hands us a reference-equal-but-new state
+  // object (which it does freely on unrelated re-renders) — silently
+  // clobbering the user's current view/edit choice.
+  createEffect(
+    on(
+      [
+        () => props.state?.readOnly ?? false,
+        () => props.state?.initialMode,
+        () => props.state?.path,
+      ],
+      ([readOnly, initialMode, path]) => {
+        if (readOnly) {
+          setMode('view');
+          return;
+        }
+        if (initialMode) setMode(initialMode);
+        else if (path && !isMarkdown(path)) setMode('edit');
+      },
+    ),
+  );
   const [draft, setDraft] = createSignal('');
   const [dirty, setDirty] = createSignal(false);
   const [error, setError] = createSignal<string | null>(null);

--- a/src/renderer/panes/knowledge.tsx
+++ b/src/renderer/panes/knowledge.tsx
@@ -1,4 +1,4 @@
-import { Show } from 'solid-js';
+import { createMemo, Show } from 'solid-js';
 import type { KnowledgeNode } from '@shared/types';
 import { BookIcon } from '../icons';
 import { usePaneScrollMemory } from './pane-scroll-memory';
@@ -55,6 +55,43 @@ export function KnowledgeView(props: {
   const todayISO = new Date().toISOString().slice(0, 10);
   const scrollRef = usePaneScrollMemory('knowledge');
 
+  // Wrap pane-level callbacks in createMemo so prop identity stays stable
+  // across unrelated parent re-runs (e.g. `expanded` flips). Without this,
+  // every toggle re-creates these arrows, invalidates DirectoryBody's
+  // specialChild / childFiles memos, and forces <For> to re-render every
+  // file card in the directory. See notes/01-design.md.
+  const renderSpecialFile = createMemo(() => (file: KnowledgeNode, dir: KnowledgeNode) => (
+    <button
+      type="button"
+      class="tree-special-file knowledge-special-file"
+      data-bucket={bucketOf(dir.relPath)}
+      onClick={(e) => {
+        e.stopPropagation();
+        props.onOpen(file.path, file.title);
+      }}
+      title={`Open ${dir.relPath || 'knowledge'} index`}
+    >
+      <span class="tree-special-badge">INDEX</span>
+      <span class="tree-special-title">{file.title}</span>
+      <Show when={file.verifiedAt}>
+        <span
+          class="tree-special-meta"
+          data-fresh={freshnessOf(file.verifiedAt, todayISO)}
+          title={`Verified ${file.verifiedAt}`}
+        >
+          {file.verifiedAt}
+        </span>
+      </Show>
+    </button>
+  ));
+  const renderFile = createMemo(() => (file: KnowledgeNode) => (
+    <KnowledgeCard
+      node={file}
+      todayISO={todayISO}
+      onOpen={() => props.onOpen(file.path, file.title)}
+    />
+  ));
+
   return (
     <div class="knowledge-pane" ref={scrollRef}>
       <TreeView<KnowledgeNode>
@@ -67,38 +104,9 @@ export function KnowledgeView(props: {
         prompts={props.prompts}
         onAfterMutation={props.onAfterMutation}
         onError={props.onError}
-        specialFile={(file) => isKnowledgeIndex(file)}
-        renderSpecialFile={(file, dir) => (
-          <button
-            type="button"
-            class="tree-special-file knowledge-special-file"
-            data-bucket={bucketOf(dir.relPath)}
-            onClick={(e) => {
-              e.stopPropagation();
-              props.onOpen(file.path, file.title);
-            }}
-            title={`Open ${dir.relPath || 'knowledge'} index`}
-          >
-            <span class="tree-special-badge">INDEX</span>
-            <span class="tree-special-title">{file.title}</span>
-            <Show when={file.verifiedAt}>
-              <span
-                class="tree-special-meta"
-                data-fresh={freshnessOf(file.verifiedAt, todayISO)}
-                title={`Verified ${file.verifiedAt}`}
-              >
-                {file.verifiedAt}
-              </span>
-            </Show>
-          </button>
-        )}
-        renderFile={(file) => (
-          <KnowledgeCard
-            node={file}
-            todayISO={todayISO}
-            onOpen={() => props.onOpen(file.path, file.title)}
-          />
-        )}
+        specialFile={isKnowledgeIndex}
+        renderSpecialFile={renderSpecialFile()}
+        renderFile={renderFile()}
       />
     </div>
   );

--- a/src/renderer/panes/resources.tsx
+++ b/src/renderer/panes/resources.tsx
@@ -1,4 +1,4 @@
-import { createSignal, Show } from 'solid-js';
+import { createMemo, createSignal, Show } from 'solid-js';
 import type { ResourceCategory, ResourceNode } from '@shared/types';
 import { usePaneScrollMemory } from './pane-scroll-memory';
 import {
@@ -42,6 +42,13 @@ export function ResourcesView(props: {
 }) {
   const scrollRef = usePaneScrollMemory('resources');
 
+  // Memoise the inline file renderer so toggling one directory's expansion
+  // doesn't invalidate every file card in the rest of the tree — see
+  // notes/01-design.md.
+  const renderFile = createMemo(() => (file: ResourceNode) => (
+    <ResourceCard node={file} actions={props.actions} />
+  ));
+
   return (
     <div class="resources-pane" ref={scrollRef}>
       <Show
@@ -83,7 +90,7 @@ export function ResourcesView(props: {
             prompts={props.prompts}
             onAfterMutation={props.onAfterMutation}
             onError={props.onError}
-            renderFile={(file) => <ResourceCard node={file} actions={props.actions} />}
+            renderFile={renderFile()}
           />
         )}
       </Show>

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from 'solid-js';
+import { createMemo, For, Show } from 'solid-js';
 import type { SkillNode, SkillTab } from '@shared/types';
 import { SKILL_TABS } from '@shared/types';
 import { usePaneScrollMemory } from './pane-scroll-memory';
@@ -76,6 +76,80 @@ export function SkillsView(props: {
 
   const affordances = (): ReadonlyArray<TreeAffordance> =>
     props.tab === 'kimi' ? READONLY_AFFORDANCES : EDITABLE_AFFORDANCES;
+
+  // Memoise pane-level callbacks so prop identity stays stable across
+  // unrelated parent re-runs (e.g. expanding one directory). Tracks
+  // `props.tab` so the special-file predicate updates when the user
+  // switches tab, but is otherwise a stable reference. See
+  // notes/01-design.md.
+  const specialFile = createMemo(() => {
+    const tab = props.tab;
+    return (file: SkillNode, dir: SkillNode): boolean => {
+      if (dir.relPath === '' && tab === 'claude' && isClaudeMd(file)) return true;
+      if (dir.relPath === '' && tab === 'kimi' && isAgentsMd(file)) return true;
+      if (tab !== 'generic' && dir.relPath !== '' && isSkillIndex(file)) return true;
+      return false;
+    };
+  });
+  const renderSpecialFile = createMemo(() => (file: SkillNode, dir: SkillNode) => {
+    if (isClaudeMd(file) || isAgentsMd(file)) {
+      const badge = isClaudeMd(file) ? 'CLAUDE' : 'AGENTS';
+      return (
+        <button
+          type="button"
+          class="tree-special-file claude-special-file"
+          onClick={(e) => {
+            e.stopPropagation();
+            props.onOpen(file.path, file.title, file.shipped);
+          }}
+          title={`Open ${file.path}`}
+          aria-label={`Open ${file.path}`}
+        >
+          <span class="tree-special-badge">{badge}</span>
+          <span class="tree-special-title">{file.title}</span>
+          <span class="tree-special-meta">{file.relPath}</span>
+        </button>
+      );
+    }
+    const shipped = file.shipped;
+    return (
+      <button
+        type="button"
+        class="tree-special-file skill-special-file"
+        classList={{
+          shipped: !!shipped,
+          diverged: !!shipped?.diverged,
+        }}
+        onClick={(e) => {
+          e.stopPropagation();
+          props.onOpen(file.path, file.title, shipped);
+        }}
+        aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
+          shipped?.diverged ? ' (shipped, locally edited)' : shipped ? ' (shipped)' : ''
+        }`}
+        title={
+          shipped?.diverged
+            ? 'SKILL.md (shipped, locally edited)'
+            : shipped
+              ? 'SKILL.md (shipped)'
+              : 'SKILL.md'
+        }
+      >
+        <span class="tree-special-badge">SKILL</span>
+        <span class="tree-special-title">{file.title}</span>
+        <Show when={shipped}>
+          <span class="tree-special-meta">{shipped?.diverged ? 'diverged' : 'shipped'}</span>
+        </Show>
+      </button>
+    );
+  });
+  const renderFile = createMemo(() => (file: SkillNode) => (
+    <SkillCard
+      node={file}
+      isYaml={isYamlSpec(file)}
+      onOpen={() => props.onOpen(file.path, file.title, file.shipped)}
+    />
+  ));
 
   // Per-tab button refs so the ARIA keyboard handler below can move focus
   // to the next/previous tab without a global DOM query.
@@ -209,78 +283,9 @@ export function SkillsView(props: {
               prompts={props.prompts}
               onAfterMutation={props.onAfterMutation}
               onError={props.onError}
-              specialFile={(file, dir) => {
-                // CLAUDE.md only surfaces in the Claude tab at the root level
-                // (Generic and Kimi readers do not inject the synthetic entry).
-                if (dir.relPath === '' && props.tab === 'claude' && isClaudeMd(file)) return true;
-                // AGENTS.md mirrors CLAUDE.md but for the Kimi tab.
-                if (dir.relPath === '' && props.tab === 'kimi' && isAgentsMd(file)) return true;
-                // Compiled tabs surface SKILL.md inside skill subdirs.
-                if (props.tab !== 'generic' && dir.relPath !== '' && isSkillIndex(file))
-                  return true;
-                return false;
-              }}
-              renderSpecialFile={(file, dir) => {
-                if (isClaudeMd(file) || isAgentsMd(file)) {
-                  const badge = isClaudeMd(file) ? 'CLAUDE' : 'AGENTS';
-                  return (
-                    <button
-                      type="button"
-                      class="tree-special-file claude-special-file"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        props.onOpen(file.path, file.title, file.shipped);
-                      }}
-                      title={`Open ${file.path}`}
-                      aria-label={`Open ${file.path}`}
-                    >
-                      <span class="tree-special-badge">{badge}</span>
-                      <span class="tree-special-title">{file.title}</span>
-                      <span class="tree-special-meta">{file.relPath}</span>
-                    </button>
-                  );
-                }
-                const shipped = file.shipped;
-                return (
-                  <button
-                    type="button"
-                    class="tree-special-file skill-special-file"
-                    classList={{
-                      shipped: !!shipped,
-                      diverged: !!shipped?.diverged,
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      props.onOpen(file.path, file.title, shipped);
-                    }}
-                    aria-label={`Open SKILL.md for ${dir.relPath || 'skills'}${
-                      shipped?.diverged ? ' (shipped, locally edited)' : shipped ? ' (shipped)' : ''
-                    }`}
-                    title={
-                      shipped?.diverged
-                        ? 'SKILL.md (shipped, locally edited)'
-                        : shipped
-                          ? 'SKILL.md (shipped)'
-                          : 'SKILL.md'
-                    }
-                  >
-                    <span class="tree-special-badge">SKILL</span>
-                    <span class="tree-special-title">{file.title}</span>
-                    <Show when={shipped}>
-                      <span class="tree-special-meta">
-                        {shipped?.diverged ? 'diverged' : 'shipped'}
-                      </span>
-                    </Show>
-                  </button>
-                );
-              }}
-              renderFile={(file) => (
-                <SkillCard
-                  node={file}
-                  isYaml={isYamlSpec(file)}
-                  onOpen={() => props.onOpen(file.path, file.title, file.shipped)}
-                />
-              )}
+              specialFile={specialFile()}
+              renderSpecialFile={renderSpecialFile()}
+              renderFile={renderFile()}
             />
           )}
         </Show>

--- a/src/renderer/panes/tree-view.tsx
+++ b/src/renderer/panes/tree-view.tsx
@@ -48,10 +48,10 @@ export interface TreeViewPromptApi {
 
 export interface TreeViewProps<TFile extends TreeViewBaseNode> {
   treeKey: TreeRoot;
-  /** The pane's root node. The root header is never rendered — its
-   *  children render directly so the pane keeps its current top-level
-   *  silhouette and the affordance buttons sit on every nested directory
-   *  (and on a synthetic ROOT chip when the root needs them). */
+  /** The directory to render. At the top level this is the pane's root —
+   *  the root header is never rendered, only its children, so the pane
+   *  keeps its current silhouette. For nested calls (recursion) it is the
+   *  subdirectory whose header + body should render here. */
   root: TFile;
   /** Read-only accessor for the set of currently-expanded directory
    *  relPaths. Solid signal so the tree re-renders on toggle. */
@@ -95,61 +95,22 @@ export interface TreeViewProps<TFile extends TreeViewBaseNode> {
   onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
   /** Fires when an IPC verb rejects so the pane can surface a toast. */
   onError: (message: string) => void;
-}
-
-export function TreeView<TFile extends TreeViewBaseNode>(props: TreeViewProps<TFile>): JSX.Element {
-  return (
-    <div class="tree-view">
-      <DirectoryBody
-        node={props.root}
-        depth={0}
-        isRoot={true}
-        treeKey={props.treeKey}
-        expanded={props.expanded}
-        onToggleExpand={props.onToggleExpand}
-        renderFile={props.renderFile}
-        renderDirSuffix={props.renderDirSuffix}
-        specialFile={props.specialFile}
-        renderSpecialFile={props.renderSpecialFile}
-        skipFile={props.skipFile}
-        affordances={props.affordances}
-        mutations={props.mutations}
-        prompts={props.prompts}
-        onAfterMutation={props.onAfterMutation}
-        onError={props.onError}
-      />
-    </div>
-  );
-}
-
-interface DirectoryBodyProps<TFile extends TreeViewBaseNode> {
-  node: TFile;
-  depth: number;
-  isRoot: boolean;
-  treeKey: TreeRoot;
-  expanded: () => ReadonlySet<string>;
-  onToggleExpand: (relPath: string) => void;
-  renderFile: (file: TFile) => JSX.Element;
-  renderDirSuffix?: (dir: TFile) => JSX.Element;
-  specialFile?: (file: TFile, dir: TFile) => boolean;
-  renderSpecialFile?: (file: TFile, dir: TFile) => JSX.Element;
-  skipFile?: (file: TFile) => boolean;
-  affordances: ReadonlyArray<TreeAffordance>;
-  mutations: TreeViewMutationApi;
-  prompts: TreeViewPromptApi;
-  onAfterMutation: (newPath: string, kind: TreeAffordance, sourceDirRelPath: string) => void;
-  onError: (message: string) => void;
+  /** Recursion bookkeeping — caller-side defaults are top-level. */
+  depth?: number;
+  isRoot?: boolean;
 }
 
 /** Render one directory: header (always visible) plus children when
- *  expanded. Root is always rendered expanded so an all-collapsed pane
- *  still shows its top-level entries. */
-function DirectoryBody<TFile extends TreeViewBaseNode>(
-  props: DirectoryBodyProps<TFile>,
-): JSX.Element {
+ *  expanded. The top-level call (`isRoot`, default true) is what the
+ *  panes invoke and adds the `<div class="tree-view">` wrapper; the
+ *  recursion below re-enters the same component with `isRoot={false}`. */
+export function TreeView<TFile extends TreeViewBaseNode>(props: TreeViewProps<TFile>): JSX.Element {
+  const depth = (): number => props.depth ?? 0;
+  const isRoot = (): boolean => props.isRoot ?? true;
+
   const childDirs = createMemo<TFile[]>(() => {
     const out: TFile[] = [];
-    for (const child of props.node.children ?? []) {
+    for (const child of props.root.children ?? []) {
       if (child.kind === 'directory') out.push(child as TFile);
     }
     return out;
@@ -157,10 +118,10 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
   const specialChild = createMemo<TFile | null>(() => {
     const test = props.specialFile;
     if (!test) return null;
-    for (const child of props.node.children ?? []) {
+    for (const child of props.root.children ?? []) {
       if (child.kind !== 'file') continue;
       const file = child as TFile;
-      if (test(file, props.node)) return file;
+      if (test(file, props.root)) return file;
     }
     return null;
   });
@@ -168,7 +129,7 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
     const out: TFile[] = [];
     const skip = props.skipFile;
     const special = specialChild();
-    for (const child of props.node.children ?? []) {
+    for (const child of props.root.children ?? []) {
       if (child.kind !== 'file') continue;
       const file = child as TFile;
       if (special && file === special) continue;
@@ -178,16 +139,12 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
     return out;
   });
 
-  return (
-    <section
-      class="tree-directory"
-      data-depth={props.depth}
-      data-root={props.isRoot ? 'true' : 'false'}
-    >
+  const body = (): JSX.Element => (
+    <section class="tree-directory" data-depth={depth()} data-root={isRoot() ? 'true' : 'false'}>
       <DirectoryHeader
-        node={props.node}
-        depth={props.depth}
-        isRoot={props.isRoot}
+        node={props.root}
+        depth={depth()}
+        isRoot={isRoot()}
         treeKey={props.treeKey}
         expanded={props.expanded}
         onToggleExpand={props.onToggleExpand}
@@ -199,16 +156,16 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
         onError={props.onError}
         directFileCount={childFiles().length + (specialChild() ? 1 : 0)}
       />
-      <Show when={isExpanded(props.expanded(), props.node.relPath, props.isRoot)}>
+      <Show when={isExpanded(props.expanded(), props.root.relPath, isRoot())}>
         <div class="tree-children">
           <Show when={specialChild() && props.renderSpecialFile}>
-            <div class="tree-special">{props.renderSpecialFile!(specialChild()!, props.node)}</div>
+            <div class="tree-special">{props.renderSpecialFile!(specialChild()!, props.root)}</div>
           </Show>
           <For each={childDirs()}>
             {(dir) => (
-              <DirectoryBody
-                node={dir}
-                depth={props.depth + 1}
+              <TreeView
+                root={dir}
+                depth={depth() + 1}
                 isRoot={false}
                 treeKey={props.treeKey}
                 expanded={props.expanded}
@@ -234,6 +191,12 @@ function DirectoryBody<TFile extends TreeViewBaseNode>(
         </div>
       </Show>
     </section>
+  );
+
+  return (
+    <Show when={isRoot()} fallback={body()}>
+      <div class="tree-view">{body()}</div>
+    </Show>
   );
 }
 


### PR DESCRIPTION
## Summary

- Toggling one directory in the Knowledge / Resources / Skills panes was re-rendering every file card in the pane because inline `renderFile` / `renderSpecialFile` / `specialFile` callbacks had fresh identities on every parent re-run. `createMemo` keeps prop identity stable so SolidJS no longer invalidates the shared TreeView's `specialChild` / `childFiles` memos on unrelated parent updates.
- Folds in four renderer audit-tail items deferred from the prior renderer review (PR #183 punch-list): per-row term listeners, virtualiser row-height drift, a pure pass-through `TreeView` wrapper, and the note-modal mode-reset effect.
- Bumps condash to 3.10.4.

## Changes

- `src/renderer/panes/knowledge.tsx`, `resources.tsx`, `skills.tsx`: wrap `renderFile`, `renderSpecialFile`, and (Skills) `specialFile` in `createMemo` and pass the memoised accessor to `TreeView`.
- `src/renderer/code-runs.tsx` (P1-7): a single `onTermData` / `onTermExit` listener on `CodeRunRows` fans out into per-row Maps; rows claim/release their slot on mount/cleanup instead of registering their own subscriptions.
- `src/renderer/logs-modal.tsx` (P2-8): row height read from the computed `--logs-row-height` CSS variable at mount; the hardcoded `19.04` is now just the first-frame fallback.
- `src/renderer/panes/tree-view.tsx` (P3-9): collapse the prior `TreeView` → `DirectoryBody` pass-through into a single recursive `TreeView` component with optional `depth` / `isRoot` recursion bookkeeping.
- `src/renderer/note-modal.tsx` (P3-11): key the mode-reset effect on `(readOnly, initialMode, path)` via `on()` so reference-equal state updates from the host no longer clobber the user's current view/edit choice.
- `package.json` / `package-lock.json`: 3.10.3 → 3.10.4.

## Watchpoints

- Solid DevTools / a temporary `console.log` in `KnowledgeCard` should now show only the toggled directory re-rendering, not every file card in the pane.
- `code-runs.tsx`: confirm new sessions still attach and stream output after the listener-Map refactor, and that the exit banner still prints on session end.
- `logs-modal.tsx`: row positioning should remain pixel-correct after the CSS-variable read; the fallback path runs only for one frame before the ResizeObserver-adjacent mount logic resolves the variable.
- `note-modal.tsx`: opening a note in view mode while the host re-renders with a new state object should no longer flip an in-progress edit back to view.