### PR TITLE
Restore Projects drag-to-status on Wayland sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ macOS and Windows are unaffected.
 
 - Run `make format` after every code change.
 - All UI must work without per-OS CSS branches (Electron + Chromium = same renderer everywhere).
+- In-window drag must use pointer events (`pointerdown` / `pointermove` / `pointerup` + `setPointerCapture`), never HTML5 drag-and-drop — Chromium's Wayland Ozone backend (forced for crisp text on Wayland sessions) silently breaks HTML5 DnD. The Projects-pane status drag follows this; terminal-tab and settings-row reorder are still HTML5 DnD (broken on Wayland) until converted. See [internals invariant 8](docs/explanation/internals.md#8-in-window-drag-uses-pointer-events-not-html5-drag-and-drop).
 - File-path conventions: every path crossing the IPC boundary is normalised to forward-slash form via `toPosix(p)` from `src/shared/path.ts`. Internal `fs` calls keep the native separator (use `path.join`); the renderer can then split on `/` without per-OS branches. Cross-OS shell wrapping (`bash -lc` / `cmd.exe /d /s /c` / `pwsh -Command`) lives in `src/main/terminals.ts`'s `wrapForShell`.
 - IPC contract is the single typed `CondashApi` interface in `src/shared/api.ts`. Functions, not URLs. Promises for request/response; events only for chokidar push.
 - Hard interaction-to-paint budget: **≤ 16 ms** for any user-initiated action. Optimistic UI is the default; rollback on IPC failure.

--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -116,6 +116,10 @@ F5 / View → Refresh covers both: it drops the git-status TTL cache, recomputes
 
 Subscriptions (`onTreeEvents`, `onTermData`, `onTermExit`, `onTermSessions`) return an unsubscribe function; the renderer holds it and calls it from `onCleanup`.
 
+### 8. In-window drag uses pointer events, not HTML5 drag-and-drop
+
+On Wayland sessions condash forces the native Wayland Ozone backend for crisp fractional-scaling text (`src/main/index.ts`). Chromium's HTML5 drag-and-drop (`draggable` + `dragstart` / `dataTransfer`) is broken under that backend — drags silently no-op ([electron#49907](https://github.com/electron/electron/issues/49907), [electron#42252](https://github.com/electron/electron/issues/42252)) — so any in-window drag must be built on **pointer events** (`pointerdown` / `pointermove` / `pointerup` + `setPointerCapture`), never HTML5 DnD. The pattern: capture the pointer on the source element once movement crosses a small threshold, never reparent the captured element mid-gesture, follow the cursor with a `pointer-events: none` clone, and commit on `pointerup` (hit-test the drop target with `elementFromPoint`). The Projects-pane status drag (`src/renderer/panes/projects-parts/cards.tsx`) follows this. **Still on HTML5 DnD and therefore broken on Wayland:** terminal-pane tab reorder (`src/renderer/terminal-pane/drag-drop.ts`) and settings-modal repo/section reorder (`repo-row.tsx`, `section-row.tsx`) — convert them the same way when next touched.
+
 ## Environment hygiene { #environment-hygiene }
 
 condash spawns subprocesses (terminals, runners, `force_stop` commands, open-with launchers). The main process scrubs the environment before each spawn to avoid leaking interpreter-specific vars into unrelated child programs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.22.0",
+      "version": "3.22.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.22.0",
+  "version": "3.22.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -257,11 +257,17 @@ body[data-dragging='project'] .group-block.drag-over {
   color: var(--text-muted);
 }
 
