### PR TITLE
Fix blank in-app PDF viewer by dropping webview partition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.19.3",
+  "version": "3.19.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.19.3",
+      "version": "3.19.4",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.19.3",
+  "version": "3.19.4",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/pdf-modal.tsx
+++ b/src/renderer/pdf-modal.tsx
@@ -45,18 +45,23 @@ export function PdfModal(props: {
         <div class="pdf-body">
           <Show when={resolved()?.url}>
             {(url) => (
-              // Lockdown the embedded webview that renders the PDF:
-              //   - `partition="pdfs"` isolates session storage so no
-              //     cookies / localStorage spill into the main session.
+              // Harden the embedded webview that renders the PDF:
               //   - `webpreferences=...` keeps Node off, isolates the
               //     context, and runs the renderer in the OS sandbox.
               // A defence-in-depth `web-contents-created` handler in
-              // main/index.ts also re-applies these settings if a
-              // future webview ships without the attribute.
+              // main/index.ts re-applies these settings if a future
+              // webview ships without the attribute.
+              //
+              // Deliberately NO `partition`: Chromium's built-in PDF
+              // viewer is a component extension registered only in the
+              // default session, so a custom partition loads the viewer
+              // chrome (scrollbars) but never paints the pages — a blank
+              // PDF. The webview only ever loads a local, path-validated
+              // `file://` PDF that sets no cookies or localStorage, so a
+              // partition would isolate nothing while breaking rendering.
               <webview
                 src={url()}
                 class="pdf-webview"
-                partition="pdfs"
                 webpreferences="contextIsolation=true,nodeIntegration=false,sandbox=true"
               />
             )}


### PR DESCRIPTION
## Summary

- Clicking a PDF opened the viewer modal but the page area rendered blank (viewer shell + scrollbars, no pages); only the "Open in OS viewer" fallback worked.
- The PDF `<webview>` carried `partition="pdfs"` from an earlier security lockdown. Chromium's built-in PDF-viewer component extension is registered only in the default session, so a custom partition loaded the viewer chrome but never painted pages.

## Changes

- `src/renderer/pdf-modal.tsx`: remove the `partition="pdfs"` attribute from the PDF `<webview>`; keep `contextIsolation` / `nodeIntegration=false` / `sandbox=true`. Rewrite the comment to record why a partition must not be reintroduced.
- Bump version to 3.19.4.

## Impact

- Restores inline PDF rendering across deliverables, notes, and the Resources pane. The webview only loads a local, path-validated `file://` PDF that sets no cookies or localStorage, so dropping the partition removes no meaningful isolation.

## Watchpoints

- No automated render assertion is possible: Electron's `capturePage` cannot capture `<webview>` surfaces, and the existing screenshot e2e never opens the PDF viewer. Rendering was confirmed in a faithful standalone harness; confirm in the running app after merge by opening any PDF.