### PR TITLE
Polish UI/UX across renderer: contrast, typography, animations, noise reduction

### DIFF
--- a/src/renderer/confirm-modal.css
+++ b/src/renderer/confirm-modal.css
@@ -26,3 +26,11 @@
   justify-content: flex-end;
   gap: 8px;
 }
+
+.confirm-actions .modal-button {
+  width: auto;
+  height: auto;
+  padding: 5px 14px;
+  font-size: 13px;
+  white-space: nowrap;
+}

--- a/src/renderer/help-modal.tsx
+++ b/src/renderer/help-modal.tsx
@@ -68,7 +68,7 @@ export function HelpModal(props: { doc: HelpDoc; onClose: () => void }) {
   return (
     <div class="modal-backdrop" onClick={props.onClose}>
       <div
-        class="modal note-modal"
+        class="modal help-modal"
         role="dialog"
         aria-modal="true"
         onClick={(e) => e.stopPropagation()}

--- a/src/renderer/modal-base.css
+++ b/src/renderer/modal-base.css
@@ -144,7 +144,7 @@
 }
 
 .head-progress[data-complete='true'] {
-  opacity: 0.55;
+  color: var(--text-faint);
 }
 
 .head-progress[data-complete='true'] .head-progress-fill {
@@ -197,7 +197,9 @@
 }
 
 .modal-button:disabled {
-  opacity: 0.45;
+  color: var(--text-faint);
+  background: var(--bg-subtle);
+  border-color: var(--border);
   cursor: not-allowed;
 }
 
@@ -233,4 +235,44 @@
   padding: 8px 14px;
   border-bottom: 1px solid var(--warn);
   font-size: 12px;
+}
+
+@keyframes modal-in {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.modal {
+  animation: modal-in 160ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@keyframes backdrop-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modal-backdrop {
+  animation: backdrop-in 160ms ease;
+}
+
+.modal-button--text {
+  width: auto;
+  height: auto;
+  padding: 5px 12px;
+  font-size: 13px;
+  white-space: nowrap;
+}
+
+.help-modal {
+  width: min(800px, 92vw);
 }

--- a/src/renderer/new-project-modal.css
+++ b/src/renderer/new-project-modal.css
@@ -118,13 +118,24 @@
 }
 
 .new-project-radio input[type='radio'] {
-  margin: 0;
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
 }
 
 .new-project-radio:has(input:checked) {
   border-color: var(--accent);
   background: var(--bg-hover);
   color: var(--accent);
+}
+
+.new-project-radio:has(input:checked)::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent);
 }
 
 .new-project-error {

--- a/src/renderer/note-modal.css
+++ b/src/renderer/note-modal.css
@@ -6,7 +6,8 @@
 
 .note-modal {
   width: min(85vw, 1600px);
-  height: 100%;
+  height: auto;
+  max-height: calc(100% - 48px);
 }
 
 .modal-button.work-on-button:hover {
@@ -237,13 +238,13 @@
 }
 
 .find-hit {
-  background: rgba(241, 196, 15, 0.45);
+  background: color-mix(in srgb, var(--col-soon) 40%, transparent);
   border-radius: 2px;
 }
 
 .find-current {
-  background: rgba(241, 196, 15, 0.85);
-  outline: 1px solid #b58900;
+  background: color-mix(in srgb, var(--col-soon) 75%, transparent);
+  outline: 1px solid var(--col-soon);
 }
 
 .md-rendered a.wikilink {

--- a/src/renderer/panes/code-pane.css
+++ b/src/renderer/panes/code-pane.css
@@ -101,9 +101,9 @@
   align-items: center;
   gap: 10px;
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -358,7 +358,7 @@
   margin-right: 4px;
   border-radius: 50%;
   background: var(--bg-elevated);
-  box-shadow: 0 0 6px var(--bg-elevated);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--col-running) 50%, transparent);
   animation: repo-live-pulse 1.6s ease-in-out infinite;
 }
 
@@ -522,9 +522,13 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 4px 0;
+  padding: 5px 0;
   font-size: 12px;
   border-radius: 4px;
