### PR TITLE
Omnibus docs tail: dev-launch guide, [!] in readme-format

### DIFF
--- a/docs/guides/dev-launch.md
+++ b/docs/guides/dev-launch.md
@@ -1,0 +1,52 @@
+---
+title: Dev launch · condash guide
+description: Run condash from a clone of the repo with hot-reload — installer-free, the path every contributor uses.
+---
+
+# Dev launch
+
+> **Audience.** Contributor — anyone running condash from source instead of an installer.
+
+**When to read this.** You cloned the repo, want to run the dashboard against your local code, and need to know which `make` target does what.
+
+## One-time install
+
+```bash
+git clone https://github.com/vcoeur/condash.git
+cd condash
+make install
+```
+
+`make install` runs `npm install` and then `electron-rebuild` against the bundled Electron's Node ABI. The rebuild step is the one that fails on a missing C/C++ toolchain — see [Contributing — prerequisites](../explanation/contributing.md#prerequisites) for the per-OS package list.
+
+## The watch loop
+
+```bash
+make dev
+```
+
+`make dev` runs three things concurrently:
+
+- `tsc --watch` typechecks `src/main/` and `src/renderer/` continuously (no emit; esbuild handles bundling).
+- `vite` serves the renderer at `localhost:5600` with hot module reload.
+- `electron` opens a single `BrowserWindow` against the dev URL. Main / preload changes restart on the next launch (`Ctrl+R` reloads the renderer in-place).
+
+If port `5600` is in use, `make kill` frees it.
+
+## `--no-sandbox` and the sandbox toggle
+
+`make dev` runs Electron with `--no-sandbox` to avoid per-worktree `chrome-sandbox` ownership fixes. The dev window only loads `localhost:5600` and local `file://` URLs — the threat surface is local-only.
+
+If you want the sandbox on while developing, drop `--no-sandbox` from `dev:electron` in `package.json` and then, once per worktree:
+
+```bash
+sudo chown root node_modules/electron/dist/chrome-sandbox
+sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
+```
+
+macOS and Windows are unaffected — the sandbox there does not require the SUID step.
+
+## See also
+
+- [Contributing](../explanation/contributing.md) — full clone-to-PR workflow including testing and style.
+- [CLI](../reference/cli.md) — the runtime command-line surface, useful once you have a build to drive.

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -136,9 +136,9 @@ condash --conception ~/src/conception projects list
 
 Or set the path through `condash config conception-path ~/src/conception` (writes to `settings.json`, picked up by both the GUI and the CLI).
 
-### `condash` says "'projects' is a CLI command, not a GUI option"
+### `condash` reports an unknown noun
 
