### PR TITLE
Add knowledge-recheck audit for deferred knowledge promotions

### DIFF
--- a/conception-template/.agents/skills/projects/close.md
+++ b/conception-template/.agents/skills/projects/close.md
@@ -24,7 +24,7 @@ Trigger: `/projects close <slug>`.
       2. Applies to more than one app, or to the ecosystem?
       3. Stays true regardless of this PR's outcome? (Survives both merge and abandonment.)
 
-      Three yes → keep. Any no → drop silently. Findings often hide outside the heuristic's reach — `## Description`, `## Steps` prose, `## Timeline`, or observation-phrased notes — so don't rely on the backstop alone.
+      Three yes → keep. Any no → drop silently — **except** when the only failing answer is #3 (the finding is durable and cross-cutting, but its truth is *established by* the not-yet-merged PR). That is a **deferred promotion**, handled in sub-step (d), not a drop. Findings often hide outside the heuristic's reach — `## Description`, `## Steps` prose, `## Timeline`, or observation-phrased notes — so don't rely on the backstop alone.
 
    b. **Run the heuristic backstop:**
 
@@ -41,6 +41,15 @@ Trigger: `/projects close <slug>`.
    - **n** → skip.
 
    Zero candidates from both reading and scan → say so and move on. Don't synthesise a prompt to fish for one.
