### PR TITLE
Make local Playwright runs headless so the window stops stealing focus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,10 @@ When changing the dev port, update **every** file:
 | `make dev` / `npm run dev` | watch mode: tsc + vite + electron |
 | `make build` / `npm run build` | compile main + renderer |
 | `make package` / `npm run package` | electron-builder installers (Linux/macOS/Windows) |
+| `make test` | build, then the Playwright suite (headless via `xvfb-run` when present) |
+| `make test-headless` | build, then Playwright under `xvfb-run` (no window; errors if `xvfb-run` absent) |
+| `make test-visible` | build, then Playwright with the window visible (watch the run) |
+| `make test-unit` / `npm run test:unit` | vitest unit suite |
 | `make typecheck` | tsc on both projects, no emit |
 | `make format` | prettier on `src/` |
 | `make kill` | free port 5600 |

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
-.PHONY: help install dev build start package typecheck format format-check test test-unit clean kill
+.PHONY: help install dev build start package typecheck format format-check test test-headless test-visible test-unit clean kill
 
 DEV_PORT     ?= 5600
 PREVIEW_PORT ?= 5601
+
+# Electron opens an on-screen window unless it runs against a virtual display.
+# Prefer xvfb-run for the Playwright suite when it's installed (the Linux dev
+# norm — mirrors CI) so the window never appears or steals focus; fall back to
+# a visible run where xvfb-run is absent (macOS/Windows). `make test-visible`
+# always shows the window; `make test-headless` always wraps and errors out if
+# xvfb-run is missing.
+XVFB_RUN  := $(shell command -v xvfb-run 2>/dev/null)
+TEST_WRAP := $(if $(XVFB_RUN),xvfb-run -a,)
 
 help:
 	@echo "Targets:"
@@ -13,7 +22,9 @@ help:
 	@echo "  typecheck    run tsc on both main and renderer"
 	@echo "  format       run prettier on src/"
 	@echo "  format-check check prettier formatting without writing"
-	@echo "  test         build then run the Playwright suite"
+	@echo "  test          build then run the Playwright suite (headless when xvfb-run is present)"
+	@echo "  test-headless build then run the suite under xvfb-run (no window; errors if xvfb-run absent)"
+	@echo "  test-visible  build then run the suite with the window visible (watch the run)"
 	@echo "  test-unit    run vitest unit suite"
 	@echo "  kill         free dev port $(DEV_PORT)"
 	@echo "  clean        remove build outputs"
@@ -43,6 +54,14 @@ format-check:
 	npx prettier --check "src/**/*.{ts,tsx,css,html,json}"
 
 test:
+	npm run build
+	$(TEST_WRAP) npm run test
+
+test-headless:
+	npm run build
+	xvfb-run -a npm run test
+
+test-visible:
 	npm run build
 	npm run test
 

--- a/docs/explanation/contributing.md
+++ b/docs/explanation/contributing.md
@@ -80,15 +80,17 @@ For renderer-only features (UI states, animations, derived signals), only the re
 ## Testing
 
 ```bash
-make typecheck    # tsc --noEmit on both projects
-make test         # vitest unit tests
-make e2e          # Playwright against a real Electron build
+make typecheck     # tsc --noEmit on both projects
+make test          # build, then the Playwright E2E suite
+make test-unit     # vitest unit tests
 ```
 
-- **Vitest** — `src/**/*.test.ts`. Fast. Pure-function tests (parsers, path helpers, regexes). `environment: 'node'`.
-- **Playwright** — `tests/*.spec.ts`. Drives the real Electron app. Slower, more authoritative. The Playwright fixture launches Electron with `CONDASH_FORCE_PROD=1` so the renderer loads the real `dist/` build, not the Vite dev server.
+- **Vitest** (`make test-unit`) — `src/**/*.test.ts`. Fast. Pure-function tests (parsers, path helpers, regexes). `environment: 'node'`.
+- **Playwright** (`make test`) — `tests/*.spec.ts`. Drives the real Electron app. Slower, more authoritative. The Playwright fixture launches Electron with `CONDASH_FORCE_PROD=1` so the renderer loads the real `dist/` build, not the Vite dev server.
 
 For a feature that touches the dashboard's behaviour, prefer Playwright. The e2e suite seeds a temporary conception tree, exercises the feature, and asserts on real DOM + real file writes.
+
+Driving the real Electron app means the suite opens an on-screen window unless it runs against a virtual display. On Linux, `make test` wraps the suite in `xvfb-run` when it's installed, so the window never appears or steals focus — the same thing CI does. `make test-headless` forces that wrap (and errors if `xvfb-run` is missing); `make test-visible` runs with the window visible when you want to watch a run. On macOS/Windows (no `xvfb`), `make test` runs visibly.
 
 ## Style and conventions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.19.1",
+      "version": "3.19.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.19.1",
+  "version": "3.19.2",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- Running the Playwright suite locally launched the real Electron window on the developer's display and stole focus for the whole run (~4 min). CI already avoids this by wrapping the suite in `xvfb-run`; local runs had no equivalent.
- `make test` now mirrors CI locally: it runs under `xvfb-run` when that's installed (the Linux dev norm), so no window appears, and falls back to a visible run where `xvfb-run` is absent (macOS/Windows).

## Changes

- `Makefile`: `make test` prefers `xvfb-run -a` when present (via a `TEST_WRAP` variable computed from `command -v xvfb-run`). Add `test-headless` (always wraps; errors if `xvfb-run` is missing) and `test-visible` (always shows the window) targets, plus help text and `.PHONY` entries.
- `docs/explanation/contributing.md`: fix the stale Testing block — it mapped `make test` to vitest and referenced a nonexistent `make e2e` target — and document the new headless default.
- `CLAUDE.md`: add `test` / `test-headless` / `test-visible` / `test-unit` to the command table.
- Version bump to 3.19.2.

## Impact

- Default `make test` becomes headless on Linux dev boxes that have `xvfb-run`; macOS/Windows local runs stay visible. CI is unaffected — it invokes `xvfb-run -a npm test` directly, not the Makefile target.