### PR TITLE
Add Outputs pane: aggregate every project's deliverables

### DIFF
--- a/docs/guides/deliverables.md
+++ b/docs/guides/deliverables.md
@@ -9,7 +9,9 @@ description: The `## Deliverables` section syntax, filename conventions, PDF gen
 
 **When to read this.** Your item produces a tangible output — a report, a design doc, an incident post-mortem — and you want it to show up on the card with a download link and an embedded viewer.
 
-Deliverables are a first-class concept: a `## Deliverables` section in a README lists one or more PDF files, and condash renders a download badge on the card plus a viewer in the expanded card.
+Deliverables are a first-class concept: a `## Deliverables` section in a README lists one or more artifacts, and condash renders them in the expanded card, in the cross-project **[Outputs pane](outputs-pane.md)**, and opens each in a type-appropriate viewer.
+
+A deliverable link can point at **any local file** (PDF, Markdown, HTML, image, …) or an **http(s) URL** (e.g. a deployed page). PDF-only was the pre-3.20 behaviour.
 
 ## The `## Deliverables` section
 
@@ -29,10 +31,24 @@ Per line:
 ```
 
 - **Label** — text shown on the card and in the viewer header.
-- **Path** — relative to the item's directory. Must end in `.pdf`.
+- **Path** — a local file relative to the item's directory (any extension), or an absolute `http(s)://` URL kept verbatim. `mailto:` and in-page `#anchor` links are ignored.
 - **Description** (optional, after ` — `) — a one-line note shown under the label.
 
 Multiple deliverables per item are fine; each renders as its own row in the Deliverables section of the item modal.
+
+### How each type opens
+
+The viewer is chosen by the link's type:
+
+| Link | Opens in |
+|------|----------|
+| `http(s)://…` | your external browser (`shell.openExternal`) |
+| `.pdf` | the in-app PDF viewer modal |
+| `.html` / `.htm` | the in-app HTML preview (sandboxed `condash-file://` webview, with an **↗ Open externally** button) |
+| `.md` / `.markdown` | the in-app note modal, read-only |
+| anything else | your OS default application (`shell.openPath`) |
+
+The HTML preview loads the file over the `condash-file://` scheme, so **relative** references inside it (`<img src="sibling.png">`, relative CSS/JS) resolve against the deliverable's own directory. Root-absolute paths (`/assets/…`) and remote assets may not load under the renderer's CSP — use **↗ Open externally** for those.
 
 ## Filename convention
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -18,6 +18,7 @@ Each guide answers one specific question.
 - **[Wikilinks between items](wikilinks.md)** — `[[other-item]]` resolves across the tree.
 - **[The knowledge tree](knowledge-tree.md)** — your reference notes, organised as cards.
 - **[The Resources pane](resources-pane.md)** — every file under `resources/` as a card with copy / open / paste-to-term actions.
+- **[The Outputs pane](outputs-pane.md)** — every project's `## Deliverables`, aggregated and grouped by project, in a left-band tab next to Projects.
 - **[The Skills pane](skills-pane.md)** — markdown skills under `.claude/skills/`, edited in place, with shipped/diverged chips.
 - **[Troubleshooting](troubleshooting.md)** — Wayland blur, dirty caches, app won't launch.
 

