### PR TITLE
Fix '+ Add action' / '+ Add launcher' save on blank row (v3.12.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -160,11 +160,17 @@ const terminalLoggingSettings = z
 
 /** Single launcher slot. `label` is the user-defined display name shown
  *  in the tab-strip dropdown; `command` is the shell command run on spawn;
- *  `title`, when present, is the initial pinned tab label. */
+ *  `title`, when present, is the initial pinned tab label.
+ *
+ *  `label` and `command` accept empty strings so a freshly-added blank row
+ *  ("+ Add launcher") survives the round-trip to disk and stays visible for
+ *  the user to fill in. The tab-strip dropdown skips entries whose `command`
+ *  is empty — same effective behaviour as the previous `.min(1)` constraint
+ *  but without the failed-save UX. */
 const launcherSchema = z
   .object({
-    label: z.string().min(1, 'label must not be empty'),
-    command: z.string().min(1, 'command must not be empty'),
+    label: z.string(),
+    command: z.string(),
     title: z.string().optional(),
   })
   .strict();
@@ -172,10 +178,13 @@ const launcherSchema = z
 const launchersSchema = z.array(launcherSchema);
 
 /** One user-configurable action template for project cards or the
- *  "+ New project" button. */
+ *  "+ New project" button. Same blank-row tolerance as `launcherSchema`:
+ *  `label` and `template` accept empty strings so a freshly-added row is
+ *  schema-valid; the project-card dropdown skips entries whose `template`
+ *  is empty. */
 const actionTemplateSchema = z
   .object({
-    label: z.string().min(1, 'label must not be empty'),
+    label: z.string(),
     template: z.string(),
     submit: z.boolean().optional(),
   })
@@ -353,14 +362,16 @@ export const DEFAULT_SKILLS_PATH = '.claude/skills';
  *   were retired. Strip silently so existing `.condash/settings.json`
  *   files keep saving (otherwise every write fails with `Unrecognised
  *   key`, which also prevents the user from flipping `enabled: true`).
- * - `terminal.launchers[]` entries missing a non-empty string `command`
- *   are dropped. The renderer-side guard (`applyLauncherEdit`, v2.28.2)
- *   already prevents writing `{ symbol, title }` entries, but a file
- *   that ended up shaped that way through a pre-v2.28.2 session or an
- *   external editor would otherwise fail every subsequent save with
- *   `terminal.launchers.<i>.command — expected string, received
- *   undefined` and lock the user out of the Settings modal. Scrub here
- *   so the next write removes the bad entry from disk.
+ * - `terminal.launchers[]` entries missing a string `command` are dropped.
+ *   The renderer-side guard (`applyLauncherEdit`, v2.28.2) already prevents
+ *   writing `{ symbol, title }` entries, but a file that ended up shaped
+ *   that way through a pre-v2.28.2 session or an external editor would
+ *   otherwise fail every subsequent save with `terminal.launchers.<i>.command
+ *   — expected string, received undefined` and lock the user out of the
+ *   Settings modal. Scrub here so the next write removes the bad entry from
+ *   disk. Blank-row placeholders (`{ label: '', command: '' }`) are kept —
+ *   they're valid since v3.12.2's schema relaxation and need to survive a
+ *   reload so the user can fill them in.
  */
 export function migrateRawSettings(parsed: unknown): unknown {
   if (!parsed || typeof parsed !== 'object') return parsed;
@@ -397,7 +408,11 @@ export function migrateRawSettings(parsed: unknown): unknown {
     const scrubbed = migrated.filter((entry) => {
       if (!entry || typeof entry !== 'object') return false;
       const command = (entry as { command?: unknown }).command;
-      return typeof command === 'string' && command.trim().length > 0;
+      if (typeof command !== 'string') return false;
+      // Empty string is a blank-row placeholder ("+ Add launcher" before
+      // typing); keep it so the user can fill it in after reload. Whitespace
+      // -only strings are treated as malformed legacy data and dropped.
+      return command === '' || command.trim().length > 0;
     });
     if (scrubbed.length === 0) {
       delete term.launchers;

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -16,6 +16,7 @@ import { SkillsView } from './panes/skills';
 import { LogsView } from './panes/logs';
 import { SearchModal } from './search-modal';
 import { SettingsModal } from './settings-modal';
+import { usableActionTemplates } from './settings-modal-parts/data';
 import { NewProjectModal } from './new-project-modal';
 import { createModalRouter } from './modal-router';
 import { createTerminalBridge } from './terminal-bridge';
@@ -421,10 +422,14 @@ function App() {
                         onToggleStep={handleToggleStep}
                         onDropProject={handleDropOnColumn}
                         onWorkOn={(p) => void bridge.handleWorkOn(p)}
-                        projectActions={terminalPrefs()?.projectActions ?? []}
+                        projectActions={usableActionTemplates(
+                          terminalPrefs()?.projectActions ?? [],
+                        )}
                         onProjectAction={(p, a) => void bridge.handleProjectAction(p, a)}
                         onNewProject={() => setNewProjectOpen(true)}
-                        newProjectActions={terminalPrefs()?.newProjectActions ?? []}
+                        newProjectActions={usableActionTemplates(
+                          terminalPrefs()?.newProjectActions ?? [],
+                        )}
                         onNewProjectAction={(a) => void bridge.handleNewProjectAction(a)}
                       />
                     </Show>
@@ -630,7 +635,7 @@ function App() {
         onOpenInEditor={handleOpenInEditor}
         onOpenDeliverable={handleOpenDeliverableFromPreview}
         onWorkOn={(p) => void bridge.handleWorkOn(p)}
-        projectActions={terminalPrefs()?.projectActions ?? []}
+        projectActions={usableActionTemplates(terminalPrefs()?.projectActions ?? [])}
         onProjectAction={(p, a) => void bridge.handleProjectAction(p, a)}
         onCreateNote={(p) => void handleCreateProjectNote(p)}
       />

--- a/src/renderer/settings-modal-parts/data.test.ts
+++ b/src/renderer/settings-modal-parts/data.test.ts
@@ -10,6 +10,7 @@ import {
   patchLauncher,
   removeActionTemplate,
   removeLauncher,
+  usableActionTemplates,
 } from './data';
 import { conceptionConfigSchema } from '../../main/config-schema';
 
@@ -110,7 +111,10 @@ describe('compactRepos — invariants', () => {
 });
 
 describe('patchLauncher', () => {
-  it('does not create an entry when only the title is set (command empty)', () => {
+  it('drops a row whose only filled field is `title` (label + command still blank)', () => {
+    // The keep-on-partial-typing rule looks at the two required text fields
+    // (`label`, `command`). `title` alone never carries a row — a launcher
+    // without a command can't spawn anything.
     expect(patchLauncher(undefined, 0, { title: 'My title' })).toBeUndefined();
   });
 
@@ -125,21 +129,29 @@ describe('patchLauncher', () => {
     expect(next).toEqual([{ label: 'λ', command: 'claude', title: 'CLD' }]);
   });
 
-  it('drops the entry when its command is cleared, even if title was set', () => {
+  it('keeps the row when only command is cleared (label still set)', () => {
     const next = patchLauncher([{ label: 'λ', command: 'claude', title: 'CLD' }], 0, {
+      command: '',
+    });
+    expect(next).toEqual([{ label: 'λ', command: '', title: 'CLD' }]);
+  });
+
+  it('drops the row when both label and command are blank, even if title is set', () => {
+    const next = patchLauncher([{ label: 'λ', command: 'claude', title: 'CLD' }], 0, {
+      label: '',
       command: '',
     });
     expect(next).toBeUndefined();
   });
 
-  it('preserves the other entry when one is cleared', () => {
+  it('preserves the other entry when one is fully cleared', () => {
     const next = patchLauncher(
       [
         { label: 'λ', command: 'claude' },
         { label: 'μ', command: 'python -m notebook' },
       ],
       0,
-      { command: '' },
+      { label: '', command: '' },
     );
     expect(next).toEqual([{ label: 'μ', command: 'python -m notebook' }]);
   });
@@ -147,6 +159,20 @@ describe('patchLauncher', () => {
   it('produces a schema-valid payload through buildSavePayload + launcherSchema', () => {
     const launchers = patchLauncher(undefined, 0, { label: 'λ', command: 'claude' });
     const payload = buildSavePayload({ terminal: { launchers } });
+    const result = conceptionConfigSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('round-trips a blank-row launcher through buildSavePayload + schema', () => {
+    // Regression: "+ Add launcher" used to fail with
+    // `terminal.launchers.0.command — expected string, received undefined`
+    // because pruneEmpty stripped the empty `label`/`command` fields, leaving
+    // `{}` rows that the schema rejected. The schema relaxation + compactor
+    // bypass keep the blank row intact end-to-end.
+    const payload = buildSavePayload({
+      terminal: { launchers: [{ label: '', command: '' }] },
+    });
+    expect(payload.terminal).toEqual({ launchers: [{ label: '', command: '' }] });
     const result = conceptionConfigSchema.safeParse(payload);
     expect(result.success).toBe(true);
   });
@@ -212,11 +238,19 @@ describe('moveLauncher', () => {
 });
 
 describe('patchActionTemplate', () => {
-  it('does not create an entry when only the label is set (template empty)', () => {
-    expect(patchActionTemplate(undefined, 0, { label: 'My label' })).toBeUndefined();
+  it('keeps a row that has only the label set (template still empty)', () => {
+    expect(patchActionTemplate(undefined, 0, { label: 'My label' })).toEqual([
+      { label: 'My label', template: '' },
+    ]);
   });
 
-  it('creates an entry once both label and template are filled', () => {
+  it('keeps a row that has only the template set (label still empty)', () => {
+    expect(patchActionTemplate(undefined, 0, { template: 'echo {slug}' })).toEqual([
+      { label: '', template: 'echo {slug}' },
+    ]);
+  });
+
+  it('creates a fully-filled entry once both label and template are set', () => {
     expect(
       patchActionTemplate(undefined, 0, {
         label: 'Claude review',
@@ -236,32 +270,41 @@ describe('patchActionTemplate', () => {
     ]);
   });
 
-  it('drops the entry when its label is cleared', () => {
+  it('keeps the row when only the label is cleared (template still set)', () => {
     const next = patchActionTemplate(
       [{ label: 'Claude review', template: 'claude "review {slug}"' }],
       0,
       { label: '' },
     );
-    expect(next).toBeUndefined();
+    expect(next).toEqual([{ label: '', template: 'claude "review {slug}"' }]);
   });
 
-  it('drops the entry when its template is cleared', () => {
+  it('keeps the row when only the template is cleared (label still set)', () => {
     const next = patchActionTemplate(
       [{ label: 'Claude review', template: 'claude "review {slug}"' }],
       0,
       { template: '' },
     );
+    expect(next).toEqual([{ label: 'Claude review', template: '' }]);
+  });
+
+  it('drops the row when both label and template are blank', () => {
+    const next = patchActionTemplate(
+      [{ label: 'Claude review', template: 'claude "review {slug}"' }],
+      0,
+      { label: '', template: '' },
+    );
     expect(next).toBeUndefined();
   });
 
-  it('preserves the other entry when one is cleared', () => {
+  it('preserves the other entry when one is fully cleared', () => {
     const next = patchActionTemplate(
       [
         { label: 'Claude review', template: 'claude "review {slug}"' },
         { label: 'Kimi summary', template: 'kimi "summarise {shortSlug}"' },
       ],
       0,
-      { label: '' },
+      { label: '', template: '' },
     );
     expect(next).toEqual([{ label: 'Kimi summary', template: 'kimi "summarise {shortSlug}"' }]);
   });
@@ -273,6 +316,18 @@ describe('patchActionTemplate', () => {
       submit: true,
     });
     const payload = buildSavePayload({ terminal: { projectActions: actions } });
+    const result = conceptionConfigSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it('round-trips a blank-row action template through buildSavePayload + schema', () => {
+    // Regression: "+ Add action" produced
+    // `terminal.projectActions.0.label — expected string, received undefined`
+    // because pruneEmpty collapsed `{ label: '', template: '' }` into `{}`.
+    const payload = buildSavePayload({
+      terminal: { projectActions: [{ label: '', template: '' }] },
+    });
+    expect(payload.terminal).toEqual({ projectActions: [{ label: '', template: '' }] });
     const result = conceptionConfigSchema.safeParse(payload);
     expect(result.success).toBe(true);
   });
@@ -338,5 +393,33 @@ describe('moveActionTemplate', () => {
   it('refuses to move past the end', () => {
     const list = [{ label: 'Claude review', template: 'claude "review {slug}"' }];
     expect(moveActionTemplate(list, 0, 1)).toBe(list);
+  });
+});
+
+describe('usableActionTemplates', () => {
+  it('keeps fully-filled rows in order', () => {
+    const rows = [
+      { label: 'Claude', template: 'claude {slug}' },
+      { label: 'Kimi', template: 'kimi {slug}' },
+    ];
+    expect(usableActionTemplates(rows)).toEqual(rows);
+  });
+
+  it('drops blank-row placeholders so dropdowns never render empty items', () => {
+    expect(
+      usableActionTemplates([
+        { label: '', template: '' },
+        { label: 'Claude', template: 'claude {slug}' },
+      ]),
+    ).toEqual([{ label: 'Claude', template: 'claude {slug}' }]);
+  });
+
+  it('drops half-typed rows where either field is blank', () => {
+    expect(
+      usableActionTemplates([
+        { label: 'Half', template: '' },
+        { label: '', template: 'half' },
+      ]),
+    ).toEqual([]);
   });
 });

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -287,19 +287,96 @@ export function pruneEmpty(value: unknown): unknown {
 /**
  * Build the JSON payload that the Settings modal hands to `writeNote` (or
  * `writeGlobalSettings`). Strips empty leaves with `pruneEmpty` for everything
- * except the `repositories` array — `compactRepos` is the canonical
- * normaliser there. Routing repos through `pruneEmpty` would erase a freshly
- * added `{ name: '' }` row's only key, leaving an empty object that
- * `compactRepos` then maps to `undefined` → `null` on serialisation, which
- * the `repoEntry` schema rejects (`repositories.<index> — Invalid input`).
+ * except the `repositories` array and the `terminal.{launchers, projectActions,
+ * newProjectActions}` arrays — those have dedicated compactors that preserve
+ * blank-row placeholders (`{ name: '' }` / `{ label: '', command: '' }` /
+ * `{ label: '', template: '' }`). Routing them through `pruneEmpty` would
+ * strip the required string fields, leaving `{}` rows that the schema
+ * rejects with `expected string, received undefined`.
  */
 export function buildSavePayload(config: RawConfig): RawConfig {
-  const { repositories, ...rest } = config;
+  const { repositories, terminal, ...rest } = config;
   const pruned = pruneEmpty(rest) as RawConfig;
+  if (terminal !== undefined) {
+    const compacted = compactTerminal(terminal as RawTerminal);
+    if (compacted !== undefined) pruned.terminal = compacted;
+  }
   if (repositories !== undefined) {
     pruned.repositories = compactRepos(repositories);
   }
   return pruned;
+}
+
+type RawTerminal = {
+  launchers?: LauncherConfig[];
+  projectActions?: ActionTemplate[];
+  newProjectActions?: ActionTemplate[];
+  [k: string]: unknown;
+};
+
+/**
+ * Pull the dynamic-row arrays out of `terminal` before pruning so blank-row
+ * placeholders survive (`pruneEmpty` would strip their empty-string required
+ * fields, leaving `{}` rows the schema rejects). Each surviving array is
+ * normalised through its compactor: `{ submit: undefined }` and `{ title: '' }`
+ * get dropped, while `{ label: '', command/template: '' }` rows are kept so
+ * the user can fill them in after a reload.
+ */
+function compactTerminal(terminal: RawTerminal): RawTerminal | undefined {
+  const { launchers, projectActions, newProjectActions, ...rest } = terminal;
+  const cleaned = (pruneEmpty(rest) as RawTerminal) ?? {};
+  if (launchers !== undefined && launchers.length > 0) {
+    cleaned.launchers = compactLaunchers(launchers);
+  }
+  if (projectActions !== undefined && projectActions.length > 0) {
+    cleaned.projectActions = compactActionTemplates(projectActions);
+  }
+  if (newProjectActions !== undefined && newProjectActions.length > 0) {
+    cleaned.newProjectActions = compactActionTemplates(newProjectActions);
+  }
+  return Object.keys(cleaned).length > 0 ? cleaned : undefined;
+}
+
+/**
+ * Normalise `launcherSchema`-shaped rows for disk: keep `label` + `command`
+ * verbatim (even when empty), drop `title` when blank/missing. Used by
+ * `buildSavePayload` to side-step `pruneEmpty` on the launchers array.
+ */
+export function compactLaunchers(arr: LauncherConfig[]): LauncherConfig[] {
+  return arr.map((l) => {
+    const out: LauncherConfig = {
+      label: l.label ?? '',
+      command: l.command ?? '',
+    };
+    if (typeof l.title === 'string' && l.title.length > 0) out.title = l.title;
+    return out;
+  });
+}
+
+/**
+ * Normalise `actionTemplateSchema`-shaped rows for disk: keep `label` +
+ * `template` verbatim, attach `submit: true` only when explicitly set.
+ */
+export function compactActionTemplates(arr: ActionTemplate[]): ActionTemplate[] {
+  return arr.map((a) => {
+    const out: ActionTemplate = {
+      label: a.label ?? '',
+      template: a.template ?? '',
+    };
+    if (a.submit === true) out.submit = true;
+    return out;
+  });
+}
+
+/**
+ * Filter project-card / new-project action rows down to the ones that can
+ * actually be rendered as menu items: both `label` and `template` non-empty.
+ * Blank-row placeholders ("+ Add action" with nothing typed yet) and
+ * half-typed rows live on disk so the Settings modal can present them, but
+ * the runtime dropdowns skip them.
+ */
+export function usableActionTemplates(arr: ActionTemplate[]): ActionTemplate[] {
+  return arr.filter((a) => a.label.trim().length > 0 && a.template.trim().length > 0);
 }
 
 export type BindTextFn = (
@@ -340,8 +417,11 @@ export function patchLauncher(
   } else {
     existing[index] = { ...existing[index], ...patch };
   }
-  // Drop entries with empty command.
-  const kept = existing.filter((l) => l.command.trim().length > 0);
+  // Drop the row only when both label and command are blank — keep partially
+  // typed rows alive so the user doesn't lose their text mid-edit. The
+  // tab-strip dropdown ignores rows with empty command, so a half-filled row
+  // is visible in Settings but inert at the terminal until it's completed.
+  const kept = existing.filter((l) => l.label.trim().length > 0 || l.command.trim().length > 0);
   return kept.length > 0 ? kept : undefined;
 }
 
@@ -391,8 +471,11 @@ export function patchActionTemplate(
   } else {
     existing[index] = { ...existing[index], ...patch };
   }
-  // Drop entries with empty label or empty template.
-  const kept = existing.filter((a) => a.label.trim().length > 0 && a.template.trim().length > 0);
+  // Drop the row only when both label and template are blank — keep partially
+  // typed rows so the user can fill the second field after the first. The
+  // project-card dropdown ignores rows where either field is empty, so a
+  // half-filled row is harmless at runtime.
+  const kept = existing.filter((a) => a.label.trim().length > 0 || a.template.trim().length > 0);
   return kept.length > 0 ? kept : undefined;
 }
 

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -474,14 +474,29 @@ export function SettingsModal(props: {
   const terminalPrefsFor = (target: SettingsTab): TerminalPrefs =>
     (parsedFor(target).terminal as TerminalPrefs | undefined) ?? {};
 
-  /** Mutate the `terminal` block on the given file via its patch fn. */
+  /** Mutate the `terminal` block on the given file via its patch fn.
+   *  Hold the dynamic-row arrays (`launchers`, `projectActions`,
+   *  `newProjectActions`) aside while `pruneEmpty` cleans the scalar keys —
+   *  otherwise pruneEmpty strips required `label`/`command`/`template`
+   *  fields whose value is '' (blank-row placeholders just added via the
+   *  "+ Add" buttons) and leaves `{}` rows that the schema rejects with
+   *  "expected string, received undefined". `buildSavePayload` runs the
+   *  matching bypass at serialise time. */
   const patchTerminal = (
     target: SettingsTab,
     mutator: (prefs: TerminalPrefs) => TerminalPrefs,
   ): Promise<void> =>
     patchFor(target)((c) => {
       const next = mutator({ ...((c.terminal as TerminalPrefs | undefined) ?? {}) });
-      const cleaned = (pruneEmpty(next) as TerminalPrefs) ?? {};
+      const { launchers, projectActions, newProjectActions, ...rest } = next;
+      const cleaned = (pruneEmpty(rest) as TerminalPrefs) ?? {};
+      if (launchers !== undefined && launchers.length > 0) cleaned.launchers = launchers;
+      if (projectActions !== undefined && projectActions.length > 0) {
+        cleaned.projectActions = projectActions;
+      }
+      if (newProjectActions !== undefined && newProjectActions.length > 0) {
+        cleaned.newProjectActions = newProjectActions;
+      }
       c.terminal = Object.keys(cleaned).length > 0 ? cleaned : undefined;
     });
 


### PR DESCRIPTION
## Summary

- Incident hotfix: clicking '+ Add action' (or '+ Add launcher') in the Settings modal crashed every subsequent save with `terminal.projectActions.0.label — Invalid input: expected string, received undefined`, with the just-added row vanishing on next render.
- Root cause: `pruneEmpty` stripped the empty-string `label`/`command`/`template` fields from the freshly-appended row, leaving `{}` that the Zod schema rejected.

## Changes

- `config-schema.ts` — Relax `launcherSchema` and `actionTemplateSchema` so `label` / `command` / `template` accept empty strings, mirroring the existing `repoEntry` design that already tolerates `{ name: '' }` blank rows.
- `config-schema.ts` — Adjust the legacy launcher scrubber in `migrateRawSettings` to keep `command: ''` placeholders while still dropping whitespace-only or non-string commands.
- `settings-modal-parts/data.ts` — New `compactTerminal` / `compactLaunchers` / `compactActionTemplates` route `terminal.{launchers, projectActions, newProjectActions}` around `pruneEmpty` at save time so blank rows survive serialisation. `buildSavePayload` calls them alongside the existing `compactRepos`.
- `settings-modal-parts/data.ts` — Flip `patchLauncher` and `patchActionTemplate`'s drop filter from AND to OR: a partially-typed row (label or command/template set, the other still blank) now survives editing instead of vanishing mid-keystroke. A row is dropped only when both required text fields are blank.
- `settings-modal-parts/data.ts` — New `usableActionTemplates(arr)` helper that the renderer dropdowns call to skip blank/half-typed rows.
- `settings-modal.tsx` — `patchTerminal` mirrors the `buildSavePayload` bypass: hold the dynamic-row arrays aside while `pruneEmpty` cleans the scalar `terminal.*` keys.
- `main.tsx` — Route the three projectActions/newProjectActions props for project-card and preview menus through `usableActionTemplates` so empty menu items never render.
- `data.test.ts` — Update partial-row drop expectations; add buildSavePayload + schema round-trip regression tests for the blank-row case in both arrays; tests for `usableActionTemplates`.
- `package.json` / `package-lock.json` — Bump to 3.12.2.

## Impact

- Settings modal can now persist `{ label: '', command: '' }` and `{ label: '', template: '' }` placeholder rows. The Zod schemas no longer enforce `.min(1)` on these required strings — consumers (`terminal-bridge`, `terminal-pane`, `column.tsx`, and the new `usableActionTemplates`) already filter empty-text rows at the dropdown boundary.

## Watchpoints

- After a save lands, the freshly-added blank row should remain visible in Settings on next open. A regression would silently re-introduce the disappearing-row UX.