### PR TITLE
Run heavy CI on every push to main; publish gated by needs:

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,12 +4,17 @@ name: Pages (docs + apt repo)
 #   - mkdocs site at the root
 #   - Debian apt repository under /apt/
 #
-# Trigger: a GitHub Release is published by release.yml on tag push,
-# or manual dispatch. release.yml ships plain `vX.Y.Z` as a stable
+# Trigger: a GitHub Release is published by main.yml on tag push,
+# or manual dispatch. main.yml ships plain `vX.Y.Z` as a stable
 # release and `vX.Y.Z-rc.N` / `-alpha*` / `-beta*` as a prerelease.
 # Both kinds carry .deb assets, so the apt scan below includes
 # prereleases (and skips drafts, whose assets aren't reachable via
 # gh release download).
+#
+# main.yml fires on push-to-main as well as tag push, but only the
+# tag-push runs go through the publish job. The build job below
+# filters out non-tag runs so we don't rebuild the apt repo on
+# every commit.
 #
 # The apt repo is rebuilt deterministically from scratch on every
 # run, but the .deb assets it ingests are cached across runs (keyed
@@ -24,15 +29,15 @@ name: Pages (docs + apt repo)
 # the GitHub Releases page; only the apt index is trimmed.
 
 on:
-  # `workflow_run` instead of `release: [published]` because release.yml
+  # `workflow_run` instead of `release: [published]` because main.yml
   # creates the prerelease via the workflow's own GITHUB_TOKEN — and
   # release events fired by GITHUB_TOKEN do NOT cascade into other
   # workflows (documented GitHub anti-loop rule). workflow_run is the
   # one trigger that DOES cascade across that boundary, and it lets us
-  # gate on release.yml succeeding so we never publish apt metadata for
+  # gate on main.yml succeeding so we never publish apt metadata for
   # a release that didn't finish uploading its .debs.
   workflow_run:
-    workflows: [release]
+    workflows: [main]
     types: [completed]
   workflow_dispatch:
 
@@ -54,10 +59,17 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Skip when the upstream release run failed. workflow_dispatch fires
-    # without a workflow_run context, so the conclusion check evaluates
-    # to '' — we accept that case too.
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    # Two filters on workflow_run triggers:
+    #   1. main.yml must have succeeded — we never rebuild the apt repo
+    #      against a half-published release.
+    #   2. The upstream run must have been triggered by a tag push, not a
+    #      branch push. main.yml runs on every commit to main as well as
+    #      every `v*` tag; only the tag-push runs go through publish, so
+    #      docs only needs to rebuild for those.
+    # workflow_dispatch fires without a workflow_run context (so both
+    # checks evaluate against null/empty values) — we accept that case
+    # explicitly for manual rebuilds.
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,93 +1,57 @@
-name: release
+name: main
 
-# Tag-driven release pipeline. Triggered only by `git push origin v*`.
+# Heavy CI on every push to main and every `v*` tag, with publish
+# gated by `needs:` chains — no out-of-band API queries.
 #
 # Shape:
 #
-#   validate-tag ──┬── fast-on-tag ────┐
-#                  │                   ├── build (matrix) ── publish
-#                  └── playwright ─────┘
+#                          ┌── fast ─────────┐
+#                          │                 │
+#   on push: main          ├── playwright ───┼── build (matrix) ──┐
+#   on push: tags v*       │                 │                    │
+#                          └── validate-tag ─┴─────────────────── publish
+#                              (tag push only)              (tag push only)
 #
-# The fast-on-tag + playwright jobs are the publish gate: typecheck,
-# vitest, and the full Electron Playwright suite all run against the
-# tag SHA. If anything fails, `build` never starts, no GH Release is
-# created, no assets are uploaded — the tag itself stays in git but
-# nothing public ships. Recovery: fix on a follow-up commit, bump,
-# re-tag, re-push.
+# Push to main: fast + playwright + build run. validate-tag and
+# publish are skipped (no tag ref). The 3-OS installer matrix
+# uploads workflow artefacts that are then discarded (retention=1d).
 #
