### PR TITLE
Bump 3.13.0: fix project-card chevron + add ActionTemplate.launcher binding

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -228,17 +228,18 @@ Per-entry actions rendered in the dropdown next to a project's **Work on** butto
   "terminal": {
     "projectActions": [
       { "label": "Claude review", "template": "claude \"review project {shortSlug}\"", "submit": true },
-      { "label": "Kimi summary", "template": "kimi \"summarise {shortSlug}\"", "submit": true }
+      { "label": "Kimi summary", "template": "kimi \"summarise {shortSlug}\"", "submit": true, "launcher": "KimiKimi" }
     ]
   }
 }
 ```
 
-| Key       | Type             | Required | Meaning                                                                                                                                                                                                         |
-| --------- | ---------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`   | string           | yes      | User-defined name shown in the dropdown. Empty or whitespace is treated as the entry being unset (no dropdown option rendered).                                |
-| `template`| string           | yes      | Text pasted into the focused terminal when the entry is selected. May contain `{slug}`, `{shortSlug}`, `{title}`, `{branch}`, `{base}`, `{kind}`, `{status}`, `{date}`, `{apps}`, `{firstApp}`, `{path}`, `{relPath}`, and global placeholders (`{today}`, `{conception}`, `{conceptionPath}`). Unknown placeholders are left verbatim so typos remain visible. Empty or whitespace is treated as the entry being unset. |
-| `submit`  | bool             | no       | When `true`, condash presses Enter after pasting the template. Default `false` — matches the current **Work on** behaviour and lets templates that end with a colon wait for the user to type the variable bit. |
+| Key        | Type             | Required | Meaning                                                                                                                                                                                                         |
+| ---------- | ---------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `label`    | string           | yes      | User-defined name shown in the dropdown. Empty or whitespace is treated as the entry being unset (no dropdown option rendered).                                |
+| `template` | string           | yes      | Text pasted into the focused terminal when the entry is selected. May contain `{slug}`, `{shortSlug}`, `{title}`, `{branch}`, `{base}`, `{kind}`, `{status}`, `{date}`, `{apps}`, `{firstApp}`, `{path}`, `{relPath}`, and global placeholders (`{today}`, `{conception}`, `{conceptionPath}`). Unknown placeholders are left verbatim so typos remain visible. Empty or whitespace is treated as the entry being unset. |
+| `submit`   | bool             | no       | When `true`, condash presses Enter after pasting the template. Default `false` — matches the current **Work on** behaviour and lets templates that end with a colon wait for the user to type the variable bit. |
+| `launcher` | string           | no       | When set, names one of `terminal.launchers[].label`. The action spawns a fresh tab using that launcher's command before typing the template — useful for binding an action to a specific agent (Claude / Kimi / shell). Empty / missing → type into the focused tab (default-launcher fallback when no tab exists, as before). A label that no longer matches a configured launcher falls through to the focused-tab flow. |
 
 ### `terminal.newProjectActions` { #terminalnewprojectactions }
 
@@ -248,17 +249,19 @@ Per-entry starter prompts rendered in the dropdown next to the **+ New project**
 {
   "terminal": {
     "newProjectActions": [
-      { "label": "Spec + design starter", "template": "start project for new feature, make spec.md note with functional specification, and design.md note with design plan:", "submit": false }
+      { "label": "Spec + design starter", "template": "start project for new feature, make spec.md note with functional specification, and design.md note with design plan:", "submit": false },
+      { "label": "Start new project (Claude)", "template": "Start new project ", "launcher": "Claude" }
     ]
   }
 }
 ```
 
-| Key       | Type             | Required | Meaning                                                                                                                                                                                                         |
-| --------- | ---------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`   | string           | yes      | User-defined name shown in the dropdown. Empty or whitespace is treated as the entry being unset.                                                              |
-| `template`| string           | yes      | Text pasted into the focused terminal. May contain global placeholders only: `{today}`, `{conception}`, `{conceptionPath}`. Unknown placeholders are left verbatim. Empty or whitespace is treated as the entry being unset. |
-| `submit`  | bool             | no       | When `true`, condash presses Enter after pasting. Default `false`.                                                                                             |
+| Key        | Type             | Required | Meaning                                                                                                                                                                                                         |
+| ---------- | ---------------- | -------- | -------------------------------------------------------------------------------------------------------------- |
+| `label`    | string           | yes      | User-defined name shown in the dropdown. Empty or whitespace is treated as the entry being unset.                                                              |
+| `template` | string           | yes      | Text pasted into the focused terminal. May contain global placeholders only: `{today}`, `{conception}`, `{conceptionPath}`. Unknown placeholders are left verbatim. Empty or whitespace is treated as the entry being unset. |
+| `submit`   | bool             | no       | When `true`, condash presses Enter after pasting. Default `false`.                                                                                             |
+| `launcher` | string           | no       | When set, names one of `terminal.launchers[].label`. The action spawns a fresh tab using that launcher's command and types the template into the new tab — gives each entry a predictable starting environment (e.g. **Start new project → Claude** always opens a fresh Claude shell). Empty / missing keeps the legacy "type into focused tab" behaviour. |
 
 > **Note.** Selecting a new-project action does **not** create a project automatically — it only types a starter prompt into the terminal. The user then prompts their agent to create the project via `condash projects create`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.12.2",
