### PR TITLE
Strip leading @ when resolving implicit worktree apps (v3.12.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/worktree/setup.test.ts
+++ b/src/main/worktree/setup.test.ts
@@ -141,6 +141,62 @@ describe('setupBranchWorktrees with a slash-bearing branch', () => {
   });
 });
 
+describe('implicit-mode resolution with `@`-prefixed apps', () => {
+  // The Apps table column in the conception README accepts `@<repo>`; project
+  // headers mirror that. The canonical repo name in `condash.json` is bare,
+  // so the resolver must strip `@` before lookup. Issue: setup/remove
+  // returned empty `created[]` / `notPresent: ["@<name>"]` until the strip
+  // was added.
+  const branch = 'at-prefix-implicit';
+
+  function writeDeclaringReadme(): void {
+    const projectDir = join(conception, 'projects/2026-05/2026-05-14-at-prefix');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, 'README.md'),
+      [
+        '---',
+        'date: 2026-05-14',
+        'kind: project',
+        'status: now',
+        'apps:',
+        '  - "@demo"',
+        `branch: ${branch}`,
+        '---',
+        '',
+        '# Test',
+      ].join('\n'),
+    );
+  }
+
+  it('setup resolves `@demo` to repo `demo` in implicit mode', async () => {
+    writeDeclaringReadme();
+    const result = await setupBranchWorktrees(conception, branch);
+    expect(result.created).toEqual([{ repo: 'demo', path: join(worktreesRoot, branch, 'demo') }]);
+    expect(result.blocked).toEqual([]);
+    expect(existsSync(join(worktreesRoot, branch, 'demo'))).toBe(true);
+  });
+
+  it('check enumerates the `demo` per-repo state when the README says `@demo`', async () => {
+    writeDeclaringReadme();
+    await setupBranchWorktrees(conception, branch);
+    const state = await checkBranchState(conception, branch);
+    expect(state.repos).toHaveLength(1);
+    expect(state.repos[0].name).toBe('demo');
+    expect(state.repos[0].worktreeExists).toBe(true);
+    expect(state.missing).toEqual([]);
+  });
+
+  it('remove resolves `@demo` to repo `demo` in implicit mode', async () => {
+    writeDeclaringReadme();
+    await setupBranchWorktrees(conception, branch);
+    const result = await removeBranchWorktrees(conception, branch);
+    expect(result.removed).toEqual([{ repo: 'demo', path: join(worktreesRoot, branch, 'demo') }]);
+    expect(result.notPresent).toEqual([]);
+    expect(existsSync(join(worktreesRoot, branch, 'demo'))).toBe(false);
+  });
+});
+
 process.on('exit', () => {
   if (prevXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
   else process.env.XDG_CONFIG_HOME = prevXdgConfigHome;

--- a/src/main/worktree/shared.test.ts
+++ b/src/main/worktree/shared.test.ts
@@ -1,0 +1,30 @@
+/**
+ * Unit tests for `rootRepoFromApp` — the implicit-mode resolver that maps
+ * an `apps:` entry from a project README to the canonical repo name in
+ * `condash.json`. Apps may carry the conception's `@` display prefix and/or
+ * an inner sub-path (`condash/frontend`); the worktree is always at the
+ * top-level repo, so both layers are stripped.
+ */
+import { describe, expect, it } from 'vitest';
+import { rootRepoFromApp } from './shared';
+
+describe('rootRepoFromApp', () => {
+  it('returns the bare name when already canonical', () => {
+    expect(rootRepoFromApp('condash')).toBe('condash');
+    expect(rootRepoFromApp('vcoeur.com')).toBe('vcoeur.com');
+  });
+
+  it('strips the leading `@` display prefix', () => {
+    expect(rootRepoFromApp('@condash')).toBe('condash');
+    expect(rootRepoFromApp('@vcoeur.com')).toBe('vcoeur.com');
+  });
+
+  it('strips inner sub-paths', () => {
+    expect(rootRepoFromApp('condash/frontend')).toBe('condash');
+    expect(rootRepoFromApp('alicepeintures.com/admin')).toBe('alicepeintures.com');
+  });
+
+  it('strips both `@` and sub-path together', () => {
+    expect(rootRepoFromApp('@condash/frontend')).toBe('condash');
+  });
+});

--- a/src/main/worktree/shared.ts
+++ b/src/main/worktree/shared.ts
@@ -105,9 +105,12 @@ export async function findItemsDeclaringBranch(
 }
 
 export function rootRepoFromApp(app: string): string {
-  // Apps may be `condash`, `vcoeur.com`, or `condash/frontend`. The worktree
-  // is always at the top-level repo, so strip the inner path.
-  return app.split('/')[0];
+  // Apps may be `condash`, `@condash`, `vcoeur.com`, or `condash/frontend`.
+  // The `@` prefix is the conception's display convention (mirrors the Apps
+  // table column) and is not part of the canonical repo name in
+  // condash.json. The worktree is always at the top-level repo, so strip
+  // both the `@` and the inner path.
+  return app.replace(/^@/, '').split('/')[0];
 }
 
 /**


### PR DESCRIPTION
## Summary

- `condash worktrees setup <branch>` / `worktrees remove <branch>` returned empty `created[]` / `notPresent: ["@<name>"]` when the declaring project's README used the `@<repo>` display convention for its `apps:` list — the documented workaround was to pass `--repo <bare-name>`. `worktrees check` looked like it worked but its per-repo state was also empty for the same reason; only `declaringItems` rendered.
- One missing `^@` strip in the shared resolver `rootRepoFromApp()` was the underlying cause; both implicit-mode mutators and the inspector consume it, so one fix lands all three paths.

## Changes

- `src/main/worktree/shared.ts` — `rootRepoFromApp()` now strips a leading `@` before splitting on `/`. Comment expanded to call out the `@<repo>` display convention.
- `src/main/worktree/shared.test.ts` — new unit tests for the resolver: bare names, `@`-prefixed names, sub-path names, and the combined case.
- `src/main/worktree/setup.test.ts` — new integration tests exercising implicit-mode `setup`, `check`, and `remove` against a project README declaring `apps: ["@demo"]` with `repos list` showing bare `demo`.
- `package.json` / `package-lock.json` — version bump to 3.12.1.

## Impact

- Project READMEs that use the conception's `@<repo>` notation in `apps:` now work with bare `condash worktrees setup/remove/check <branch>` — no `--repo` flag needed.