-.row[draggable='true'] {
+.row.draggable {
   cursor: grab;
+  /* Pointer-drag uses mousedown+move; suppress text selection so a drag
+   * doesn't paint a selection across the card. */
+  user-select: none;
 }
 
-.row[draggable='true']:active {
+/* While a card is being dragged, show the grabbing cursor across the pane
+ * regardless of which lane the pointer is over. */
+body[data-dragging='project'],
+body[data-dragging='project'] .row {
   cursor: grabbing;
 }
 

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -4,7 +4,6 @@ import { KNOWN_STATUSES } from '@shared/types';
 import { TerminalIcon } from '../../icons';
 import { ActionDropdownButton } from '../../action-dropdown-button';
 import {
-  DRAG_MIME,
   Group,
   MARKER_LABEL,
   dateRangeLabel,
@@ -19,6 +18,15 @@ import {
   writeCollapseEntry,
 } from './data';
 import { KindGlyph, StepIcon, StepProgress, WarnIcon } from './icons';
+
+// Status lane the pointer currently hovers during a card drag (null = none).
+// Module scope so every GroupBlock highlights its lane reactively while the
+// dragged Card drives the gesture, without threading a signal through props.
+const [overStatus, setOverStatus] = createSignal<string | null>(null);
+
+// Movement past this many pixels turns a press into a drag — below it the
+// press stays a click so cards still open on a plain click.
+const DRAG_THRESHOLD_PX = 4;
 
 export function GroupBlock(props: {
   group: Group;
@@ -48,7 +56,6 @@ export function GroupBlock(props: {
   // Keyboard alternative for the status drag — same callback as the drop,
   // signature `(path, newStatus)`, so cards can call it directly.
   const onChangeStatus = props.onDropProject;
-  const [over, setOver] = createSignal(false);
   const initialStored = readCollapseMap()[props.group.status];
   const [userExpanded, setUserExpanded] = createSignal<boolean | null>(
     typeof initialStored === 'boolean' ? initialStored : null,
@@ -65,51 +72,16 @@ export function GroupBlock(props: {
     writeCollapseEntry(props.group.status, next);
   };
 
-  const isAcceptable = (event: DragEvent): boolean => {
-    const types = event.dataTransfer?.types;
-    return types ? Array.from(types).includes(DRAG_MIME) : false;
-  };
-
-  const handleDragEnter = (e: DragEvent) => {
-    if (!isAcceptable(e)) return;
-    e.preventDefault();
-    setOver(true);
-  };
-
-  const handleDragOver = (e: DragEvent) => {
-    if (!isAcceptable(e)) return;
-    e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = 'move';
-    // Self-heal: dragenter/dragleave can race when a fixed-position ghost
-    // hovers above the section, occasionally clearing the over state mid-
-    // hover. dragover fires continuously while the cursor is on the
-    // target, so re-asserting here keeps the highlight stable.
-    setOver(true);
-  };
-
-  const handleDragLeave = (e: DragEvent) => {
-    if (e.currentTarget === e.target) setOver(false);
-  };
-
-  const handleDrop = (e: DragEvent) => {
-    if (!isAcceptable(e)) return;
-    e.preventDefault();
-    setOver(false);
-    const path = e.dataTransfer?.getData(DRAG_MIME);
-    if (path) props.onDropProject(path, props.group.status);
-  };
-
+  // Drop detection lives on the dragged Card (pointer hit-test on release);
+  // the lane only needs to highlight when the pointer is over it. `overStatus`
+  // is the shared module signal the dragging Card writes.
   const isEmpty = (): boolean => props.group.items.length === 0;
   return (
     <section
       class="group-block"
-      classList={{ 'drag-over': over(), collapsed: !isOpen() }}
+      classList={{ 'drag-over': overStatus() === props.group.status, collapsed: !isOpen() }}
       data-status={props.group.status}
       data-empty={isEmpty() ? 'true' : 'false'}
-      onDragEnter={handleDragEnter}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
     >
       <header
         class="group-header"
@@ -245,69 +217,133 @@ export function Card(props: {
   const [expanded, setExpanded] = createSignal(false);
 
   const handleHeaderClick = (event: MouseEvent) => {
+    // A click synthesised at the end of a drag must not also open the card.
+    if (draggedThisGesture) {
+      draggedThisGesture = false;
+      return;
+    }
     if ((event.target as HTMLElement).closest('.step-toggle, .expander, .row-action')) return;
     props.onOpen(props.item);
   };
 
-  // Custom ghost state — Chromium in this Electron build ignores opacity
-  // on setDragImage clones (the native snapshotter falls back to the
-  // opaque source screenshot regardless of how we position or style the
-  // element we hand to setDragImage). Instead: hide the native drag
-  // image with a 1×1 transparent png, then render our own translucent
-  // ghost div that follows the cursor via a document-level dragover
-  // listener. The ghost is removed on dragend.
-  let ghostElement: HTMLElement | null = null;
+  // Pointer-based status drag. Native HTML5 drag-and-drop is silently broken
+  // under Chromium's Wayland Ozone backend (electron#49907 / #42252), which
+  // condash forces on Wayland sessions for crisp fractional-scaling text — so
+  // the card drag is built on pointer events instead. We capture the pointer
+  // on the source card and never reparent it mid-gesture (pointer-drag
+  // invariant shared with condash-python); a translucent clone follows the
+  // cursor and the drop lane is hit-tested from the pointer on release.
+  let dragPointerId: number | null = null;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let dragging = false;
+  // Set when a gesture crossed the move threshold; consumed by the click that
+  // the browser synthesises on release so the drag doesn't also open the card.
+  let draggedThisGesture = false;
+  let ghost: HTMLElement | null = null;
   let ghostOffsetX = 0;
   let ghostOffsetY = 0;
-  const onGlobalDragOver = (e: DragEvent) => {
-    if (!ghostElement) return;
-    ghostElement.style.transform = `translate(${e.clientX - ghostOffsetX}px, ${e.clientY - ghostOffsetY}px)`;
+
+  // Status lane under the pointer. The ghost is `pointer-events: none`, so
+  // elementFromPoint sees the lane beneath it.
+  const statusUnderPointer = (clientX: number, clientY: number): string | null => {
+    const el = document.elementFromPoint(clientX, clientY);
+    const block = el?.closest('.group-block[data-status]') as HTMLElement | null;
+    return block?.dataset.status ?? null;
   };
 
-  const handleDragStart = (event: DragEvent) => {
-    if (!event.dataTransfer) return;
-    event.dataTransfer.setData(DRAG_MIME, props.item.path);
-    event.dataTransfer.effectAllowed = 'move';
+  const positionGhost = (clientX: number, clientY: number) => {
+    if (!ghost) return;
+    ghost.style.transform = `translate(${clientX - ghostOffsetX}px, ${clientY - ghostOffsetY}px)`;
+  };
 
-    // Hide the native drag image — Chromium's auto-snapshot would
-    // otherwise render an opaque copy of the source card.
-    const blank = new Image();
-    blank.src = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-    event.dataTransfer.setDragImage(blank, 0, 0);
-
-    // Build a translucent clone to use as our own ghost. Positioned
-    // fixed so its transform follows the cursor regardless of scroll.
-    const source = event.currentTarget as HTMLElement;
-    const sourceWidth = source.offsetWidth;
+  const beginDrag = (card: HTMLElement, clientX: number, clientY: number) => {
+    dragging = true;
+    draggedThisGesture = true;
+    const sourceWidth = card.offsetWidth;
     ghostOffsetX = sourceWidth / 2;
     ghostOffsetY = 24;
-    ghostElement = source.cloneNode(true) as HTMLElement;
-    ghostElement.querySelectorAll('.title-actions').forEach((el) => el.remove());
-    ghostElement.querySelectorAll('.step-list').forEach((el) => el.remove());
-    ghostElement.style.opacity = '0.85';
-    ghostElement.style.position = 'fixed';
-    ghostElement.style.top = '0';
-    ghostElement.style.left = '0';
-    ghostElement.style.width = `${sourceWidth}px`;
-    ghostElement.style.opacity = '0.55';
-    ghostElement.style.pointerEvents = 'none';
-    ghostElement.style.zIndex = '99999';
-    ghostElement.style.transform = `translate(${event.clientX - ghostOffsetX}px, ${event.clientY - ghostOffsetY}px)`;
-    document.body.appendChild(ghostElement);
-    document.addEventListener('dragover', onGlobalDragOver);
-
-    // body flag lets every .group-block inflate its drop zone via CSS
-    // without each section having to listen for a global drag.
+    // A plain fixed-position clone we own renders exactly as styled (unlike a
+    // setDragImage clone, whose opacity Chromium ignores).
+    ghost = card.cloneNode(true) as HTMLElement;
+    ghost.querySelectorAll('.title-actions, .steps-list').forEach((el) => el.remove());
+    ghost.style.position = 'fixed';
+    ghost.style.top = '0';
+    ghost.style.left = '0';
+    ghost.style.margin = '0';
+    ghost.style.width = `${sourceWidth}px`;
+    ghost.style.opacity = '0.55';
+    ghost.style.pointerEvents = 'none';
+    ghost.style.zIndex = '99999';
+    document.body.appendChild(ghost);
+    positionGhost(clientX, clientY);
+    // body flag lets every empty .group-block inflate its drop zone via CSS.
     document.body.dataset.dragging = 'project';
   };
 
-  const handleDragEnd = () => {
-    delete document.body.dataset.dragging;
-    if (ghostElement) {
-      ghostElement.remove();
-      ghostElement = null;
+  const endDrag = () => {
+    if (ghost) {
+      ghost.remove();
+      ghost = null;
     }
-    document.removeEventListener('dragover', onGlobalDragOver);
+    delete document.body.dataset.dragging;
+    dragging = false;
+    setOverStatus(null);
+  };
+
+  const handlePointerDown = (event: PointerEvent) => {
+    if (!isDraggable() || event.button !== 0) return;
+    // Let interactive children (work-on dropdown, expander, step toggles)
+    // keep their own click behaviour.
+    if (
+      (event.target as HTMLElement).closest('.title-actions, .expander, .step-toggle, .row-action')
+    ) {
+      return;
+    }
+    dragPointerId = event.pointerId;
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    dragging = false;
+    draggedThisGesture = false;
+    // No capture yet — a press that never crosses the threshold stays a plain
+    // click, so card-open / child clicks are untouched. Capture is taken in
+    // handlePointerMove the moment the drag actually begins.
+  };
+
+  const handlePointerMove = (event: PointerEvent) => {
+    if (dragPointerId !== event.pointerId) return;
+    if (!dragging) {
+      if (Math.hypot(event.clientX - dragStartX, event.clientY - dragStartY) < DRAG_THRESHOLD_PX) {
+        return;
+      }
+      const card = event.currentTarget as HTMLElement;
+      // Capture so move/up keep arriving even once the cursor leaves the card.
+      card.setPointerCapture(event.pointerId);
+      beginDrag(card, event.clientX, event.clientY);
+    }
+    positionGhost(event.clientX, event.clientY);
+    setOverStatus(statusUnderPointer(event.clientX, event.clientY));
+  };
+
+  const handlePointerUp = (event: PointerEvent) => {
+    if (dragPointerId !== event.pointerId) return;
+    const card = event.currentTarget as HTMLElement;
+    const wasDragging = dragging;
+    const targetStatus = wasDragging ? statusUnderPointer(event.clientX, event.clientY) : null;
+    if (card.hasPointerCapture(event.pointerId)) card.releasePointerCapture(event.pointerId);
+    dragPointerId = null;
+    endDrag();
+    if (wasDragging && targetStatus && props.onChangeStatus && targetStatus !== props.item.status) {
+      props.onChangeStatus(props.item.path, targetStatus);
+    }
+  };
+
+  const handlePointerCancel = (event: PointerEvent) => {
+    if (dragPointerId !== event.pointerId) return;
+    const card = event.currentTarget as HTMLElement;
+    if (card.hasPointerCapture(event.pointerId)) card.releasePointerCapture(event.pointerId);
+    dragPointerId = null;
+    endDrag();
   };
 
   // Cmd/Ctrl+1..N maps to KNOWN_STATUSES[0..N-1]; ignore anything else so
@@ -337,13 +373,15 @@ export function Card(props: {
   return (
     <article
       class="row"
+      classList={{ draggable: isDraggable() }}
       title={props.item.path}
       aria-label={`${props.item.title}, ${props.item.status}`}
       data-status-card={props.item.status}
-      draggable={isDraggable()}
       tabIndex={0}
-      onDragStart={isDraggable() ? handleDragStart : undefined}
-      onDragEnd={isDraggable() ? handleDragEnd : undefined}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
       onKeyDown={handleKeyDown}
     >
       <div class="row-head" onClick={handleHeaderClick}>

--- a/tests/status-drag.spec.ts
+++ b/tests/status-drag.spec.ts
@@ -3,25 +3,56 @@ import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { bootApp } from './fixtures/electron-app';
 
+const samplePath = (conceptionDir: string) =>
+  join(conceptionDir, 'projects', '2026-04', '2026-04-26-sample', 'README.md');
+
 test('status drag rewrites the README on disk', async () => {
   const booted = await bootApp();
   try {
-    // Drag-and-drop in Electron via Playwright is flaky; exercise the IPC path
-    // directly. The renderer's setStatus + watcher round-trip is what we care
-    // about here.
-    const path = join(
-      booted.conceptionDir,
-      'projects',
-      '2026-04',
-      '2026-04-26-sample',
-      'README.md',
-    );
-    await booted.window.evaluate(
-      ({ p }) => window.condash.setStatus(p, 'done'),
-      { p: path },
-    );
+    // The renderer's setStatus + watcher round-trip is what we care about
+    // here; exercise the IPC path directly without the pointer gesture.
+    const path = samplePath(booted.conceptionDir);
+    await booted.window.evaluate(({ p }) => window.condash.setStatus(p, 'done'), { p: path });
     const onDisk = await readFile(path, 'utf8');
     expect(onDisk).toContain('**Status**: done');
+  } finally {
+    await booted.cleanup();
+  }
+});
+
+test('pointer-drag a card onto another lane changes its status', async () => {
+  const booted = await bootApp();
+  try {
+    const { window } = booted;
+    const card = window.locator('article.row').first();
+    await expect(card).toHaveAttribute('data-status-card', 'now');
+
+    // Drive a real pointer gesture (down → past the drag threshold → over the
+    // target lane → up). HTML5 drag-and-drop is broken under Wayland Ozone, so
+    // the drag is built on pointer events — this test exercises that path.
+    const box = await card.boundingBox();
+    if (!box) throw new Error('card has no bounding box');
+    const startX = box.x + box.width / 2;
+    const startY = box.y + 16;
+    await window.mouse.move(startX, startY);
+    await window.mouse.down();
+    // Cross the 4px threshold so the drag begins and empty lanes inflate.
+    await window.mouse.move(startX, startY + 14, { steps: 3 });
+
+    const lane = window.locator('.group-block[data-status="review"]');
+    const laneBox = await lane.boundingBox();
+    if (!laneBox) throw new Error('review lane has no bounding box');
+    await window.mouse.move(laneBox.x + laneBox.width / 2, laneBox.y + laneBox.height / 2, {
+      steps: 8,
+    });
+    await window.mouse.up();
+
+    // Optimistic UI moves the card immediately; the README rewrite is the
+    // durable proof the drop committed.
+    await expect(card).toHaveAttribute('data-status-card', 'review');
+    await expect
+      .poll(async () => await readFile(samplePath(booted.conceptionDir), 'utf8'))
+      .toContain('**Status**: review');
   } finally {
     await booted.cleanup();
   }


### PR DESCRIPTION
## Summary

- On Wayland sessions, dragging a project card onto another status lane silently did nothing; the same build worked on X11. Native HTML5 drag-and-drop is broken under Chromium's Wayland Ozone backend (electron#49907, #42252), which condash forces on Wayland sessions for crisp fractional-scaling text.
- Rebuilds the card status drag on pointer events, which work under Wayland — keeping the crisp-text behaviour intact.

## Changes

- `src/renderer/panes/projects-parts/cards.tsx`: replace the `draggable`/`dragstart`/`dataTransfer` drag with a pointer-event gesture — capture the pointer on the source card once movement crosses a 4px threshold, follow the cursor with a `pointer-events:none` clone, highlight the hovered lane via a shared signal, and commit the status change on `pointerup` (drop lane resolved via `elementFromPoint`). Capturing only after the threshold leaves click-to-open and child-button clicks untouched.
- `src/renderer/panes/projects-pane.css`: cursor / `user-select` rules keyed off a `.draggable` class instead of the `[draggable]` attribute; grabbing cursor during a drag.
- `tests/status-drag.spec.ts`: add a Playwright pointer-gesture test (down → past threshold → over the target lane → up) asserting the card changes lanes and the README status is rewritten on disk.
- `CLAUDE.md`, `docs/explanation/internals.md`: document the invariant — in-window drag uses pointer events, never HTML5 DnD.
- Version bump to 3.22.1.

## Impact

- User-facing drag behaviour is unchanged; only the underlying mechanism changed. The keyboard alternative (Ctrl/Cmd+1..N) and the action dropdown are unaffected.

## Watchpoints

- Terminal-pane tab reorder and settings-modal repo/section reorder still use HTML5 DnD, so they remain broken on Wayland — same root cause, tracked separately.