### PR TITLE
Make reconcile the sole writer of terminal tabs (v3.10.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.10.3",
+      "version": "3.10.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/config-walk.ts
+++ b/src/main/config-walk.ts
@@ -1,4 +1,5 @@
 import { isAbsolute, join } from 'node:path';
+import type { TerminalPrefs } from '../shared/types';
 
 /**
  * Shared configuration-walk helpers. Both `repos.ts` (for the flat repo list
@@ -33,6 +34,7 @@ export type RawRepo =
 export interface ConfigShape {
   workspace_path?: string;
   repositories?: RawRepo[];
+  terminal?: TerminalPrefs;
 }
 
 /** True when `entry` is a section-marker variant of `RawRepo`. */

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -240,8 +240,7 @@ export async function spawnTerminal(
           cwd,
           spawn: { cmd: program, argv },
         },
-        (config as { terminal?: { logging?: import('../shared/types').TerminalLoggingPrefs } })
-          .terminal?.logging,
+        config.terminal?.logging,
       )
     : null;
   const session: Session = {
@@ -337,6 +336,13 @@ function isAlive(p: pty.IPty | null): boolean {
   }
 }
 
+/** Cap for how long stopSession will wait for force_stop to settle before
+ * moving on to the SIGKILL grace period. The detached child is unref'd at
+ * spawn time so the main process exit isn't blocked; this timeout just
+ * unblocks the awaiter so a slow / hung force_stop script can't stall the
+ * tab-close path. */
+const FORCE_STOP_TIMEOUT_MS = 3000;
+
 function runForceStop(command: string): Promise<void> {
   // Tokenise + shell:false to mirror launchers.runForceStopRepo. Routing
   // the user-configured force_stop: string through the shell costs us
@@ -355,12 +361,19 @@ function runForceStop(command: string): Promise<void> {
       stdio: 'ignore',
       shell: false,
     });
+    // Detach the child from the main process event loop so a script that
+    // outlives the kill path (intentional or hung) doesn't hold the awaiter
+    // open beyond the timeout.
+    child.unref();
     let settled = false;
+    let timer: NodeJS.Timeout | null = null;
     const finish = () => {
       if (settled) return;
       settled = true;
+      if (timer) clearTimeout(timer);
       resolve();
     };
+    timer = setTimeout(finish, FORCE_STOP_TIMEOUT_MS);
     child.on('error', finish);
     child.on('exit', finish);
   });

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -39,6 +39,25 @@ export interface TerminalBridge {
   handlePasteToTerm: (text: string) => Promise<void>;
 }
 
+/** Upper bound on animation frames waited for the pane to mount after
+ *  `ensureTerminalOpen()`. At ~60 Hz this is ~200 ms — comfortably more
+ *  than a Solid render pass yet still tight enough to surface a genuine
+ *  mount failure as a no-op rather than an indefinite hang. */
+const HANDLE_WAIT_FRAMES = 12;
+
+/** Wait until `deps.terminalHandle()` returns non-null, or the frame cap
+ *  expires. The previous `queueMicrotask` spin (single microtask) was just
+ *  shy of an actual paint and intermittently returned before the Solid
+ *  effect that registered the handle had run. */
+async function waitForTerminalHandle(deps: TerminalBridgeDeps): Promise<TerminalPaneHandle | null> {
+  for (let i = 0; i < HANDLE_WAIT_FRAMES; i++) {
+    const handle = deps.terminalHandle();
+    if (handle) return handle;
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  }
+  return deps.terminalHandle();
+}
+
 /** Bridges between dashboard actions (per-card work-on, open-in-term,
  *  screenshot paste) and the terminal pane. Centralises the "spawn a
  *  shell first if there isn't one" dance so callers don't repeat it. */
@@ -47,7 +66,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     const text = `work on ${project.slug}`;
     if (!deps.terminalHandle()) {
       deps.ensureTerminalOpen();
-      await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+      await waitForTerminalHandle(deps);
     }
     const handle = deps.terminalHandle();
     if (!handle) return;
