### PR TITLE
Bump CI actions off Node 20 to Node-24-compatible versions

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -26,10 +26,10 @@ jobs:
           - windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -134,7 +134,7 @@ jobs:
       # error` so an empty release dir fails the matrix job loudly instead of
       # silently producing an empty publish.
       - name: Upload installers as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: installers-${{ matrix.os }}
           path: |

--- a/.github/workflows/_fast.yml
+++ b/.github/workflows/_fast.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
@@ -27,7 +27,7 @@ jobs:
       # so we don't pay the ~20-40 s native rebuild on warm runs.
       - name: Cache node_modules + electron caches
         id: deps-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules

--- a/.github/workflows/_playwright.yml
+++ b/.github/workflows/_playwright.yml
@@ -19,17 +19,17 @@ jobs:
     timeout-minutes: 25
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           cache: 'npm'
 
       - name: Cache node_modules + electron caches
         id: deps-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -38,7 +38,7 @@ jobs:
           key: deps-ubuntu-${{ hashFiles('package-lock.json') }}-electron-33
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('package-lock.json') }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload Playwright artefacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: playwright-failure-artefacts
           path: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -72,10 +72,10 @@ jobs:
     # explicitly for manual rebuilds.
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success' && startsWith(github.event.workflow_run.head_branch, 'v')) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           # No uv.lock in this repo (we use ephemeral `uv run --with`).
@@ -89,7 +89,7 @@ jobs:
           sudo apt-get install -y aptly gnupg
 
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Build mkdocs site
         run: uv run --with "mkdocs-material==9.5.49" mkdocs build --strict
@@ -118,7 +118,7 @@ jobs:
           echo "fingerprint=$fingerprint" >> "$GITHUB_OUTPUT"
 
       - name: Cache .deb assets
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: debs
           key: condash-debs-v1-${{ steps.tags.outputs.fingerprint }}
@@ -196,7 +196,7 @@ jobs:
           ls -la site/apt/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./site
 
@@ -209,4 +209,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -26,7 +26,7 @@ jobs:
     outputs:
       code: ${{ steps.f.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: f

--- a/.github/workflows/pr-heavy.yml
+++ b/.github/workflows/pr-heavy.yml
@@ -29,7 +29,7 @@ jobs:
     outputs:
       code: ${{ steps.f.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - id: f

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
     outputs:
       changed: ${{ steps.check.outputs.changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Need both parents of the merge commit for the tree diff.
           fetch-depth: 0
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history for ancestry check)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -168,7 +168,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all installer artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: release-staging
           # merge-multiple flattens installers-<os>/ into one directory so

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.19.2",
+      "version": "3.19.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.19.2",
+  "version": "3.19.3",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- GitHub forces the Node 24 runtime by default on 2026-06-02 and removes Node 20 from the runner entirely on 2026-09-16; every action in CI currently runs on a Node-20 major and emits the deprecation annotation.
- Bumps all 22 `uses:` references to the lowest Node-24-compatible major, each verified against the action's `action.yml` `runs.using` field, and patches the app version to 3.19.3.
- Pin style (floating major tags) and the Node-20 *build* toolchain (`node-version: '20'`) are intentionally unchanged — this moves only the action runtimes.

## Changes

- `actions/checkout` v4 → v5, `actions/setup-node` v4 → v5, `actions/cache` v4 → v5 across `_fast`, `_playwright`, `_build`, `pr-fast`, `pr-heavy`, `release`, `docs`.
- `actions/upload-artifact` v4 → v6 (`_build`, `_playwright`).
- `actions/download-artifact` v4 → v7 in `release` — v5 and v6 still run on Node 20.
- Pages lane in `docs`: `actions/configure-pages` v5 → v6, `actions/deploy-pages` v4 → v5, `actions/upload-pages-artifact` v3 → v5 (v4 still nests a Node-20 `upload-artifact`; v5 nests `upload-artifact@v7.0.0`), `astral-sh/setup-uv` v4 → v7.
- Patch bump `package.json` + `package-lock.json` 3.19.2 → 3.19.3.

## Watchpoints

- The PR lanes (`pr-fast` + `pr-heavy`) exercise only `checkout`/`setup-node`/`cache`/`upload-artifact`; their run should carry no "Node.js 20 actions are deprecated" annotation.
- `download-artifact` runs only in `release.yml`'s tag-path publish job, and the `docs.yml` Pages actions run only after a release (or manual dispatch) — neither fires on a pull request. Both are verified when the `v3.19.3` tag is pushed: the publish job downloads the matrix installers, and the cascading docs run rebuilds and deploys the site.
- Highest-risk bump is `upload-pages-artifact` v3 → v5 (two majors): the `github-pages` artifact contract with `deploy-pages` must still hold — confirmed by the docs deploy at release.