-# Why gate at tag time rather than on push to main: PR coverage is
-# intentionally minimal (fast checks only — see pr.yml). The complete
-# suite — installer matrix on three OSes, full Playwright, NSIS 6010
-# detection — runs here, once, immediately before publication.
+# Tag push: same heavy CI plus validate-tag and publish. publish
+# `needs: [validate-tag, build]` — if anything before it failed,
+# `needs:` itself blocks the job from starting. No GH Release is
+# created and no assets uploaded.
 #
-# Why not matrix-publishes-directly: GitHub's API is inconsistent
-# between the by-tag lookup, the by-id lookup, and the list endpoint
-# (verified live: a freshly-created prerelease was findable by id/tag but
-# absent from /releases?per_page=100 for several minutes). electron-builder's
-# release lookup loses the race against this lag — it doesn't find the
-# pre-existing release and tries to create its own, fragmenting assets
-# across N drafts/prereleases per matrix job.
+# Why heavy CI runs twice per release (once on the merge to main,
+# once on the tag against the same SHA): keeping the gate as a pure
+# `needs:` chain inside one workflow is the cheapest possible
+# guarantee that "publish only if green for this SHA" — no commit-
+# status lookups, no workflow_run plumbing carrying state between
+# workflows. The duplicate run is ~7 minutes of GHA time per release.
 #
-# Bulletproof pattern: each matrix job builds locally with `--publish
-# never`, uploads its `release/` directory as a workflow artifact, and a
-# final `publish` job downloads all of them and runs a single `gh release
-# upload` against one release. Only one process ever talks to the GH
-# Release API.
+# Why one combined workflow rather than main-then-release via
+# workflow_run: artefact handoff across workflow_run boundaries is
+# possible but fragile, and the `needs:` form leaves the publish
+# job's gate visible in one file.
+#
+# Recovery on tag-time failure: fix on a follow-up commit, bump,
+# re-tag against the new SHA, re-push. The tag itself stays in git
+# but nothing public ships.
 
 on:
   push:
+    branches:
+      - main
     tags:
       - 'v*'
 
 permissions:
-  # contents:write is required for the publish job to create the GH
-  # Release and upload assets via the workflow's GITHUB_TOKEN.
+  # publish needs contents:write to create the GH Release and upload
+  # assets via the workflow's GITHUB_TOKEN.
   contents: write
 
 jobs:
-  validate-tag:
-    name: Validate tag + package.json version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      # Reject malformed tags before any matrix job spins up. The release
-      # workflow only handles stable `vX.Y.Z` tags; prerelease suffixes
-      # (`-rc.N`, `-alpha*`, `-beta*`) ride through the same publish job
-      # but still need the leading semver triplet to match. Catches typos
-      # like `v3.12..1` or `v3.12` before they create a broken Release.
-      - name: Validate tag shape
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
-            echo "Tag '$TAG' is not a valid vX.Y.Z[-suffix] release tag." >&2
-            exit 1
-          fi
-          echo "Tag $TAG is valid."
-
-      # Assert that package.json's version matches the tag (sans leading
-      # `v`). Catches "forgot to bump" — the bump commit must land on
-      # main before the tag is pushed, per the conception release rule.
-      - name: Assert package.json version matches tag
-        env:
-          TAG: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          PKG_VERSION=$(node -p "require('./package.json').version")
-          EXPECTED="${TAG#v}"
-          if [[ "$PKG_VERSION" != "$EXPECTED" ]]; then
-            echo "package.json version ($PKG_VERSION) does not match tag ($EXPECTED)." >&2
-            echo "Bump package.json before pushing the tag." >&2
-            exit 1
-          fi
-          echo "package.json version $PKG_VERSION matches tag $TAG."
-
-  fast-on-tag:
+  fast:
     name: Fast checks (typecheck + unit)
-    needs: validate-tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -99,6 +63,10 @@ jobs:
           node-version: '20'
           cache: 'npm'
 
+      # Cache node_modules + the electron/electron-builder caches. On a
+      # hit we skip npm ci entirely — the `electron-rebuild` postinstall
+      # output for node-pty is part of node_modules and is restored too,
+      # so we don't pay the ~20-40 s native rebuild on warm runs.
       - name: Cache node_modules + electron caches
         id: deps-cache
         uses: actions/cache@v4
