### PR TITLE
Bump 3.18.1: fix settings-tree-expansion test flake — tmp leak across vi.doMock factories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.18.0",
+      "version": "3.18.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.18.0",
+  "version": "3.18.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/ipc/settings-tree-expansion.test.ts
+++ b/src/main/ipc/settings-tree-expansion.test.ts
@@ -52,8 +52,16 @@ beforeEach(async () => {
   vi.resetModules();
   tmp = mkdtempSync(join(tmpdir(), 'condash-settings-ipc-'));
   settingsPathValue = join(tmp, 'settings.json');
-  // Override the user-data dir so `settingsPath()` lands in the temp dir.
-  vi.doMock('../user-data-dir', () => ({ userDataDir: () => tmp }));
+  // Capture this test's tmp path as a *local const* inside the factory
+  // closure. Without this, the factory references the module-scope
+  // `let tmp` by name — and a fire-and-forget `withSettingsQueue` write
+  // queued during the previous test resolves `settingsPath()` (which
+  // calls `userDataDir() => tmp`) *after* `tmp` has been reassigned in
+  // this test's beforeEach, leaking the previous test's write into this
+  // test's settings.json. Surfaced 2026-05-19 in the v3.18.0 release CI
+  // (test 3 saw `['explicit']` from test 2's `skillsClaude` write).
+  const isolatedTmp = tmp;
+  vi.doMock('../user-data-dir', () => ({ userDataDir: () => isolatedTmp }));
 
   handlers = {};
   const { ipcMain } = await import('electron');
@@ -67,7 +75,18 @@ beforeEach(async () => {
   registerSettingsIpc({ onLayoutChange: () => undefined });
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Drain the settings queue before removing the tmp dir so any pending
+  // opportunistic writes can complete (or fail safely) before their
+  // target disappears. The module-scope `settingsQueue` lives in the
+  // *previous* import of `../settings`; reading it back via the still-
+  // cached import keeps that exact instance.
+  try {
+    const { drainSettingsQueue } = await import('../settings');
+    await drainSettingsQueue();
+  } catch {
+    // The module may not be loaded yet (very-first test) — that's fine.
+  }
   rmSync(tmp, { recursive: true, force: true });
   vi.doUnmock('../user-data-dir');
 });

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -20,6 +20,18 @@ function withSettingsQueue<T>(work: () => Promise<T>): Promise<T> {
   return next;
 }
 
+/**
+ * Wait for every queued settings write to settle. Test-only surface —
+ * `afterEach` calls this so the in-flight opportunistic rewrite from
+ * `getTreeExpansion` (and any future fire-and-forget queue user)
+ * finishes before the next test's `vi.doMock('../user-data-dir', …)`
+ * swaps the path under it. Resolves once the chain is drained, even if
+ * individual entries rejected.
+ */
+export async function drainSettingsQueue(): Promise<void> {
+  await settingsQueue.catch(() => undefined);
+}
+
 export const DEFAULT_LAYOUT: LayoutState = {
   projects: true,
   working: 'code',


### PR DESCRIPTION
## Summary

- The v3.18.0 tag pipeline (release workflow, fast-checks job) failed on the legacy-skills migration test in `src/main/ipc/settings-tree-expansion.test.ts`. The same test had been passing across v3.15.0–v3.17.0 by coincidence — root cause is a tmp-path leak between tests, surfaced by enough microtask interleaving to make test 2's fire-and-forget write land in test 3's settings.json.
- The Build + Publish jobs were skipped, so no GitHub Release was actually cut for v3.18.0. This PR ships the test-isolation fix as 3.18.1, after which v3.18.0 can be deleted and v3.18.1 re-tagged from this bump commit.

## Changes

- `src/main/ipc/settings-tree-expansion.test.ts` — `beforeEach` now captures `tmp` as a local `const isolatedTmp` inside the `vi.doMock` factory closure, instead of relying on the module-scope `let tmp` (which gets reassigned by the next test before the previous test's queued opportunistic write completes). `afterEach` awaits `drainSettingsQueue()` before removing the tmp dir.
- `src/main/settings.ts` — exports `drainSettingsQueue()` so the test (and any future fire-and-forget queue user) can await every queued write before tearing down its mocked filesystem.
- `package.json` + `package-lock.json` — 3.18.0 → 3.18.1.

## Impact

- Test-only fix on the surface, but `drainSettingsQueue` is a new public export from `src/main/settings.ts`. No production callers use it; intended for tests that race against the opportunistic legacy-key rewrite inside `getTreeExpansion`.
- Stress-ran the affected test 10× locally — green every time. Full unit suite (624 tests) green; main type-check clean.

## Watchpoints

- Watch the v3.18.1 tag pipeline's fast-checks job for the same test name. If it fails again, the factory-closure capture didn't take and we need to look at `vi.resetModules` interaction with already-cached factory factories.