### PR TITLE
Bump 3.18.0: settings modal UX revamp — save button, search, drag-and-drop, diff view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -55,6 +55,23 @@ export const SECTIONS: SectionMeta[] = [
   { id: 'terminal:conception', label: 'Terminal', tab: 'conception' },
 ];
 
+/**
+ * Top-level RawConfig keys that each section reads/writes. Used by the
+ * rail's dirty-pip computation: a section is dirty when any of its keys
+ * differ between disk and the active draft. `recents:global` is intentionally
+ * empty — recents are managed outside the settings modal.
+ */
+export const SECTION_KEYS: Record<Section, readonly (keyof RawConfig)[]> = {
+  'recents:global': [],
+  'appearance:global': ['theme', 'cardMinWidth'],
+  'terminal:global': ['terminal'],
+  'workspace:conception': ['workspace_path', 'worktrees_path', 'resources_path', 'skills_path'],
+  'repositories:conception': ['repositories'],
+  'open-with:conception': ['open_with'],
+  'appearance:conception': ['theme', 'cardMinWidth'],
+  'terminal:conception': ['terminal'],
+};
+
 export interface TabMeta {
   id: SettingsTab;
   label: string;
@@ -133,12 +150,17 @@ export type TerminalStringFieldKey =
   | 'move_tab_left_shortcut'
   | 'move_tab_right_shortcut';
 
+export type TerminalStringFieldKind = 'plain' | 'path' | 'shortcut';
+
 export interface TerminalStringField {
   key: TerminalStringFieldKey;
   label: string;
   /** Per-OS placeholder. `default` is used when the platform is unknown. */
   placeholder: Partial<Record<Platform | 'default', string>>;
   hint?: string;
+  /** Drives field-specific rendering: 'path' adds an [abs] chip, 'shortcut'
+   *  swaps in a click-to-capture button. Defaults to 'plain'. */
+  kind?: TerminalStringFieldKind;
 }
 
 export const TERMINAL_STRING_FIELDS: TerminalStringField[] = [
@@ -146,6 +168,7 @@ export const TERMINAL_STRING_FIELDS: TerminalStringField[] = [
     key: 'shell',
     label: 'Shell',
     placeholder: { linux: '/bin/bash', darwin: '/bin/zsh', win32: 'cmd.exe', default: '/bin/bash' },
+    kind: 'path',
   },
   {
     key: 'screenshot_dir',
@@ -156,18 +179,31 @@ export const TERMINAL_STRING_FIELDS: TerminalStringField[] = [
       win32: 'C:\\Users\\you\\Pictures\\Screenshots',
       default: '~/Pictures/Screenshots',
     },
+    kind: 'path',
   },
-  { key: 'shortcut', label: 'Toggle terminal pane', placeholder: { default: 'Ctrl+`' } },
+  {
+    key: 'shortcut',
+    label: 'Toggle terminal pane',
+    placeholder: { default: 'Ctrl+`' },
+    kind: 'shortcut',
+  },
   {
     key: 'screenshot_paste_shortcut',
     label: 'Paste latest screenshot path',
     placeholder: { default: 'Ctrl+Shift+V' },
+    kind: 'shortcut',
   },
-  { key: 'move_tab_left_shortcut', label: 'Move tab left', placeholder: { default: 'Ctrl+Left' } },
+  {
+    key: 'move_tab_left_shortcut',
+    label: 'Move tab left',
+    placeholder: { default: 'Ctrl+Left' },
+    kind: 'shortcut',
+  },
   {
     key: 'move_tab_right_shortcut',
     label: 'Move tab right',
     placeholder: { default: 'Ctrl+Right' },
+    kind: 'shortcut',
   },
 ];
 
@@ -379,6 +415,18 @@ export function compactActionTemplates(arr: ActionTemplate[]): ActionTemplate[] 
  */
 export function usableActionTemplates(arr: ActionTemplate[]): ActionTemplate[] {
   return arr.filter((a) => a.label.trim().length > 0 && a.template.trim().length > 0);
+}
+
+/** Shared drag-and-drop callback bundle. The owning parent (e.g.
+ *  `RepositoriesSection`) holds the dragging-state signals; rows just emit
+ *  events and read flags. */
+export interface DndHandlers {
+  onDragStart: (index: number) => void;
+  onDragOver: (index: number) => void;
+  onDrop: (index: number) => void;
+  onDragEnd: () => void;
+  isDragging: (index: number) => boolean;
+  isDropTarget: (index: number) => boolean;
 }
 
 export type BindTextFn = (

--- a/src/renderer/settings-modal-parts/fields.tsx
+++ b/src/renderer/settings-modal-parts/fields.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from 'solid-js';
+import { createContext, createMemo, createSignal, For, Show, useContext } from 'solid-js';
 import type { JSX } from 'solid-js';
 import type {
   ActionTemplate,
@@ -12,6 +12,7 @@ import type {
 } from '@shared/types';
 import { DEFAULT_CARD_MIN_WIDTH } from '@shared/types';
 import {
+  type BindTextFn,
   type ColorEntry,
   CURSOR_STYLES,
   pick,
@@ -22,6 +23,116 @@ import {
 } from './data';
 import { FieldBadgeRow, type InheritanceState } from './badges';
 
+// --- Search context ---------------------------------------------------
+
+interface SearchContextValue {
+  /** Active query (already trimmed externally). Empty string = no filter. */
+  query: () => string;
+  /** Returns true when the haystack matches the active query OR when the
+   *  query is empty. Case-insensitive substring match. */
+  hasMatch: (haystack: string) => boolean;
+}
+
+const FALLBACK_SEARCH: SearchContextValue = {
+  query: () => '',
+  hasMatch: () => true,
+};
+
+const SearchContext = createContext<SearchContextValue>(FALLBACK_SEARCH);
+
+/** Hook for descendants that want to filter their own rendering on the
+ *  active query. Returns the noop context when no provider is mounted, so
+ *  components can be reused outside the Settings modal. */
+export function useSearch(): SearchContextValue {
+  return useContext(SearchContext);
+}
+
+/** Mounts the search context. The modal owns the query signal and wraps
+ *  every section in this provider. */
+export function SearchProvider(props: { query: () => string; children: JSX.Element }): JSX.Element {
+  const value: SearchContextValue = {
+    query: props.query,
+    hasMatch: (haystack) => {
+      const q = props.query().trim().toLowerCase();
+      if (!q) return true;
+      return haystack.toLowerCase().includes(q);
+    },
+  };
+  return <SearchContext.Provider value={value}>{props.children}</SearchContext.Provider>;
+}
+
+// --- Subgroup (collapsible) ------------------------------------------
+
+const SUBGROUP_OPEN_KEY = 'condash:settings-modal:subgroup-open';
+
+function readSubgroupOpen(id: string, defaultOpen: boolean): boolean {
+  try {
+    const raw = window.localStorage.getItem(SUBGROUP_OPEN_KEY);
+    if (!raw) return defaultOpen;
+    const map = JSON.parse(raw) as Record<string, boolean>;
+    return typeof map[id] === 'boolean' ? map[id] : defaultOpen;
+  } catch {
+    return defaultOpen;
+  }
+}
+
+function writeSubgroupOpen(id: string, open: boolean): void {
+  try {
+    const raw = window.localStorage.getItem(SUBGROUP_OPEN_KEY);
+    const map = raw ? (JSON.parse(raw) as Record<string, boolean>) : {};
+    map[id] = open;
+    window.localStorage.setItem(SUBGROUP_OPEN_KEY, JSON.stringify(map));
+  } catch {
+    // Private-mode browsers throw on localStorage writes; the subgroup
+    // simply forgets its open state across reloads — acceptable.
+  }
+}
+
+/** Collapsible subgroup with a `<h3>` heading. Participates in search:
+ *  when the active query matches neither the title nor `keywords`, the
+ *  subgroup hides entirely. When a query is active and the subgroup
+ *  matches, it force-opens so the user can see what matched without an
+ *  extra click. */
+export function Subgroup(props: {
+  id: string;
+  title: string;
+  /** Extra match text (label and hint strings from descendants). When
+   *  omitted, only the title participates in search matching. */
+  keywords?: string;
+  defaultOpen?: boolean;
+  children: JSX.Element;
+}): JSX.Element {
+  const search = useSearch();
+  const matchesSearch = createMemo(() => search.hasMatch(`${props.title} ${props.keywords ?? ''}`));
+  const [userOpen, setUserOpen] = createSignal(
+    readSubgroupOpen(props.id, props.defaultOpen ?? false),
+  );
+  const open = createMemo(() => (search.query().trim().length > 0 ? matchesSearch() : userOpen()));
+  return (
+    <Show when={matchesSearch()}>
+      <details
+        class="settings-subgroup"
+        open={open()}
+        data-subgroup-id={props.id}
+        onToggle={(e) => {
+          if (search.query().trim().length > 0) return;
+          const isOpen = e.currentTarget.open;
+          setUserOpen(isOpen);
+          writeSubgroupOpen(props.id, isOpen);
+        }}
+      >
+        <summary class="settings-subgroup-summary">
+          <span class="settings-subgroup-chevron" aria-hidden="true">
+            ▸
+          </span>
+          <h3>{props.title}</h3>
+        </summary>
+        <div class="settings-subgroup-body">{props.children}</div>
+      </details>
+    </Show>
+  );
+}
+
 /** Field row that pairs a labelled control with an inheritance badge.
  *  Used on the conception tab; pass `state="inherits"` and `hide` from the
  *  global tab if it ever needs the same shape. */
@@ -30,12 +141,28 @@ export function FieldWithBadge(props: {
   hint?: string;
   state: InheritanceState;
   onRemove: () => void;
+  /** Path-scope tag: 'abs' shows an [abs] chip, 'rel' shows [rel]. Omit
+   *  for non-path fields. */
+  pathScope?: 'abs' | 'rel';
   children: JSX.Element;
 }): JSX.Element {
   return (
     <label class="settings-field-with-badge">
       <span class="settings-field-row">
-        <span class="settings-field-label">{props.label}</span>
+        <span class="settings-field-label">
+          {props.label}
+          <Show when={props.pathScope}>
+            {(scope) => (
+              <span
+                class="settings-path-chip"
+                classList={{ 'settings-path-chip--rel': scope() === 'rel' }}
+                title={scope() === 'abs' ? 'Absolute path' : 'Relative to conception root'}
+              >
+                {scope()}
+              </span>
+            )}
+          </Show>
+        </span>
         <FieldBadgeRow state={props.state} onRemove={props.onRemove} />
       </span>
       {props.children}
@@ -74,44 +201,73 @@ export function ThemePicker(props: {
 }
 
 /** Five card-min-width fields — shared between tabs. */
+const CARD_DENSITY_FIELDS = [
+  { key: 'projects', label: 'Project cards (Projects pane)', short: 'Project' },
+  { key: 'code', label: 'Code cards (Code pane)', short: 'Code' },
+  { key: 'knowledge', label: 'Knowledge cards (Knowledge pane)', short: 'Knowledge' },
+  { key: 'resources', label: 'Resource cards (Resources pane)', short: 'Resource' },
+  { key: 'skills', label: 'Skill cards (Skills pane)', short: 'Skill' },
+] as const;
+
 export function CardDensityFields(props: {
   resolve: (key: keyof CardMinWidthPrefs) => number;
   onChange: (patch: CardMinWidthPrefs) => void;
 }): JSX.Element {
   return (
-    <div class="settings-grid">
-      <For
-        each={
-          [
-            { key: 'projects', label: 'Project cards (Projects pane)' },
-            { key: 'code', label: 'Code cards (Code pane)' },
-            { key: 'knowledge', label: 'Knowledge cards (Knowledge pane)' },
-            { key: 'resources', label: 'Resource cards (Resources pane)' },
-            { key: 'skills', label: 'Skill cards (Skills pane)' },
-          ] as const
-        }
-      >
-        {(field) => (
-          <label>
-            <span>{field.label}</span>
-            <input
-              type="number"
-              min="120"
-              max="2400"
-              step="10"
-              value={props.resolve(field.key)}
-              onChange={(e) => {
-                const raw = e.currentTarget.value;
-                const parsed = raw === '' ? DEFAULT_CARD_MIN_WIDTH[field.key] : Number(raw);
-                if (!Number.isFinite(parsed)) return;
-                props.onChange({ [field.key]: parsed });
-              }}
-            />
-            <small class="settings-field-hint">
-              Min width in CSS pixels. Default {DEFAULT_CARD_MIN_WIDTH[field.key]}.
-            </small>
-          </label>
-        )}
+    <>
+      <CardDensityPreview resolve={props.resolve} />
+      <div class="settings-grid">
+        <For each={CARD_DENSITY_FIELDS}>
+          {(field) => (
+            <label>
+              <span>{field.label}</span>
+              <input
+                type="number"
+                min="120"
+                max="2400"
+                step="10"
+                value={props.resolve(field.key)}
+                onChange={(e) => {
+                  const raw = e.currentTarget.value;
+                  const parsed = raw === '' ? DEFAULT_CARD_MIN_WIDTH[field.key] : Number(raw);
+                  if (!Number.isFinite(parsed)) return;
+                  props.onChange({ [field.key]: parsed });
+                }}
+              />
+              <small class="settings-field-hint">
+                Min width in CSS pixels. Default {DEFAULT_CARD_MIN_WIDTH[field.key]}.
+              </small>
+            </label>
+          )}
+        </For>
+      </div>
+    </>
+  );
+}
+
+/** Renders five fake cards, one per pane, sized to the current
+ *  min-width values so the user sees the relative scale before saving. */
+function CardDensityPreview(props: {
+  resolve: (key: keyof CardMinWidthPrefs) => number;
+}): JSX.Element {
+  return (
+    <div class="settings-density-preview" aria-hidden="true">
+      <For each={CARD_DENSITY_FIELDS}>
+        {(field) => {
+          const px = (): number => props.resolve(field.key);
+          // Visual is half-scale so 5 cards at default 300 px all fit
+          // inside the modal viewport; the on-card label still shows the
+          // real px value so the relative-size intent is unambiguous.
+          return (
+            <div
+              class="settings-density-preview-card"
+              style={{ width: `${Math.round(px() / 2)}px` }}
+            >
+              <span class="settings-density-preview-label">{field.short}</span>
+              <span class="settings-density-preview-width">{px()}px</span>
+            </div>
+          );
+        }}
       </For>
     </div>
   );
@@ -121,6 +277,12 @@ function ActionTemplateSection(props: {
   title: string;
   hint: string;
   idPrefix: string;
+  /** Stable subgroup id (e.g. "global.terminal.project-actions"). When
+   *  set, the section renders inside a collapsible Subgroup that also
+   *  participates in search. */
+  subgroupId?: string;
+  /** Extra search keywords (e.g. "project action template launcher"). */
+  keywords?: string;
   bindText: (
     id: string,
     persisted: () => string | undefined,
@@ -143,9 +305,19 @@ function ActionTemplateSection(props: {
 }): JSX.Element {
   const usableLaunchers = (): LauncherConfig[] =>
     props.launchers().filter((l) => l.label.trim().length > 0 && l.command.trim().length > 0);
-  return (
+  // Stable id for the sibling Launchers subgroup — the "Manage launchers"
+  // link uses this to scroll-into-view + force-open the disclosure.
+  const launchersAnchor = props.idPrefix.replace(/\.[^.]+$/, '.launchers');
+  const focusLaunchers = (): void => {
+    const el = document.querySelector<HTMLDetailsElement>(
+      `details[data-subgroup-id="${launchersAnchor}"]`,
+    );
+    if (!el) return;
+    el.open = true;
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+  const body = (): JSX.Element => (
     <>
-      <h3>{props.title}</h3>
       <p class="settings-field-hint">{props.hint}</p>
       <For each={props.items()}>
         {(action, idx) => (
@@ -175,7 +347,17 @@ function ActionTemplateSection(props: {
               />
             </label>
             <label>
-              <span>Launcher</span>
+              <span class="settings-field-label-row">
+                <span>Launcher</span>
+                <button
+                  type="button"
+                  class="settings-inline-link"
+                  onClick={focusLaunchers}
+                  title="Jump to the Launchers list"
+                >
+                  Manage launchers →
+                </button>
+              </span>
               <select
                 value={action.launcher ?? ''}
                 onChange={(e) => {
@@ -233,6 +415,224 @@ function ActionTemplateSection(props: {
       </button>
     </>
   );
+  return (
+    <Show
+      when={props.subgroupId}
+      fallback={
+        <>
+          <h3>{props.title}</h3>
+          {body()}
+        </>
+      }
+    >
+      <Subgroup
+        id={props.subgroupId!}
+        title={props.title}
+        keywords={`${props.hint} ${props.keywords ?? ''}`}
+      >
+        {body()}
+      </Subgroup>
+    </Show>
+  );
+}
+
+/** Best-effort CSS colour validation. Accepts hex (`#rgb` / `#rrggbb` /
+ *  `#rrggbbaa`), `color-mix(`/`rgb(`/`hsl(` functional notations, and any
+ *  string that the browser confirms as a valid colour by round-tripping
+ *  through `CSS.supports`. Empty strings are valid (inherit). */
+function isValidCssColor(value: string | undefined): boolean {
+  if (!value) return true;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return true;
+  if (/^#[0-9a-f]{3,8}$/i.test(trimmed)) return true;
+  if (typeof CSS !== 'undefined' && typeof CSS.supports === 'function') {
+    return CSS.supports('color', trimmed);
+  }
+  // Fallback for non-browser test environments — accept named colours.
+  return /^[a-z][a-z0-9-]*$/i.test(trimmed);
+}
+
+/** ANSI colour input with a live swatch and native colour-picker overlay.
+ *  Replaces the plain `<input type="text">` for the 21 terminal colour
+ *  fields. The swatch reflects whatever the user types (any CSS colour
+ *  string). Clicking the swatch opens an invisible `<input type="color">`
+ *  which writes a hex string back through the same save path. Invalid
+ *  values surface a red border + inline message without blocking save. */
+function ColorField(props: {
+  entry: ColorEntry;
+  idPrefix: string;
+  value: () => string | undefined;
+  bindText: BindTextFn;
+  onChange: (next: string) => void;
+}): JSX.Element {
+  let pickerRef: HTMLInputElement | undefined;
+  const swatchColor = (): string => {
+    const v = props.value();
+    return v && v.trim().length > 0 && isValidCssColor(v) ? v : 'transparent';
+  };
+  const invalid = (): boolean => !isValidCssColor(props.value());
+  return (
+    <label class="settings-color">
+      <span>{props.entry.label}</span>
+      <span class="settings-color-input">
+        <button
+          type="button"
+          class="settings-color-swatch"
+          style={{ background: swatchColor() }}
+          title={`Pick ${props.entry.label.toLowerCase()}`}
+          aria-label={`Open colour picker for ${props.entry.label}`}
+          onClick={() => pickerRef?.click()}
+        />
+        <input
+          type="text"
+          placeholder="—"
+          classList={{ 'settings-input--invalid': invalid() }}
+          aria-invalid={invalid()}
+          {...props.bindText(
+            `${props.idPrefix}.xterm.colors.${props.entry.key}`,
+            props.value,
+            (v) => {
+              props.onChange(v);
+              return Promise.resolve();
+            },
+          )}
+        />
+        <input
+          ref={(el) => (pickerRef = el)}
+          type="color"
+          class="settings-color-picker"
+          aria-hidden="true"
+          tabIndex={-1}
+          value={(() => {
+            const v = props.value();
+            return v && /^#[0-9a-f]{6}$/i.test(v.trim()) ? v.trim() : '#000000';
+          })()}
+          onInput={(e) => props.onChange(e.currentTarget.value)}
+        />
+      </span>
+      <Show when={invalid()}>
+        <small class="settings-field-error">Not a recognised CSS colour.</small>
+      </Show>
+    </label>
+  );
+}
+
+/** Serialise a keyboard event to the modifier-chained string format the
+ *  rest of condash uses (`Ctrl+Shift+V`, `Cmd+Left`, etc.). Returns null
+ *  for events that produced no key character (modifier-only press, IME). */
+function serializeShortcut(e: KeyboardEvent): string | null {
+  const parts: string[] = [];
+  if (e.ctrlKey) parts.push('Ctrl');
+  if (e.metaKey) parts.push('Cmd');
+  if (e.altKey) parts.push('Alt');
+  if (e.shiftKey) parts.push('Shift');
+  const k = e.key;
+  // Don't accept a bare modifier as the final key — the user is still
+  // composing.
+  if (k === 'Control' || k === 'Meta' || k === 'Alt' || k === 'Shift') return null;
+  if (k.length === 1) {
+    parts.push(k.toUpperCase());
+  } else {
+    // Named keys: pass-through, capitalising. e.g. 'ArrowLeft' → 'Left',
+    // 'Backquote' is unlikely as e.key, but if so leave it. Browsers emit
+    // 'ArrowLeft' on arrow keys — strip the 'Arrow' prefix for legibility.
+    parts.push(k.replace(/^Arrow/, ''));
+  }
+  return parts.join('+');
+}
+
+/** Click-to-capture keyboard shortcut input. When idle, renders the stored
+ *  shortcut as a chip-like button; when capturing, listens for the next
+ *  full key combination and stores its serialisation. Esc aborts;
+ *  Backspace clears. */
+function ShortcutCapture(props: {
+  id: string;
+  value: () => string | undefined;
+  placeholder: string;
+  onChange: (next: string) => void;
+}): JSX.Element {
+  const [capturing, setCapturing] = createSignal(false);
+  const handleKey = (e: KeyboardEvent): void => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.key === 'Escape') {
+      setCapturing(false);
+      return;
+    }
+    if (e.key === 'Backspace' && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      props.onChange('');
+      setCapturing(false);
+      return;
+    }
+    const serial = serializeShortcut(e);
+    if (!serial) return;
+    props.onChange(serial);
+    setCapturing(false);
+  };
+  return (
+    <button
+      type="button"
+      class="settings-shortcut"
+      classList={{ 'settings-shortcut--capturing': capturing() }}
+      onClick={() => setCapturing((c) => !c)}
+      onKeyDown={(e) => {
+        if (!capturing()) return;
+        handleKey(e);
+      }}
+      title={
+        capturing()
+          ? 'Press a key combination (Esc to cancel, Backspace to clear)'
+          : 'Click to rebind'
+      }
+    >
+      {capturing()
+        ? 'Press a key combination…'
+        : props.value() && props.value()!.trim().length > 0
+          ? props.value()
+          : props.placeholder}
+    </button>
+  );
+}
+
+/** Tiny fake terminal that picks up whatever CSS colour vars are set by
+ *  the live xterm.colors values. Updates as the user types — no IPC needed
+ *  because the draft tree is reactive. Useful sanity check before saving. */
+function TerminalColorPreview(props: { xterm: () => TerminalXtermPrefs }): JSX.Element {
+  const styleVars = (): Record<string, string> => {
+    const colors = props.xterm().colors ?? {};
+    const vars: Record<string, string> = {};
+    if (colors.background) vars['--preview-bg'] = colors.background;
+    if (colors.foreground) vars['--preview-fg'] = colors.foreground;
+    if (colors.cursor) vars['--preview-cursor'] = colors.cursor;
+    if (colors.selection_background) vars['--preview-selection'] = colors.selection_background;
+    if (colors.green) vars['--preview-green'] = colors.green;
+    if (colors.red) vars['--preview-red'] = colors.red;
+    if (colors.yellow) vars['--preview-yellow'] = colors.yellow;
+    if (colors.blue) vars['--preview-blue'] = colors.blue;
+    if (colors.magenta) vars['--preview-magenta'] = colors.magenta;
+    if (colors.cyan) vars['--preview-cyan'] = colors.cyan;
+    if (colors.bright_black) vars['--preview-muted'] = colors.bright_black;
+    return vars;
+  };
+  return (
+    <pre class="settings-terminal-preview" style={styleVars()} aria-hidden="true">
+      <span class="preview-muted">$ </span>
+      <span class="preview-green">ls</span> -la
+      {'\n'}
+      <span class="preview-blue">drwxr-xr-x</span>
+      {'  '}
+      <span class="preview-muted">20 alice staff</span>
+      {'  640 May 19 10:23 '}
+      <span class="preview-cyan">.</span>
+      {'\n'}
+      <span class="preview-yellow">warning:</span> 1 deprecated import (
+      <span class="preview-magenta">legacy</span>){'\n'}
+      <span class="preview-red">error:</span> connection refused
+      {'\n'}
+      <span class="preview-muted">$ </span>
+      <span class="preview-cursor">█</span>
+    </pre>
+  );
 }
 
 /** Terminal section content — string fields, xterm font/cursor/buffer,
@@ -276,106 +676,149 @@ export function TerminalFields(props: {
   // explicitly set the flag. `undefined` and `false` both render unchecked.
   const loggingEnabled = (): boolean => logging().enabled === true;
   const idPrefix = `${props.target}.terminal`;
+  const subgroupId = (suffix: string): string => `${props.target}.terminal.${suffix}`;
+  // Static keyword strings drive search matching. Concatenating field
+  // labels keeps the index in sync with the rendered content — when a
+  // field is renamed, the search behaviour updates with it.
+  const behaviourKeywords = TERMINAL_STRING_FIELDS.map((f) => f.label).join(' ');
   return (
     <>
-      <h3>Behaviour &amp; shortcuts</h3>
-      <div class="settings-grid">
-        <For each={TERMINAL_STRING_FIELDS}>
-          {(field) => (
-            <label>
-              <span>{field.label}</span>
-              <input
-                type="text"
-                placeholder={pick(field.placeholder, props.platform())}
-                {...props.bindText(
-                  `${idPrefix}.${field.key}`,
-                  () => (props.prefs() as Record<string, unknown>)[field.key] as string | undefined,
-                  (v) => props.setString(field.key, v),
-                )}
-              />
-              <Show when={field.hint}>
-                <small class="settings-field-hint">{field.hint}</small>
-              </Show>
-            </label>
+      <Subgroup
+        id={subgroupId('behaviour')}
+        title="Behaviour & shortcuts"
+        keywords={`shell screenshot shortcut keybinding ${behaviourKeywords}`}
+        defaultOpen
+      >
+        <div class="settings-grid">
+          <For each={TERMINAL_STRING_FIELDS}>
+            {(field) => (
+              <label>
+                <span class="settings-field-label-row">
+                  <span>{field.label}</span>
+                  <Show when={field.kind === 'path'}>
+                    <span class="settings-path-chip" title="Absolute path">
+                      abs
+                    </span>
+                  </Show>
+                </span>
+                <Show
+                  when={field.kind === 'shortcut'}
+                  fallback={
+                    <input
+                      type="text"
+                      placeholder={pick(field.placeholder, props.platform())}
+                      {...props.bindText(
+                        `${idPrefix}.${field.key}`,
+                        () =>
+                          (props.prefs() as Record<string, unknown>)[field.key] as
+                            | string
+                            | undefined,
+                        (v) => props.setString(field.key, v),
+                      )}
+                    />
+                  }
+                >
+                  <ShortcutCapture
+                    id={`${idPrefix}.${field.key}`}
+                    value={() =>
+                      (props.prefs() as Record<string, unknown>)[field.key] as string | undefined
+                    }
+                    placeholder={pick(field.placeholder, props.platform())}
+                    onChange={(v) => void props.setString(field.key, v)}
+                  />
+                </Show>
+                <Show when={field.hint}>
+                  <small class="settings-field-hint">{field.hint}</small>
+                </Show>
+              </label>
+            )}
+          </For>
+        </div>
+      </Subgroup>
+
+      <Subgroup
+        id={subgroupId('launchers')}
+        title="Launchers"
+        keywords="launcher tab command title dropdown"
+        defaultOpen
+      >
+        <p class="settings-field-hint">
+          Each entry renders an option in the terminal tab-strip dropdown. Label is what you see in
+          the dropdown; title becomes the pinned tab name at spawn time (falls back to command); an
+          inline rename still wins.
+        </p>
+        <For each={props.launchers()}>
+          {(launcher, idx) => (
+            <div class="settings-launcher-row">
+              <label>
+                <span>Label</span>
+                <input
+                  type="text"
+                  placeholder="Claude"
+                  {...props.bindText(
+                    `${idPrefix}.launchers.${idx()}.label`,
+                    () => launcher.label || undefined,
+                    (v) => props.patchLauncher(idx(), { label: v }),
+                  )}
+                />
+              </label>
+              <label>
+                <span>Command</span>
+                <input
+                  type="text"
+                  placeholder="claude"
+                  {...props.bindText(
+                    `${idPrefix}.launchers.${idx()}.command`,
+                    () => launcher.command || undefined,
+                    (v) => props.patchLauncher(idx(), { command: v }),
+                  )}
+                />
+              </label>
+              <label>
+                <span>Title</span>
+                <input
+                  type="text"
+                  placeholder="Claude"
+                  {...props.bindText(
+                    `${idPrefix}.launchers.${idx()}.title`,
+                    () => launcher.title || undefined,
+                    (v) => props.patchLauncher(idx(), { title: v }),
+                  )}
+                />
+              </label>
+              <div class="settings-launcher-actions">
+                <button type="button" title="Remove" onClick={() => props.removeLauncher(idx())}>
+                  ×
+                </button>
+                <button
+                  type="button"
+                  title="Move up"
+                  disabled={idx() === 0}
+                  onClick={() => props.moveLauncher(idx(), -1)}
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  title="Move down"
+                  disabled={idx() === props.launchers().length - 1}
+                  onClick={() => props.moveLauncher(idx(), 1)}
+                >
+                  ↓
+                </button>
+              </div>
+            </div>
           )}
         </For>
-      </div>
-
-      <h3>Launchers</h3>
-      <p class="settings-field-hint">
-        Each entry renders an option in the terminal tab-strip dropdown. Label is what you see in
-        the dropdown; title becomes the pinned tab name at spawn time (falls back to command); an
-        inline rename still wins.
-      </p>
-      <For each={props.launchers()}>
-        {(launcher, idx) => (
-          <div class="settings-launcher-row">
-            <label>
-              <span>Label</span>
-              <input
-                type="text"
-                placeholder="Claude"
-                {...props.bindText(
-                  `${idPrefix}.launchers.${idx()}.label`,
-                  () => launcher.label || undefined,
-                  (v) => props.patchLauncher(idx(), { label: v }),
-                )}
-              />
-            </label>
-            <label>
-              <span>Command</span>
-              <input
-                type="text"
-                placeholder="claude"
-                {...props.bindText(
-                  `${idPrefix}.launchers.${idx()}.command`,
-                  () => launcher.command || undefined,
-                  (v) => props.patchLauncher(idx(), { command: v }),
-                )}
-              />
-            </label>
-            <label>
-              <span>Title</span>
-              <input
-                type="text"
-                placeholder="Claude"
-                {...props.bindText(
-                  `${idPrefix}.launchers.${idx()}.title`,
-                  () => launcher.title || undefined,
-                  (v) => props.patchLauncher(idx(), { title: v }),
-                )}
-              />
-            </label>
-            <div class="settings-launcher-actions">
-              <button type="button" title="Remove" onClick={() => props.removeLauncher(idx())}>
-                ×
-              </button>
-              <button
-                type="button"
-                title="Move up"
-                disabled={idx() === 0}
-                onClick={() => props.moveLauncher(idx(), -1)}
-              >
-                ↑
-              </button>
-              <button
-                type="button"
-                title="Move down"
-                disabled={idx() === props.launchers().length - 1}
-                onClick={() => props.moveLauncher(idx(), 1)}
-              >
-                ↓
-              </button>
-            </div>
-          </div>
-        )}
-      </For>
-      <button type="button" class="settings-add-launcher" onClick={() => props.addLauncher()}>
-        + Add launcher
-      </button>
+        <button type="button" class="settings-add-launcher" onClick={() => props.addLauncher()}>
+          + Add launcher
+        </button>
+      </Subgroup>
 
       <ActionTemplateSection
         title="Project actions"
+        subgroupId={subgroupId('project-actions')}
+        keywords="project action template launcher submit work-on"
         hint="Each entry appears in the dropdown next to the project's Work-on button. Templates accept {slug}, {title}, {branch}, {apps}, … (see Help). Launcher (when set) spawns a fresh tab using that launcher's command instead of typing into the focused tab."
         idPrefix={`${idPrefix}.projectActions`}
         bindText={props.bindText}
@@ -389,6 +832,8 @@ export function TerminalFields(props: {
 
       <ActionTemplateSection
         title="New project actions"
+        subgroupId={subgroupId('new-project-actions')}
+        keywords="new project action launcher template start"
         hint="Each entry appears in the dropdown next to the + New project button. Templates accept {today}, {conception}, {conceptionPath}. Launcher (when set) spawns a fresh tab — e.g. bind 'Start new project' to a Claude launcher to get a fresh Claude shell on every click."
         idPrefix={`${idPrefix}.newProjectActions`}
         bindText={props.bindText}
@@ -400,247 +845,260 @@ export function TerminalFields(props: {
         move={props.moveNewProjectAction}
       />
 
-      <h3>Font</h3>
-      <div class="settings-grid">
-        <label>
-          <span>Font family</span>
-          <input
-            type="text"
-            placeholder="ui-monospace, Menlo, Consolas, monospace"
-            {...props.bindText(
-              `${idPrefix}.xterm.font_family`,
-              () => props.xterm().font_family,
-              (v) => props.updateXterm({ font_family: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Font size (px)</span>
-          <input
-            type="number"
-            min="6"
-            max="48"
-            value={props.xterm().font_size ?? ''}
-            placeholder="12"
-            onChange={(e) =>
-              void props.updateXterm({
-                font_size: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-        </label>
-        <label>
-          <span>Line height</span>
-          <input
-            type="number"
-            step="0.05"
-            min="0.8"
-            max="2"
-            value={props.xterm().line_height ?? ''}
-            placeholder="1.0"
-            onChange={(e) =>
-              void props.updateXterm({
-                line_height: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-        </label>
-        <label>
-          <span>Letter spacing (px)</span>
-          <input
-            type="number"
-            step="0.5"
-            value={props.xterm().letter_spacing ?? ''}
-            placeholder="0"
-            onChange={(e) =>
-              void props.updateXterm({
-                letter_spacing: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-        </label>
-        <label>
-          <span>Font weight</span>
-          <input
-            type="text"
-            placeholder="normal | 400 | 500"
-            {...props.bindText(
-              `${idPrefix}.xterm.font_weight`,
-              () =>
-                props.xterm().font_weight !== undefined
-                  ? String(props.xterm().font_weight)
-                  : undefined,
-              (v) => props.updateXterm({ font_weight: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Bold weight</span>
-          <input
-            type="text"
-            placeholder="bold | 600 | 700"
-            {...props.bindText(
-              `${idPrefix}.xterm.font_weight_bold`,
-              () =>
-                props.xterm().font_weight_bold !== undefined
-                  ? String(props.xterm().font_weight_bold)
-                  : undefined,
-              (v) => props.updateXterm({ font_weight_bold: v || undefined }),
-            )}
-          />
-        </label>
-      </div>
+      <Subgroup
+        id={subgroupId('font')}
+        title="Font"
+        keywords="font family size line height letter spacing weight bold"
+      >
+        <div class="settings-grid">
+          <label>
+            <span>Font family</span>
+            <input
+              type="text"
+              placeholder="ui-monospace, Menlo, Consolas, monospace"
+              {...props.bindText(
+                `${idPrefix}.xterm.font_family`,
+                () => props.xterm().font_family,
+                (v) => props.updateXterm({ font_family: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Font size (px)</span>
+            <input
+              type="number"
+              min="6"
+              max="48"
+              value={props.xterm().font_size ?? ''}
+              placeholder="12"
+              onChange={(e) =>
+                void props.updateXterm({
+                  font_size: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+          </label>
+          <label>
+            <span>Line height</span>
+            <input
+              type="number"
+              step="0.05"
+              min="0.8"
+              max="2"
+              value={props.xterm().line_height ?? ''}
+              placeholder="1.0"
+              onChange={(e) =>
+                void props.updateXterm({
+                  line_height: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+          </label>
+          <label>
+            <span>Letter spacing (px)</span>
+            <input
+              type="number"
+              step="0.5"
+              value={props.xterm().letter_spacing ?? ''}
+              placeholder="0"
+              onChange={(e) =>
+                void props.updateXterm({
+                  letter_spacing: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+          </label>
+          <label>
+            <span>Font weight</span>
+            <input
+              type="text"
+              placeholder="normal | 400 | 500"
+              {...props.bindText(
+                `${idPrefix}.xterm.font_weight`,
+                () =>
+                  props.xterm().font_weight !== undefined
+                    ? String(props.xterm().font_weight)
+                    : undefined,
+                (v) => props.updateXterm({ font_weight: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Bold weight</span>
+            <input
+              type="text"
+              placeholder="bold | 600 | 700"
+              {...props.bindText(
+                `${idPrefix}.xterm.font_weight_bold`,
+                () =>
+                  props.xterm().font_weight_bold !== undefined
+                    ? String(props.xterm().font_weight_bold)
+                    : undefined,
+                (v) => props.updateXterm({ font_weight_bold: v || undefined }),
+              )}
+            />
+          </label>
+        </div>
+      </Subgroup>
 
-      <h3>Cursor &amp; buffer</h3>
-      <div class="settings-grid">
-        <label>
-          <span>Cursor style</span>
-          <select
-            value={props.xterm().cursor_style ?? 'block'}
-            onChange={(e) =>
-              void props.updateXterm({
-                cursor_style: e.currentTarget.value as 'block' | 'underline' | 'bar',
-              })
-            }
-          >
-            <For each={CURSOR_STYLES}>
-              {(opt) => <option value={opt.value}>{opt.label}</option>}
-            </For>
-          </select>
-        </label>
-        <label class="settings-checkbox">
-          <input
-            type="checkbox"
-            checked={props.xterm().cursor_blink !== false}
-            onChange={(e) => void props.updateXterm({ cursor_blink: e.currentTarget.checked })}
-          />
-          <span>Cursor blink</span>
-        </label>
-        <label>
-          <span>Scrollback (lines)</span>
-          <input
-            type="number"
-            min="0"
-            max="100000"
-            value={props.xterm().scrollback ?? ''}
-            placeholder="10000"
-            onChange={(e) =>
-              void props.updateXterm({
-                scrollback: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-        </label>
-        <label class="settings-checkbox">
-          <input
-            type="checkbox"
-            checked={props.xterm().ligatures === true}
-            onChange={(e) =>
-              void props.updateXterm({ ligatures: e.currentTarget.checked || undefined })
-            }
-          />
-          <span>Programming-font ligatures</span>
-        </label>
-      </div>
+      <Subgroup
+        id={subgroupId('cursor-buffer')}
+        title="Cursor & buffer"
+        keywords="cursor blink style scrollback ligatures buffer"
+      >
+        <div class="settings-grid">
+          <label>
+            <span>Cursor style</span>
+            <select
+              value={props.xterm().cursor_style ?? 'block'}
+              onChange={(e) =>
+                void props.updateXterm({
+                  cursor_style: e.currentTarget.value as 'block' | 'underline' | 'bar',
+                })
+              }
+            >
+              <For each={CURSOR_STYLES}>
+                {(opt) => <option value={opt.value}>{opt.label}</option>}
+              </For>
+            </select>
+          </label>
+          <label class="settings-checkbox">
+            <input
+              type="checkbox"
+              checked={props.xterm().cursor_blink !== false}
+              onChange={(e) => void props.updateXterm({ cursor_blink: e.currentTarget.checked })}
+            />
+            <span>Cursor blink</span>
+          </label>
+          <label>
+            <span>Scrollback (lines)</span>
+            <input
+              type="number"
+              min="0"
+              max="100000"
+              value={props.xterm().scrollback ?? ''}
+              placeholder="10000"
+              onChange={(e) =>
+                void props.updateXterm({
+                  scrollback: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+          </label>
+          <label class="settings-checkbox">
+            <input
+              type="checkbox"
+              checked={props.xterm().ligatures === true}
+              onChange={(e) =>
+                void props.updateXterm({ ligatures: e.currentTarget.checked || undefined })
+              }
+            />
+            <span>Programming-font ligatures</span>
+          </label>
+        </div>
+      </Subgroup>
 
-      <h3>Colours</h3>
-      <p class="settings-hint">
-        Leave a field blank to inherit the active theme. Values are CSS colours (hex, named,{' '}
-        <code>color-mix(...)</code>).
-      </p>
-      <div class="settings-color-grid">
-        <For each={TERMINAL_COLORS}>
-          {(entry) => (
-            <label class="settings-color">
-              <span>{entry.label}</span>
-              <input
-                type="text"
-                placeholder="—"
-                {...props.bindText(
-                  `${idPrefix}.xterm.colors.${entry.key}`,
-                  () => props.xterm().colors?.[entry.key],
-                  (v) => {
-                    props.updateColor(entry.key, v);
-                    return Promise.resolve();
-                  },
-                )}
+      <Subgroup
+        id={subgroupId('colours')}
+        title="Colours"
+        keywords="colour color ansi foreground background cursor selection palette hex theme"
+      >
+        <p class="settings-hint">
+          Leave a field blank to inherit the active theme. Values are CSS colours (hex, named,{' '}
+          <code>color-mix(...)</code>).
+        </p>
+        <div class="settings-color-grid">
+          <For each={TERMINAL_COLORS}>
+            {(entry) => (
+              <ColorField
+                entry={entry}
+                idPrefix={idPrefix}
+                value={() => props.xterm().colors?.[entry.key]}
+                bindText={props.bindText}
+                onChange={(v) => props.updateColor(entry.key, v)}
               />
-            </label>
-          )}
-        </For>
-      </div>
+            )}
+          </For>
+        </div>
+        <TerminalColorPreview xterm={props.xterm} />
+      </Subgroup>
 
-      <h3>Logging</h3>
-      <p class="settings-hint">
-        Off by default for privacy. When enabled, every terminal tab records its rendered output to{' '}
-        <code>.condash/logs/YYYY/MM/DD/HHMMSS-&lt;id&gt;.txt</code> with sidecar
-        <code> .meta.json</code>. The <code> .condash/</code> tree is gitignored by default.
-        Toggling off does not delete past transcripts — the Logs pane keeps browsing them.
-      </p>
-      <div class="settings-grid">
-        <label class="settings-checkbox">
-          <input
-            type="checkbox"
-            checked={loggingEnabled()}
-            onChange={(e) => void props.updateLogging({ enabled: e.currentTarget.checked })}
-          />
-          <span>Record terminal sessions to disk</span>
-        </label>
-        <label>
-          <span>Retention (days)</span>
-          <input
-            type="number"
-            min="0"
-            max="3650"
-            value={logging().retentionDays ?? ''}
-            placeholder="14"
-            onChange={(e) =>
-              void props.updateLogging({
-                retentionDays: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-          <small class="settings-field-hint">
-            Day-directories older than this are removed on next janitor run.
-            <code> 0</code> disables age-based eviction.
-          </small>
-        </label>
-        <label>
-          <span>Max total size (MB)</span>
-          <input
-            type="number"
-            min="0"
-            value={logging().maxDirMb ?? ''}
-            placeholder="500"
-            onChange={(e) =>
-              void props.updateLogging({
-                maxDirMb: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-          <small class="settings-field-hint">
-            When over this cap, the oldest day-directory is removed first.
-          </small>
-        </label>
-        <label>
-          <span>Scrollback (lines)</span>
-          <input
-            type="number"
-            min="100"
-            value={logging().scrollback ?? ''}
-            placeholder="10000"
-            onChange={(e) =>
-              void props.updateLogging({
-                scrollback: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
-              })
-            }
-          />
-          <small class="settings-field-hint">
-            How many lines the headless xterm retains per session. Larger → bigger
-            <code> .txt</code> files; smaller → older output rolls off the top.
-          </small>
-        </label>
-      </div>
+      <Subgroup
+        id={subgroupId('logging')}
+        title="Logging"
+        keywords="logging record session transcript retention disk size scrollback privacy"
+      >
+        <p class="settings-hint">
+          Off by default for privacy. When enabled, every terminal tab records its rendered output
+          to <code>.condash/logs/YYYY/MM/DD/HHMMSS-&lt;id&gt;.txt</code> with sidecar
+          <code> .meta.json</code>. The <code> .condash/</code> tree is gitignored by default.
+          Toggling off does not delete past transcripts — the Logs pane keeps browsing them.
+        </p>
+        <div class="settings-grid">
+          <label class="settings-checkbox">
+            <input
+              type="checkbox"
+              checked={loggingEnabled()}
+              onChange={(e) => void props.updateLogging({ enabled: e.currentTarget.checked })}
+            />
+            <span>Record terminal sessions to disk</span>
+          </label>
+          <label>
+            <span>Retention (days)</span>
+            <input
+              type="number"
+              min="0"
+              max="3650"
+              value={logging().retentionDays ?? ''}
+              placeholder="14"
+              onChange={(e) =>
+                void props.updateLogging({
+                  retentionDays: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+            <small class="settings-field-hint">
+              Day-directories older than this are removed on next janitor run.
+              <code> 0</code> disables age-based eviction.
+            </small>
+          </label>
+          <label>
+            <span>Max total size (MB)</span>
+            <input
+              type="number"
+              min="0"
+              value={logging().maxDirMb ?? ''}
+              placeholder="500"
+              onChange={(e) =>
+                void props.updateLogging({
+                  maxDirMb: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+            <small class="settings-field-hint">
+              When over this cap, the oldest day-directory is removed first.
+            </small>
+          </label>
+          <label>
+            <span>Scrollback (lines)</span>
+            <input
+              type="number"
+              min="100"
+              value={logging().scrollback ?? ''}
+              placeholder="10000"
+              onChange={(e) =>
+                void props.updateLogging({
+                  scrollback: e.currentTarget.value ? Number(e.currentTarget.value) : undefined,
+                })
+              }
+            />
+            <small class="settings-field-hint">
+              How many lines the headless xterm retains per session. Larger → bigger
+              <code> .txt</code> files; smaller → older output rolls off the top.
+            </small>
+          </label>
+        </div>
+      </Subgroup>
     </>
   );
 }

--- a/src/renderer/settings-modal-parts/repo-row.tsx
+++ b/src/renderer/settings-modal-parts/repo-row.tsx
@@ -1,6 +1,31 @@
-import { For, Show } from 'solid-js';
+import { createSignal, For, Show } from 'solid-js';
 import type { RawRepo, RawSubmoduleRepo } from '../../main/config-schema';
-import { type BindTextFn, moveItem } from './data';
+import { type BindTextFn, type DndHandlers, moveItem } from './data';
+
+const REPO_ROW_OPEN_KEY = 'condash:settings-modal:repo-row-open';
+
+function readRepoOpen(id: string, defaultOpen: boolean): boolean {
+  try {
+    const raw = window.localStorage.getItem(REPO_ROW_OPEN_KEY);
+    if (!raw) return defaultOpen;
+    const map = JSON.parse(raw) as Record<string, boolean>;
+    return typeof map[id] === 'boolean' ? map[id] : defaultOpen;
+  } catch {
+    return defaultOpen;
+  }
+}
+
+function writeRepoOpen(id: string, open: boolean): void {
+  try {
+    const raw = window.localStorage.getItem(REPO_ROW_OPEN_KEY);
+    const map = raw ? (JSON.parse(raw) as Record<string, boolean>) : {};
+    map[id] = open;
+    window.localStorage.setItem(REPO_ROW_OPEN_KEY, JSON.stringify(map));
+  } catch {
+    // Same private-mode fallback as Subgroup — collapse state simply
+    // doesn't persist across reloads.
+  }
+}
 
 /**
  * One row in a repositories list. Always shows the full editable surface
@@ -23,6 +48,9 @@ export function RepoRow(props: {
   onMove: (delta: -1 | 1) => void;
   onRemove: () => void;
   onPatch: (next: RawRepo) => Promise<void>;
+  /** Optional drag-and-drop callbacks. Submodule rows pass `undefined` —
+   *  DnD only happens at the top level for now. */
+  dnd?: DndHandlers;
 }) {
   const obj = (): RepoRowObject =>
     typeof props.entry === 'string' ? { name: props.entry } : props.entry;
@@ -32,23 +60,111 @@ export function RepoRow(props: {
 
   const submodules = (): RawSubmoduleRepo[] => obj().submodules ?? [];
 
+  /** True when the row has anything *other than* its name filled in. A blank
+   *  row's name is allowed to be empty (it's effectively a not-yet-saved
+   *  placeholder); a row with a label / run / path but no name is the
+   *  "required" error condition the asterisk + red border flag. */
+  const hasContent = (): boolean => {
+    const o = obj();
+    return Boolean(
+      o.label || o.path || o.run || o.force_stop || o.install || o.pinned_branch || o.env?.length,
+    );
+  };
+  const nameMissing = (): boolean => hasContent() && !obj().name.trim();
+
+  // Collapse state per row, keyed by the row's idPrefix (which is stable
+  // for the lifetime of the conception's repository list — adding/
+  // removing entries shifts indices, but each row's open state is
+  // visually scoped enough that drift is acceptable).
+  const [open, setOpen] = createSignal(readRepoOpen(props.idPrefix, false));
+  // Force-open when the row is invalid so the user sees the affected fields
+  // without an extra click; same for actively-dragging rows so the drag
+  // image is the summary header (not the expanded form).
+  const effectiveOpen = (): boolean => open() && !nameMissing();
+  const toggleOpen = (): void => {
+    const next = !open();
+    setOpen(next);
+    writeRepoOpen(props.idPrefix, next);
+  };
+
+  const summary = (): string => {
+    const o = obj();
+    const parts: string[] = [];
+    if (o.name) parts.push(o.name);
+    else parts.push('(unnamed)');
+    if (o.path && o.path !== o.name) parts.push(`· ${o.path}`);
+    if (o.run) parts.push(`· ${o.run}`);
+    return parts.join(' ');
+  };
+
   const updateSubmodules = (
     mutate: (subs: RawSubmoduleRepo[]) => RawSubmoduleRepo[],
   ): Promise<void> => patchObj({ submodules: mutate(submodules()) });
 
   return (
-    <div class="settings-repo-row">
+    <div
+      class="settings-repo-row"
+      classList={{
+        'settings-repo-row--dragging': props.dnd?.isDragging(props.index) ?? false,
+        'settings-repo-row--drop-target': props.dnd?.isDropTarget(props.index) ?? false,
+        'settings-repo-row--collapsed': !effectiveOpen(),
+      }}
+      data-invalid={nameMissing() ? 'true' : undefined}
+      draggable={props.dnd ? true : undefined}
+      onDragStart={(e) => {
+        if (!props.dnd) return;
+        e.dataTransfer?.setData('text/plain', String(props.index));
+        if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
+        props.dnd.onDragStart(props.index);
+      }}
+      onDragOver={(e) => {
+        if (!props.dnd) return;
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        props.dnd.onDragOver(props.index);
+      }}
+      onDrop={(e) => {
+        if (!props.dnd) return;
+        e.preventDefault();
+        props.dnd.onDrop(props.index);
+      }}
+      onDragEnd={() => props.dnd?.onDragEnd()}
+    >
       <div class="settings-repo-row-head">
+        <Show when={props.dnd}>
+          <span class="settings-repo-drag-handle" title="Drag to reorder" aria-hidden="true">
+            ⋮⋮
+          </span>
+        </Show>
+        <button
+          type="button"
+          class="settings-repo-toggle"
+          aria-expanded={effectiveOpen()}
+          aria-label={effectiveOpen() ? 'Collapse repository' : 'Expand repository'}
+          onClick={toggleOpen}
+        >
+          <span class="settings-repo-toggle-chevron" aria-hidden="true">
+            ▸
+          </span>
+        </button>
         <input
           type="text"
           class="settings-repo-name"
-          placeholder="repo-name"
+          classList={{ 'settings-input--invalid': nameMissing() }}
+          placeholder="repo-name *"
+          aria-invalid={nameMissing()}
+          aria-label="Repository name (required)"
           {...props.bindText(
             `${props.idPrefix}.name`,
             () => obj().name,
             (v) => patchObj({ name: v }),
           )}
         />
+        <Show when={!effectiveOpen()}>
+          <span class="settings-repo-summary" onClick={toggleOpen}>
+            {summary()}
+          </span>
+        </Show>
         <button
           class="modal-button"
           title="Move up"
@@ -69,129 +185,134 @@ export function RepoRow(props: {
           ×
         </button>
       </div>
-      <div class="settings-repo-row-detail">
-        <label>
-          <span>Path</span>
-          <input
-            type="text"
-            placeholder="defaults to name"
-            {...props.bindText(
-              `${props.idPrefix}.path`,
-              () => obj().path,
-              (v) => patchObj({ path: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Label</span>
-          <input
-            type="text"
-            placeholder="Friendly subtitle"
-            {...props.bindText(
-              `${props.idPrefix}.label`,
-              () => obj().label,
-              (v) => patchObj({ label: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Run command</span>
-          <input
-            type="text"
-            placeholder="make dev"
-            {...props.bindText(
-              `${props.idPrefix}.run`,
-              () => obj().run,
-              (v) => patchObj({ run: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Force stop</span>
-          <input
-            type="text"
-            placeholder="fuser -k 5600/tcp"
-            {...props.bindText(
-              `${props.idPrefix}.force_stop`,
-              () => obj().force_stop,
-              (v) => patchObj({ force_stop: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Install command</span>
-          <input
-            type="text"
-            placeholder="npm install"
-            {...props.bindText(
-              `${props.idPrefix}.install`,
-              () => obj().install,
-              (v) => patchObj({ install: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Pinned branch</span>
-          <input
-            type="text"
-            placeholder="main"
-            {...props.bindText(
-              `${props.idPrefix}.pinned_branch`,
-              () => obj().pinned_branch,
-              (v) => patchObj({ pinned_branch: v || undefined }),
-            )}
-          />
-        </label>
-        <label>
-          <span>Env files (comma-separated)</span>
-          <input
-            type="text"
-            placeholder=".env, .env.local"
-            {...props.bindText(
-              `${props.idPrefix}.env`,
-              () => (obj().env ?? []).join(', '),
-              async (v) => {
-                const list = v
-                  .split(',')
-                  .map((s) => s.trim())
-                  .filter(Boolean);
-                await patchObj({ env: list.length > 0 ? list : undefined });
-              },
-            )}
-          />
-        </label>
-      </div>
-      <Show when={submodules().length > 0}>
-        <div class="settings-repo-submodules">
-          <span class="settings-field-label">Sub repos</span>
-          <For each={submodules()}>
-            {(sub, idx) => (
-              <RepoRow
-                entry={sub}
-                idPrefix={`${props.idPrefix}.sub[${idx()}]`}
-                index={idx()}
-                total={submodules().length}
-                bindText={props.bindText}
-                onMove={(delta) => void updateSubmodules((all) => moveItem(all, idx(), delta))}
-                onRemove={() => void updateSubmodules((all) => all.filter((_, i) => i !== idx()))}
-                onPatch={(next) =>
-                  updateSubmodules((all) =>
-                    all.map((e, i) => (i === idx() ? (next as RawSubmoduleRepo) : e)),
-                  )
-                }
-              />
-            )}
-          </For>
+      <Show when={nameMissing()}>
+        <p class="settings-repo-name-error">Name is required when the row has other fields.</p>
+      </Show>
+      <Show when={effectiveOpen()}>
+        <div class="settings-repo-row-detail">
+          <label>
+            <span>Path</span>
+            <input
+              type="text"
+              placeholder="defaults to name"
+              {...props.bindText(
+                `${props.idPrefix}.path`,
+                () => obj().path,
+                (v) => patchObj({ path: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Label</span>
+            <input
+              type="text"
+              placeholder="Friendly subtitle"
+              {...props.bindText(
+                `${props.idPrefix}.label`,
+                () => obj().label,
+                (v) => patchObj({ label: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Run command</span>
+            <input
+              type="text"
+              placeholder="make dev"
+              {...props.bindText(
+                `${props.idPrefix}.run`,
+                () => obj().run,
+                (v) => patchObj({ run: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Force stop</span>
+            <input
+              type="text"
+              placeholder="fuser -k 5600/tcp"
+              {...props.bindText(
+                `${props.idPrefix}.force_stop`,
+                () => obj().force_stop,
+                (v) => patchObj({ force_stop: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Install command</span>
+            <input
+              type="text"
+              placeholder="npm install"
+              {...props.bindText(
+                `${props.idPrefix}.install`,
+                () => obj().install,
+                (v) => patchObj({ install: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Pinned branch</span>
+            <input
+              type="text"
+              placeholder="main"
+              {...props.bindText(
+                `${props.idPrefix}.pinned_branch`,
+                () => obj().pinned_branch,
+                (v) => patchObj({ pinned_branch: v || undefined }),
+              )}
+            />
+          </label>
+          <label>
+            <span>Env files (comma-separated)</span>
+            <input
+              type="text"
+              placeholder=".env, .env.local"
+              {...props.bindText(
+                `${props.idPrefix}.env`,
+                () => (obj().env ?? []).join(', '),
+                async (v) => {
+                  const list = v
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter(Boolean);
+                  await patchObj({ env: list.length > 0 ? list : undefined });
+                },
+              )}
+            />
+          </label>
+        </div>
+        <Show when={submodules().length > 0}>
+          <div class="settings-repo-submodules">
+            <span class="settings-field-label">Sub repos</span>
+            <For each={submodules()}>
+              {(sub, idx) => (
+                <RepoRow
+                  entry={sub}
+                  idPrefix={`${props.idPrefix}.sub[${idx()}]`}
+                  index={idx()}
+                  total={submodules().length}
+                  bindText={props.bindText}
+                  onMove={(delta) => void updateSubmodules((all) => moveItem(all, idx(), delta))}
+                  onRemove={() => void updateSubmodules((all) => all.filter((_, i) => i !== idx()))}
+                  onPatch={(next) =>
+                    updateSubmodules((all) =>
+                      all.map((e, i) => (i === idx() ? (next as RawSubmoduleRepo) : e)),
+                    )
+                  }
+                />
+              )}
+            </For>
+          </div>
+        </Show>
+        <div class="settings-list-actions">
+          <button
+            class="modal-button"
+            onClick={() => void updateSubmodules((all) => [...all, { name: '' }])}
+          >
+            + Add sub repo
+          </button>
         </div>
       </Show>
-      <div class="settings-list-actions">
-        <button
-          class="modal-button"
-          onClick={() => void updateSubmodules((all) => [...all, { name: '' }])}
-        >
-          + Add sub repo
-        </button>
-      </div>
     </div>
   );
 }

--- a/src/renderer/settings-modal-parts/section-recent-conceptions.tsx
+++ b/src/renderer/settings-modal-parts/section-recent-conceptions.tsx
@@ -23,6 +23,10 @@ export function RecentConceptionsSection(): JSX.Element {
     setVersion((v) => v + 1);
   };
 
+  const handleOpen = (path: string): void => {
+    void window.condash.openConception(path);
+  };
+
   return (
     <section id="settings-section-recents:global" class="settings-section">
       <h2>Recent conception paths</h2>
@@ -32,20 +36,35 @@ export function RecentConceptionsSection(): JSX.Element {
       </p>
       <Show
         when={(recents() ?? []).length > 0}
-        fallback={<p class="settings-empty">No recents yet.</p>}
+        fallback={
+          <div class="settings-empty">
+            <p>No recent conceptions yet.</p>
+            <p class="settings-empty-hint">
+              Use <kbd>File → Open conception…</kbd> or drop a folder on the dock icon to add one.
+            </p>
+          </div>
+        }
       >
         <ul class="settings-recents-list">
           <For each={recents()}>
             {(path) => (
               <li class="settings-recents-row">
-                <code class="settings-recents-path">{path}</code>
                 <button
                   type="button"
-                  class="modal-button"
+                  class="settings-recents-open"
+                  onClick={() => handleOpen(path)}
+                  title="Switch to this conception"
+                >
+                  <code class="settings-recents-path">{path}</code>
+                </button>
+                <button
+                  type="button"
+                  class="modal-button settings-recents-remove"
                   onClick={() => void handleRemove(path)}
                   title="Remove from recents"
+                  aria-label={`Remove ${path} from recents`}
                 >
-                  Remove
+                  ×
                 </button>
               </li>
             )}

--- a/src/renderer/settings-modal-parts/section-row.tsx
+++ b/src/renderer/settings-modal-parts/section-row.tsx
@@ -1,6 +1,6 @@
-import type { JSX } from 'solid-js';
+import { Show, type JSX } from 'solid-js';
 import type { RawRepo } from '../../main/config-schema';
-import type { BindTextFn } from './data';
+import type { BindTextFn, DndHandlers } from './data';
 
 /**
  * One row in the repositories list that is a `{ section: "…" }` marker — a
@@ -17,10 +17,44 @@ export function SectionRow(props: {
   onMove: (delta: -1 | 1) => void;
   onRemove: () => void;
   onPatch: (next: RawRepo) => Promise<void>;
+  dnd?: DndHandlers;
 }): JSX.Element {
   return (
-    <div class="settings-repo-row settings-repo-row--section">
+    <div
+      class="settings-repo-row settings-repo-row--section"
+      classList={{
+        'settings-repo-row--dragging': props.dnd?.isDragging(props.index) ?? false,
+        'settings-repo-row--drop-target': props.dnd?.isDropTarget(props.index) ?? false,
+      }}
+      draggable={props.dnd ? true : undefined}
+      onDragStart={(e) => {
+        if (!props.dnd) return;
+        e.dataTransfer?.setData('text/plain', String(props.index));
+        if (e.dataTransfer) e.dataTransfer.effectAllowed = 'move';
+        props.dnd.onDragStart(props.index);
+      }}
+      onDragOver={(e) => {
+        if (!props.dnd) return;
+        e.preventDefault();
+        if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
+        props.dnd.onDragOver(props.index);
+      }}
+      onDrop={(e) => {
+        if (!props.dnd) return;
+        e.preventDefault();
+        props.dnd.onDrop(props.index);
+      }}
+      onDragEnd={() => props.dnd?.onDragEnd()}
+    >
       <div class="settings-repo-row-head">
+        <Show when={props.dnd}>
+          <span class="settings-repo-drag-handle" title="Drag to reorder" aria-hidden="true">
+            ⋮⋮
+          </span>
+        </Show>
+        <span class="settings-repo-section-marker" aria-hidden="true">
+          §
+        </span>
         <input
           type="text"
           class="settings-repo-section-name"

--- a/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
+++ b/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
@@ -6,7 +6,7 @@
  * modal shell.
  */
 
-import { For, Show, type JSX } from 'solid-js';
+import { createSignal, For, Show, type JSX } from 'solid-js';
 import { isSectionMarker, type RawRepo } from '../../main/config-schema';
 import { type BindTextFn, OPEN_WITH_SLOTS, type RawConfig } from './data';
 import { FieldBadgeRow, type InheritanceState } from './badges';
@@ -48,8 +48,53 @@ export function RepositoriesSection(props: RepositoriesSectionProps): JSX.Elemen
       return next;
     });
 
+  /** Move `from` to `to`, clamping `to` into the valid range. Used by the
+   *  drag-and-drop drop handler — `to` is the target slot, which may be
+   *  past the array's end when dropping below the last row. */
+  const moveRepoTo = (from: number, to: number): Promise<void> =>
+    updateRepos((entries) => {
+      if (from === to) return entries;
+      const next = entries.slice();
+      const [removed] = next.splice(from, 1);
+      const clamped = Math.max(0, Math.min(to, next.length));
+      next.splice(clamped, 0, removed);
+      return next;
+    });
+
   const updateRepoEntry = (index: number, patch: (entry: RawRepo) => RawRepo): Promise<void> =>
     updateRepos((entries) => entries.map((e, i) => (i === index ? patch(e) : e)));
+
+  // Drag-and-drop state. `dragIndex` is the row currently being dragged;
+  // `dropIndex` is the gap we'd insert before if the user released now.
+  // Both reset on dragend so a cancelled drag doesn't leave stale outlines.
+  const [dragIndex, setDragIndex] = createSignal<number | null>(null);
+  const [dropIndex, setDropIndex] = createSignal<number | null>(null);
+  const dnd = {
+    onDragStart: (index: number) => {
+      setDragIndex(index);
+    },
+    onDragOver: (index: number) => {
+      if (dragIndex() === null) return;
+      setDropIndex(index);
+    },
+    onDrop: (index: number) => {
+      const from = dragIndex();
+      if (from === null) return;
+      setDragIndex(null);
+      setDropIndex(null);
+      // When dragging downward, the source slot moved up by 1 once we
+      // remove it; compensate so "drop above row 5" lands at index 4 (not
+      // index 5 — which would skip over the source's old neighbour).
+      const target = from < index ? index - 1 : index;
+      void moveRepoTo(from, target);
+    },
+    onDragEnd: () => {
+      setDragIndex(null);
+      setDropIndex(null);
+    },
+    isDragging: (index: number): boolean => dragIndex() === index,
+    isDropTarget: (index: number): boolean => dropIndex() === index && dragIndex() !== index,
+  };
 
   return (
     <section id="settings-section-repositories:conception" class="settings-section">
@@ -82,6 +127,7 @@ export function RepositoriesSection(props: RepositoriesSectionProps): JSX.Elemen
                   onMove={(delta) => void moveRepo(index(), delta)}
                   onRemove={() => void removeRepo(index())}
                   onPatch={(next) => updateRepoEntry(index(), () => next)}
+                  dnd={dnd}
                 />
               }
             >
@@ -94,6 +140,7 @@ export function RepositoriesSection(props: RepositoriesSectionProps): JSX.Elemen
                 onMove={(delta) => void moveRepo(index(), delta)}
                 onRemove={() => void removeRepo(index())}
                 onPatch={(next) => updateRepoEntry(index(), () => next)}
+                dnd={dnd}
               />
             </Show>
           )}
@@ -147,16 +194,30 @@ export function OpenWithSection(props: OpenWithSectionProps): JSX.Element {
       </div>
       <p class="settings-hint">
         Three slots used by the per-folder &quot;Open in…&quot; menu. <code>{'{path}'}</code> is
-        substituted with the absolute path. Clear the command to remove the slot.
+        substituted with the absolute path.
       </p>
       <div class="settings-grid settings-grid--wide">
         <For each={OPEN_WITH_SLOTS}>
           {(slot) => {
             const current = (): { label?: string; command?: string } =>
               props.parsed().open_with?.[slot.key] ?? {};
+            const hasContent = (): boolean => Boolean(current().label || current().command);
             return (
               <div class="settings-open-with">
-                <span class="settings-field-label">{slot.label}</span>
+                <div class="settings-open-with-head">
+                  <span class="settings-field-label">{slot.label}</span>
+                  <Show when={hasContent()}>
+                    <button
+                      type="button"
+                      class="settings-open-with-remove"
+                      title={`Remove ${slot.label} slot`}
+                      aria-label={`Remove ${slot.label} slot`}
+                      onClick={() => void updateOpenWithSlot(slot.key, { command: '', label: '' })}
+                    >
+                      ×
+                    </button>
+                  </Show>
+                </div>
                 <input
                   type="text"
                   placeholder={`Open in ${slot.label.toLowerCase()}`}

--- a/src/renderer/settings-modal-parts/sections-workspace.tsx
+++ b/src/renderer/settings-modal-parts/sections-workspace.tsx
@@ -58,6 +58,7 @@ export function WorkspaceSection(props: WorkspaceSectionProps): JSX.Element {
       <div class="settings-grid settings-grid--wide">
         <FieldWithBadge
           label="Workspace path"
+          pathScope="abs"
           state={props.stateOf('workspace_path')}
           onRemove={() => void props.removeOverride('workspace_path')}
         >
@@ -73,6 +74,7 @@ export function WorkspaceSection(props: WorkspaceSectionProps): JSX.Element {
         </FieldWithBadge>
         <FieldWithBadge
           label="Worktrees path"
+          pathScope="abs"
           state={props.stateOf('worktrees_path')}
           onRemove={() => void props.removeOverride('worktrees_path')}
         >
@@ -88,6 +90,7 @@ export function WorkspaceSection(props: WorkspaceSectionProps): JSX.Element {
         </FieldWithBadge>
         <FieldWithBadge
           label="Resources directory"
+          pathScope="rel"
           hint="Relative to the conception root. Browsed by the Resources pane."
           state={props.stateOf('resources_path')}
           onRemove={() => void props.removeOverride('resources_path')}
@@ -104,6 +107,7 @@ export function WorkspaceSection(props: WorkspaceSectionProps): JSX.Element {
         </FieldWithBadge>
         <FieldWithBadge
           label="Skills directory"
+          pathScope="rel"
           hint="Relative to the conception root. Markdown files here are editable from the Skills pane."
           state={props.stateOf('skills_path')}
           onRemove={() => void props.removeOverride('skills_path')}

--- a/src/renderer/settings-modal.css
+++ b/src/renderer/settings-modal.css
@@ -215,7 +215,10 @@
 }
 
 .settings-rail-item {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
   width: 100%;
   text-align: left;
   background: transparent;
@@ -231,6 +234,18 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.settings-rail-item-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.settings-rail-item-pip {
+  color: var(--accent);
+  font-size: 11px;
+  line-height: 1;
 }
 
 .settings-rail-item:hover {
@@ -567,14 +582,28 @@
   background: var(--bg-subtle);
 }
 
+/* E2 — Section markers now read as inline headings rather than dashed
+ * card boxes that mimic repo rows. No border + transparent background +
+ * a § glyph signal the row is a label, not editable repo data. */
 .settings-repo-row--section {
-  background: var(--bg-subtle);
-  border-style: dashed;
-  margin-top: 12px;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  border-bottom: 1px solid var(--border);
+  border-radius: 0;
+  margin: 18px 0 4px;
+  padding: 6px 4px 4px;
 }
 
 .settings-repo-row--section:first-child {
   margin-top: 0;
+}
+
+.settings-repo-section-marker {
+  font-family: var(--font-display);
+  color: var(--text-faint);
+  font-size: 16px;
+  font-weight: 700;
 }
 
 .settings-repo-section-name {
@@ -582,6 +611,13 @@
   min-width: 0;
   font-weight: 600;
   font-size: 14px;
+  background: transparent !important;
+  border-color: transparent !important;
+}
+
+.settings-repo-section-name:focus {
+  background: var(--bg-subtle) !important;
+  border-color: var(--accent) !important;
 }
 
 .settings-repo-row-detail label {
@@ -819,4 +855,560 @@
    * input styles set on bare `label > input` selectors elsewhere; the
    * extra wrapping div would otherwise lose those rules. */
   margin-top: 2px;
+}
+
+/* ---- Search bar -------------------------------------------------------- */
+
+.settings-search-bar {
+  position: relative;
+  flex-shrink: 0;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+
+.settings-search {
+  width: 100%;
+  padding: 7px 32px 7px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-subtle);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+
+.settings-search:focus {
+  outline: none;
+  border-color: var(--accent);
+  background: var(--bg);
+}
+
+.settings-search-clear {
+  position: absolute;
+  right: 24px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.settings-search-clear:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+/* ---- Header Save button -- emphasises the primary action when dirty.  */
+
+.settings-save {
+  font-weight: 500;
+}
+
+.settings-save--dirty {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+.settings-save--dirty:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+/* ---- Collapsible subgroup -- promoted from <h3> into a <details> tag. */
+
+.settings-subgroup {
+  margin: 12px 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+}
+
+.settings-subgroup > .settings-subgroup-summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  cursor: pointer;
+  user-select: none;
+  border-radius: 8px;
+}
+
+.settings-subgroup > .settings-subgroup-summary::-webkit-details-marker {
+  display: none;
+}
+
+.settings-subgroup > .settings-subgroup-summary:hover {
+  background: var(--bg-hover);
+}
+
+.settings-subgroup-chevron {
+  display: inline-block;
+  transition: transform 0.15s ease;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.settings-subgroup[open] > .settings-subgroup-summary .settings-subgroup-chevron {
+  transform: rotate(90deg);
+}
+
+.settings-subgroup > .settings-subgroup-summary h3 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.settings-subgroup-body {
+  padding: 6px 14px 14px;
+  border-top: 1px solid var(--border);
+}
+
+/* ---- Colour field — swatch + text + hidden native picker ------------- */
+
+.settings-color-input {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-color-swatch {
+  flex-shrink: 0;
+  width: 20px;
+  height: 20px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  background-image:
+    linear-gradient(45deg, var(--bg-subtle) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--bg-subtle) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--bg-subtle) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--bg-subtle) 75%);
+  background-size: 8px 8px;
+  background-position:
+    0 0,
+    0 4px,
+    4px -4px,
+    -4px 0;
+  position: relative;
+  overflow: hidden;
+}
+
+.settings-color-swatch::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: inherit;
+}
+
+.settings-color-swatch:hover {
+  border-color: var(--accent);
+}
+
+.settings-color-input input[type='text'] {
+  flex: 1;
+  min-width: 0;
+}
+
+.settings-color-picker {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+  width: 1px;
+  height: 1px;
+}
+
+/* ---- Live terminal preview (under the colour grid) ------------------- */
+
+.settings-terminal-preview {
+  margin: 14px 0 0;
+  padding: 10px 12px;
+  background: var(--preview-bg, #1a1b26);
+  color: var(--preview-fg, #c0caf5);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
+.settings-terminal-preview .preview-muted {
+  color: var(--preview-muted, #565f89);
+}
+.settings-terminal-preview .preview-green {
+  color: var(--preview-green, #9ece6a);
+}
+.settings-terminal-preview .preview-red {
+  color: var(--preview-red, #f7768e);
+}
+.settings-terminal-preview .preview-yellow {
+  color: var(--preview-yellow, #e0af68);
+}
+.settings-terminal-preview .preview-blue {
+  color: var(--preview-blue, #7aa2f7);
+}
+.settings-terminal-preview .preview-magenta {
+  color: var(--preview-magenta, #bb9af7);
+}
+.settings-terminal-preview .preview-cyan {
+  color: var(--preview-cyan, #7dcfff);
+}
+.settings-terminal-preview .preview-cursor {
+  color: var(--preview-cursor, #f7768e);
+  animation: preview-cursor-blink 1s steps(2, end) infinite;
+}
+
+@keyframes preview-cursor-blink {
+  to {
+    opacity: 0.25;
+  }
+}
+
+/* ---- Card-density preview strip -------------------------------------- */
+
+.settings-density-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 6px 0 16px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  overflow-x: auto;
+}
+
+.settings-density-preview-card {
+  flex-shrink: 0;
+  height: 56px;
+  padding: 8px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  font-size: 11px;
+}
+
+.settings-density-preview-label {
+  color: var(--text);
+  font-weight: 600;
+}
+
+.settings-density-preview-width {
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+/* ---- Path chip ([abs] / [rel]) -------------------------------------- */
+
+.settings-path-chip {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  vertical-align: middle;
+  text-transform: lowercase;
+}
+
+.settings-path-chip--rel {
+  background: var(--bg-elevated);
+  color: var(--text-faint);
+}
+
+/* ---- Field label row ------------------------------------------------- */
+
+.settings-field-label-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+/* ---- Shortcut capture button ---------------------------------------- */
+
+.settings-shortcut {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 5px 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  text-align: left;
+  min-height: 28px;
+}
+
+.settings-shortcut:hover {
+  border-color: var(--accent);
+}
+
+.settings-shortcut--capturing {
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  font-style: italic;
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.settings-shortcut:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* ---- Inline link (jump to subgroup) --------------------------------- */
+
+.settings-inline-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--accent);
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.settings-inline-link:hover {
+  filter: brightness(1.2);
+}
+
+/* ---- Open-with remove ------------------------------------------------ */
+
+.settings-open-with-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.settings-open-with-remove {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.settings-open-with-remove:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+/* ---- Inline validation (D3) + required (D2) -------------------------- */
+
+.settings-input--invalid {
+  border-color: var(--danger, #d44) !important;
+  outline-color: var(--danger, #d44);
+}
+
+.settings-input--invalid:focus {
+  border-color: var(--danger, #d44) !important;
+}
+
+.settings-field-error {
+  color: var(--danger, #d44);
+  font-size: 11px;
+  margin-top: 2px;
+}
+
+.settings-repo-name-error {
+  color: var(--danger, #d44);
+  font-size: 11px;
+  margin: 4px 0 0;
+}
+
+.settings-repo-row[data-invalid='true'] {
+  border-color: var(--danger, #d44);
+  background: color-mix(in srgb, var(--danger, #d44) 4%, transparent);
+}
+
+/* ---- Repo row: collapse + drag ------------------------------------- */
+
+.settings-repo-row--collapsed {
+  padding-bottom: 8px;
+}
+
+.settings-repo-toggle {
+  width: 22px;
+  height: 22px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.settings-repo-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
+.settings-repo-toggle-chevron {
+  display: inline-block;
+  transition: transform 0.15s ease;
+}
+
+.settings-repo-row:not(.settings-repo-row--collapsed) .settings-repo-toggle-chevron {
+  transform: rotate(90deg);
+}
+
+.settings-repo-summary {
+  flex: 1;
+  min-width: 0;
+  color: var(--text-faint);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.settings-repo-summary:hover {
+  color: var(--text-muted);
+}
+
+.settings-repo-drag-handle {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 22px;
+  color: var(--text-faint);
+  cursor: grab;
+  font-size: 11px;
+  user-select: none;
+}
+
+.settings-repo-drag-handle:hover {
+  color: var(--text-muted);
+}
+
+.settings-repo-row--dragging {
+  opacity: 0.5;
+}
+
+.settings-repo-row--drop-target {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+/* ---- Diff view toggle (G1) ----------------------------------------- */
+
+.settings-diff-toggle {
+  font-size: 12px;
+}
+
+.settings-diff-toggle--on {
+  background: var(--accent);
+  color: var(--bg);
+  border-color: var(--accent);
+}
+
+.settings-modal[data-diff-only='true'] .settings-section-frame[data-section-state='inherits'] {
+  display: none;
+}
+
+/* ---- Recents: click-to-open --------------------------------------- */
+
+.settings-recents-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.settings-recents-open {
+  flex: 1;
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 6px 10px;
+  cursor: pointer;
+  color: var(--text);
+  font: inherit;
+  overflow: hidden;
+}
+
+.settings-recents-open:hover {
+  background: var(--bg-hover);
+  border-color: var(--border);
+}
+
+.settings-recents-open .settings-recents-path {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-recents-remove {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  font-size: 16px;
+  line-height: 1;
+}
+
+.settings-empty-hint {
+  margin-top: 6px;
+  color: var(--text-faint);
+  font-size: 12px;
+}
+
+.settings-empty-hint kbd {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 1px 5px;
+  font-family: var(--font-mono);
+  font-size: 11px;
 }

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -24,12 +24,14 @@ import {
   removeLauncher,
   type Section,
   SECTIONS,
+  SECTION_KEYS,
   type SettingsTab,
   TABS,
   TERMINAL_STRING_FIELDS,
 } from './settings-modal-parts/data';
-import { inheritanceState } from './settings-modal-parts/badges';
+import { inheritanceState, stableEqual } from './settings-modal-parts/badges';
 import type { InheritanceState } from './settings-modal-parts/badges';
+import { SearchProvider } from './settings-modal-parts/fields';
 import { parseErrorOf, parseRawConfig } from './settings-modal-parts/parse';
 import {
   AppearanceSection,
@@ -130,14 +132,51 @@ export function SettingsModal(props: {
   const [savedAt, setSavedAt] = createSignal<number | null>(null);
   const [pending, setPending] = createSignal(false);
 
-  // Buffered text-input drafts. Each text field updates a draft on `onInput`
-  // and commits on `onChange` (blur / Enter). The dirty signal drives the
-  // back-arrow confirm dialog: drafts present means there are typed-but-
-  // unblurred edits that haven't reached disk yet.
-  const [drafts, setDrafts] = createSignal<Record<string, string>>({});
+  // Two-layer draft model.
+  //
+  // - **Tree drafts** (globalDraft / conceptionDraft): the entire RawConfig
+  //   object as it would be saved. Non-null means the user has staged at
+  //   least one mutation (toggle, dropdown, array op, blurred text commit)
+  //   that hasn't reached disk. Cleared by Save (after flush) or Discard.
+  //
+  // - **Text drafts** (textDrafts): per-input-id ephemeral string for
+  //   mid-typing UX. Commits to its tree draft on blur via the saver
+  //   registered by `bindText`. Cleared on flush.
+  //
+  // Tree-draft existence is the single source of truth for "dirty"; text
+  // drafts are a UX-only buffer so the input doesn't fight the user's
+  // cursor while they type.
+  const [globalDraft, setGlobalDraft] = createSignal<RawConfig | null>(null);
+  const [conceptionDraft, setConceptionDraft] = createSignal<RawConfig | null>(null);
+  const [textDrafts, setTextDrafts] = createSignal<Record<string, string>>({});
   const [closeConfirm, setCloseConfirm] = createSignal(false);
+  // Search filter — empty string disables filtering. Passed through
+  // SearchProvider so every Subgroup (and any other component that calls
+  // useSearch()) can match its own keywords against the active query.
+  const [searchQuery, setSearchQuery] = createSignal('');
+  // Diff view (G1) — when on, the Conception tab hides every section
+  // whose top-level keys all inherit from global. Acts as a quick way to
+  // audit "what does this conception actually change?". Persisted per-
+  // machine so the user doesn't re-toggle on every open.
+  const DIFF_KEY = 'condash:settings-modal:diff-only';
+  const [diffOnly, setDiffOnly] = createSignal(
+    typeof window !== 'undefined' && window.localStorage.getItem(DIFF_KEY) === '1',
+  );
+  const toggleDiff = (): void => {
+    setDiffOnly((d) => {
+      const next = !d;
+      try {
+        window.localStorage.setItem(DIFF_KEY, next ? '1' : '0');
+      } catch {
+        // localStorage may throw in private mode — same fallback shape as
+        // the rest of this modal: the preference simply resets on next open.
+      }
+      return next;
+    });
+  };
 
-  const isDirty = (): boolean => Object.keys(drafts()).length > 0;
+  const isDirty = (): boolean =>
+    globalDraft() !== null || conceptionDraft() !== null || Object.keys(textDrafts()).length > 0;
 
   const [content, { mutate: mutateContent }] = createResource(
     () => configurationPath(),
@@ -208,102 +247,59 @@ export function SettingsModal(props: {
   });
 
   // --- Parsed memos ---------------------------------------------------
+  //
+  // `disk*` memos reflect what's on disk right now (CAS baseline at save
+  // time). `parsed` / `globalParsed` overlay the active tree draft on top
+  // so every section component, badge, and bound input automatically reads
+  // the draft-aware view. Sections take a `parsed: () => RawConfig` getter
+  // and don't need to know drafts exist.
 
-  const parsed = createMemo<RawConfig>(() => parseRawConfig(content() ?? ''));
-  const globalParsed = createMemo<RawConfig>(() => parseRawConfig(globalContent() ?? ''));
+  const diskConception = createMemo<RawConfig>(() => parseRawConfig(content() ?? ''));
+  const diskGlobal = createMemo<RawConfig>(() => parseRawConfig(globalContent() ?? ''));
+
+  const parsed = createMemo<RawConfig>(() => conceptionDraft() ?? diskConception());
+  const globalParsed = createMemo<RawConfig>(() => globalDraft() ?? diskGlobal());
 
   const parseError = createMemo<string | null>(() => parseErrorOf(content() ?? ''));
   const globalParseError = createMemo<string | null>(() => parseErrorOf(globalContent() ?? ''));
 
-  // --- patchFile factory ----------------------------------------------
+  // --- Stage (draft-tree mutators) -----------------------------------
 
-  /** Apply `mutator` to a parsed JSON file, drop empty leaves, and
-   *  persist via the caller-supplied write IPC's atomic CAS. Wraps the
-   *  shared parse → mutate → stringify → write flow that both
-   *  patchConfig (condash.json) and patchSettings (settings.json) need —
-   *  the two files differ only in where they read from and how they
-   *  write, captured by `read` / `write`. */
-  const patchFile = async (
-    fileLabel: string,
-    read: () => string,
-    write: (text: string, next: string) => Promise<string>,
-    onWritten: (written: string) => void,
-    mutator: (config: RawConfig) => void,
-  ): Promise<void> => {
-    const text = read();
-    let parsed: RawConfig;
-    try {
-      parsed = (text ? (JSON.parse(text) as RawConfig) : {}) as RawConfig;
-    } catch (err) {
-      setError(`${fileLabel} is invalid: ${(err as Error).message}. Open it externally to repair.`);
-      return;
+  /** Mutate the tree draft for `target`, lazily seeding from disk on
+   *  first stage. Synchronous: the caller's mutator runs, the draft
+   *  signal updates, and every consumer (badges, inputs, previews)
+   *  re-derives without any IPC round-trip. Returns Promise<void> for
+   *  call-site compatibility with the pre-draft API — every existing
+   *  `await patchConfig(...)` still resolves immediately. */
+  const stage = (target: SettingsTab, mutator: (c: RawConfig) => void): Promise<void> => {
+    if (target === 'global') {
+      setGlobalDraft((current) => {
+        const base: RawConfig = current ? { ...current } : structuredClone(diskGlobal());
+        mutator(base);
+        return base;
+      });
+    } else {
+      setConceptionDraft((current) => {
+        const base: RawConfig = current ? { ...current } : structuredClone(diskConception());
+        mutator(base);
+        return base;
+      });
     }
-    mutator(parsed);
-    const next = JSON.stringify(buildSavePayload(parsed), null, 2) + '\n';
-    if (next === text) return;
-    setError(null);
-    setPending(true);
-    try {
-      const written = await write(text, next);
-      onWritten(written);
-      setSavedAt(Date.now());
-      scheduleSavedAtClear();
-    } catch (err) {
-      setError((err as Error).message);
-    } finally {
-      setPending(false);
-    }
+    return Promise.resolve();
   };
 
-  /** Apply `mutator` to the parsed condash.json, drop empty leaves, and
-   *  persist via the same atomic CAS path used by every other note write.
-   *  Path swap: read from configurationPath() (which may be the legacy
-   *  configuration.json) and always write to writePath (canonical
-   *  condash.json). On the first write to a fresh condash.json the file
-   *  doesn't yet exist, so writeNote's drift check sees `''` on disk —
-   *  pass `''` as the expected baseline when writing to a new path.
-   *  After a successful write, the canonical condash.json now exists
-   *  (or has been updated) — re-point the read resource so the next
-   *  refresh round-trip lands on the right file. The conception config
-   *  is canonicalised through the Zod schema on the main side, so the
-   *  bytes that reach disk can differ from `next` (e.g. Zod reorders new
-   *  keys into schema order). Cache the actual written content so the
-   *  next save's CAS baseline matches disk. */
-  const patchConfig = (mutator: (config: RawConfig) => void): Promise<void> => {
-    const readFrom = configurationPath();
-    return patchFile(
-      'condash.json',
-      () => content() ?? '',
-      (text, next) => {
-        const expected = readFrom === writePath ? text : '';
-        return window.condash.writeNote(writePath, expected, next);
-      },
-      (written) => {
-        mutateContent(written);
-        if (readFrom !== writePath) mutateReadPath(writePath);
-      },
-      mutator,
-    );
-  };
+  /** Stage a mutation to the conception tree draft. */
+  const patchConfig = (mutator: (config: RawConfig) => void): Promise<void> =>
+    stage('conception', mutator);
 
-  /** Apply `mutator` to the parsed settings.json, drop empty leaves, and
-   *  persist via writeGlobalSettings' atomic CAS. Mirrors patchConfig but
-   *  writes to the per-machine file. Every Global-tab editor goes through
-   *  this; the long-standing setTheme / setLayout / termSetPrefs IPC verbs
-   *  continue to write here too for the rest of the app. */
+  /** Stage a mutation to the global tree draft. */
   const patchSettings = (mutator: (settings: RawConfig) => void): Promise<void> =>
-    patchFile(
-      'settings.json',
-      () => globalContent() ?? '',
-      (text, next) => window.condash.writeGlobalSettings(text, next),
-      mutateGlobalContent,
-      mutator,
-    );
+    stage('global', mutator);
 
   /** Patch the right file based on `target`. */
   const patchFor = (target: SettingsTab) => (target === 'global' ? patchSettings : patchConfig);
 
-  /** Read the parsed source-of-truth for the given target. */
+  /** Read the parsed source-of-truth for the given target. Draft-aware. */
   const parsedFor = (target: SettingsTab): RawConfig =>
     target === 'global' ? globalParsed() : parsed();
 
@@ -311,6 +307,35 @@ export function SettingsModal(props: {
 
   const stateOf = <K extends keyof RawConfig>(key: K): InheritanceState =>
     inheritanceState(key, globalParsed(), parsed());
+
+  /** True when any of the keys owned by `id` differ between the disk
+   *  snapshot and the active draft. Drives the rail's unsaved-changes pip
+   *  next to each section label. */
+  const sectionDirty = (id: Section): boolean => {
+    const keys = SECTION_KEYS[id];
+    if (keys.length === 0) return false;
+    const isGlobal = id.endsWith(':global');
+    const disk = isGlobal ? diskGlobal() : diskConception();
+    const effective = isGlobal ? globalParsed() : parsed();
+    for (const k of keys) {
+      if (!stableEqual(disk[k], effective[k])) return true;
+    }
+    return false;
+  };
+
+  /** True when every conception-side key owned by `id` is in the
+   *  'inherits' state (i.e. the conception doesn't override anything in
+   *  that section). Used by the diff-view to hide pure-inheritance
+   *  sections on the Conception tab. */
+  const sectionFullyInherits = (id: Section): boolean => {
+    if (!id.endsWith(':conception')) return false;
+    const keys = SECTION_KEYS[id];
+    if (keys.length === 0) return true;
+    for (const k of keys) {
+      if (stateOf(k) !== 'inherits') return false;
+    }
+    return true;
+  };
 
   /** Drop a top-level key from condash.json. Used by the "Remove
    *  override" / "Reset to global" buttons. */
@@ -334,19 +359,20 @@ export function SettingsModal(props: {
 
   // --- Draft-buffered text input -------------------------------------
 
-  // Maps each text-field id to its current commit handler so that the
-  // close-confirm "Save and close" path can flush all uncommitted drafts
-  // in one go without re-deriving each field's save logic.
-  const draftSavers = new Map<string, (value: string) => Promise<void>>();
+  // Maps each text-field id to its current commit handler so we can drain
+  // any uncommitted text drafts into their tree drafts before writing.
+  const draftSavers = new Map<string, (value: string) => Promise<void> | void>();
 
   /**
-   * Bind a text input to the draft buffer + commit-on-blur flow.
-   * Returns the props an `<input>` should spread: value, onInput, onChange.
+   * Bind a text input. On every keystroke the value lives in `textDrafts`
+   * (so the cursor doesn't fight a re-render); on blur the value commits
+   * via `save`, which stages it into the tree draft. Nothing reaches disk
+   * until Save is clicked.
    */
   const bindText = (
     id: string,
     persisted: () => string | undefined,
-    save: (value: string) => Promise<void>,
+    save: (value: string) => Promise<void> | void,
   ): {
     value: string;
     onInput: (e: InputEvent & { currentTarget: HTMLInputElement }) => void;
@@ -354,14 +380,14 @@ export function SettingsModal(props: {
   } => {
     draftSavers.set(id, save);
     return {
-      value: drafts()[id] ?? persisted() ?? '',
+      value: textDrafts()[id] ?? persisted() ?? '',
       onInput: (e) => {
         const next = e.currentTarget.value;
-        setDrafts((d) => ({ ...d, [id]: next }));
+        setTextDrafts((d) => ({ ...d, [id]: next }));
       },
       onChange: (e) => {
         const next = e.currentTarget.value;
-        setDrafts((d) => {
+        setTextDrafts((d) => {
           const copy = { ...d };
           delete copy[id];
           return copy;
@@ -371,28 +397,118 @@ export function SettingsModal(props: {
     };
   };
 
-  /** Flush every draft to disk in parallel; resolve once all writes settle. */
-  const flushDrafts = async (): Promise<void> => {
-    const snapshot = drafts();
+  /** Drain the text-draft layer into tree drafts. Called as the first step
+   *  of any flush so on-screen typed-but-unblurred edits don't get lost. */
+  const drainTextDrafts = async (): Promise<void> => {
+    const snapshot = textDrafts();
     const ids = Object.keys(snapshot);
     if (ids.length === 0) return;
-    setDrafts({});
-    await Promise.all(
-      ids.map((id) => {
-        const saver = draftSavers.get(id);
-        return saver ? saver(snapshot[id]) : Promise.resolve();
-      }),
-    );
+    setTextDrafts({});
+    for (const id of ids) {
+      const saver = draftSavers.get(id);
+      if (saver) await saver(snapshot[id]);
+    }
+  };
+
+  /** Write a single tree draft to disk through its CAS write IPC. Returns
+   *  true if it actually wrote (false when the serialized draft matches
+   *  disk byte-for-byte — common right after a Discard-then-edit-back). */
+  const writeTreeDraft = async (
+    draft: RawConfig,
+    expected: string,
+    write: (text: string, next: string) => Promise<string>,
+    onWritten: (written: string) => void,
+  ): Promise<boolean> => {
+    const next = JSON.stringify(buildSavePayload(draft), null, 2) + '\n';
+    if (next === expected) return false;
+    const written = await write(expected, next);
+    onWritten(written);
+    return true;
+  };
+
+  /** Persist all staged drafts (text + tree) in one round. Writes proceed
+   *  in parallel across the two files but each goes through its own CAS
+   *  guard so a concurrent external edit surfaces as a per-file error. */
+  const flushDrafts = async (): Promise<void> => {
+    await drainTextDrafts();
+    if (!globalDraft() && !conceptionDraft()) {
+      // Nothing to write — the text drain may have produced no tree-level
+      // changes (e.g. blurred field re-typed to its original value).
+      setSavedAt(Date.now());
+      scheduleSavedAtClear();
+      return;
+    }
+    setError(null);
+    setPending(true);
+    try {
+      const tasks: Promise<unknown>[] = [];
+      const gd = globalDraft();
+      if (gd) {
+        tasks.push(
+          writeTreeDraft(
+            gd,
+            globalContent() ?? '',
+            (text, next) => window.condash.writeGlobalSettings(text, next),
+            (written) => {
+              mutateGlobalContent(written);
+              // Live-fire the theme + card-min-width props once the global
+              // file actually changed, so the rest of the app picks up the
+              // new CSS variables without a re-mount.
+              const g = parseRawConfig(written);
+              if (g.theme && g.theme !== props.theme) props.onChangeTheme(g.theme);
+              if (g.cardMinWidth) props.onChangeCardMinWidth(g.cardMinWidth);
+              setGlobalDraft(null);
+            },
+          ),
+        );
+      }
+      const cd = conceptionDraft();
+      if (cd) {
+        const readFrom = configurationPath();
+        const expectedConception = readFrom === writePath ? (content() ?? '') : '';
+        tasks.push(
+          writeTreeDraft(
+            cd,
+            expectedConception,
+            (text, next) => window.condash.writeNote(writePath, text, next),
+            (written) => {
+              mutateContent(written);
+              if (readFrom !== writePath) mutateReadPath(writePath);
+              setConceptionDraft(null);
+            },
+          ),
+        );
+      }
+      await Promise.all(tasks);
+      setSavedAt(Date.now());
+      scheduleSavedAtClear();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setPending(false);
+    }
+  };
+
+  /** Drop every staged change. The next render falls back to disk content.
+   *  Doesn't restore the live theme prop if the user previewed a different
+   *  one via the radio — that prop only fires on Save. */
+  const discardDrafts = (): void => {
+    setGlobalDraft(null);
+    setConceptionDraft(null);
+    setTextDrafts({});
+    setError(null);
   };
 
   const handleSaveAndClose = async (): Promise<void> => {
     setCloseConfirm(false);
     await flushDrafts();
-    props.onClose();
+    // If the save errored, leave the modal open so the user sees the
+    // banner. Otherwise close.
+    if (!error()) props.onClose();
   };
 
   const handleDiscardAndClose = (): void => {
-    setDrafts({});
+    discardDrafts();
     setCloseConfirm(false);
     props.onClose();
   };
@@ -417,9 +533,9 @@ export function SettingsModal(props: {
       }
       c.cardMinWidth = Object.keys(merged).length > 0 ? merged : undefined;
     });
-    // Notify the rest of the app via the existing prop callback so the
-    // CSS variables update without a re-mount.
-    props.onChangeCardMinWidth(patch);
+    // Live preview only inside the modal (see card-density preview strip
+    // in C3). The app-wide CSS variables update when the user clicks Save
+    // — see flushDrafts.
   };
 
   const setConceptionCardMinWidth = (patch: CardMinWidthPrefs): Promise<void> =>
@@ -454,8 +570,9 @@ export function SettingsModal(props: {
     await patchSettings((c) => {
       c.theme = next;
     });
-    // Keep the live theme prop in lock-step with settings.json.
-    props.onChangeTheme(next);
+    // The live theme prop only updates when the user clicks Save — the
+    // radio shows the staged choice inside the modal via themeFor(),
+    // while the rest of the app keeps the disk theme until flush.
   };
 
   const setConceptionTheme = (next: Theme): Promise<void> =>
@@ -676,6 +793,7 @@ export function SettingsModal(props: {
         role="dialog"
         aria-modal="true"
         aria-label="Settings"
+        data-diff-only={diffOnly() ? 'true' : 'false'}
         onClick={(e) => e.stopPropagation()}
       >
         <header class="modal-head settings-head">
@@ -697,17 +815,50 @@ export function SettingsModal(props: {
               …
             </span>
           </Show>
-          <Show when={savedAt() !== null && !pending()}>
+          <Show when={savedAt() !== null && !pending() && !isDirty()}>
             <span class="modal-saved" title="Saved">
               ✓
             </span>
           </Show>
           <Show when={isDirty() && !pending()}>
-            <span class="modal-dirty" title="Unsaved edits in a focused field">
+            <span class="modal-dirty" title="Unsaved changes — click Save to write to disk">
               ●
             </span>
           </Show>
           <span class="settings-head-spacer" />
+          <Show when={tab() === 'conception'}>
+            <button
+              type="button"
+              class="modal-button settings-diff-toggle"
+              classList={{ 'settings-diff-toggle--on': diffOnly() }}
+              onClick={toggleDiff}
+              title={
+                diffOnly()
+                  ? 'Showing only sections this conception overrides — click to show all'
+                  : 'Hide sections that fully inherit from global'
+              }
+              aria-pressed={diffOnly()}
+            >
+              {diffOnly() ? 'Overrides only ✓' : 'Overrides only'}
+            </button>
+          </Show>
+          <button
+            class="modal-button settings-save"
+            classList={{ 'settings-save--dirty': isDirty() }}
+            onClick={() => void flushDrafts()}
+            disabled={!isDirty() || pending()}
+            title="Save staged changes to disk"
+          >
+            Save
+          </button>
+          <button
+            class="modal-button"
+            onClick={discardDrafts}
+            disabled={!isDirty() || pending()}
+            title="Drop every staged change and revert to the file on disk"
+          >
+            Discard
+          </button>
           <button
             class="modal-button"
             onClick={attemptClose}
@@ -741,6 +892,28 @@ export function SettingsModal(props: {
           </For>
         </div>
 
+        <div class="settings-search-bar">
+          <input
+            type="search"
+            class="settings-search"
+            placeholder="Search settings…"
+            value={searchQuery()}
+            onInput={(e) => setSearchQuery(e.currentTarget.value)}
+            aria-label="Filter settings"
+          />
+          <Show when={searchQuery().trim().length > 0}>
+            <button
+              type="button"
+              class="settings-search-clear"
+              onClick={() => setSearchQuery('')}
+              title="Clear search"
+              aria-label="Clear search"
+            >
+              ×
+            </button>
+          </Show>
+        </div>
+
         <Show when={parseError()}>
           <div class="modal-error">
             condash.json failed to parse — {parseError()}. Edit it externally to repair.
@@ -767,21 +940,22 @@ export function SettingsModal(props: {
                       classList={{ active: section() === s.id }}
                       onClick={() => scrollToSection(s.id)}
                     >
-                      {s.label}
+                      <span class="settings-rail-item-label">{s.label}</span>
+                      <Show when={sectionDirty(s.id)}>
+                        <span
+                          class="settings-rail-item-pip"
+                          title="Section has unsaved changes"
+                          aria-label="Unsaved changes"
+                        >
+                          ●
+                        </span>
+                      </Show>
                     </button>
                   </li>
                 )}
               </For>
             </ul>
             <div class="settings-rail-actions">
-              <button
-                class="modal-button"
-                onClick={() => void flushDrafts()}
-                disabled={!isDirty()}
-                title="Flush any focused-but-unblurred edits to disk"
-              >
-                Save
-              </button>
               <button
                 class="modal-button"
                 onClick={() => {
@@ -818,132 +992,169 @@ export function SettingsModal(props: {
               });
             }}
           >
-            {/* Global tabpanel ----------------------------------------- */}
-            <div
-              role="tabpanel"
-              id="settings-panel-global"
-              aria-labelledby="settings-tab-global"
-              class="settings-tabpanel"
-              classList={{ 'settings-tabpanel--hidden': tab() !== 'global' }}
-            >
-              <RecentConceptionsSection />
+            <SearchProvider query={searchQuery}>
+              {/* Global tabpanel ----------------------------------------- */}
+              <div
+                role="tabpanel"
+                id="settings-panel-global"
+                aria-labelledby="settings-tab-global"
+                class="settings-tabpanel"
+                classList={{ 'settings-tabpanel--hidden': tab() !== 'global' }}
+              >
+                <RecentConceptionsSection />
 
-              <AppearanceSection
-                target="global"
-                themeFor={themeFor}
-                setTheme={setGlobalTheme}
-                cardMinWidthFor={cardMinWidthFor}
-                setCardMinWidth={setGlobalCardMinWidth}
-              />
+                <AppearanceSection
+                  target="global"
+                  themeFor={themeFor}
+                  setTheme={setGlobalTheme}
+                  cardMinWidthFor={cardMinWidthFor}
+                  setCardMinWidth={setGlobalCardMinWidth}
+                />
 
-              <TerminalSection
-                target="global"
-                bindText={bindText}
-                prefs={() => terminalPrefsFor('global')}
-                xterm={() => xtermPrefsFor('global')}
-                setString={(k, v) => setTerminalString('global', k, v)}
-                launchers={() => terminalPrefsFor('global').launchers ?? []}
-                patchLauncher={(i, p) => patchLauncherField('global', i, p)}
-                addLauncher={() => addLauncherField('global')}
-                removeLauncher={(i) => removeLauncherField('global', i)}
-                moveLauncher={(i, d) => moveLauncherField('global', i, d)}
-                projectActions={() => terminalPrefsFor('global').projectActions ?? []}
-                patchProjectAction={(i, p) => patchProjectActionField('global', i, p)}
-                addProjectAction={() => addProjectActionField('global')}
-                removeProjectAction={(i) => removeProjectActionField('global', i)}
-                moveProjectAction={(i, d) => moveProjectActionField('global', i, d)}
-                newProjectActions={() => terminalPrefsFor('global').newProjectActions ?? []}
-                patchNewProjectAction={(i, p) => patchNewProjectActionField('global', i, p)}
-                addNewProjectAction={() => addNewProjectActionField('global')}
-                removeNewProjectAction={(i) => removeNewProjectActionField('global', i)}
-                moveNewProjectAction={(i, d) => moveNewProjectActionField('global', i, d)}
-                updateXterm={(p) => updateXterm('global', p)}
-                updateColor={(k, v) => updateColor('global', k, v)}
-                updateLogging={(p) => updateLogging('global', p)}
-                platform={platform}
-              />
-            </div>
+                <TerminalSection
+                  target="global"
+                  bindText={bindText}
+                  prefs={() => terminalPrefsFor('global')}
+                  xterm={() => xtermPrefsFor('global')}
+                  setString={(k, v) => setTerminalString('global', k, v)}
+                  launchers={() => terminalPrefsFor('global').launchers ?? []}
+                  patchLauncher={(i, p) => patchLauncherField('global', i, p)}
+                  addLauncher={() => addLauncherField('global')}
+                  removeLauncher={(i) => removeLauncherField('global', i)}
+                  moveLauncher={(i, d) => moveLauncherField('global', i, d)}
+                  projectActions={() => terminalPrefsFor('global').projectActions ?? []}
+                  patchProjectAction={(i, p) => patchProjectActionField('global', i, p)}
+                  addProjectAction={() => addProjectActionField('global')}
+                  removeProjectAction={(i) => removeProjectActionField('global', i)}
+                  moveProjectAction={(i, d) => moveProjectActionField('global', i, d)}
+                  newProjectActions={() => terminalPrefsFor('global').newProjectActions ?? []}
+                  patchNewProjectAction={(i, p) => patchNewProjectActionField('global', i, p)}
+                  addNewProjectAction={() => addNewProjectActionField('global')}
+                  removeNewProjectAction={(i) => removeNewProjectActionField('global', i)}
+                  moveNewProjectAction={(i, d) => moveNewProjectActionField('global', i, d)}
+                  updateXterm={(p) => updateXterm('global', p)}
+                  updateColor={(k, v) => updateColor('global', k, v)}
+                  updateLogging={(p) => updateLogging('global', p)}
+                  platform={platform}
+                />
+              </div>
 
-            {/* Conception tabpanel ----------------------------------- */}
-            <div
-              role="tabpanel"
-              id="settings-panel-conception"
-              aria-labelledby="settings-tab-conception"
-              class="settings-tabpanel"
-              classList={{ 'settings-tabpanel--hidden': tab() !== 'conception' }}
-            >
-              <WorkspaceSection
-                bindText={bindText}
-                parsed={parsed}
-                stateOf={stateOf}
-                removeOverride={removeOverride}
-                patchConfig={patchConfig}
-                platform={platform}
-              />
+              {/* Conception tabpanel ----------------------------------- */}
+              <div
+                role="tabpanel"
+                id="settings-panel-conception"
+                aria-labelledby="settings-tab-conception"
+                class="settings-tabpanel"
+                classList={{ 'settings-tabpanel--hidden': tab() !== 'conception' }}
+              >
+                <div
+                  class="settings-section-frame"
+                  data-section-state={
+                    sectionFullyInherits('workspace:conception') ? 'inherits' : 'overridden'
+                  }
+                >
+                  <WorkspaceSection
+                    bindText={bindText}
+                    parsed={parsed}
+                    stateOf={stateOf}
+                    removeOverride={removeOverride}
+                    patchConfig={patchConfig}
+                    platform={platform}
+                  />
+                </div>
 
-              <RepositoriesSection
-                parsed={parsed}
-                bindText={bindText}
-                stateOf={stateOf}
-                removeOverride={removeOverride}
-                patchConfig={patchConfig}
-              />
+                <div
+                  class="settings-section-frame"
+                  data-section-state={
+                    sectionFullyInherits('repositories:conception') ? 'inherits' : 'overridden'
+                  }
+                >
+                  <RepositoriesSection
+                    parsed={parsed}
+                    bindText={bindText}
+                    stateOf={stateOf}
+                    removeOverride={removeOverride}
+                    patchConfig={patchConfig}
+                  />
+                </div>
 
-              <OpenWithSection
-                parsed={parsed}
-                bindText={bindText}
-                stateOf={stateOf}
-                removeOverride={removeOverride}
-                patchConfig={patchConfig}
-              />
+                <div
+                  class="settings-section-frame"
+                  data-section-state={
+                    sectionFullyInherits('open-with:conception') ? 'inherits' : 'overridden'
+                  }
+                >
+                  <OpenWithSection
+                    parsed={parsed}
+                    bindText={bindText}
+                    stateOf={stateOf}
+                    removeOverride={removeOverride}
+                    patchConfig={patchConfig}
+                  />
+                </div>
 
-              <AppearanceSection
-                target="conception"
-                themeFor={themeFor}
-                setTheme={setConceptionTheme}
-                cardMinWidthFor={cardMinWidthFor}
-                setCardMinWidth={setConceptionCardMinWidth}
-                themeBadge={{
-                  stateOf: () => stateOf('theme'),
-                  removeOverride: () => void removeOverride('theme'),
-                }}
-                cardMinWidthBadge={{
-                  stateOf: () => stateOf('cardMinWidth'),
-                  removeOverride: () => void removeOverride('cardMinWidth'),
-                }}
-              />
+                <div
+                  class="settings-section-frame"
+                  data-section-state={
+                    sectionFullyInherits('appearance:conception') ? 'inherits' : 'overridden'
+                  }
+                >
+                  <AppearanceSection
+                    target="conception"
+                    themeFor={themeFor}
+                    setTheme={setConceptionTheme}
+                    cardMinWidthFor={cardMinWidthFor}
+                    setCardMinWidth={setConceptionCardMinWidth}
+                    themeBadge={{
+                      stateOf: () => stateOf('theme'),
+                      removeOverride: () => void removeOverride('theme'),
+                    }}
+                    cardMinWidthBadge={{
+                      stateOf: () => stateOf('cardMinWidth'),
+                      removeOverride: () => void removeOverride('cardMinWidth'),
+                    }}
+                  />
+                </div>
 
-              <TerminalSection
-                target="conception"
-                bindText={bindText}
-                prefs={() => terminalPrefsFor('conception')}
-                xterm={() => xtermPrefsFor('conception')}
-                setString={(k, v) => setTerminalString('conception', k, v)}
-                launchers={() => terminalPrefsFor('conception').launchers ?? []}
-                patchLauncher={(i, p) => patchLauncherField('conception', i, p)}
-                addLauncher={() => addLauncherField('conception')}
-                removeLauncher={(i) => removeLauncherField('conception', i)}
-                moveLauncher={(i, d) => moveLauncherField('conception', i, d)}
-                projectActions={() => terminalPrefsFor('conception').projectActions ?? []}
-                patchProjectAction={(i, p) => patchProjectActionField('conception', i, p)}
-                addProjectAction={() => addProjectActionField('conception')}
-                removeProjectAction={(i) => removeProjectActionField('conception', i)}
-                moveProjectAction={(i, d) => moveProjectActionField('conception', i, d)}
-                newProjectActions={() => terminalPrefsFor('conception').newProjectActions ?? []}
-                patchNewProjectAction={(i, p) => patchNewProjectActionField('conception', i, p)}
-                addNewProjectAction={() => addNewProjectActionField('conception')}
-                removeNewProjectAction={(i) => removeNewProjectActionField('conception', i)}
-                moveNewProjectAction={(i, d) => moveNewProjectActionField('conception', i, d)}
-                updateXterm={(p) => updateXterm('conception', p)}
-                updateColor={(k, v) => updateColor('conception', k, v)}
-                updateLogging={(p) => updateLogging('conception', p)}
-                platform={platform}
-                badge={{
-                  stateOf: () => stateOf('terminal'),
-                  removeOverride: () => void removeOverride('terminal'),
-                }}
-              />
-            </div>
+                <div
+                  class="settings-section-frame"
+                  data-section-state={
+                    sectionFullyInherits('terminal:conception') ? 'inherits' : 'overridden'
+                  }
+                >
+                  <TerminalSection
+                    target="conception"
+                    bindText={bindText}
+                    prefs={() => terminalPrefsFor('conception')}
+                    xterm={() => xtermPrefsFor('conception')}
+                    setString={(k, v) => setTerminalString('conception', k, v)}
+                    launchers={() => terminalPrefsFor('conception').launchers ?? []}
+                    patchLauncher={(i, p) => patchLauncherField('conception', i, p)}
+                    addLauncher={() => addLauncherField('conception')}
+                    removeLauncher={(i) => removeLauncherField('conception', i)}
+                    moveLauncher={(i, d) => moveLauncherField('conception', i, d)}
+                    projectActions={() => terminalPrefsFor('conception').projectActions ?? []}
+                    patchProjectAction={(i, p) => patchProjectActionField('conception', i, p)}
+                    addProjectAction={() => addProjectActionField('conception')}
+                    removeProjectAction={(i) => removeProjectActionField('conception', i)}
+                    moveProjectAction={(i, d) => moveProjectActionField('conception', i, d)}
+                    newProjectActions={() => terminalPrefsFor('conception').newProjectActions ?? []}
+                    patchNewProjectAction={(i, p) => patchNewProjectActionField('conception', i, p)}
+                    addNewProjectAction={() => addNewProjectActionField('conception')}
+                    removeNewProjectAction={(i) => removeNewProjectActionField('conception', i)}
+                    moveNewProjectAction={(i, d) => moveNewProjectActionField('conception', i, d)}
+                    updateXterm={(p) => updateXterm('conception', p)}
+                    updateColor={(k, v) => updateColor('conception', k, v)}
+                    updateLogging={(p) => updateLogging('conception', p)}
+                    platform={platform}
+                    badge={{
+                      stateOf: () => stateOf('terminal'),
+                      removeOverride: () => void removeOverride('terminal'),
+                    }}
+                  />
+                </div>
+              </div>
+            </SearchProvider>
           </div>
         </div>
 
@@ -957,13 +1168,13 @@ export function SettingsModal(props: {
               onClick={(e) => e.stopPropagation()}
             >
               <h3>Save before closing?</h3>
-              <p>You have edits in a focused field that haven't been written yet.</p>
+              <p>You have staged changes that haven't been written to disk yet.</p>
               <div class="settings-confirm-actions">
                 <button class="modal-button" onClick={() => setCloseConfirm(false)}>
-                  Cancel
+                  Keep editing
                 </button>
                 <button class="modal-button" onClick={handleDiscardAndClose}>
-                  Discard
+                  Discard and close
                 </button>
                 <button class="modal-button" onClick={() => void handleSaveAndClose()}>
                   Save and close


### PR DESCRIPTION
## Summary

- Replaces immediate-IPC writes in the Settings modal with a staged-draft model so a single Save button (Discard alongside it) flushes every kind of change at once.
- Closes the findability gap on ~80 fields: top-of-modal search, collapsible Terminal subgroups, and a per-section unsaved-changes pip in the rail.
- Adds direct-feedback affordances where text inputs were opaque: live colour swatches + fake-terminal preview, card-density preview strip, click-to-capture shortcut binding.
- Scales the repo editor: rows collapse by default, drag-and-drop reorder, section markers re-render as plain headings instead of dashed cards.
- Conception tab gains an "Overrides only" toggle that hides fully-inherited sections; recents become click-to-open with an empty-state hint; Open-with slots gain an explicit per-slot remove.

## Changes

- `src/renderer/settings-modal.tsx` — two-layer draft model (tree drafts per file + per-id text drafts); replaces `patchFile` with sync `stage` mutator; new `flushDrafts` + `discardDrafts`; header Save/Discard buttons; per-section dirty pip in the rail (`sectionDirty`); diff-view toggle + `sectionFullyInherits` helper; SearchProvider wraps both panels.
- `src/renderer/settings-modal-parts/fields.tsx` — adds SearchContext + `<Subgroup>` collapsible; wraps Terminal subgroups (Behaviour, Launchers, Project actions, New project actions, Font, Cursor & buffer, Colours, Logging) so search hides non-matches and force-opens matches; `<ColorField>` swatch + native picker + CSS-supports validation; `<TerminalColorPreview>`; `<CardDensityPreview>` half-scale strip; `<ShortcutCapture>` button with key-serialiser; "Manage launchers →" inline link from action rows; `[abs]` / `[rel]` `pathScope` on `FieldWithBadge`.
- `src/renderer/settings-modal-parts/data.ts` — `SECTION_KEYS` map (section → top-level RawConfig keys, used by dirty pip + diff view); `DndHandlers` interface; `TerminalStringField` gains `kind: 'plain' | 'path' | 'shortcut'`.
- `src/renderer/settings-modal-parts/repo-row.tsx` — collapse-by-default with persisted state, name-required marker, DnD wiring; `nameMissing` invariant force-expands invalid rows.
- `src/renderer/settings-modal-parts/section-row.tsx` — § glyph + DnD; simpler heading shape.
- `src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx` — parent owns `dragIndex`/`dropIndex` signals; new `moveRepoTo`; Open-with rows gain per-slot remove button.
- `src/renderer/settings-modal-parts/sections-workspace.tsx` — passes `pathScope="abs"` for workspace/worktrees and `pathScope="rel"` for resources/skills.
- `src/renderer/settings-modal-parts/section-recent-conceptions.tsx` — full-row click-to-open via `openConception(path)`, dedicated remove icon, structured empty state.
- `src/renderer/settings-modal.css` — ~250 lines added: search bar, save-button accent, subgroup disclosure, color swatch + preview, density strip, path chip, shortcut button, inline link, repo collapse + drag handle + drop target, section-frame diff-hiding, recents click-to-open.
- `package.json` + `package-lock.json` — 3.17.0 → 3.18.0.

## Impact

- Theme + cardMinWidth changes now reach the rest of the app only at Save (previously fired immediately on each change). Inside the modal the radio/preview reflects the staged choice via `themeFor()`.
- Conception tab visibly contracts when fully-inherited sections are hidden by the diff toggle — UX-only, no schema change.
- No backend / schema changes; existing `.condash/settings.json` and `settings.json` parse unchanged.

## Watchpoints

- D1 widens the unsaved-state window from milliseconds to as long as the user keeps the modal open. The CAS guard still catches concurrent external edits — verify the error path renders when an out-of-band edit lands before Save.
- HTML5 DnD on Linux can fire spurious `dragend` events. Drop-target outline + `isDragging` opacity are reset on `onDragEnd`; re-test reorder with a real mouse before tagging.
- The `CSS.supports('color', …)` call in `isValidCssColor` is the renderer-only path; non-browser test environments fall back to a string regex.