+
+   d. **Deferred-promotion markers.** Two directions, both riding the `## Timeline`:
+
+      - **New deferral** (a candidate from (a)/(b) that fails *only* #3): don't promote, don't drop. Append an open marker naming the fact + candidate location:
+        `- YYYY-MM-DD — [knowledge-recheck:pending] <fact>; re-test after PR #NNN merges → candidate knowledge/<path>.md`.
+      - **Resolve existing**: re-walk the timeline for any `[knowledge-recheck:pending]` not matched by a later `[knowledge-recheck:done]`. If that PR has now merged, re-run the three-question test → promote via `/knowledge update` (then stamp `**Transferred:**`) or drop, and append the closing marker:
+        `- YYYY-MM-DD — [knowledge-recheck:done] promoted → knowledge/<path>.md` (or `dropped — <reason>`).
+
+      Closing the project does **not** clear an unresolved `pending` marker — if its PR is still open, leave it; the `knowledge-recheck` audit (`condash audit`, `/tidy`) keeps surfacing it across closed projects until a `done` marker lands.
 
 5. **Flip status + append timeline:**
 

--- a/conception-template/.agents/skills/projects/update.md
+++ b/conception-template/.agents/skills/projects/update.md
@@ -40,3 +40,21 @@ After every notes write — not just at close — re-read the paragraph you just
 Three yes → invoke `/knowledge update` now (don't wait for `/projects close`), link the resulting body file under `## Notes` in the project README, and stamp the origin paragraph in the note: `**Transferred:** YYYY-MM-DD → <knowledge-path>`. Any no → leave it in `notes/` only.
 
 Catching durable findings at write-time keeps `knowledge/` fresh while context is loaded; deferring them all to `/projects close` risks losing the fact in heuristic-grep blind spots. `/projects close` still performs a final pass and stamping for anything that slipped through.
+
+### Deferred promotion — when the *only* failing answer is #3
+
+A finding can be durable (#1) and cross-cutting (#2) yet fail #3 because its truth is *established by this PR* (a field rename, a new convention, a behaviour the change introduces) — until the PR merges, writing it to `knowledge/` would assert something a review could still invalidate. Don't promote it, but don't silently drop it either: record a **deferred promotion** so it gets re-tested after merge.
+
+Append a `## Timeline` entry carrying the open marker, naming the fact and the candidate location:
+
+```
+- YYYY-MM-DD — [knowledge-recheck:pending] <fact one-liner>; re-test after PR #NNN merges → candidate knowledge/<path>.md
+```
+
+When the PR merges, re-run the three-question test. Whatever the outcome — promote via `/knowledge update`, or drop because it didn't survive review — append the closing marker:
+
+```
+- YYYY-MM-DD — [knowledge-recheck:done] promoted → knowledge/<path>.md   (or: dropped — <reason>)
+```
+
+The `knowledge-recheck` audit check (`condash audit`, `/tidy`) flags any `[knowledge-recheck:pending]` not matched by a later `[knowledge-recheck:done]`, **including in `done` projects** — so a deferral closing the project doesn't bury it. Matching is by chronological order (each close resolves the most recent open), so re-deferral and multiple concurrent deferrals both work.

--- a/conception-template/.agents/skills/tidy/body.md
+++ b/conception-template/.agents/skills/tidy/body.md
@@ -19,7 +19,7 @@ For an at-a-glance read without the triage walk, `condash audit` and `condash kn
 
 | Arg                 | Meaning                                                                                       |
 |---------------------|-----------------------------------------------------------------------------------------------|
-| `check=<list>`      | Comma-separated subset of `lfs,binaries,cross-repo,worktrees,index,stale_verification`. Default: all. |
+| `check=<list>`      | Comma-separated subset of `lfs,binaries,cross-repo,worktrees,index,knowledge-recheck,stale_verification`. Default: all. |
 | `dry-run`           | Print the proposed fixes but do not apply, even after confirmation.                           |
 
 ## Procedure
@@ -35,7 +35,7 @@ condash knowledge verify --json
 
 If the user passed `check=...`:
 
-- For values in `lfs,binaries,cross-repo,worktrees,index`: forward as `--include <list>` to `audit` (drop `stale_verification` from the list).
+- For values in `lfs,binaries,cross-repo,worktrees,index,knowledge-recheck`: forward as `--include <list>` to `audit` (drop `stale_verification` from the list).
 - If the list contains `stale_verification`: still call `verify`. Otherwise skip it.
 
 The two responses share the same per-issue shape:
@@ -120,6 +120,7 @@ Surface every issue with `fix.autoFix === false` as a numbered list, grouped by 
 
 - `binaries` — "consider migrating to LFS or removing". Decision is per-file: large fixtures legitimately stay; cached PDFs should usually go.
 - `cross-repo` (after the rename hunt found nothing) — print the file + line and the dangling reference. The user has to decide whether to update the link or drop the source paragraph.
+- `knowledge-recheck` — print the project + the `opened` date + the deferred fact from the message. A finding was parked (durable + cross-cutting, but its truth waited on a PR) and never re-tested. If that PR has merged, re-run the three-question durability test now: promote via `/knowledge update` then append a `[knowledge-recheck:done]` timeline marker, or drop with a `done` marker noting why. Never auto-promote — condition 3 needs human judgement, which is why `autoFix` is `false`.
 - `stale_verification` — print the path:line, the date, and the `**Verified:**` `where` field. Ask the user to either *re-confirm* (re-read the source, then `condash knowledge stamp <path>` to bump the date) or *update the surrounding text*. Never bump the date on the user's behalf — that lies about freshness.
 - `install_git_lfs` (info from `lfs` check) — only emitted when `git-lfs` is missing on the host. One-line "install git-lfs to enable this check".
 - `create_knowledge_dir` — only emitted when `knowledge/` is missing. Could be intentional (early-stage conception). Surface and move on.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -167,6 +167,7 @@ condash audit --include lfs,binaries
 | `cross-repo` | Cross-repo wikilinks or relative paths that escape the conception |
 | `worktrees` | Same shape as `worktrees mismatch` — items declaring a `branch` with no on-disk worktree, or vice versa |
 | `index` | `index.md` files out of sync with the on-disk tree |
+| `knowledge-recheck` | Projects with a deferred knowledge promotion (a `[knowledge-recheck:pending]` timeline marker) never resolved by a later `[knowledge-recheck:done]`. Checked across all statuses, `done` included |
 
 `--include <list>` restricts to a comma-separated subset.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/cli/commands/audit.test.ts
+++ b/src/cli/commands/audit.test.ts
@@ -10,7 +10,9 @@ import {
   makeTmpConception,
   parseJsonEnvelope,
   rmConception,
+  writeProjectReadme,
 } from './test-helpers';
+import type { AuditIssue } from '../../main/audit';
 import { CliError } from '../output';
 
 let conceptionPath: string;
@@ -64,9 +66,60 @@ describe('runAuditCommand', () => {
     );
     const checks = parseJsonEnvelope<{ summary: { checksRun: string[] } }>(stdout).data!.summary
       .checksRun;
-    for (const c of ['lfs', 'binaries', 'cross-repo', 'worktrees', 'index']) {
+    for (const c of ['lfs', 'binaries', 'cross-repo', 'worktrees', 'index', 'knowledge-recheck']) {
       expect(checks).toContain(c);
     }
+  });
+
+  it('flags an unresolved knowledge-recheck marker, even on a done project', async () => {
+    await writeProjectReadme(conceptionPath, 'deferred-thing', {
+      date: '2026-05-22',
+      kind: 'project',
+      status: 'done',
+      body: [
+        '## Timeline',
+        '',
+        '- 2026-05-22 — [knowledge-recheck:pending] field rename; re-test after PR #5 merges.',
+        '- 2026-05-23 — Closed. Shipped.',
+        '',
+      ].join('\n'),
+    });
+    const { stdout } = await captureStdout(() =>
+      runAuditCommand(
+        { noun: 'audit', verb: '', positional: [], flags: { include: 'knowledge-recheck' } },
+        jsonCtx(),
+        conceptionPath,
+      ),
+    );
+    const issues = parseJsonEnvelope<{ issues: AuditIssue[] }>(stdout).data!.issues;
+    const recheck = issues.filter((i) => i.check === 'knowledge-recheck');
+    expect(recheck).toHaveLength(1);
+    expect(recheck[0].severity).toBe('warn');
+    expect(recheck[0].message).toContain('field rename');
+  });
+
+  it('does not flag a knowledge-recheck that was later resolved', async () => {
+    await writeProjectReadme(conceptionPath, 'resolved-thing', {
+      date: '2026-05-22',
+      kind: 'project',
+      status: 'done',
+      body: [
+        '## Timeline',
+        '',
+        '- 2026-05-22 — [knowledge-recheck:pending] field rename; re-test after PR #5 merges.',
+        '- 2026-06-01 — [knowledge-recheck:done] promoted to knowledge/topics/ops/x.md.',
+        '',
+      ].join('\n'),
+    });
+    const { stdout } = await captureStdout(() =>
+      runAuditCommand(
+        { noun: 'audit', verb: '', positional: [], flags: { include: 'knowledge-recheck' } },
+        jsonCtx(),
+        conceptionPath,
+      ),
+    );
+    const issues = parseJsonEnvelope<{ issues: AuditIssue[] }>(stdout).data!.issues;
+    expect(issues.filter((i) => i.check === 'knowledge-recheck')).toHaveLength(0);
   });
 
   it('rejects an unknown --include check with USAGE', async () => {

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -3,7 +3,14 @@ import { CliError, ExitCodes, emit, type OutputContext } from '../output';
 import { assertNoExtraFlags, type ParsedArgs } from '../parser';
 import { UNIVERSAL_FOOTER } from '../help';
 
-const ALL_AUDIT_CHECKS: AuditCheckName[] = ['lfs', 'binaries', 'cross-repo', 'worktrees', 'index'];
+const ALL_AUDIT_CHECKS: AuditCheckName[] = [
+  'lfs',
+  'binaries',
+  'cross-repo',
+  'worktrees',
+  'index',
+  'knowledge-recheck',
+];
 
 const KNOWN_FLAGS_AUDIT = ['include'] as const;
 

--- a/src/main/audit.ts
+++ b/src/main/audit.ts
@@ -14,6 +14,10 @@
  *                   whose Status is not `done` are checked.)
  *  - `index`      — every directory under `knowledge/` carries an `index.md`
  *                   listing its children; flag dangling and orphan entries.
+ *  - `knowledge-recheck` — projects with a deferred knowledge promotion
+ *                   (a `[knowledge-recheck:pending]` timeline marker) that
+ *                   was never resolved by a later `[knowledge-recheck:done]`.
+ *                   Checked across all statuses, `done` included.
  *
  * Stamps live in `condash knowledge verify` — not duplicated here. The audit
  * verb composes that one too via the same envelope.
@@ -30,6 +34,7 @@
 import { checkBinaries } from './audit/binaries';
 import { checkCrossRepo } from './audit/cross-repo';
 import { checkIndex } from './audit/index-check';
+import { checkKnowledgeRecheck } from './audit/knowledge-recheck';
 import { checkLfs } from './audit/lfs';
 import { checkWorktrees } from './audit/worktrees';
 import type { AuditCheckName, AuditIssue, AuditReport } from './audit/shared';
@@ -58,6 +63,9 @@ export async function runAudit(
           break;
         case 'index':
           issues.push(...(await checkIndex(conceptionPath)));
+          break;
+        case 'knowledge-recheck':
+          issues.push(...(await checkKnowledgeRecheck(conceptionPath)));
           break;
         default:
           issues.push({

--- a/src/main/audit/knowledge-recheck.test.ts
+++ b/src/main/audit/knowledge-recheck.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for the `knowledge-recheck` audit check — the balanced-bracket
+ * matching of `[knowledge-recheck:pending]` against later
+ * `[knowledge-recheck:done]` timeline markers.
+ */
+import { describe, expect, it } from 'vitest';
+import { unresolvedRechecks } from './knowledge-recheck';
+
+/** Build a timeline entry whose text carries the given marker token. */
+function entry(
+  date: string,
+  marker: 'pending' | 'done' | 'none',
+  label = '',
+): {
+  date: string;
+  text: string;
+} {
+  const token =
+    marker === 'pending'
+      ? '[knowledge-recheck:pending]'
+      : marker === 'done'
+        ? '[knowledge-recheck:done]'
+        : '';
+  return { date, text: `${token} ${label}`.trim() };
+}
+
+describe('unresolvedRechecks', () => {
+  it('returns nothing when there are no markers', () => {
+    expect(
+      unresolvedRechecks([
+        entry('2026-05-22', 'none', 'Project created'),
+        entry('2026-05-23', 'none', 'PR opened'),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('flags a lone pending marker', () => {
+    const open = unresolvedRechecks([entry('2026-05-22', 'pending', 'fact A')]);
+    expect(open).toHaveLength(1);
+    expect(open[0].date).toBe('2026-05-22');
+    expect(open[0].text).toContain('fact A');
+  });
+
+  it('clears a pending matched by a later done', () => {
+    expect(
+      unresolvedRechecks([
+        entry('2026-05-22', 'pending', 'fact A'),
+        entry('2026-06-01', 'done', 'promoted'),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('re-deferral (pending → done → pending) leaves the latest pending open', () => {
+    const open = unresolvedRechecks([
+      entry('2026-05-22', 'pending', 'fact A'),
+      entry('2026-06-01', 'done', 'promoted'),
+      entry('2026-06-10', 'pending', 'fact A again'),
+    ]);
+    expect(open).toHaveLength(1);
+    expect(open[0].date).toBe('2026-06-10');
+  });
+
+  it('two concurrent pendings, one closed, leaves one open', () => {
+    const open = unresolvedRechecks([
+      entry('2026-05-22', 'pending', 'fact A'),
+      entry('2026-05-23', 'pending', 'fact B'),
+      entry('2026-06-01', 'done', 'resolved one'),
+    ]);
+    expect(open).toHaveLength(1);
+  });
+
+  it('balances multiple pairs to zero', () => {
+    expect(
+      unresolvedRechecks([
+        entry('2026-05-22', 'pending', 'A'),
+        entry('2026-05-23', 'pending', 'B'),
+        entry('2026-06-01', 'done', 'B done'),
+        entry('2026-06-02', 'done', 'A done'),
+      ]),
+    ).toEqual([]);
+  });
+
+  it('a stray done with nothing open is a no-op', () => {
+    expect(unresolvedRechecks([entry('2026-06-01', 'done', 'orphan close')])).toEqual([]);
+  });
+
+  it('an old done followed by a new pending flags the new pending', () => {
+    const open = unresolvedRechecks([
+      entry('2026-05-01', 'done', 'old cycle close'),
+      entry('2026-05-22', 'pending', 'new fact'),
+    ]);
+    expect(open).toHaveLength(1);
+    expect(open[0].date).toBe('2026-05-22');
+  });
+});

--- a/src/main/audit/knowledge-recheck.ts
+++ b/src/main/audit/knowledge-recheck.ts
@@ -1,0 +1,70 @@
+/**
+ * `knowledge-recheck` audit check — projects that deferred a knowledge
+ * promotion and never re-ran the durability test after merge.
+ *
+ * The three-yes test (`knowledge/conventions.md`) promotes a finding to
+ * `knowledge/` only if it (1) holds beyond the task, (2) spans more than one
+ * app, and (3) stays true regardless of the PR's outcome. A finding that
+ * passes #1 and #2 but fails *only* #3 — its truth is established by a
+ * not-yet-merged PR — must be re-tested after merge, not dropped. That
+ * deferral is recorded as a `## Timeline` entry carrying
+ * `RECHECK_PENDING_MARKER`; resolving it (promote-or-drop after merge) is a
+ * later entry carrying `RECHECK_DONE_MARKER`.
+ *
+ * A project has outstanding work iff, walking the timeline in chronological
+ * (source) order, an open marker is left unmatched by a later close marker.
+ * Unlike `worktrees`, this check does NOT skip `done` projects — the whole
+ * point is that closing a project must not bury an unresolved recheck.
+ */
+
+import { promises as fs } from 'node:fs';
+import { relative } from 'node:path';
+import { findProjectReadmes } from '../walk';
+import { parseTimelineEntries } from '../mutate';
+import { type AuditIssue, RECHECK_PENDING_MARKER, RECHECK_DONE_MARKER } from './shared';
+
+/** A timeline entry that opened a knowledge recheck and was never closed. */
+export interface UnresolvedRecheck {
+  date: string;
+  text: string;
+}
+
+/**
+ * Match close markers against open ones in source order. Each close marker
+ * resolves the most recent still-open marker (LIFO); a close with nothing
+ * open is a no-op (the count floors at zero). Returns the open markers left
+ * unmatched at the end — the outstanding rechecks.
+ */
+export function unresolvedRechecks(
+  entries: readonly { date: string; text: string }[],
+): UnresolvedRecheck[] {
+  const open: UnresolvedRecheck[] = [];
+  for (const entry of entries) {
+    if (entry.text.includes(RECHECK_PENDING_MARKER)) {
+      open.push({ date: entry.date, text: entry.text });
+    } else if (entry.text.includes(RECHECK_DONE_MARKER)) {
+      open.pop();
+    }
+  }
+  return open;
+}
+
+export async function checkKnowledgeRecheck(conceptionPath: string): Promise<AuditIssue[]> {
+  const issues: AuditIssue[] = [];
+  const readmes = await findProjectReadmes(conceptionPath);
+  for (const readme of readmes) {
+    const raw = await fs.readFile(readme, 'utf8').catch(() => null);
+    if (raw === null) continue;
+    for (const open of unresolvedRechecks(parseTimelineEntries(raw))) {
+      issues.push({
+        check: 'knowledge-recheck',
+        severity: 'warn',
+        file: relative(conceptionPath, readme),
+        line: null,
+        message: `Deferred knowledge promotion never re-checked (opened ${open.date}): ${open.text}`,
+        fix: { action: 'recheck_deferred_knowledge', autoFix: false, openedOn: open.date },
+      });
+    }
+  }
+  return issues;
+}

--- a/src/main/audit/shared.ts
+++ b/src/main/audit/shared.ts
@@ -12,7 +12,24 @@ import { exec } from '../exec';
 import type { ConfigShape } from '../config-walk';
 import { getEffectiveConceptionConfig } from '../effective-config';
 
-export type AuditCheckName = 'lfs' | 'binaries' | 'cross-repo' | 'worktrees' | 'index';
+export type AuditCheckName =
+  | 'lfs'
+  | 'binaries'
+  | 'cross-repo'
+  | 'worktrees'
+  | 'index'
+  | 'knowledge-recheck';
+
+/**
+ * Timeline tokens for the deferred-knowledge-promotion state machine
+ * (the `knowledge-recheck` check). An entry carrying the *pending* token
+ * records a finding that passed the three-yes durability test except that
+ * its truth depended on a not-yet-merged PR; the *done* token, in a later
+ * entry, records that the deferral was resolved after merge (promoted or
+ * dropped). See `conception-template/knowledge/conventions.md`.
+ */
+export const RECHECK_PENDING_MARKER = '[knowledge-recheck:pending]';
+export const RECHECK_DONE_MARKER = '[knowledge-recheck:done]';
 
 export interface AuditIssue {
   check: AuditCheckName | string;


### PR DESCRIPTION
## Summary

- A finding can be durable and cross-cutting yet unsafe to record as shared knowledge until the PR that establishes its truth merges — so today it tends to be parked in a note and silently forgotten. This adds a lightweight way to park it on the project Timeline and an audit that will not let it be lost.
- New `condash audit` check `knowledge-recheck` flags any project — closed ones included — whose deferred promotion was never resolved.

## Changes

- `src/main/audit/knowledge-recheck.ts` — new check plus the pure `unresolvedRechecks()` matcher: a balanced-bracket walk over Timeline markers in chronological order (each close resolves the most recent open), so re-deferral and multiple concurrent deferrals both work.
- `src/main/audit/shared.ts` — `knowledge-recheck` added to `AuditCheckName`; exported the `[knowledge-recheck:pending]` / `[knowledge-recheck:done]` marker-token constants.
- `src/main/audit.ts` and `src/cli/commands/audit.ts` — register the check (dispatch switch + `ALL_AUDIT_CHECKS`), so it folds into `--include all` and the `/tidy` flow with no extra flag.
- Shipped skills: the projects update/close flows now document the deferred-promotion branch (a finding failing only condition 3 — its truth established by the not-yet-merged PR — is written as a pending marker, then re-tested and resolved after merge); the tidy skill lists the new check and its punch-list guidance.
- `docs/reference/cli.md` — audit check table row.
- Tests: 8 pure ordering cases + 2 integration cases (flagged on a `done` project; cleared once a done marker lands).
- Minor version bump to 3.22.0.

## Impact

- `condash audit`, `--include all`, and the `/tidy` triage now surface one new `warn`-level issue type. It is `autoFix: false` (resolving it needs human judgement), so it always lands on the punch-list, never an auto-fix. Existing checks are unchanged.
- The convention rides the existing project Timeline — no schema, parser, or template change; projects without markers are unaffected.