+}
+
+.branch-row:hover {
+  background: var(--bg-hover);
 }
 
 .branch-row + .branch-row {

--- a/src/renderer/panes/code-parts/branch-filter.tsx
+++ b/src/renderer/panes/code-parts/branch-filter.tsx
@@ -78,7 +78,22 @@ export function BranchFilter(props: {
   const isNoneMode = (): boolean => !props.stickyAll && props.selected.size === 0;
 
   return (
-    <Show when={props.available.length > 0}>
+    <Show
+      when={props.available.length > 0}
+      fallback={
+        <div class="branch-filter-bar">
+          <button
+            type="button"
+            class="branch-filter-trigger"
+            disabled
+            title="No multi-branch repos to filter"
+          >
+            <span class="branch-filter-trigger-label">Branches (none)</span>
+            <ChevronDownIcon />
+          </button>
+        </div>
+      }
+    >
       <div class="branch-filter-bar">
         <button
           ref={(el) => {
@@ -157,7 +172,9 @@ export function BranchFilter(props: {
                           onChange={() => props.onToggle(branch)}
                           aria-label={`Pin branch ${branch}`}
                         />
-                        <span class="branch-filter-item-name">{branch}</span>
+                        <span class="branch-filter-item-name" title={branch}>
+                          {branch}
+                        </span>
                         <Show when={isActiveProject()}>
                           <span
                             class="branch-filter-item-badge"

--- a/src/renderer/panes/code-parts/repo-row.tsx
+++ b/src/renderer/panes/code-parts/repo-row.tsx
@@ -88,22 +88,24 @@ export function RepoRow(props: {
       }}
     >
       <header class="repo-head">
-        <span class="repo-name">{cardTitle()}</span>
-        <Show when={secondaryName()}>
-          <span class="repo-dirname" title={`Directory: ${displayName()}`}>
-            {secondaryName()}
-          </span>
-        </Show>
-        <Show when={liveBranchLabel()}>
-          <span
-            class="repo-live-branch"
-            title={`Running: ${liveBranchLabel()}`}
-            aria-label={`Running on ${liveBranchLabel()}`}
-          >
-            <span class="repo-live-dot-inline" aria-hidden="true" />
-            <span class="repo-live-branch-label">{liveBranchLabel()}</span>
-          </span>
-        </Show>
+        <span style={{ display: 'flex', 'align-items': 'center', gap: '8px', 'flex-wrap': 'wrap' }}>
+          <span class="repo-name">{cardTitle()}</span>
+          <Show when={secondaryName()}>
+            <span class="repo-dirname" title={`Directory: ${displayName()}`}>
+              {secondaryName()}
+            </span>
+          </Show>
+          <Show when={liveBranchLabel()}>
+            <span
+              class="repo-live-branch"
+              title={`Running: ${liveBranchLabel()}`}
+              aria-label={`Running on ${liveBranchLabel()}`}
+            >
+              <span class="repo-live-dot-inline" aria-hidden="true" />
+              <span class="repo-live-branch-label">{liveBranchLabel()}</span>
+            </span>
+          </Show>
+        </span>
         <span class="spacer" />
         <Show when={props.repo.parent}>
           <span class="repo-kind-tag" title="Submodule, configured under repositories">

--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 22px 28px 28px;
+  padding: 24px 28px 28px;
   min-height: 0;
   overflow-y: auto;
   background: var(--bg-panel);
@@ -11,11 +11,11 @@
 
 .projects-filter {
   position: sticky;
-  top: -22px;
+  top: -24px;
   z-index: 3;
   background: var(--bg-panel);
   padding: 12px 0 8px;
-  margin: -22px 0 0;
+  margin: -24px 0 0;
 }
 
 .projects-filter-input {
@@ -70,7 +70,14 @@
  * must stay fully opaque so the create-first-project affordance is legible. */
 .group-block[data-empty='true']:not([data-status='now']) {
   padding: 2px 0;
-  opacity: 0.45;
+}
+
+.group-block[data-empty='true']:not([data-status='now']) .group-header {
+  color: var(--text-faint);
+}
+
+.group-block[data-empty='true']:not([data-status='now']) .group-header .dot {
+  background: var(--border-strong);
 }
 
 .group-block[data-empty='true'] .group-header {
@@ -181,7 +188,6 @@ body[data-dragging='project'] .group-block.drag-over {
   border-radius: 50%;
   background: var(--col-status, var(--text-faint));
   flex-shrink: 0;
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--col-status, var(--text-faint)) 18%, transparent);
 }
 
 .group-header .name {
@@ -214,7 +220,7 @@ body[data-dragging='project'] .group-block.drag-over {
    * shrunken card on narrow windows. The min is set from settings.json
    * (`cardMinWidth.projects`); the fallback below mirrors the bundled
    * default in `DEFAULT_CARD_MIN_WIDTH`. */
-  grid-template-columns: repeat(auto-fill, minmax(min(var(--card-min-projects, 650px), 100%), 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(var(--card-min-projects, 520px), 100%), 1fr));
   gap: 12px;
   padding: 0;
 }
@@ -277,7 +283,9 @@ body[data-dragging='project'] .group-block.drag-over {
   contain: layout paint;
   transition:
     background-color 140ms ease,
-    border-color 140ms ease;
+    border-color 140ms ease,
+    transform 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .row::before {
@@ -317,6 +325,14 @@ body[data-dragging='project'] .group-block.drag-over {
 .row:hover {
   border-color: var(--border-strong);
   background: var(--bg-hover);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-lift);
+}
+
+.row:hover .title-actions,
+.row:focus-visible .title-actions,
+.row:focus-within .title-actions {
+  opacity: 1;
 }
 
 /* Focus ring on cards. The card is tabIndex={0} so the user can land on
@@ -360,6 +376,8 @@ body[data-dragging='project'] .group-block.drag-over {
    * line of text — the button is 28 px tall, the title cap height
    * sits a couple of pixels below the box top. */
   margin-top: -1px;
+  opacity: 0;
+  transition: opacity 120ms ease;
 }
 
 .row .title {
@@ -414,9 +432,9 @@ body[data-dragging='project'] .group-block.drag-over {
   display: flex;
   align-items: flex-start;
   gap: 8px;
-  font-size: var(--text-md);
-  line-height: 1.5;
-  color: var(--text);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  color: var(--text-body);
 }
 
 .row .summary.next-step .next-step-marker {
@@ -470,17 +488,9 @@ body[data-dragging='project'] .group-block.drag-over {
   min-width: 0;
 }
 
-/* Card body has two stacked meta rows now:
- *   .meta-context — apps + branch (top one, only rendered when there's
- *     anything to show).
- *   .meta-bottom  — step progress + dates (always rendered when there's
- *     either, dates pinned to the right).
- * The shared `.meta` rules above (flex, gap, font-size) cover layout;
- * these only tweak spacing between the two rows. */
-.row .meta-context {
-  margin-top: 4px;
-}
-
+/* Single meta row at the bottom of the card: step progress + apps +
+ * branch + dates (dates pinned to the right). The shared `.meta` rules
+ * above (flex, gap, font-size) cover layout; this only tweaks spacing. */
 .row .meta-bottom {
   margin-top: 2px;
 }
@@ -490,9 +500,6 @@ body[data-dragging='project'] .group-block.drag-over {
   font-size: var(--text-2xs);
   color: var(--text-faint);
   letter-spacing: 0.01em;
-}
-
-.row .meta-icon.branch .branch-text {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -597,7 +604,7 @@ body[data-dragging='project'] .group-block.drag-over {
  * grey too — green at 100% reads as "celebrate", which isn't what we
  * want when scanning a Done bucket. */
 .row .meta-icon.expander[data-complete='true'] {
-  opacity: 0.55;
+  color: var(--text-faint);
 }
 
 .row .meta-icon.expander[data-complete='true'] .progress-fill {
@@ -611,8 +618,8 @@ body[data-dragging='project'] .group-block.drag-over {
 }
 
 .row .meta-icon.expander .progress-track {
-  width: 36px;
-  height: 4px;
+  width: clamp(56px, 12%, 96px);
+  height: 5px;
   border-radius: 2px;
   background: var(--bg-subtle);
   overflow: hidden;
@@ -634,9 +641,9 @@ body[data-dragging='project'] .group-block.drag-over {
 }
 
 .row .meta-icon.expander .expander-arrow {
-  font-size: 9px;
+  font-size: var(--text-xs);
   color: var(--text-faint);
-  margin-left: 2px;
+  margin-left: 4px;
 }
 
 .row .meta-icon.warn {

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -281,7 +281,14 @@ export function Card(props: {
     const sourceWidth = source.offsetWidth;
     ghostOffsetX = sourceWidth / 2;
     ghostOffsetY = 24;
-    ghostElement = source.cloneNode(true) as HTMLElement;
+    const head = source.querySelector('.row-head');
+    ghostElement = (head ? head.cloneNode(true) : source.cloneNode(true)) as HTMLElement;
+    ghostElement.querySelectorAll('.title-actions').forEach((el) => el.remove());
+    ghostElement.style.padding = '12px 16px';
+    ghostElement.style.borderRadius = 'var(--radius-lg)';
+    ghostElement.style.background = 'var(--bg-elevated)';
+    ghostElement.style.border = '1px solid var(--border)';
+    ghostElement.style.boxShadow = '0 8px 24px rgba(0,0,0,0.18)';
     ghostElement.style.position = 'fixed';
     ghostElement.style.top = '0';
     ghostElement.style.left = '0';
@@ -335,6 +342,7 @@ export function Card(props: {
     <article
       class="row"
       title={props.item.path}
+      aria-label={`${props.item.title}, ${props.item.status}`}
       data-status-card={props.item.status}
       draggable={isDraggable()}
       tabIndex={0}
@@ -347,7 +355,7 @@ export function Card(props: {
             work-on action pinned to the right. */}
         <div class="title-row">
           <h3 class="title">
-            <Show when={props.item.kind !== 'unknown'}>
+            <Show when={props.item.kind !== 'unknown' && props.item.kind !== 'project'}>
               <KindGlyph kind={props.item.kind} />
             </Show>
             <span class="title-text">{props.item.title}</span>
@@ -383,32 +391,15 @@ export function Card(props: {
           )}
         </Show>
 
-        {/* Row 3: apps + branch — the project's where/in. Pulled out of
-            the packed meta row so the card has a clean "context" line
-            independent of step progress. */}
-        <Show when={props.item.apps.length > 0 || props.item.branch}>
-          <div class="meta meta-context">
-            <Show when={props.item.apps.length > 0}>
-              <span class="meta-icon apps" title={props.item.apps.join(', ')}>
-                <span class="apps-text">{props.item.apps.join(', ')}</span>
-              </span>
-            </Show>
-            <Show when={props.item.branch}>
-              <span class="meta-icon branch" title={`branch: ${props.item.branch}`}>
-                <span class="branch-text">{props.item.branch}</span>
-              </span>
-            </Show>
-          </div>
-        </Show>
-
-        {/* Row 4: step completion (left) + first/last dates (right).
-            Last row on the card. The dates come from the slug
-            (creation) and the most recent ## Timeline entry. */}
+        {/* Row 3: step completion + apps + branch + dates. Last row on
+            the card. The dates come from the slug (creation) and the
+            most recent ## Timeline entry. */}
         <div class="meta meta-bottom">
           <Show when={hasSteps(props.item.stepCounts)}>
             <button
               class="meta-icon expander"
               data-complete={isStepCountsComplete(props.item.stepCounts) ? 'true' : undefined}
+              aria-expanded={expanded()}
               onClick={(e) => {
                 e.stopPropagation();
                 setExpanded((v) => !v);
@@ -418,6 +409,16 @@ export function Card(props: {
               <StepProgress counts={props.item.stepCounts} />
               <span class="expander-arrow">{expanded() ? '▾' : '▸'}</span>
             </button>
+          </Show>
+          <Show when={props.item.apps.length > 0}>
+            <span class="meta-icon apps" title={props.item.apps.join(', ')}>
+              {props.item.apps.join(', ')}
+            </span>
+          </Show>
+          <Show when={props.item.branch}>
+            <span class="meta-icon branch" title={`branch: ${props.item.branch}`}>
+              {props.item.branch}
+            </span>
           </Show>
           <Show when={statusUnknown()}>
             <span class="meta-icon warn" title={`Unknown status: ${props.item.status}`}>

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -281,14 +281,10 @@ export function Card(props: {
     const sourceWidth = source.offsetWidth;
     ghostOffsetX = sourceWidth / 2;
     ghostOffsetY = 24;
-    const head = source.querySelector('.row-head');
-    ghostElement = (head ? head.cloneNode(true) : source.cloneNode(true)) as HTMLElement;
+    ghostElement = source.cloneNode(true) as HTMLElement;
     ghostElement.querySelectorAll('.title-actions').forEach((el) => el.remove());
-    ghostElement.style.padding = '12px 16px';
-    ghostElement.style.borderRadius = 'var(--radius-lg)';
-    ghostElement.style.background = 'var(--bg-elevated)';
-    ghostElement.style.border = '1px solid var(--border)';
-    ghostElement.style.boxShadow = '0 8px 24px rgba(0,0,0,0.18)';
+    ghostElement.querySelectorAll('.step-list').forEach((el) => el.remove());
+    ghostElement.style.opacity = '0.85';
     ghostElement.style.position = 'fixed';
     ghostElement.style.top = '0';
     ghostElement.style.left = '0';

--- a/src/renderer/panes/tree-view.css
+++ b/src/renderer/panes/tree-view.css
@@ -19,25 +19,12 @@
 /* Indent every nested directory off the depth attribute. The root
  * directory (`data-depth="0"`) hugs the pane's edge; children indent
  * by 16 px per level so a deeply nested tree stays compact. */
-.tree-directory[data-depth='1'] > .tree-children {
-  padding-left: 16px;
-}
-.tree-directory[data-depth='2'] > .tree-children {
-  padding-left: 16px;
-}
-.tree-directory[data-depth='3'] > .tree-children {
-  padding-left: 16px;
-}
-.tree-directory[data-depth='4'] > .tree-children {
-  padding-left: 16px;
-}
-
 .tree-children {
   display: flex;
   flex-direction: column;
   gap: 8px;
   border-left: 1px dashed var(--border);
-  padding-left: 14px;
+  padding-left: 16px;
 }
 
 /* The root node's children sit flush — no rail, no indent. The pane
@@ -53,9 +40,9 @@
   align-items: center;
   gap: 8px;
   font-family: var(--font-ui);
-  font-size: 10px;
+  font-size: 11px;
   font-weight: 600;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
   color: var(--text-muted);
   cursor: default;

--- a/src/renderer/project-preview.css
+++ b/src/renderer/project-preview.css
@@ -11,7 +11,7 @@
   overflow-y: auto;
   padding: 16px 20px 20px;
   display: grid;
-  grid-template-columns: 2fr 3fr;
+  grid-template-columns: minmax(260px, 2fr) 3fr;
   gap: 24px;
   align-items: start;
 }
@@ -163,7 +163,7 @@
   position: absolute;
   top: calc(100% + 6px);
   left: 0;
-  z-index: 10;
+  z-index: 101;
   display: flex;
   flex-direction: column;
   padding: 4px;
@@ -174,6 +174,8 @@
     0 10px 28px rgba(0, 0, 0, 0.45),
     0 2px 6px rgba(0, 0, 0, 0.25);
   min-width: 132px;
+  max-height: 240px;
+  overflow-y: auto;
   text-transform: none;
   letter-spacing: 0;
 }

--- a/src/renderer/search-modal.css
+++ b/src/renderer/search-modal.css
@@ -3,7 +3,7 @@
 /* Top-anchored backdrop — the modal hugs the top of the viewport (command-
  * palette feel) and only grows downward as results come in. The double-
  * class selector beats `.modal-backdrop`'s single-class default centring,
- * which lives in note-modal.css and loads after this file. */
+ * which lives in modal-base.css. */
 .modal-backdrop.search-modal-backdrop {
   align-items: flex-start;
   padding-top: 6vh;
@@ -70,6 +70,11 @@
     background 120ms ease,
     color 120ms ease,
     border-color 120ms ease;
+  flex-shrink: 0;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .search-source-pill:hover {
@@ -114,6 +119,16 @@
   background: var(--bg-hover);
 }
 
+.search-row[data-selected='true'] {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.search-modal-body .search-project-header[data-selected='true'],
+.search-modal-body .search-project-files .search-row[data-selected='true'] {
+  background: var(--bg-hover);
+}
+
 /* Per-token highlight palette. The mark element ships token-index-modulo-4
  * variants so multi-word queries paint each token a distinct colour. The
  * `dim` modifier lowers the saturation for the path-line highlight so the
@@ -123,18 +138,23 @@
   padding: 0 1px;
   border-radius: 2px;
   background: color-mix(in srgb, var(--col-later) 35%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--col-later) 20%, transparent);
 }
 .search-mark-0 {
   background: color-mix(in srgb, var(--col-later) 35%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--col-later) 20%, transparent);
 }
 .search-mark-1 {
   background: color-mix(in srgb, var(--col-soon) 28%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--col-soon) 20%, transparent);
 }
 .search-mark-2 {
   background: color-mix(in srgb, var(--col-now) 22%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--col-now) 20%, transparent);
 }
 .search-mark-3 {
   background: color-mix(in srgb, var(--col-review) 22%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--col-review) 20%, transparent);
 }
 .search-mark.dim {
   background: color-mix(in srgb, currentColor 14%, transparent);
@@ -253,6 +273,22 @@
   background: var(--bg-subtle);
   border-radius: var(--radius);
   text-align: center;
+}
+
+.search-source-hints {
+  margin-top: 6px;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.search-source-hint-link {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: var(--accent);
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 /* "where in the file" tags surfaced before each snippet — tiny chip that

--- a/src/renderer/search-modal.tsx
+++ b/src/renderer/search-modal.tsx
@@ -1,4 +1,5 @@
 import {
+  createEffect,
   createMemo,
   createResource,
   createSignal,
@@ -45,6 +46,7 @@ export function SearchModal(props: {
   const [input, setInput] = createSignal('');
   const [query, setQuery] = createSignal('');
   const [sourceFilter, setSourceFilter] = createSignal<SourceFilter>('all');
+  const [selectedIndex, setSelectedIndex] = createSignal<number>(-1);
   let inputEl: HTMLInputElement | undefined;
   let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -88,8 +90,39 @@ export function SearchModal(props: {
     return totalCount();
   });
 
+  const filterHints = createMemo(() => {
+    const current = sourceFilter();
+    const hints: { label: string; filter: SourceFilter; count: number }[] = [];
+    if (current !== 'projects' && projectCount() > 0)
+      hints.push({ label: 'Projects', filter: 'projects', count: projectCount() });
+    if (current !== 'knowledge' && knowledgeCount() > 0)
+      hints.push({ label: 'Knowledge', filter: 'knowledge', count: knowledgeCount() });
+    if (current !== 'resources' && resourcesCount() > 0)
+      hints.push({ label: 'Resources', filter: 'resources', count: resourcesCount() });
+    if (current !== 'skills' && skillsCount() > 0)
+      hints.push({ label: 'Skills', filter: 'skills', count: skillsCount() });
+    if (current !== 'logs' && logsCount() > 0)
+      hints.push({ label: 'Logs', filter: 'logs', count: logsCount() });
+    return hints;
+  });
+
+  createEffect(() => {
+    const idx = selectedIndex();
+    // Track results so the effect re-runs when rows are added/removed.
+    results();
+    document.querySelectorAll('.search-row').forEach((el, i) => {
+      el.toggleAttribute('data-selected', i === idx);
+    });
+  });
+
+  const changeFilter = (filter: SourceFilter): void => {
+    setSelectedIndex(-1);
+    setSourceFilter(filter);
+  };
+
   const onInput = (value: string): void => {
     setInput(value);
+    setSelectedIndex(-1);
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => setQuery(value), 200);
   };
@@ -99,6 +132,26 @@ export function SearchModal(props: {
       e.preventDefault();
       e.stopPropagation();
       props.onClose();
+      return;
+    }
+    const rows = document.querySelectorAll('.search-row');
+    const totalVisibleResults = rows.length;
+    if (totalVisibleResults === 0) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.min(i + 1, totalVisibleResults - 1));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setSelectedIndex((i) => Math.max(i - 1, 0));
+      return;
+    }
+    if (e.key === 'Enter' && selectedIndex() >= 0) {
+      e.preventDefault();
+      const selected = rows[selectedIndex()] as HTMLElement | undefined;
+      selected?.click();
+      return;
     }
   };
 
@@ -158,7 +211,7 @@ export function SearchModal(props: {
               classList={{ active: sourceFilter() === 'all' }}
               role="radio"
               aria-checked={sourceFilter() === 'all'}
-              onClick={() => setSourceFilter('all')}
+              onClick={() => changeFilter('all')}
             >
               All <span class="search-source-count">{totalCount()}</span>
             </button>
@@ -167,7 +220,7 @@ export function SearchModal(props: {
               classList={{ active: sourceFilter() === 'projects' }}
               role="radio"
               aria-checked={sourceFilter() === 'projects'}
-              onClick={() => setSourceFilter('projects')}
+              onClick={() => changeFilter('projects')}
             >
               Projects <span class="search-source-count">{projectCount()}</span>
             </button>
@@ -176,7 +229,7 @@ export function SearchModal(props: {
               classList={{ active: sourceFilter() === 'knowledge' }}
               role="radio"
               aria-checked={sourceFilter() === 'knowledge'}
-              onClick={() => setSourceFilter('knowledge')}
+              onClick={() => changeFilter('knowledge')}
             >
               Knowledge <span class="search-source-count">{knowledgeCount()}</span>
             </button>
@@ -185,7 +238,7 @@ export function SearchModal(props: {
               classList={{ active: sourceFilter() === 'resources' }}
               role="radio"
               aria-checked={sourceFilter() === 'resources'}
-              onClick={() => setSourceFilter('resources')}
+              onClick={() => changeFilter('resources')}
             >
               Resources <span class="search-source-count">{resourcesCount()}</span>
             </button>
@@ -194,7 +247,7 @@ export function SearchModal(props: {
               classList={{ active: sourceFilter() === 'skills' }}
               role="radio"
               aria-checked={sourceFilter() === 'skills'}
-              onClick={() => setSourceFilter('skills')}
+              onClick={() => changeFilter('skills')}
             >
               Skills <span class="search-source-count">{skillsCount()}</span>
             </button>
@@ -203,7 +256,7 @@ export function SearchModal(props: {
               classList={{ active: sourceFilter() === 'logs' }}
               role="radio"
               aria-checked={sourceFilter() === 'logs'}
-              onClick={() => setSourceFilter('logs')}
+              onClick={() => changeFilter('logs')}
             >
               Logs <span class="search-source-count">{logsCount()}</span>
             </button>
@@ -217,6 +270,24 @@ export function SearchModal(props: {
                 fallback={
                   <div class="empty">
                     {grouped().total === 0 ? 'No matches.' : `No matches in ${sourceFilter()}.`}
+                    <Show when={grouped().total > 0 && sourceFilter() !== 'all'}>
+                      <div class="search-source-hints">
+                        Also found in{' '}
+                        <For each={filterHints()}>
+                          {(hint, i) => (
+                            <span class="search-source-hint-item">
+                              <Show when={i() > 0}>, </Show>
+                              <button
+                                class="search-source-hint-link"
+                                onClick={() => changeFilter(hint.filter)}
+                              >
+                                {hint.label} ({hint.count})
+                              </button>
+                            </span>
+                          )}
+                        </For>
+                      </div>
+                    </Show>
                   </div>
                 }
               >

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -29,18 +29,21 @@
   /* Warm-paper light theme — feels like an editorial page. */
   --bg: #ece9dd;
   --bg-panel: var(--bg);
+  --bg-base: var(--bg-panel);
   --bg-elevated: #ffffff;
   --bg-subtle: #f3f1ea;
+  --bg-tertiary: var(--bg-subtle);
   --bg-hover: #e3dfd0;
   --text: #1a1a1c;
+  --text-primary: var(--text);
   --text-body: #3a3933;
   --text-muted: #6b6960;
   /* Bumped from #a09c91 — that was ~2.6:1 over bg, failing AA. */
-  --text-faint: #807c70;
+  --text-faint: #706c60;
   --border: #e8e3d6;
   --border-strong: #d6cfbf;
   --accent: #4f46e5;
-  --warn: #c0392b;
+  --warn: #b03020;
 
   /* Status palette — saturated red→green temperature scale so the six
    * statuses are still distinguishable at 8 px. The previous mauve-to-
@@ -53,8 +56,8 @@
    *   done     = neutral gray (archived)
    * Light-mode values; dark-mode mirrors below. */
   --col-now: #c0392b;
-  --col-review: #d97e2c;
-  --col-soon: #d6a31f;
+  --col-review: #c96e1c;
+  --col-soon: #c09010;
   --col-later: #3a78c2;
   --col-backlog: #5b7088;
   --col-done: #5a6068;
@@ -120,11 +123,13 @@
    * --text-sm section headers, --text-md body/summaries, --text-lg
    * card titles). Glyph-sized rules (expander arrow 9px, twisty 14px,
    * + button 16px) keep raw px because they're icons, not text. */
-  --text-2xs: 10px;
-  --text-xs: 11px;
-  --text-sm: 12px;
-  --text-md: 13px;
-  --text-lg: 15px;
+  --text-2xs: 11px;
+  --text-xs: 12px;
+  --text-sm: 13px;
+  --text-md: 14px;
+  --text-lg: 16px;
+
+  color-scheme: light;
 }
 
 /* Dark theme — applied either by OS preference (when no [data-theme] override)
@@ -180,6 +185,11 @@
     --kind-incident: #d68a4a;
     --kind-document: #c9b35a;
     color-scheme: dark;
+
+    ::selection {
+      background: var(--accent);
+      color: #14120e;
+    }
   }
 }
 
@@ -220,6 +230,11 @@
   color-scheme: dark;
 }
 
+[data-theme='dark'] ::selection {
+  background: var(--accent);
+  color: #14120e;
+}
+
 [data-theme='light'] {
   color-scheme: light;
 }
@@ -254,6 +269,11 @@
 }
 .kind-glyph[data-kind='document'] {
   --kind-color: var(--kind-document);
+}
+
+::selection {
+  background: var(--accent);
+  color: #fff;
 }
 
 * {
@@ -570,6 +590,7 @@ button:hover {
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
   font-size: var(--text-sm);
   max-width: 80vw;
+  animation: toast-in 200ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .toast[data-kind='error'] {
@@ -588,4 +609,24 @@ button:hover {
 .toast[data-kind='info'] {
   border-color: color-mix(in srgb, var(--accent) 45%, var(--border-strong));
   color: var(--text-primary);
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translate(-50%, 12px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  text-wrap: pretty;
 }

--- a/src/renderer/terminal-pane.css
+++ b/src/renderer/terminal-pane.css
@@ -145,9 +145,24 @@
   cursor: col-resize;
   background: var(--border);
   transition: background 100ms ease;
+  position: relative;
 }
 
-.terminal-splitter:hover {
+.terminal-splitter::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 24px;
+  background: color-mix(in srgb, var(--text-muted) 25%, transparent);
+  border-radius: 1px;
+  transition: background 100ms ease;
+}
+
+.terminal-splitter:hover,
+.terminal-splitter:hover::after {
   background: var(--accent);
 }
 
@@ -178,10 +193,11 @@
   padding: 2px 4px 2px 8px;
   border: 1px solid var(--border);
   border-radius: 4px;
-  font-size: 11px;
+  font-size: var(--text-xs);
   cursor: pointer;
   background: var(--bg-elevated);
   max-width: 220px;
+  min-width: 80px;
   flex-shrink: 0;
 }
 
@@ -283,15 +299,6 @@
   padding: 0 8px;
   font-size: 14px;
   letter-spacing: 0.02em;
-}
-
-/* Both the floppy (U+1F5AB) and the magnifying glass (U+1F50D + U+FE0E)
- * are pictograms, not text. Drop the strip's default 600 weight back to
- * normal so they don't render visually heavier than the +/λ glyphs. */
-.terminal-tab-add[aria-label='Save buffer'],
-.terminal-tab-add[aria-label='Find'] {
-  font-size: 15px;
-  font-weight: 400;
 }
 
 .terminal-tab[draggable='true'] {

--- a/src/renderer/terminal-pane.css
+++ b/src/renderer/terminal-pane.css
@@ -293,6 +293,12 @@
   font-weight: 600;
 }
 
+.terminal-tab-add[data-label] {
+  width: auto;
+  padding: 0 6px;
+  font-size: var(--text-xs);
+}
+
 .terminal-tab-add.launcher {
   width: auto;
   min-width: 22px;

--- a/src/renderer/terminal-pane/column.tsx
+++ b/src/renderer/terminal-pane/column.tsx
@@ -261,6 +261,7 @@ export function TerminalColumn(props: TerminalColumnProps) {
         <span class="terminal-tab-strip-spacer" />
         <button
           class="terminal-tab-add"
+          data-label="save"
           onClick={(e) => {
             e.stopPropagation();
             props.onSaveBuffer(props.col);
@@ -272,6 +273,7 @@ export function TerminalColumn(props: TerminalColumnProps) {
         </button>
         <button
           class="terminal-tab-add"
+          data-label="find"
           onClick={(e) => {
             e.stopPropagation();
             props.onOpenSearch(props.col);

--- a/src/renderer/terminal-pane/column.tsx
+++ b/src/renderer/terminal-pane/column.tsx
@@ -268,7 +268,7 @@ export function TerminalColumn(props: TerminalColumnProps) {
           title="Save the active terminal buffer to a file"
           aria-label="Save buffer"
         >
-          🖫
+          Save
         </button>
         <button
           class="terminal-tab-add"
@@ -279,10 +279,7 @@ export function TerminalColumn(props: TerminalColumnProps) {
           title="Find in buffer (Ctrl+F)"
           aria-label="Find"
         >
-          {/* U+1F50D + U+FE0E forces the text-style monochrome glyph, so
-           *  the lens matches the floppy's weight instead of the colour
-           *  emoji default. */}
-          🔍︎
+          Find
         </button>
       </div>
       <div class="terminal-host" ref={(el) => props.registerHost(props.col, el)} />

--- a/src/renderer/welcome-screen.css
+++ b/src/renderer/welcome-screen.css
@@ -27,18 +27,18 @@
 .welcome-tagline {
   text-align: center;
   margin: 0;
-  color: var(--color-fg-muted, #6c7686);
+  color: var(--text-muted);
 }
 
 .welcome-path {
   text-align: center;
   margin: 0 0 1.5rem 0;
   font-size: 0.85rem;
-  color: var(--color-fg-muted, #6c7686);
+  color: var(--text-muted);
 }
 
 .welcome-path code {
-  background: var(--color-bg-subtle, rgba(0, 0, 0, 0.04));
+  background: var(--bg-subtle);
   padding: 0.1rem 0.4rem;
   border-radius: 3px;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
@@ -57,13 +57,13 @@
 
 .welcome-intro {
   margin: 0 0 0.5rem 0;
-  color: var(--color-fg, #2a2f37);
+  color: var(--text);
   font-size: 0.95rem;
   line-height: 1.5;
 }
 
 .welcome-intro code {
-  background: var(--color-bg-subtle, rgba(0, 0, 0, 0.04));
+  background: var(--bg-hover);
   padding: 0.05rem 0.35rem;
   border-radius: 3px;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
@@ -79,8 +79,8 @@
 .welcome-card {
   text-align: start;
   padding: 1rem;
-  background: var(--color-bg-card, #ffffff);
-  border: 1px solid var(--color-border, rgba(0, 0, 0, 0.12));
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
   border-radius: 8px;
   cursor: pointer;
   transition:
@@ -120,7 +120,7 @@
 }
 
 .welcome-card-body {
-  color: var(--color-fg-muted, #6c7686);
+  color: var(--text-muted);
   font-size: 0.85rem;
   line-height: 1.4;
 }
@@ -136,15 +136,16 @@
 }
 
 .welcome-dismiss-link {
-  background: none;
-  border: none;
-  color: var(--color-fg-muted, #6c7686);
+  padding: 6px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text-muted);
+  background: transparent;
   cursor: pointer;
   font-size: 0.85rem;
-  text-decoration: underline;
-  padding: 0.4rem;
 }
 
 .welcome-dismiss-link:hover {
-  color: var(--color-fg, #2a2f37);
+  background: var(--bg-hover);
+  color: var(--text);
 }


### PR DESCRIPTION
## Summary

- Fixes accessibility issues including undefined CSS tokens, low-contrast status colors, and sub-10px text sizes.
- Adds subtle entrance animations to modals and toasts to improve perceived responsiveness.
- Reduces visual noise on project cards by hiding repeating icons, collapsing meta rows, and revealing actions on hover.

## Changes

- `styles.css` — define missing `--text-primary`, `--bg-base`, `--bg-tertiary`; bump type scale 10–15px → 11–16px; improve light-mode contrast for `--warn`, `--text-faint`, `--col-soon`, `--col-review`; add `color-scheme: light`; add `::selection` theming and `text-wrap: pretty`; add toast slide-up animation
- `modal-base.css` — add modal scale+fade entrance animation and backdrop fade; add `.modal-button--text` modifier; replace opacity-based disabled/complete states with explicit color tokens
- `confirm-modal.css` — allow text labels in modal buttons (width: auto)
- `note-modal.css` — replace hardcoded yellow find highlight with `--col-soon` tokens; fix `height: 100%` clipping shadow
- `search-modal.css` + `search-modal.tsx` — add keyboard navigation (ArrowUp/ArrowDown/Enter); show clickable filter hints in empty state; increase search mark contrast; cap pill widths
- `welcome-screen.css` — replace hardcoded fallback colors with theme tokens; restyle dismiss link as a bordered pill
- `new-project-modal.css` — hide native radio circles; render custom checked dot
- `project-preview.css` — add `minmax(260px, …)` to sidebar grid; constrain status menu height and z-index
- `help-modal.tsx` — use dedicated `.help-modal` width class
- `projects-pane.css` — reduce default card min-width 650px → 520px; add card hover lift; show title-actions only on hover/focus; flatten meta rows; enlarge step progress track and expander arrow
- `cards.tsx` — hide default `kind: project` glyph; improve drag ghost (clone head only, strip actions); add `aria-label` and `aria-expanded`
- `code-pane.css` — increase branch row padding; add branch row hover background; fix live badge glow color
- `repo-row.tsx` — wrap left-side head items to prevent status badge orphaning on wrap
- `branch-filter.tsx` — render disabled trigger when no multi-branch repos exist; add branch name tooltips
- `tree-view.css` — unify indent to 16px at all depths; increase directory header size
- `terminal-pane.css` — add splitter grip pseudo-element; increase tab min-width and font size
- `terminal-pane/column.tsx` — replace emoji glyphs with text labels