@@ -66,7 +85,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
   const handleOpenInTerm = async (repo: RepoEntry, worktree: Worktree): Promise<void> => {
     if (!deps.terminalHandle()) {
       deps.ensureTerminalOpen();
-      await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+      await waitForTerminalHandle(deps);
     }
     const handle = deps.terminalHandle();
     if (!handle) return;
@@ -115,7 +134,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
   const handlePasteToTerm = async (text: string): Promise<void> => {
     if (!deps.terminalHandle()) {
       deps.ensureTerminalOpen();
-      await new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+      await waitForTerminalHandle(deps);
     }
     const handle = deps.terminalHandle();
     if (!handle) {

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -106,6 +106,11 @@ export function TerminalPane(props: {
   // the right column, not always 'left'.
   let nextSpawnColumn: Column = 'left';
 
+  // Stash of caller-supplied label/pinned per spawned id. `reconcile` is the
+  // sole writer of the tabs signal; `spawn` records intent here so the
+  // following onTermSessions broadcast inserts the tab with the right label.
+  const pendingSpawnIntent = new Map<string, { label: string; pinned?: boolean }>();
+
   const xterms = new Map<
     string,
     {
@@ -266,22 +271,28 @@ export function TerminalPane(props: {
     const known = new Set(tabs().map((t) => t.id));
     for (const s of snap) {
       if (s.side !== 'my' || known.has(s.id)) continue;
+      // Await termAttach first so that any in-flight `spawn` invoke reply has
+      // resolved by the time we build the tab — `pendingSpawnIntent` is set
+      // synchronously after `termSpawn` returns, and we want to read it here.
+      const attach = await window.condash.termAttach(s.id);
+      const intent = pendingSpawnIntent.get(s.id);
+      pendingSpawnIntent.delete(s.id);
       const meta = readMeta()[s.id];
-      const label = meta?.label ?? (s.repo ? `${s.repo} (run)` : 'shell');
+      const label = intent?.label ?? meta?.label ?? (s.repo ? `${s.repo} (run)` : 'shell');
       const column: Column = meta?.column ?? nextSpawnColumn;
       nextSpawnColumn = 'left';
+      const pinned = intent?.pinned ?? meta?.pinned;
       const tab: Tab = {
         id: s.id,
         side: 'my',
         column,
         label,
         customName: meta?.customName,
-        pinned: meta?.pinned,
+        pinned,
         exited: s.exited,
       };
       setTabs((prev) => [...prev, tab]);
-      setMeta(s.id, { label, customName: meta?.customName, column, pinned: meta?.pinned });
-      const attach = await window.condash.termAttach(s.id);
+      setMeta(s.id, { label, customName: meta?.customName, column, pinned });
       mountForSession(s.id, column, attach?.output);
       setActiveIn(column, s.id);
       setActiveColumn(column);
@@ -345,13 +356,11 @@ export function TerminalPane(props: {
   ): Promise<string> => {
     const { id } = await window.condash.termSpawn(request);
     const pinned = opts?.pinned;
+    // Record intent first — reconcile reads it before falling back to meta
+    // or default labels. Setting intent before setMeta keeps the two reads
+    // synchronous from reconcile's perspective.
+    pendingSpawnIntent.set(id, { label, pinned });
     setMeta(id, { label, column: nextSpawnColumn, pinned });
-    // `broadcastSessions()` in main fires before the `termSpawn` invoke
-    // reply resolves here, so reconcile typically inserts the Tab with the
-    // fallback label ('shell' / '<repo> (run)') and no `pinned` flag —
-    // readMeta returns nothing because we hadn't written yet. Patch the
-    // Tab with the caller's intent now that we know the id.
-    setTabs((prev) => prev.map((t) => (t.id === id ? { ...t, label, pinned } : t)));
     return id;
   };
 


### PR DESCRIPTION
## Summary

- Closes a race in the bottom "My terms" pane where the post-`termSpawn` `setTabs` patch was a no-op when reconcile hadn't yet inserted the row, leaving the fallback `shell` / `<repo> (run)` label and an unpinned tab.
- `pendingSpawnIntent` now carries the caller's label + pinned flag, and `reconcile` is the sole writer of the tabs signal. Reconcile awaits `termAttach` before building the tab so a concurrent `spawn` invoke has resolved and recorded intent.
- Folds three terminal-subsystem audit-tail items that dropped out of PR #183.

## Changes

- `src/renderer/terminal-pane.tsx`: add `pendingSpawnIntent` map; reorder `reconcile` so the `termAttach` await runs before tab insertion; intent consumed before the `readMeta` / repo fallback; `spawn` records intent and no longer patches `setTabs`.
- `src/renderer/terminal-bridge.ts`: replace single-`queueMicrotask` spin with a bounded `requestAnimationFrame` poll (12 frames ≈ 200 ms) for the pane handle after `ensureTerminalOpen()`.
- `src/main/terminals.ts`: `runForceStop` unrefs the detached child and adds a 3 s settle timeout so a hung force_stop script can't stall the tab-close path.
- `src/main/config-walk.ts`: extend `ConfigShape` with `terminal?: TerminalPrefs` so `terminals.ts` reads `config.terminal?.logging` directly instead of double-casting.
- `package.json` / `package-lock.json`: bump to 3.10.4.

## Impact

- Spawn callers (Code-pane Run, launcher buttons, terminal bridge) no longer rely on the patch-after-broadcast trick — the tab is born with the right label and pin state.
- `runForceStop` now resolves deterministically within 3 s; downstream `stopSession` SIGKILL grace timing is unchanged.

## Watchpoints

- Tab label for fast-back-to-back launcher spawns: each spawn must consume its own intent (verified by Playwright `terminal-tab-titles`, but worth eyeballing during a real session).
- Hung `force_stop` scripts now timeout after 3 s — if a user's script needs longer, the SIGKILL fallback still runs, but the kill path returns sooner than before.