--- a/docs/guides/outputs-pane.md
+++ b/docs/guides/outputs-pane.md
@@ -1,0 +1,33 @@
+# The Outputs pane
+
+The Outputs pane is a tab in the **left band, next to Projects** — *not* in the right working-surface slot with Code / Knowledge / Resources / Skills / Logs. The left band carries a `[Projects] [Outputs]` tab strip at the top; click **Outputs** to switch the band to it. Which tab was last active is remembered across launches (the `leftView` layout field).
+
+## What it shows
+
+Every project whose README has a `## Deliverables` section, **grouped by project** (newest first). Each group header shows the project title, a status pill, and the date; expand it to see the project's deliverables.
+
+It is **parse-only**: the pane reuses the deliverables already parsed from each README for the Projects pane — there is no separate filesystem scan and no dedicated `outputs/` directory to maintain. A project appears here the moment it links at least one deliverable, and disappears when it links none.
+
+Each deliverable row carries a coarse type tag derived from the link:
+
+| Tag    | Link |
+|--------|------|
+| `URL`  | `http(s)://…` |
+| `PDF`  | `.pdf` |
+| `HTML` | `.html` / `.htm` |
+| `MD`   | `.md` / `.markdown` |
+| `IMAGE`| `.png` / `.jpg` / `.svg` / … |
+| `FILE` | anything else |
+
+## Opening a deliverable
+
+Click a row to open it. The viewer is chosen by type — PDF and HTML preview in-app, URLs open in your browser, Markdown opens read-only, everything else hands off to your OS default app. See **[Deliverables](deliverables.md#how-each-type-opens)** for the full table and the HTML-preview relative-asset notes.
+
+## Empty state
+
+When no project links a deliverable, the pane shows a one-line pointer: link artifacts under a project's `## Deliverables`.
+
+## See also
+
+- **[Deliverables](deliverables.md)** — the `## Deliverables` syntax, accepted link types, and how each opens.
+- **[The Resources pane](resources-pane.md)** — the conception-global file browser (right slot), distinct from this per-project aggregation.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -343,6 +343,7 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
   },
   "layout": {
     "projects": true,
+    "leftView": "projects",
     "working": "code",
     "terminal": false,
     "projectsWidth": 420
@@ -388,7 +389,8 @@ Workspace-shape keys (`workspace_path`, `worktrees_path`, `resources_path`, `ski
 
 | Field           | Type                                                       | Meaning                                                                                                                       |
 | --------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `projects`      | bool                                                       | Show or hide the Projects pane on the left edge.                                                                              |
+| `projects`      | bool                                                       | Show or hide the left band.                                                                                                  |
+| `leftView`      | `'projects' \| 'outputs'`                                  | Which view fills the left band — the Projects list or the Outputs aggregation of every project's `## Deliverables`. Switched by the band's tab strip. Defaults to `'projects'`. |
 | `working`       | `'code' \| 'knowledge' \| 'resources' \| 'skills' \| 'logs' \| null` | Six-state. `'code'`, `'knowledge'`, `'resources'`, `'skills'`, or `'logs'` shows that pane in the working slot; `null` hides them all. |
 | `terminal`      | bool                                                       | Show or hide the Terminal pane at the bottom.                                                                                 |
 | `projectsWidth` | non-negative int                                           | Pixel width of the Projects pane after the user drags the splitter.                                                           |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,7 @@ nav:
     - Wikilinks between items: guides/wikilinks.md
     - The knowledge tree: guides/knowledge-tree.md
     - The resources pane: guides/resources-pane.md
+    - The outputs pane: guides/outputs-pane.md
     - The skills pane: guides/skills-pane.md
     - Deliverables and PDFs: guides/deliverables.md
     - Extend the management skill: guides/skill-extensions.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.19.4",
+  "version": "3.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.19.4",
+      "version": "3.20.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.19.4",
+  "version": "3.20.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -218,6 +218,9 @@ const terminalSettings = z
 const layoutSchema = z
   .object({
     projects: z.boolean(),
+    // Optional: layouts persisted before `leftView` existed omit it; the read
+    // path back-fills from DEFAULT_LAYOUT.
+    leftView: z.union([z.literal('projects'), z.literal('outputs')]).optional(),
     working: z.union([
       z.literal('code'),
       z.literal('knowledge'),

--- a/src/main/parse.test.ts
+++ b/src/main/parse.test.ts
@@ -264,3 +264,82 @@ apps: []
     expect(project.stepCounts.done).toBe(1);
   });
 });
+
+describe('deliverables parsing', () => {
+  const header = `---
+date: 2026-05-20
+kind: project
+status: done
+apps: []
+---
+
+# Test
+`;
+
+  it('accepts local links of any extension, not just PDF', async () => {
+    const body = `${header}
+## Deliverables
+
+- [Report](report.pdf) — the compiled report
+- [Module 1](outputs/module-1.html)
+- [Notes export](notes/summary.md)
+- [Diagram](assets/diagram.svg)
+`;
+    const path = await writeReadme('2026-05-20-mixed', body);
+    const project = await parseReadme(path);
+    const dir = join(tmp, '2026-05-20-mixed');
+    expect(project.deliverableCount).toBe(4);
+    expect(project.deliverables.map((d) => d.label)).toEqual([
+      'Report',
+      'Module 1',
+      'Notes export',
+      'Diagram',
+    ]);
+    // Local targets resolve to absolute posix paths under the project dir.
+    expect(project.deliverables[0].path).toBe(join(dir, 'report.pdf').split('\\').join('/'));
+    expect(project.deliverables[1].path).toBe(
+      join(dir, 'outputs/module-1.html').split('\\').join('/'),
+    );
+    expect(project.deliverables[0].description).toBe('the compiled report');
+  });
+
+  it('keeps http(s) URLs verbatim', async () => {
+    const body = `${header}
+## Deliverables
+
+- [Live module](https://example.netlify.app/module) — deployed
+`;
+    const path = await writeReadme('2026-05-20-url', body);
+    const project = await parseReadme(path);
+    expect(project.deliverables).toHaveLength(1);
+    expect(project.deliverables[0].path).toBe('https://example.netlify.app/module');
+  });
+
+  it('skips mailto: and in-page anchors', async () => {
+    const body = `${header}
+## Deliverables
+
+- [Email me](mailto:alice@example.com)
+- [Section](#summary)
+- [Real](file.pdf)
+`;
+    const path = await writeReadme('2026-05-20-skip', body);
+    const project = await parseReadme(path);
+    expect(project.deliverables.map((d) => d.label)).toEqual(['Real']);
+  });
+
+  it('only collects links under the ## Deliverables heading', async () => {
+    const body = `${header}
+## Notes
+
+- [Not a deliverable](elsewhere.pdf)
+
+## Deliverables
+
+- [Yes](yes.pdf)
+`;
+    const path = await writeReadme('2026-05-20-scope', body);
+    const project = await parseReadme(path);
+    expect(project.deliverables.map((d) => d.label)).toEqual(['Yes']);
+  });
+});

--- a/src/main/parse.ts
+++ b/src/main/parse.ts
@@ -13,7 +13,14 @@ import { toPosix } from '../shared/path';
 import { parseTimelineEntries } from './mutate';
 
 const STEP_LINE = /^\s*-\s\[([ ~x!-])\]\s+(.*)$/;
-const DELIVERABLE_LINE = /^\s*-\s\[([^\]]+)\]\(([^)]+\.pdf)\)(?:\s*[—\-:]\s*(.*))?\s*$/i;
+// `- [label](target) — optional description`. `target` is any link: a local
+// file of any extension (resolved relative to the project dir) or an http(s)
+// URL (kept verbatim). `mailto:` and in-page `#anchor` targets are filtered in
+// extractDeliverables. Broadened from PDF-only so md / html / image / URL
+// deliverables surface in the Outputs pane.
+const DELIVERABLE_LINE = /^\s*-\s\[([^\]]+)\]\(([^)]+)\)(?:\s*[—\-:]\s*(.*))?\s*$/i;
+const DELIVERABLE_URL = /^https?:\/\//i;
+const DELIVERABLE_SKIP = /^(mailto:|#)/i;
 const SUMMARY_MAX = 300;
 
 export async function parseReadme(path: string): Promise<Project> {
@@ -161,10 +168,16 @@ function extractDeliverables(lines: readonly string[], itemDir: string): Deliver
     const match = line.match(DELIVERABLE_LINE);
     if (!match) continue;
     const [, label, rawPath, description] = match;
-    const absolute = isAbsolute(rawPath) ? rawPath : resolve(itemDir, rawPath);
+    const target = rawPath.trim();
+    // mailto: and in-page anchors are navigation, not deliverables.
+    if (DELIVERABLE_SKIP.test(target)) continue;
+    // URLs are kept verbatim; local links resolve against the project dir.
+    const value = DELIVERABLE_URL.test(target)
+      ? target
+      : toPosix(isAbsolute(target) ? target : resolve(itemDir, target));
     out.push({
       label: label.trim(),
-      path: toPosix(absolute),
+      path: value,
       description: description?.trim() || undefined,
     });
   }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -34,6 +34,7 @@ export async function drainSettingsQueue(): Promise<void> {
 
 export const DEFAULT_LAYOUT: LayoutState = {
   projects: true,
+  leftView: 'projects',
   working: 'code',
   terminal: true,
   projectsWidth: 320,

--- a/src/renderer/deliverable-open.ts
+++ b/src/renderer/deliverable-open.ts
@@ -1,0 +1,42 @@
+import type { Setter } from 'solid-js';
+import type { ModalState } from './note-modal';
+
+export interface DeliverableOpenSetters {
+  setPdfPath: Setter<string | null>;
+  setHtmlPath: Setter<string | null>;
+  setModal: Setter<ModalState>;
+}
+
+/**
+ * Open a deliverable target by type. `target` is either a resolved local path
+ * or a verbatim http(s) URL (`Deliverable.path`):
+ *
+ *   - http(s) URL → external browser
+ *   - .pdf        → in-app PDF modal
+ *   - .html/.htm  → in-app HTML preview
+ *   - .md         → in-app read-only markdown viewer
+ *   - everything else → OS default application
+ *
+ * Shared by the project-preview deliverables list and the Outputs pane so both
+ * route every artifact the same way.
+ */
+export function openDeliverableTarget(target: string, setters: DeliverableOpenSetters): void {
+  const lower = target.toLowerCase();
+  if (/^https?:\/\//i.test(target)) {
+    void window.condash.openExternal(target);
+    return;
+  }
+  if (lower.endsWith('.pdf')) {
+    setters.setPdfPath(target);
+    return;
+  }
+  if (lower.endsWith('.html') || lower.endsWith('.htm')) {
+    setters.setHtmlPath(target);
+    return;
+  }
+  if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
+    setters.setModal({ path: target, readOnly: true });
+    return;
+  }
+  void window.condash.openPath(target);
+}

--- a/src/renderer/hooks/use-layout.ts
+++ b/src/renderer/hooks/use-layout.ts
@@ -1,5 +1,16 @@
 import { createSignal } from 'solid-js';
-import type { LayoutState, WorkingSurface } from '@shared/types';
+import type { LayoutState, LeftView, WorkingSurface } from '@shared/types';
+
+/** Renderer-side default; mirrors the main-process `DEFAULT_LAYOUT`. Used both
+ *  for the pre-load signal value and to back-fill fields a persisted layout
+ *  predates (e.g. `leftView`). */
+const DEFAULT_LAYOUT: LayoutState = {
+  projects: true,
+  leftView: 'projects',
+  working: 'code',
+  terminal: true,
+  projectsWidth: 320,
+};
 
 export interface UseLayoutDeps {
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
@@ -14,6 +25,9 @@ export interface UseLayout {
   updateLayout: (patch: Partial<LayoutState>) => void;
   toggleProjects: () => void;
   toggleTerminal: () => void;
+  /** Switch the left band between Projects and Outputs. Showing a view also
+   *  ensures the left band is visible. */
+  setLeftView: (next: LeftView) => void;
   selectWorking: (next: WorkingSurface) => void;
   ensureTerminalOpen: () => void;
   /** Any of the three top-band panes is on — when all three are off only
@@ -37,16 +51,13 @@ export function useLayout(deps: UseLayoutDeps): UseLayout {
   // Composite-layout state — replaces the prior single-`tab` selector.
   // Default mirrors the persisted server-side default until the real
   // value loads (avoids a frame of empty UI).
-  const [layout, setLayoutState] = createSignal<LayoutState>({
-    projects: true,
-    working: 'code',
-    terminal: true,
-    projectsWidth: 320,
-  });
+  const [layout, setLayoutState] = createSignal<LayoutState>({ ...DEFAULT_LAYOUT });
 
   void window.condash
     .getLayout()
-    .then(setLayoutState)
+    // Merge over the defaults so a layout persisted before a field existed
+    // (e.g. `leftView`) is back-filled rather than landing as `undefined`.
+    .then((loaded) => setLayoutState({ ...DEFAULT_LAYOUT, ...loaded }))
     .catch((err) => deps.flashToast(`Could not load layout: ${(err as Error).message}`, 'error'));
 
   const updateLayout = (patch: Partial<LayoutState>): void => {
@@ -59,6 +70,9 @@ export function useLayout(deps: UseLayoutDeps): UseLayout {
 
   const toggleProjects = (): void => updateLayout({ projects: !layout().projects });
   const toggleTerminal = (): void => updateLayout({ terminal: !layout().terminal });
+  // Selecting a left view also opens the band, so the tab can't switch to a
+  // pane that isn't shown.
+  const setLeftView = (next: LeftView): void => updateLayout({ leftView: next, projects: true });
   const selectWorking = (next: WorkingSurface): void => updateLayout({ working: next });
   const ensureTerminalOpen = (): void => {
     if (!layout().terminal) updateLayout({ terminal: true });
@@ -117,6 +131,7 @@ export function useLayout(deps: UseLayoutDeps): UseLayout {
     updateLayout,
     toggleProjects,
     toggleTerminal,
+    setLeftView,
     selectWorking,
     ensureTerminalOpen,
     topBandVisible,

--- a/src/renderer/hooks/use-modals.ts
+++ b/src/renderer/hooks/use-modals.ts
@@ -10,6 +10,8 @@ export interface UseModals {
   setPreviewPath: Setter<string | null>;
   pdfPath: () => string | null;
   setPdfPath: Setter<string | null>;
+  htmlPath: () => string | null;
+  setHtmlPath: Setter<string | null>;
   helpDoc: () => HelpDoc | null;
   setHelpDoc: Setter<HelpDoc | null>;
   searchModalOpen: () => boolean;
@@ -45,6 +47,7 @@ export function useModals(): UseModals {
   const [modal, setModal] = createSignal<ModalState>(null);
   const [previewPath, setPreviewPath] = createSignal<string | null>(null);
   const [pdfPath, setPdfPath] = createSignal<string | null>(null);
+  const [htmlPath, setHtmlPath] = createSignal<string | null>(null);
   const [helpDoc, setHelpDoc] = createSignal<HelpDoc | null>(null);
   const [searchModalOpen, setSearchModalOpen] = createSignal(false);
   const [settingsOpen, setSettingsOpen] = createSignal(false);
@@ -69,6 +72,8 @@ export function useModals(): UseModals {
     setPreviewPath,
     pdfPath,
     setPdfPath,
+    htmlPath,
+    setHtmlPath,
     helpDoc,
     setHelpDoc,
     searchModalOpen,

--- a/src/renderer/hooks/use-project-actions.ts
+++ b/src/renderer/hooks/use-project-actions.ts
@@ -2,6 +2,7 @@ import { createMemo, type Setter } from 'solid-js';
 import type { Deliverable, KnowledgeNode, Project, Step } from '@shared/types';
 import { applyStatus, applyStepMarker, groupByStatus, nextMarker } from '../panes/projects';
 import { buildSlugIndex } from '../wikilinks';
+import { openDeliverableTarget } from '../deliverable-open';
 import type { ModalState } from '../note-modal';
 import type { ModalRouter } from '../modal-router';
 import type { PromptModalState } from '../prompt-modal';
@@ -14,6 +15,7 @@ export interface UseProjectActionsDeps {
   setModal: Setter<ModalState>;
   setPreviewPath: Setter<string | null>;
   setPdfPath: Setter<string | null>;
+  setHtmlPath: Setter<string | null>;
   openPrompt: (init: Omit<PromptModalState, 'resolve'>) => Promise<string | null>;
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
 }
@@ -93,11 +95,11 @@ export function useProjectActions(deps: UseProjectActionsDeps): UseProjectAction
   };
 
   const handleOpenDeliverableFromPreview = (deliverable: Deliverable): void => {
-    if (deliverable.path.toLowerCase().endsWith('.pdf')) {
-      deps.setPdfPath(deliverable.path);
-    } else {
-      void window.condash.openInEditor(deliverable.path);
-    }
+    openDeliverableTarget(deliverable.path, {
+      setPdfPath: deps.setPdfPath,
+      setHtmlPath: deps.setHtmlPath,
+      setModal: deps.setModal,
+    });
   };
 
   const handleOpenFileFromPreview = (path: string, previewPath: () => string | null): void => {

--- a/src/renderer/hooks/use-tree-actions.ts
+++ b/src/renderer/hooks/use-tree-actions.ts
@@ -3,6 +3,7 @@ import type { SkillNode, SkillTab, TreeRoot } from '@shared/types';
 import type { TreeAffordance, TreeViewMutationApi, TreeViewPromptApi } from '../panes/tree-view';
 import type { ResourcesViewActions } from '../panes/resources';
 import type { ModalState } from '../note-modal';
+import { openDeliverableTarget } from '../deliverable-open';
 import type { createTreeStore } from '../tree-store';
 import type { TerminalBridge } from '../terminal-bridge';
 import type { PromptModalState } from '../prompt-modal';
@@ -18,6 +19,7 @@ export interface UseTreeActionsDeps {
   openPrompt: (init: Omit<PromptModalState, 'resolve'>) => Promise<string | null>;
   setModal: Setter<ModalState>;
   setPdfPath: Setter<string | null>;
+  setHtmlPath: Setter<string | null>;
   setSettingsOpen: Setter<boolean>;
   bridge: TerminalBridge;
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
@@ -87,11 +89,11 @@ export function useTreeActions(deps: UseTreeActionsDeps): UseTreeActions {
   };
 
   const handleOpenDeliverable = (path: string): void => {
-    if (path.toLowerCase().endsWith('.pdf')) {
-      deps.setPdfPath(path);
-    } else {
-      void window.condash.openInEditor(path);
-    }
+    openDeliverableTarget(path, {
+      setPdfPath: deps.setPdfPath,
+      setHtmlPath: deps.setHtmlPath,
+      setModal: deps.setModal,
+    });
   };
 
   const handleOpenKnowledgeFile = (path: string, title?: string): void => {

--- a/src/renderer/html-modal.css
+++ b/src/renderer/html-modal.css
@@ -1,0 +1,20 @@
+/* ---- HTML preview modal ------------------------------------------------ */
+
+.html-modal {
+  width: min(1100px, 100%);
+  height: 100%;
+}
+
+.html-body {
+  flex: 1;
+  display: flex;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.html-webview {
+  flex: 1;
+  display: flex;
+  border: none;
+  background: #fff;
+}

--- a/src/renderer/html-modal.tsx
+++ b/src/renderer/html-modal.tsx
@@ -1,0 +1,69 @@
+import { useModalEscHandler } from './modal-helpers';
+import { pathToCondashFileUrl } from './markdown';
+import './html-modal.css';
+
+/**
+ * In-app preview for a local HTML deliverable. Mirrors `PdfModal`: a sandboxed
+ * `<webview>` with an "open externally" escape hatch in the header.
+ *
+ * Loaded over `condash-file:///<abs>` rather than `file://` so relative
+ * references inside the document (e.g. `<img src="sibling.jpg">`, relative CSS
+ * / JS) resolve against the deliverable's own directory and are served by the
+ * conception-sandboxed protocol handler in main/index.ts. Root-absolute paths
+ * (`/assets/...`) and remote assets may not load under the renderer CSP — the
+ * "open externally" button is the fallback for those documents.
+ */
+export function HtmlModal(props: {
+  path: string;
+  onClose: () => void;
+  onOpenExternally: (path: string) => void;
+}) {
+  useModalEscHandler(props.onClose);
+
+  const filename = (): string => props.path.split('/').pop() ?? props.path;
+  const url = (): string => pathToCondashFileUrl(props.path);
+
+  return (
+    <div class="modal-backdrop" onClick={props.onClose}>
+      <div
+        class="modal html-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`HTML: ${filename()}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header class="modal-head">
+          <span class="modal-title">{filename()}</span>
+          <span class="modal-path">{props.path}</span>
+          <button
+            class="modal-button"
+            onClick={() => props.onOpenExternally(props.path)}
+            title="Open in external browser"
+          >
+            ↗
+          </button>
+          <button class="modal-button" onClick={props.onClose} title="Close (Esc)">
+            ×
+          </button>
+        </header>
+        <div class="html-body">
+          {/* Hardened webview: Node off, context isolated, OS-sandboxed. The
+              defence-in-depth `web-contents-created` handler in main/index.ts
+              re-applies these if the attribute is ever dropped.
+
+              Deliberately NO `partition` — same lesson as the PDF viewer
+              (3.19.4): a custom partition runs in a non-default session.
+              Worse here, the `condash-file://` protocol handler is registered
+              on the *default* session, so a partitioned webview can't resolve
+              the document or its relative assets at all (blank). The webview
+              only loads a local, conception-sandboxed file. */}
+          <webview
+            src={url()}
+            class="html-webview"
+            webpreferences="contextIsolation=true,nodeIntegration=false,sandbox=true"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -5,10 +5,12 @@ import { NoteModal } from './note-modal';
 import { ProjectPreview } from './project-preview';
 import { TerminalPane, type TerminalPaneHandle } from './terminal-pane';
 import { PdfModal } from './pdf-modal';
+import { HtmlModal } from './html-modal';
 import { HelpModal } from './help-modal';
 import { WelcomeScreen } from './welcome-screen';
 import { PromptModal } from './prompt-modal';
 import { ProjectsView } from './panes/projects';
+import { OutputsView } from './panes/outputs';
 import { KnowledgeView } from './panes/knowledge';
 import { CodeView } from './panes/code';
 import { ResourcesView } from './panes/resources';
@@ -96,6 +98,8 @@ function App() {
     setPreviewPath,
     pdfPath,
     setPdfPath,
+    htmlPath,
+    setHtmlPath,
     helpDoc,
     setHelpDoc,
     searchModalOpen,
@@ -127,6 +131,7 @@ function App() {
     updateLayout,
     toggleProjects,
     toggleTerminal,
+    setLeftView,
     selectWorking,
     ensureTerminalOpen,
     topBandVisible,
@@ -254,6 +259,7 @@ function App() {
     openPrompt,
     setModal,
     setPdfPath,
+    setHtmlPath,
     setSettingsOpen,
     bridge,
     flashToast,
@@ -279,6 +285,7 @@ function App() {
     setModal,
     setPreviewPath,
     setPdfPath,
+    setHtmlPath,
     openPrompt,
     flashToast,
   });
@@ -427,21 +434,54 @@ function App() {
               <div class="top-band" ref={(el) => (topBandRef = el)} style={topBandStyle()}>
                 <Show when={layout().projects}>
                   <section class="pane pane-projects">
+                    {/* Left-band tab strip: Projects | Outputs. The band's
+                        visibility is still `layout().projects`; this only swaps
+                        which view fills it. */}
+                    <div class="left-tabs" role="tablist" aria-label="Left pane">
+                      <button
+                        class="left-tab"
+                        classList={{ active: layout().leftView === 'projects' }}
+                        role="tab"
+                        aria-selected={layout().leftView === 'projects'}
+                        onClick={() => setLeftView('projects')}
+                      >
+                        Projects
+                      </button>
+                      <button
+                        class="left-tab"
+                        classList={{ active: layout().leftView === 'outputs' }}
+                        role="tab"
+                        aria-selected={layout().leftView === 'outputs'}
+                        onClick={() => setLeftView('outputs')}
+                      >
+                        Outputs
+                      </button>
+                    </div>
                     <Show
-                      when={(projects() ?? []).length > 0}
-                      fallback={<div class="empty">No projects found under projects/.</div>}
+                      when={layout().leftView === 'outputs'}
+                      fallback={
+                        <Show
+                          when={(projects() ?? []).length > 0}
+                          fallback={<div class="empty">No projects found under projects/.</div>}
+                        >
+                          <ProjectsView
+                            buckets={projectsTabGroups()}
+                            onOpen={handleOpenProject}
+                            onToggleStep={handleToggleStep}
+                            onDropProject={handleDropOnColumn}
+                            onWorkOn={(p) => void bridge.handleWorkOn(p)}
+                            projectActions={projectActionItems()}
+                            onProjectAction={(p, a) => void bridge.handleProjectAction(p, a)}
+                            onNewProject={() => setNewProjectOpen(true)}
+                            newProjectActions={newProjectActionItems()}
+                            onNewProjectAction={(a) => void bridge.handleNewProjectAction(a)}
+                          />
+                        </Show>
+                      }
                     >
-                      <ProjectsView
-                        buckets={projectsTabGroups()}
-                        onOpen={handleOpenProject}
-                        onToggleStep={handleToggleStep}
-                        onDropProject={handleDropOnColumn}
-                        onWorkOn={(p) => void bridge.handleWorkOn(p)}
-                        projectActions={projectActionItems()}
-                        onProjectAction={(p, a) => void bridge.handleProjectAction(p, a)}
-                        onNewProject={() => setNewProjectOpen(true)}
-                        newProjectActions={newProjectActionItems()}
-                        onNewProjectAction={(a) => void bridge.handleNewProjectAction(a)}
+                      <OutputsView
+                        projects={projects() ?? []}
+                        onOpenDeliverable={(d) => handleOpenDeliverable(d.path)}
                       />
                     </Show>
                   </section>
@@ -686,6 +726,14 @@ function App() {
           path={pdfPath()!}
           onClose={() => router.closeChildModal(() => setPdfPath(null))}
           onOpenInOs={handleOpenInEditor}
+        />
+      </Show>
+
+      <Show when={htmlPath()}>
+        <HtmlModal
+          path={htmlPath()!}
+          onClose={() => router.closeChildModal(() => setHtmlPath(null))}
+          onOpenExternally={(p) => void window.condash.openExternal(p)}
         />
       </Show>
 

--- a/src/renderer/markdown.ts
+++ b/src/renderer/markdown.ts
@@ -77,7 +77,21 @@ function relativeToCondashFile(baseDir: string, src: string): string {
     if (seg === '..') baseSegments.pop();
     else baseSegments.push(seg);
   }
-  const encoded = baseSegments.map((s) => encodeURIComponent(s)).join('/');
+  return pathToCondashFileUrl(baseSegments.join('/'));
+}
+
+/** Build a `condash-file:///<abs>` URL for an absolute path (posix or native).
+ *  Each path segment is URI-encoded; the triple slash means "no host" so the
+ *  pathname carries the full absolute path. The custom protocol handler in
+ *  main/index.ts serves it from inside the conception tree. Shared by the
+ *  relative-image rewriter above and the HTML preview modal. */
+export function pathToCondashFileUrl(absPath: string): string {
+  const encoded = absPath
+    .replace(/\\/g, '/')
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
   return `condash-file:///${encoded}`;
 }
 

--- a/src/renderer/panes/outputs-pane.css
+++ b/src/renderer/panes/outputs-pane.css
@@ -1,0 +1,132 @@
+/* Outputs pane — left-band aggregation of every project's `## Deliverables`,
+ * grouped by project. Deliverable rows reuse the global `.deliverable-*`
+ * classes from project-preview.css; only the grouping scaffolding and the
+ * per-item kind tag live here. */
+
+.outputs-stack {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 10px 12px 16px;
+  background: var(--bg-panel);
+}
+
+.outputs-head {
+  font-size: 11px;
+  color: var(--text-muted);
+  padding: 0 2px 8px;
+  border-bottom: 1px solid var(--border-subtle, var(--border));
+  margin-bottom: 8px;
+}
+
+.outputs-group {
+  margin-bottom: 10px;
+}
+
+.outputs-group-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 2px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.outputs-group-head::-webkit-details-marker {
+  display: none;
+}
+
+/* Disclosure caret — a right-pointing triangle that rotates open. */
+.outputs-caret {
+  flex: none;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-width: 4px 0 4px 6px;
+  border-color: transparent transparent transparent var(--text-muted);
+  transition: transform 0.12s ease;
+}
+.outputs-group[open] > .outputs-group-head .outputs-caret {
+  transform: rotate(90deg);
+}
+
+.outputs-group-title {
+  flex: 1 1 auto;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.outputs-group-date {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Status pill — colour keyed off the same per-status variables the
+ * Projects pane uses. */
+.outputs-status {
+  flex: none;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 999px;
+  color: var(--col-status, var(--text-muted));
+  border: 1px solid var(--col-status, var(--border));
+}
+.outputs-status[data-status='now'] {
+  --col-status: var(--col-now);
+}
+.outputs-status[data-status='review'] {
+  --col-status: var(--col-review);
+}
+.outputs-status[data-status='later'] {
+  --col-status: var(--col-later);
+}
+.outputs-status[data-status='backlog'] {
+  --col-status: var(--col-backlog);
+}
+.outputs-status[data-status='done'] {
+  --col-status: var(--col-done);
+}
+.outputs-status[data-status='?'] {
+  --col-status: var(--col-unknown);
+}
+
+.outputs-deliverables {
+  padding: 4px 0 4px 14px;
+}
+
+/* Coarse type tag in front of each deliverable label. */
+.outputs-kind {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  min-width: 34px;
+  text-align: center;
+}
+.outputs-kind[data-kind='url'] {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.outputs-empty {
+  padding: 20px 16px;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: center;
+  line-height: 1.5;
+}
+.outputs-empty code {
+  font-family: var(--font-mono);
+  font-size: 12px;
+}

--- a/src/renderer/panes/outputs.tsx
+++ b/src/renderer/panes/outputs.tsx
@@ -1,0 +1,98 @@
+import { For, Show } from 'solid-js';
+import type { Deliverable, Project } from '@shared/types';
+import './outputs-pane.css';
+import { usePaneScrollMemory } from './pane-scroll-memory';
+
+const KNOWN_STATUSES = ['now', 'review', 'later', 'backlog', 'done'];
+
+/** Coarse type tag shown next to each deliverable, derived from its target.
+ *  http(s) links are URLs; everything else is keyed off the extension. */
+function deliverableKind(path: string): string {
+  if (/^https?:\/\//i.test(path)) return 'url';
+  const ext = path.slice(path.lastIndexOf('.') + 1).toLowerCase();
+  if (ext === 'pdf') return 'pdf';
+  if (ext === 'html' || ext === 'htm') return 'html';
+  if (ext === 'md' || ext === 'markdown') return 'md';
+  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'avif'].includes(ext)) return 'image';
+  return 'file';
+}
+
+/**
+ * Outputs pane — aggregates every project's `## Deliverables` across the whole
+ * conception, grouped by project (newest first). Parse-only: it consumes the
+ * already-loaded projects list rather than scanning the filesystem.
+ */
+export function OutputsView(props: {
+  projects: Project[];
+  onOpenDeliverable: (deliverable: Deliverable) => void;
+}) {
+  const scrollRef = usePaneScrollMemory('outputs');
+
+  // Slug starts with the ISO date, so a descending slug sort is newest-first.
+  const groups = (): Project[] =>
+    props.projects
+      .filter((project) => project.deliverables.length > 0)
+      .slice()
+      .sort((a, b) => b.slug.localeCompare(a.slug));
+
+  const totalItems = (): number =>
+    groups().reduce((sum, project) => sum + project.deliverables.length, 0);
+
+  return (
+    <div class="outputs-stack" ref={scrollRef}>
+      <Show
+        when={groups().length > 0}
+        fallback={
+          <div class="outputs-empty">
+            No project outputs yet — link artifacts under a project's
+            <code>## Deliverables</code>.
+          </div>
+        }
+      >
+        <div class="outputs-head">
+          {groups().length} {groups().length === 1 ? 'project' : 'projects'} · {totalItems()}{' '}
+          {totalItems() === 1 ? 'item' : 'items'}
+        </div>
+        <For each={groups()}>
+          {(project) => (
+            <details class="outputs-group" open>
+              <summary class="outputs-group-head">
+                <span class="outputs-caret" aria-hidden="true" />
+                <span class="outputs-group-title">{project.title}</span>
+                <span
+                  class="outputs-status"
+                  data-status={KNOWN_STATUSES.includes(project.status) ? project.status : '?'}
+                >
+                  {project.status}
+                </span>
+                <span class="outputs-group-date">{project.slug.slice(0, 10)}</span>
+              </summary>
+              <ul class="deliverables-list outputs-deliverables">
+                <For each={project.deliverables}>
+                  {(deliverable) => (
+                    <li class="deliverable-row">
+                      <button
+                        class="deliverable-button"
+                        onClick={() => props.onOpenDeliverable(deliverable)}
+                        title={deliverable.path}
+                      >
+                        <span class="outputs-kind" data-kind={deliverableKind(deliverable.path)}>
+                          {deliverableKind(deliverable.path)}
+                        </span>
+                        <span class="deliverable-label">{deliverable.label}</span>
+                        <Show when={deliverable.description}>
+                          <span class="deliverable-desc">— {deliverable.description}</span>
+                        </Show>
+                        <span class="deliverable-path">{deliverable.path}</span>
+                      </button>
+                    </li>
+                  )}
+                </For>
+              </ul>
+            </details>
+          )}
+        </For>
+      </Show>
+    </div>
+  );
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -492,6 +492,38 @@ button:hover {
   border-right: 1px solid var(--border);
 }
 
+/* Left-band tab strip — switches the left pane between Projects and Outputs.
+ * Fixed-height row at the top; the active view's scroller flexes below it. */
+.left-tabs {
+  display: flex;
+  flex: none;
+  gap: 2px;
+  padding: 6px 8px 0;
+  background: var(--bg-panel);
+  border-bottom: 1px solid var(--border);
+}
+
+.left-tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 6px 10px;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.left-tab:hover {
+  color: var(--text-primary);
+}
+
+.left-tab.active {
+  color: var(--text-primary);
+  border-bottom-color: var(--accent);
+}
+
 .empty {
   display: flex;
   flex-direction: column;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,7 +46,9 @@ export interface Step {
 export interface Deliverable {
   /** Label as written between the [ ] of `- [label](path) — desc`. */
   label: string;
-  /** Resolved absolute path on disk. */
+  /** The link target. A local file is a resolved absolute (posix) path on
+   *  disk; an http(s) link is kept verbatim as the URL. Callers distinguish
+   *  the two by an `https?://` prefix test. */
   path: string;
   /** Optional trailing description after ' — '. */
   description?: string;
@@ -168,6 +170,10 @@ export interface LogsOpenRequest {
  * All four are mutually exclusive: showing one swaps the others out. */
 export type WorkingSurface = 'code' | 'knowledge' | 'resources' | 'skills' | 'logs' | null;
 
+/** Left-band view — which pane fills the left band when it is visible.
+ * Switched by the `[Projects][Outputs]` tab strip at the top of the band. */
+export type LeftView = 'projects' | 'outputs';
+
 /** Active tab in the Skills pane. */
 export type SkillTab = 'generic' | 'claude' | 'kimi';
 
@@ -180,6 +186,10 @@ export const SKILL_TABS: readonly SkillTab[] = ['generic', 'claude', 'kimi'] as 
  * restores its previous dimensions. */
 export interface LayoutState {
   projects: boolean;
+  /** Which view fills the left band when it is visible. Projects is the
+   * default; Outputs aggregates every project's `## Deliverables`. Switched
+   * by the left-band tab strip; the band's visibility is still `projects`. */
+  leftView: LeftView;
   /** Code / Knowledge / hidden — single right-slot tristate. */
   working: WorkingSurface;
   terminal: boolean;

--- a/tests/outputs.spec.ts
+++ b/tests/outputs.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Outputs pane e2e — boots the production build against a fixture project that
+ * carries a `## Deliverables` section with mixed link types (pdf / html / md /
+ * URL), switches the left band to the Outputs tab, and opens the in-app HTML
+ * preview. Also doubles as the manual-verification screenshot source
+ * (tests/screenshots-out/outputs/).
+ */
+
+import { test, expect } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { bootApp } from './fixtures/electron-app';
+
+const outDir = resolve(__dirname, 'screenshots-out', 'outputs');
+
+async function seedDeliverables(conceptionDir: string): Promise<void> {
+  const projectDir = join(conceptionDir, 'projects', '2026-05', '2026-05-20-demo-outputs');
+  const outputs = join(projectDir, 'outputs');
+  await mkdir(outputs, { recursive: true });
+
+  await writeFile(
+    join(projectDir, 'README.md'),
+    [
+      '---',
+      'date: 2026-05-20',
+      'kind: project',
+      'status: done',
+      'apps: []',
+      '---',
+      '',
+      '# Demo outputs',
+      '',
+      '## Deliverables',
+      '',
+      '- [Module 1](outputs/module-1.html) — interactive module',
+      '- [Report](outputs/report.pdf) — compiled report',
+      '- [Summary](outputs/summary.md)',
+      '- [Live deploy](https://example.com/module)',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+
+  // HTML with a *relative* sibling asset — the case the condash-file:// preview
+  // must resolve. SVG keeps the asset text-only (no binary encoding).
+  await writeFile(
+    join(outputs, 'module-1.html'),
+    [
+      '<!doctype html><html><head><meta charset="utf-8"><title>Module 1</title></head>',
+      '<body style="font-family:sans-serif;padding:24px">',
+      '<h1>Module 1</h1>',
+      '<p>Relative sibling asset below:</p>',
+      '<img src="logo.svg" width="240" height="120" alt="logo">',
+      '</body></html>',
+    ].join('\n'),
+    'utf8',
+  );
+  await writeFile(
+    join(outputs, 'logo.svg'),
+    "<svg xmlns='http://www.w3.org/2000/svg' width='240' height='120'>" +
+      "<rect width='100%' height='100%' fill='#2d6cdf'/>" +
+      "<text x='20' y='66' fill='#fff' font-size='28' font-family='sans-serif'>sibling.svg</text>" +
+      '</svg>\n',
+    'utf8',
+  );
+  await writeFile(join(outputs, 'summary.md'), '# Summary\n\nText.\n', 'utf8');
+  await writeFile(join(outputs, 'report.pdf'), '%PDF-1.4\n% demo\n', 'utf8');
+}
+
+test('outputs tab aggregates deliverables and previews HTML', async () => {
+  const booted = await bootApp({ prepare: seedDeliverables });
+  const { app, window, cleanup } = booted;
+  try {
+    await window.setViewportSize({ width: 1400, height: 900 });
+    await window.locator('.edge-strip-left').first().waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Switch the left band from Projects to Outputs via the in-pane tab.
+    await window.locator('.left-tab', { hasText: 'Outputs' }).click();
+
+    // One group (only the project that has deliverables), four rows.
+    const groups = window.locator('.outputs-group');
+    await expect(groups).toHaveCount(1);
+    await expect(window.locator('.outputs-group-title')).toHaveText('Demo outputs');
+    const rows = window.locator('.outputs-deliverables .deliverable-row');
+    await expect(rows).toHaveCount(4);
+
+    await mkdir(outDir, { recursive: true });
+    await window.screenshot({ path: join(outDir, 'outputs-pane.png') });
+
+    // Open the local HTML deliverable → in-app preview over condash-file://.
+    await window.locator('.deliverable-button', { hasText: 'Module 1' }).click();
+    await expect(window.locator('.html-modal')).toBeVisible();
+    // Chromium normalises the triple-slash empty-host form to
+    // `condash-file://<seg0>/<rest>` (first path segment becomes the host);
+    // the protocol handler reconstructs the absolute path from host+pathname.
+    const src = await window.locator('.html-webview').getAttribute('src');
+    expect(src ?? '').toMatch(/^condash-file:\/\//);
+    expect(src ?? '').toMatch(/module-1\.html$/);
+
+    await window.waitForTimeout(400);
+    await window.screenshot({ path: join(outDir, 'html-modal.png') });
+  } finally {
+    await cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- New **Outputs** pane: a left-band tab beside Projects that aggregates every project's `## Deliverables`, grouped by project. Parse-only — it reuses the deliverables already parsed for the Projects pane, so there is no new filesystem scan and no physical `outputs/` directory.
- Deliverable links are no longer PDF-only: any local file (Markdown, HTML, image, …) or an `http(s)` URL is accepted, and each opens in a type-appropriate viewer.

## Changes

- `src/main/parse.ts`: broaden the `## Deliverables` link parser past `.pdf` — accept any local file (resolved relative to the project dir) and verbatim `http(s)` URLs; skip `mailto:` and in-page `#anchor` links. Unit tests added in `parse.test.ts`.
- `src/shared/types.ts`, `src/main/settings.ts`, `src/main/config-schema.ts`, `src/renderer/hooks/use-layout.ts`: add a `leftView` (`'projects' | 'outputs'`) layout field, default `'projects'`, persisted and back-filled for layouts saved before it existed.
- `src/renderer/panes/outputs.tsx` (+ `outputs-pane.css`): the grouped-by-project Outputs view — status pill, date, per-item kind tag.
- `src/renderer/main.tsx`: a `[Projects] [Outputs]` tab strip in the left band that switches the band's content.
- `src/renderer/html-modal.tsx` (+ `html-modal.css`): in-app HTML preview over a sandboxed `condash-file://` webview, with an "↗ open externally" button.
- `src/renderer/deliverable-open.ts`: shared per-type open routing (`pdf` → PDF modal, local `html` → HTML preview, URL → external browser, `md` → read-only note modal, else → OS default), used by both the Outputs pane and the project-preview deliverables list.
- `tests/outputs.spec.ts`: e2e covering the tab, the grouped aggregation, and the HTML preview resolving a relative sibling asset.
- Docs: deliverables guide, new Outputs-pane guide, config reference (`leftView`), mkdocs nav.

## Impact

- Adds an optional `leftView` key to the persisted `layout` settings; older configs back-fill to `'projects'`.
- The HTML-preview webview runs with **no** `partition`: the standard `condash-file://` scheme handler is registered on the default session, so a custom partition would fail to resolve the document and its relative assets — the same root cause as the 3.19.4 blank-PDF fix. Sandbox / contextIsolation hardening is kept.

## Watchpoints

- HTML deliverables that reference root-absolute asset paths (`/assets/…`) or remote assets won't fully render in the in-app preview (renderer CSP); the "↗ open externally" button is the fallback.