@@ -127,7 +95,6 @@ jobs:
 
   playwright:
     name: Playwright suite
-    needs: validate-tag
     runs-on: ubuntu-latest
     # The suite takes ~1-2 min locally; CI runners are slower and need
     # generous headroom for the screenshots spec (~20 s) and Electron's
@@ -170,9 +137,6 @@ jobs:
         run: npm ci
 
       - name: Install Playwright browsers
-        # `@playwright/test` ships the Electron driver, but the
-        # `_electron` API still relies on Playwright's bundled bits being
-        # downloaded. `--with-deps` covers any extra system libs.
         run: npx playwright install --with-deps chromium
 
       - name: Build renderer + main
@@ -191,17 +155,75 @@ jobs:
             tests/screenshots-out/
           if-no-files-found: ignore
 
+  validate-tag:
+    name: Validate tag (shape + version + reachable from main)
+    # Only runs for `v*` tag pushes — never on commits to main.
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for ancestry check)
+        uses: actions/checkout@v4
+        with:
+          # Need enough history to run `git merge-base --is-ancestor`
+          # against origin/main. Shallow clones miss the ancestry.
+          fetch-depth: 0
+
+      # Reject malformed tags before any matrix job spins up. The release
+      # path only handles stable `vX.Y.Z` tags and prerelease suffixes
+      # (`-rc.N`, `-alpha*`, `-beta*`); they all need the leading semver
+      # triplet to match. Catches typos like `v3.12..1` or `v3.12`.
+      - name: Validate tag shape
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.+-]+)?$ ]]; then
+            echo "Tag '$TAG' is not a valid vX.Y.Z[-suffix] release tag." >&2
+            exit 1
+          fi
+          echo "Tag $TAG is valid."
+
+      # Assert that package.json's version matches the tag (sans leading
+      # `v`). Catches "forgot to bump" — the bump commit must land on
+      # main before the tag is pushed, per the conception release rule.
+      - name: Assert package.json version matches tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED="${TAG#v}"
+          if [[ "$PKG_VERSION" != "$EXPECTED" ]]; then
+            echo "package.json version ($PKG_VERSION) does not match tag ($EXPECTED)." >&2
+            echo "Bump package.json before pushing the tag." >&2
+            exit 1
+          fi
+          echo "package.json version $PKG_VERSION matches tag $TAG."
+
+      # Refuse to release a tag that isn't reachable from origin/main.
+      # This enforces "tags ship code that has landed in main" — no
+      # one-off feature-branch tags, no detached commits.
+      - name: Assert tag SHA is reachable from origin/main
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          git fetch origin main --quiet
+          TAG_SHA=$(git rev-parse "$TAG^{commit}")
+          if ! git merge-base --is-ancestor "$TAG_SHA" origin/main; then
+            echo "Tag $TAG ($TAG_SHA) is not reachable from origin/main." >&2
+            echo "Tags must point at commits that have landed on main." >&2
+            exit 1
+          fi
+          echo "Tag $TAG ($TAG_SHA) is reachable from origin/main."
+
   build:
     name: Build (${{ matrix.os }})
-    # build is the installer matrix. It only starts after the fast checks
-    # + Playwright pass for the tag SHA — that's the publish gate.
-    # Windows installer-smoke catches NSIS warning 6010 (unreferenced
-    # Function, treated as an error by electron-builder); v2.18.24/.25
-    # shipped broken because that build only ran on tag push and the
-    # failures only appeared after the tag was already pushed. With the
-    # gate in place, build failures here block publish before any GH
-    # Release exists, so the same kind of slip can't repeat.
-    needs: [fast-on-tag, playwright]
+    # The installer matrix gates publish via `needs:`. On a main push the
+    # build still runs (validates that the merged SHA produces installers
+    # cleanly on all three OSes), but its artefacts are dropped after a
+    # day. On a tag push the same artefacts feed publish.
+    needs: [fast, playwright]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -316,11 +338,8 @@ jobs:
           fi
           echo "AppImage AppRun patch verified."
 