+  "version": "3.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.12.2",
+      "version": "3.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.12.2",
+  "version": "3.13.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -181,12 +181,21 @@ const launchersSchema = z.array(launcherSchema);
  *  "+ New project" button. Same blank-row tolerance as `launcherSchema`:
  *  `label` and `template` accept empty strings so a freshly-added row is
  *  schema-valid; the project-card dropdown skips entries whose `template`
- *  is empty. */
+ *  is empty.
+ *
+ *  `launcher`, when set, names one of `terminal.launchers[].label`. The
+ *  action spawns a fresh tab with that launcher's command then types the
+ *  template into it — gives users a way to bind, e.g., "Start new project"
+ *  to a Claude / Kimi / shell launcher instead of typing into whatever
+ *  shell happens to be focused. Empty / missing keeps the legacy behaviour
+ *  (type into the focused tab; spawn the default launcher only if no tab
+ *  exists). */
 const actionTemplateSchema = z
   .object({
     label: z.string(),
     template: z.string(),
     submit: z.boolean().optional(),
+    launcher: z.string().optional(),
   })
   .strict();
 

--- a/src/renderer/action-split-button.css
+++ b/src/renderer/action-split-button.css
@@ -134,34 +134,60 @@
   flex-shrink: 0;
 }
 
-/* Card-specific sizing override. */
-.row-action.work-on .action-split-button {
+/* Card-specific sizing override. The selectors are *compound* (no space)
+ * because `row-action` and `work-on` live on the same element as
+ * `action-split-button` — a descendant combinator would never match. */
+.action-split-button.row-action.work-on {
+  /* `.row .row-action` in projects-pane.css forces a hard 28×28 box on every
+   * row action button. That sizing fits a single-icon button but squeezes
+   * this two-child split button so the caret either renders at 0 px or is
+   * clipped by `overflow: hidden`. Reset to natural width / height + drop
+   * the row-action chrome we don't want here (the inner buttons supply
+   * their own background and padding). */
+  width: auto;
+  height: auto;
   border: none;
   background: transparent;
   padding: 0;
+  overflow: visible;
 }
 
-.row-action.work-on .action-split-primary {
-  padding: 4px;
-}
-
-.row-action.work-on .action-split-caret {
-  width: 16px;
-  border-left: none;
-}
-
-/* Modal-header sizing override. */
-.modal-button.work-on-button .action-split-button {
-  border: none;
+.action-split-button.row-action.work-on:hover {
   background: transparent;
-  padding: 0;
+  border-color: transparent;
 }
 
-.modal-button.work-on-button .action-split-primary {
+.action-split-button.row-action.work-on .action-split-primary {
   padding: 4px;
 }
 
-.modal-button.work-on-button .action-split-caret {
+.action-split-button.row-action.work-on .action-split-caret {
   width: 18px;
   border-left: none;
+}
+
+/* Modal-header sizing override — same compound-selector fix as above. */
+.action-split-button.modal-button.work-on-button {
+  width: auto;
+  height: auto;
+  border: none;
+  background: transparent;
+  padding: 0;
+  overflow: visible;
+}
+
+.action-split-button.modal-button.work-on-button .action-split-primary {
+  padding: 4px;
+}
+
+.action-split-button.modal-button.work-on-button .action-split-caret {
+  width: 20px;
+  border-left: none;
+}
+
+/* "+ New project" header action — pad the caret enough that the chevron
+ * gets a comfortable 24 px hit target instead of the default 22 px so the
+ * dropdown isn't a pixel-hunt next to the primary text. */
+.action-split-button.new-project-button .action-split-caret {
+  width: 24px;
 }

--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -741,29 +741,29 @@ body[data-dragging='project'] .group-block.drag-over {
   letter-spacing: 0.01em;
 }
 
+/* `.new-project-button` is the outer wrapper of the ActionSplitButton (it
+ * carries both `.action-split-button` and `.new-project-button` classes).
+ * Keep the border/background/font tokens here but *don't* add padding on
+ * the wrapper — the inner primary button supplies its own padding and any
+ * wrapper padding becomes a dead zone that visually looks like the
+ * "+ New project" button but doesn't fire its onClick. The wrapper is also
+ * inert pointer-wise (no onClick); only its child <button>s are. */
 .new-project-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px 6px 8px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-subtle);
-  color: var(--text);
-  cursor: pointer;
   font: inherit;
   font-size: var(--text-md);
   font-weight: 600;
-  transition:
-    background 100ms ease,
-    border-color 100ms ease,
-    color 100ms ease;
+  color: var(--text);
 }
 
-.new-project-button:hover {
-  background: var(--bg-hover);
-  border-color: var(--accent);
-  color: var(--accent);
+.new-project-button .action-split-primary {
+  padding: 6px 8px 6px 8px;
+}
+
+.new-project-button .action-split-primary,
+.new-project-button .action-split-caret {
+  /* Pull the wrapper's "look like a button" colour onto the inner buttons
+   * so the hover transition still moves the entire control as one. */
+  color: var(--text);
 }
 
 .new-project-button-plus {

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -355,7 +355,8 @@ export function compactLaunchers(arr: LauncherConfig[]): LauncherConfig[] {
 
 /**
  * Normalise `actionTemplateSchema`-shaped rows for disk: keep `label` +
- * `template` verbatim, attach `submit: true` only when explicitly set.
+ * `template` verbatim, attach `submit: true` only when explicitly set, and
+ * attach `launcher` only when set to a non-empty string.
  */
 export function compactActionTemplates(arr: ActionTemplate[]): ActionTemplate[] {
   return arr.map((a) => {
@@ -364,6 +365,7 @@ export function compactActionTemplates(arr: ActionTemplate[]): ActionTemplate[] 
       template: a.template ?? '',
     };
     if (a.submit === true) out.submit = true;
+    if (typeof a.launcher === 'string' && a.launcher.length > 0) out.launcher = a.launcher;
     return out;
   });
 }

--- a/src/renderer/settings-modal-parts/fields.tsx
+++ b/src/renderer/settings-modal-parts/fields.tsx
@@ -131,11 +131,18 @@ function ActionTemplateSection(props: {
     onChange: (e: Event & { currentTarget: HTMLInputElement }) => void;
   };
   items: () => ActionTemplate[];
+  /** Configured launchers, exposed in the per-row Launcher dropdown. Only
+   *  entries with a non-empty label/command are useful — the picker
+   *  filters again at render time so freshly-added blank rows don't show
+   *  up as ghost options. */
+  launchers: () => LauncherConfig[];
   patch: (index: number, patch: Partial<ActionTemplate>) => Promise<void>;
   add: () => Promise<void>;
   remove: (index: number) => Promise<void>;
   move: (index: number, delta: -1 | 1) => Promise<void>;
 }): JSX.Element {
+  const usableLaunchers = (): LauncherConfig[] =>
+    props.launchers().filter((l) => l.label.trim().length > 0 && l.command.trim().length > 0);
   return (
     <>
       <h3>{props.title}</h3>
@@ -166,6 +173,28 @@ function ActionTemplateSection(props: {
                   (v) => props.patch(idx(), { template: v }),
                 )}
               />
+            </label>
+            <label>
+              <span>Launcher</span>
+              <select
+                value={action.launcher ?? ''}
+                onChange={(e) => {
+                  const value = e.currentTarget.value;
+                  void props.patch(idx(), { launcher: value || undefined });
+                }}
+              >
+                <option value="">(focused tab)</option>
+                <For each={usableLaunchers()}>
+                  {(l) => <option value={l.label}>{l.label}</option>}
+                </For>
+                <Show
+                  when={
+                    action.launcher && !usableLaunchers().some((l) => l.label === action.launcher)
+                  }
+                >
+                  <option value={action.launcher!}>{action.launcher} (not configured)</option>
+                </Show>
+              </select>
             </label>
             <label class="settings-checkbox">
               <input
@@ -347,10 +376,11 @@ export function TerminalFields(props: {
 
       <ActionTemplateSection
         title="Project actions"
-        hint="Each entry appears in the dropdown next to the project's Work-on button. Templates accept {slug}, {title}, {branch}, {apps}, … (see Help)."
+        hint="Each entry appears in the dropdown next to the project's Work-on button. Templates accept {slug}, {title}, {branch}, {apps}, … (see Help). Launcher (when set) spawns a fresh tab using that launcher's command instead of typing into the focused tab."
         idPrefix={`${idPrefix}.projectActions`}
         bindText={props.bindText}
         items={props.projectActions}
+        launchers={props.launchers}
         patch={props.patchProjectAction}
         add={props.addProjectAction}
         remove={props.removeProjectAction}
@@ -359,10 +389,11 @@ export function TerminalFields(props: {
 
       <ActionTemplateSection
         title="New project actions"
-        hint="Each entry appears in the dropdown next to the + New project button. Templates accept {today}, {conception}, {conceptionPath}."
+        hint="Each entry appears in the dropdown next to the + New project button. Templates accept {today}, {conception}, {conceptionPath}. Launcher (when set) spawns a fresh tab — e.g. bind 'Start new project' to a Claude launcher to get a fresh Claude shell on every click."
         idPrefix={`${idPrefix}.newProjectActions`}
         bindText={props.bindText}
         items={props.newProjectActions}
+        launchers={props.launchers}
         patch={props.patchNewProjectAction}
         add={props.addNewProjectAction}
         remove={props.removeNewProjectAction}

--- a/src/renderer/terminal-bridge.test.ts
+++ b/src/renderer/terminal-bridge.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { createTerminalBridge } from './terminal-bridge';
 import type { TerminalPaneHandle } from './terminal-pane';
-import type { ActionTemplate, Project } from '@shared/types';
+import type { ActionTemplate, Project, TerminalPrefs } from '@shared/types';
 
 type FakeHandle = {
   spawn: ReturnType<typeof vi.fn>;
@@ -23,11 +23,11 @@ function makeFakeHandle(): FakeHandle {
   };
 }
 
-function makeDeps(handle: FakeHandle | null = null) {
+function makeDeps(handle: FakeHandle | null = null, prefs: TerminalPrefs = {}) {
   return {
     terminalHandle: () => handle as unknown as TerminalPaneHandle | null,
     ensureTerminalOpen: vi.fn(),
-    terminalPrefs: () => ({}),
+    terminalPrefs: (): TerminalPrefs => prefs,
     flashToast: vi.fn(),
     conceptionPath: () => '/home/alice/src/vcoeur/conception',
   };
@@ -148,5 +148,84 @@ describe('handleNewProjectAction', () => {
     expect(handle.typeIntoActive).toHaveBeenLastCalledWith('\r');
     expect(handle.typeIntoActive).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
+  });
+
+  it('spawns the bound launcher and types into the new tab when action.launcher is set', async () => {
+    const handle = makeFakeHandle();
+    const prefs: TerminalPrefs = {
+      launchers: [
+        { label: 'Claude', command: 'claude' },
+        { label: 'KimiKimi', command: 'kimi-kimi' },
+      ],
+    };
+    const bridge = createTerminalBridge(makeDeps(handle, prefs));
+    const action: ActionTemplate = {
+      label: 'Start new project',
+      template: 'Start new project ',
+      launcher: 'KimiKimi',
+    };
+    await bridge.handleNewProjectAction(action);
+    // Spawned the bound launcher, not the default
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(
+      { label: 'KimiKimi', command: 'kimi-kimi' },
+      'my',
+    );
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('Start new project ');
+  });
+
+  it('falls back to the focused-tab flow when action.launcher does not match any configured launcher', async () => {
+    const handle = makeFakeHandle();
+    const prefs: TerminalPrefs = {
+      launchers: [{ label: 'Claude', command: 'claude' }],
+    };
+    const bridge = createTerminalBridge(makeDeps(handle, prefs));
+    const action: ActionTemplate = {
+      label: 'Start new project',
+      template: 'Start new project ',
+      launcher: 'NonExistent',
+    };
+    await bridge.handleNewProjectAction(action);
+    // No spawn — handle is already active, fell through to the default flow
+    expect(handle.spawnUserShell).not.toHaveBeenCalled();
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('Start new project ');
+  });
+
+  it('skips a launcher whose command is empty (treats it as not configured)', async () => {
+    const handle = makeFakeHandle();
+    const prefs: TerminalPrefs = {
+      launchers: [
+        { label: 'Claude', command: 'claude' },
+        { label: 'EmptyLauncher', command: '' },
+      ],
+    };
+    const bridge = createTerminalBridge(makeDeps(handle, prefs));
+    const action: ActionTemplate = {
+      label: 'Start new project',
+      template: 'Start new project ',
+      launcher: 'EmptyLauncher',
+    };
+    await bridge.handleNewProjectAction(action);
+    expect(handle.spawnUserShell).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleProjectAction with launcher binding', () => {
+  it('spawns the bound launcher before typing the substituted template', async () => {
+    const handle = makeFakeHandle();
+    const prefs: TerminalPrefs = {
+      launchers: [{ label: 'Claude', command: 'claude' }],
+    };
+    const bridge = createTerminalBridge(makeDeps(handle, prefs));
+    const action: ActionTemplate = {
+      label: 'Review',
+      template: 'review {shortSlug}',
+      launcher: 'Claude',
+    };
+    await bridge.handleProjectAction(sampleProject, action);
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(
+      { label: 'Claude', command: 'claude' },
+      'my',
+    );
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('review foo-bar');
   });
 });

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -75,6 +75,19 @@ async function waitForTerminalHandle(deps: TerminalBridgeDeps): Promise<Terminal
   return deps.terminalHandle();
 }
 
+/** Look up a launcher by `label` from current terminal prefs. Returns null
+ *  for an empty/missing label or when no configured launcher matches by
+ *  label *and* has a non-empty command (matches `defaultLauncher`'s
+ *  "usable" rule). */
+function findLauncherByLabel(
+  prefs: TerminalPrefs | undefined,
+  label: string | undefined,
+): LauncherConfig | null {
+  if (!label) return null;
+  const launchers = prefs?.launchers ?? [];
+  return launchers.find((l) => l.label === label && l.command.trim().length > 0) ?? null;
+}
+
 /** Bridges between dashboard actions (per-card work-on, open-in-term,
  *  screenshot paste) and the terminal pane. Centralises the "spawn a
  *  shell first if there isn't one" dance so callers don't repeat it. */
@@ -99,6 +112,40 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     return handle;
   };
 
+  /** Action-aware preamble: when the action binds a launcher (one of the
+   *  configured `terminal.launchers[].label`), spawn a fresh tab using
+   *  that launcher's command on every click — keeps "Start new project →
+   *  Claude" predictable instead of typing into whatever tab happens to
+   *  be focused. Falls back to `ensureTermAndShell()` when no launcher
+   *  is bound or the bound label no longer resolves. */
+  const ensureTermForAction = async (
+    action: ActionTemplate,
+  ): Promise<TerminalPaneHandle | null> => {
+    const launcher = findLauncherByLabel(deps.terminalPrefs(), action.launcher);
+    if (!launcher) return ensureTermAndShell();
+    if (!deps.terminalHandle()) {
+      deps.ensureTerminalOpen();
+      await waitForTerminalHandle(deps);
+    }
+    const handle = deps.terminalHandle();
+    if (!handle) return null;
+    deps.ensureTerminalOpen();
+    try {
+      await handle.spawnUserShell(launcher, 'my');
+    } catch (err) {
+      deps.flashToast(`Could not spawn ${launcher.label}: ${(err as Error).message}`, 'error');
+      return null;
+    }
+    // The session arrives via the onTermSessions snapshot listener, which
+    // reconciles + sets the new tab active. Give it one paint (≈ a frame)
+    // to land so the immediately-following typeIntoActive writes to the
+    // new tab and not the previously-focused one. setTimeout(0) instead
+    // of requestAnimationFrame so this stays callable in unit tests
+    // (jsdom env doesn't define rAF).
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    return handle;
+  };
+
   const handleWorkOn = async (project: Project): Promise<void> => {
     const text = `work on ${project.slug}`;
     const handle = await ensureTermAndShell();
@@ -109,7 +156,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
   const handleProjectAction = async (project: Project, action: ActionTemplate): Promise<void> => {
     const ctx = projectContext(project, deps.conceptionPath() ?? undefined);
     const text = substitute(action.template, ctx);
-    const handle = await ensureTermAndShell();
+    const handle = await ensureTermForAction(action);
     if (!handle) return;
     handle.typeIntoActive(text);
     if (action.submit) {
@@ -124,7 +171,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     const today = new Date().toISOString().slice(0, 10);
     const ctx = globalContext(today, deps.conceptionPath() ?? '');
     const text = substitute(action.template, ctx);
-    const handle = await ensureTermAndShell();
+    const handle = await ensureTermForAction(action);
     if (!handle) return;
     handle.typeIntoActive(text);
     if (action.submit) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -448,6 +448,12 @@ export interface ActionTemplate {
   template: string;
   /** When true, press Enter after typing. Default false. */
   submit?: boolean;
+  /** When set, names one of `terminal.launchers[].label`. The action then
+   *  spawns a fresh tab using that launcher's command before typing the
+   *  template (e.g. bind "Start new project" to a Claude / Kimi / shell
+   *  launcher). Empty / missing → type into the focused tab, spawning the
+   *  default launcher only if no tab exists. */
+  launcher?: string;
 }
 
 export interface TerminalPrefs {


### PR DESCRIPTION
## Summary
- The project-card action chevron and the modal-header work-on chevron were effectively unclickable; the `+ New project` button had a dead padded region around the primary; `Start new project` (and any newProjectAction) couldn't be pinned to a specific launcher.
- This PR converts the descendant-combinator overrides in `action-split-button.css` to compound selectors so the variant chrome actually applies, reclaims the wrapper's hit area on `.new-project-button`, and adds an optional `launcher` field to ActionTemplate so each action can spawn a fresh tab in a specific launcher (Claude / Kimi / shell).

## Changes
- `src/renderer/action-split-button.css`: rewrite the per-variant overrides as compound selectors (`.action-split-button.row-action.work-on`, `.action-split-button.modal-button.work-on-button`) so they match the same-element wrapper. Reset `width`/`height`/`padding`/`overflow` per variant; bump caret widths to 18 px (card), 20 px (modal), 24 px (+ New project).
- `src/renderer/panes/projects-pane.css`: strip the dead `padding` / `cursor: pointer` / `display` / `background` / `border` block from `.new-project-button` — those properties belong on (and are supplied by) the inner buttons; the old wrapper padding became a no-op zone visually indistinguishable from the button.
- `src/shared/types.ts`, `src/main/config-schema.ts`: add optional `launcher` field to `ActionTemplate` (Zod schema + TS type, with doc comment).
- `src/renderer/terminal-bridge.ts`: when an action carries a `launcher` that resolves to a configured `terminal.launchers[]` entry, spawn a fresh tab using that launcher's command before typing the template. Falls back to the existing focused-tab flow when the field is empty / missing / does not resolve.
- `src/renderer/settings-modal-parts/fields.tsx`: add a Launcher `<select>` to the per-row editor for both `projectActions` and `newProjectActions`; `(focused tab)` as the empty value; a `(not configured)` ghost option appears if the saved label no longer matches a launcher.
- `src/renderer/settings-modal-parts/data.ts`: `compactActionTemplates` preserves the `launcher` field (only when non-empty) so it round-trips to disk.
- `src/renderer/terminal-bridge.test.ts`: 4 new cases covering the launcher binding (spawn-then-type happy path, missing launcher falls back to focused-tab flow, empty-command launcher treated as unconfigured, projectAction binding parallel to newProjectAction).
- `docs/reference/config.md`: document the new `launcher` field for both `projectActions` and `newProjectActions`.
- `package.json` + `package-lock.json`: 3.12.2 → 3.13.0.

## Impact
- Existing `condash.json` files with no `launcher` field behave identically to before. Adding `launcher: "Claude"` to a `newProjectActions` entry switches that entry to spawn-fresh-tab semantics on every click.
- Settings UI gains a per-row Launcher dropdown; the picker filters to launchers with non-empty label and command.
- electron-updater: tag `v3.13.0` against the bump-commit SHA after merge.

## Watchpoints
- The launcher-bound spawn path uses `setTimeout(0)` before `typeIntoActive` to give the `onTermSessions` snapshot listener a tick to reconcile and set the new tab active. If typed text occasionally lands in the *previous* tab instead of the new one, that's the race to widen.