-From v2.14.0 the GUI launcher (`condash`) and the CLI launcher (`condash`) are split. `condash <noun>` errors out with a hint. Re-run as `condash <noun>`. See [`condash --help`](../reference/cli.md) for the full list of nouns.
+The single `condash` binary dispatches GUI vs. CLI based on argv (see [CLI — How dispatch works](../reference/cli.md#how-dispatch-works)). If you typed a typo for a CLI noun (e.g. `condash projct list`), `condash` reports `unknown noun` and exits with code 2. Re-run with the correct noun — `condash --help` lists every accepted one.
 
 ## Reading the toasts
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,7 +7,7 @@ description: The condash command-line surface — list projects, search, manage 
 
 > **Audience.** Daily user and Developer.
 
-`condash` is the command-line companion to the dashboard. From v2.14.0 the GUI launcher (`condash`) and the CLI launcher (`condash`) are two separate entries on PATH. The .deb / AppImage / DMG / NSIS installers drop both — same packaged Electron binary underneath, different launchers. `condash` runs the binary in plain-Node mode (`ELECTRON_RUN_AS_NODE=1`) against the bundled CLI script. No Chromium boots, no window opens, output goes to stdout / stderr.
+`condash` is the command-line companion to the dashboard. A single binary on PATH dispatches both modes: bare `condash` (no args, or `condash gui`) launches the packaged Electron GUI; `condash <noun> <verb> [args]` runs the bundled CLI script with no window — output goes to stdout / stderr.
 
 ```
 condash <noun> <verb> [args] [--flags]
@@ -23,12 +23,12 @@ The CLI exists because skills (`/projects`, `/knowledge`, `/tidy`) and shell scr
 | `condash --help` | Print the top-level CLI help |
 | `condash --version` | Print the CLI version |
 | `condash <noun> <verb>` | Run a CLI verb against the resolved conception path |
-| `make dev` (from source) | Watch mode: tsc + vite + Electron with `--no-sandbox` |
-| `make package` (from source) | Per-OS installers under `release/` via electron-builder |
+
+For running condash from a source clone (`make install`, `make dev`, `make package`), see [Dev launch](../guides/dev-launch.md).
 
 ## How dispatch works
 
-The two launchers are physically separate scripts. `condash` always boots the Electron GUI; if it sees a CLI noun (`projects`, `knowledge`, …) on its argv it errors with a hint to use `condash` instead. `condash` always runs the bundled CLI script under plain Node — it never starts Chromium.
+One binary, one launcher: the `condash` entry on PATH inspects its argv. With no positional argument (or with the literal `gui` first), it boots the Electron GUI. With a known CLI noun (`projects`, `knowledge`, …) first, it runs the bundled CLI script in plain-Node mode (no Chromium, no window). An unknown first positional reports an unknown noun and exits with code 2 (usage).
 
 CLI nouns:
 
@@ -272,24 +272,6 @@ condash skills install
 # Pipe to jq.
 condash projects list --json | jq '.data[] | select(.kind == "incident")'
 ```
-
-## Dev launch
-
-From a clone of the repo:
-
-```bash
-make install      # one-off — npm install + electron-rebuild
-make dev          # watch: esbuild rebuilds main + cli, vite serves renderer, electron reloads
-```
-
-`make dev` runs the Electron build with `--no-sandbox` to avoid per-worktree `chrome-sandbox` ownership fixes. The dev window only loads `localhost:5600` and local `file://` URLs — the threat surface is local-only. Drop `--no-sandbox` from `dev:electron` in `package.json` if you want the sandbox on, then once per worktree:
-
-```bash
-sudo chown root node_modules/electron/dist/chrome-sandbox
-sudo chmod 4755 node_modules/electron/dist/chrome-sandbox
-```
-
-macOS and Windows are unaffected.
 
 ## What's not in the CLI
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -42,7 +42,7 @@ Lives at `<conception_path>/.condash/settings.json`. Don't commit it — the aut
   "workspace_path": "/home/you/src",
   "worktrees_path": "/home/you/src/worktrees",
   "resources_path": "resources",
-  "skills_path": ".claude/skills",
+  "skills_path": ".agents/skills",
   "repositories": [
     "condash",
     {

--- a/docs/reference/readme-format.md
+++ b/docs/reference/readme-format.md
@@ -205,6 +205,23 @@ Bold-prose form: comma-separated, backtick-wrapped. Trailing `(…)` parenthetic
 
 Either way, the resulting list powers the dashboard's per-app filter chips.
 
+## Step markers
+
+The `## Steps` list uses five canonical markers, recognised by the parser
+and round-tripped by every writer (CLI mutation verbs, GUI step-toggle,
+the markdown editor):
+
+- `- [ ]` — **todo.** Not yet started.
+- `- [~]` — **doing.** In flight.
+- `- [x]` — **done.** Resolved successfully.
+- `- [!]` — **blocked.** Surfacing a problem that needs attention; counts
+  toward the milestone total but not toward resolved.
+- `- [-]` — **dropped.** Resolved by removing the work; counts as resolved
+  for the progress bar.
+
+The canonical list lives in `src/shared/types.ts` (`STEP_MARKERS`). Any
+marker outside this set is treated as plain prose by the parser.
+
 ## Body conventions
 
 Header fields only describe the item's metadata. The body (everything after the title, in YAML form; everything after the first `##`, in bold-prose form) carries the content — goal, scope, steps, timeline, deliverables, notes. See:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,6 +91,7 @@ nav:
     - The skills pane: guides/skills-pane.md
     - Deliverables and PDFs: guides/deliverables.md
     - Extend the management skill: guides/skill-extensions.md
+    - Dev launch from a clone: guides/dev-launch.md
     - Troubleshooting: guides/troubleshooting.md
 
   - Reference:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.15.0",
+      "version": "3.15.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.15.0",
+  "version": "3.15.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- Tail-end of the 2026-05-18 omnibus review follow-up: the docs sweep agent's last three edits arrived after PR #196 was already open and got dropped from the merge. This PR re-applies them on top of v3.15.0.
- Bumps 3.15.0 → 3.15.1 (patch — docs-only).

## Changes

- New `docs/guides/dev-launch.md` carries the contributor "run from a clone" prose (one-time install, the watch loop, `--no-sandbox` toggle). Linked from `docs/reference/cli.md` so the reference page no longer mixes tutorial content into the runtime surface (the Diátaxis hygiene fix the review called out).
- `docs/reference/cli.md`: the "Dev launch" section is removed (lifted to the new guide) and the top-of-page GUI/CLI dispatch prose is rewritten to describe the current single-binary argv-dispatch (`condash` vs. `condash gui` vs. `condash <noun> <verb>`).
- `docs/reference/readme-format.md` gains a **Step markers** section enumerating the canonical five (` `, `~`, `x`, `!`, `-`) — the `[!]` blocked marker shipped in v3.15.0 had no dedicated mention.
- `docs/reference/config.md` example: `skills_path: .claude/skills` → `.agents/skills` to match the post-skills-rewrite reality (the compiled-target dir is now under `.claude/skills/` but the source-of-truth that conceptions edit is `.agents/skills/`).
- `docs/guides/troubleshooting.md`: rewrite the v2.14.0-era "split launchers" troubleshooting entry to match the single-binary dispatch behaviour and point at the dispatch reference section.
- `mkdocs.yml`: add `Dev launch from a clone: guides/dev-launch.md` to the Guides nav.

## Impact

- Docs-only — no runtime change. The MkDocs nav has one new entry; in-app help bundle is unchanged (the bundled set is `welcome`, `quick-start`, `shortcuts`, `configuration`, `cli`, `why-markdown` — `dev-launch` is contributor-facing, not user-facing).