-      # Capture only the installer bundles + channel files. Skip the
-      # `linux-unpacked/`, `mac/`, `win-unpacked/` working directories,
-      # the `builder-debug.yml`, and the `.blockmap` artifacts ship as
-      # standalone files (no skip needed). `if-no-files-found: error` so
-      # an empty release dir fails the matrix job loudly instead of
+      # Capture only the installer bundles + channel files. `if-no-files-found:
+      # error` so an empty release dir fails the matrix job loudly instead of
       # silently producing an empty publish.
       - name: Upload installers as workflow artifact
         uses: actions/upload-artifact@v4
@@ -338,7 +357,10 @@ jobs:
 
   publish:
     name: Publish to GitHub Release
-    needs: build
+    # Only on tag push, and only if validate-tag + build (and thus
+    # fast + playwright by transitive `needs:` chain) all succeeded.
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [validate-tag, build]
     runs-on: ubuntu-latest
     steps:
       - name: Download all installer artifacts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,16 +5,14 @@ name: pr
 # Scope: format-check, typecheck, build, vitest. That's it.
 #
 # What's deliberately NOT here:
-#   - Playwright (moved to release.yml — runs at tag time, gates publish).
+#   - Playwright (moved to main.yml — runs on every push to main and
+#     every `v*` tag, gates publish).
 #   - Installer-smoke (electron-builder on ubuntu/windows/macos —
-#     moved to release.yml's build matrix, also gates publish).
-# The complete suite runs once per tag, immediately before any GH
-# Release is created. PR coverage stays minimal so the runs-often
-# pipeline is actually fast.
-#
-# Push to main is intentionally NOT a trigger here. After a PR merges
-# the bump commit lands quietly on main; nothing runs again until a
-# `vX.Y.Z` tag is pushed.
+#     moved to main.yml's build matrix, also gates publish).
+# The heavy suite runs once per merge to main and once per tag. PR
+# coverage stays minimal so the runs-often pipeline is actually fast,
+# and the post-merge / pre-tag gate stays inside CI rather than
+# spread across out-of-band checks.
 
 on:
   pull_request:
@@ -27,7 +25,7 @@ on:
 
 concurrency:
   # Cancel in-flight PR runs when a newer commit lands on the same PR
-  # branch. Tag-time release runs never cancel each other (see release.yml).
+  # branch. main.yml runs never cancel each other.
   group: pr-${{ github.ref }}
   cancel-in-progress: true
 

--- a/docs/explanation/contributing.md
+++ b/docs/explanation/contributing.md
@@ -109,8 +109,8 @@ Native modules (`electron`, `node-pty`) stay external — esbuild leaves them as
 
 Two GitHub Actions workflows guard `main`:
 
-- **`.github/workflows/pr.yml`** runs on every `pull_request` to `main`. A single Ubuntu job runs `prettier --check` + `npm run typecheck` + `npm run build` + `npx vitest run`. That's it — no installer build, no Playwright. The complete suite runs on tag push (see below). Push to `main` does **not** re-trigger this workflow; merges are quiet.
-- **`.github/workflows/release.yml`** runs on tag push (`v*`). After validating tag shape + `package.json` version match, it runs the fast checks again on the tag SHA, then the full Playwright suite (Ubuntu + xvfb), then the three-OS installer matrix (`electron-builder --publish never` on Ubuntu / macOS / Windows including the AppImage AppRun patch). Only when all of those succeed does the `publish` job create the GitHub Release and upload assets. Anything red blocks publish — the tag stays in git but nothing public ships. The Windows installer leg is the load-bearing one: `build/installer.nsh`'s NSIS hooks only get assembled into the full installer template when `electron-builder` runs, so NSIS warning 6010 (treated as an error) only surfaces here. Gating publish on it means a broken Windows installer can no longer ship a tag.
+- **`.github/workflows/pr.yml`** runs on every `pull_request` to `main`. A single Ubuntu job runs `prettier --check` + `npm run typecheck` + `npm run build` + `npx vitest run`. That's it — no installer build, no Playwright. Target wall-clock is ≤ 90 s so the runs-often pipeline stays fast. Push to `main` does **not** trigger `pr.yml` — `main.yml` covers that.
+- **`.github/workflows/main.yml`** runs on every push to `main` **and** every `v*` tag. It runs the fast checks, the full Playwright suite (Ubuntu + xvfb), and the three-OS installer matrix (`electron-builder --publish never` on Ubuntu / macOS / Windows including the AppImage AppRun patch). On a push to `main` it stops there — installer artefacts are uploaded and dropped after a day; nothing is published. On a `v*` tag push it additionally runs `validate-tag` (tag shape + `package.json` version match + tag SHA reachable from `origin/main`) and `publish` (creates the GitHub Release and uploads assets). The `publish` job depends on `validate-tag` + `build` via `needs:` — pure CI gating, no out-of-band commit-status checks — so anything red blocks the release. The tag stays in git but nothing public ships. The Windows installer leg is the load-bearing one: `build/installer.nsh`'s NSIS hooks only get assembled into the full installer template when `electron-builder` runs, so NSIS warning 6010 (treated as an error) only surfaces here. Gating publish on it means a broken Windows installer can no longer ship a tag — and now the same matrix also catches the regression at merge time, before any tag is pushed.
 
 ## Documentation changes
 
