### PR TITLE
Bump 3.10.6: re-tag #187 (v3.10.5 was claimed by a parallel session)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.10.5",
+      "version": "3.10.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- PR #187 shipped on `package.json: 3.10.5`, but the `v3.10.5` tag had already been pushed by a parallel session pointing at a commit that was never merged into `main`.
- Bumps to `3.10.6` so the release tag for #187’\s work points at code that is actually on `main`.

## Changes

- `package.json` / `package-lock.json`: 3.10.5 → 3.10.6.

## Impact

- Frees `v3.10.6` as the release tag for the CLI-handler-tests + 4-audit-tail-fixes work merged in #187. The orphan `v3.10.5` tag on the remote is left in place (no force-delete).
- Other in-flight feature branches currently sitting on `3.10.6` will need to bump again on their next rebase — same pattern these branches have already been following (`3.10.4 → 3.10.5 → 3.10.6` chain in their commit messages).