@@ -134,7 +134,7 @@ Every code change that affects user-visible behaviour ships with a docs update i
 
 - **Issues** — file at [`github.com/vcoeur/condash/issues`](https://github.com/vcoeur/condash/issues). For bugs, include the OS, the condash version (footer of the dashboard), and a minimal repro tree if you can.
 - **PRs** — branch from `main`, open a PR against `main`. The PR template asks for a Summary, a Changes list, and an optional Impact / Watchpoints section.
-- **Releases** — tagged `vMAJOR.MINOR.PATCH`. PATCH for bug fixes and docs; MINOR for new behaviour; MAJOR for breaking config or Markdown changes. Tag pushes trigger the release workflow automatically.
+- **Releases** — tagged `vMAJOR.MINOR.PATCH`. PATCH for bug fixes and docs; MINOR for new behaviour; MAJOR for breaking config or Markdown changes. Tag pushes trigger `main.yml`'s `publish` job automatically (gated behind the heavy CI matrix).
 
 ## What to work on
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.18.1",
+      "version": "3.19.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.18.1",
+  "version": "3.19.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- Reverses the v3.17.0 gate model: heavy CI (fast + Playwright + 3-OS installer matrix) now runs on every push to `main` and every `v*` tag, not just at tag time.
- `publish` is gated by a `needs:` chain inside one workflow file — no out-of-band `gh api` queries or commit-status lookups.
- Adds a reachable-from-main check to `validate-tag`, so a tag pointing at a non-main commit refuses to publish.

## Changes

- New `.github/workflows/main.yml` combining `fast`, `playwright`, `validate-tag`, `build` (3-OS matrix), and `publish`. Triggers on push to `main` and on `v*` tags. `validate-tag` + `publish` are conditional on `startsWith(github.ref, 'refs/tags/v')`; the rest run unconditionally.
- `validate-tag` now performs three checks: tag shape, `package.json` version match, and `git merge-base --is-ancestor` against `origin/main`.
- `release.yml` deleted (replaced by `main.yml`).
- `pr.yml` behaviour unchanged; comments updated to point at `main.yml`.
- `docs.yml`: `workflow_run` retargeted from `[release]` to `[main]`, and the `build` job's `if:` filter narrowed so it only fires on tag-push runs of `main.yml` (otherwise the apt repo would rebuild on every commit to main).
- `docs/explanation/contributing.md`: rewrites the "Two workflows guard main" paragraph to describe the new shape.
- Bump 3.18.1 → 3.19.0.

## Impact

- GHA minutes per merge to `main` go up ~7 min (the heavy lane previously did not run on main pushes).
- Heavy CI runs twice per release (once on the merge to main, once on the tag against the same SHA) — accepted as the cost of keeping the gate as a pure `needs:` chain.

## Watchpoints

- `github.event.workflow_run.head_branch` is assumed to carry the tag name (without `refs/tags/`) for tag-push events — first tag push will confirm. If wrong, `docs.yml`'s tag-only filter mismatches and the apt repo either rebuilds on every main commit (wasteful but safe) or never rebuilds (broken until manually `workflow_dispatch`-ed).
- `validate-tag` uses `fetch-depth: 0` so the ancestry check has the full history; without it `merge-base` fails on shallow clones.