### PR TITLE
Add OpenCode as a first-class compile target

### DIFF
--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -1,17 +1,18 @@
 # The Skills pane
 
-The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the right working-surface slot (`Ctrl+L` to switch in). It surfaces three trees through a single tab bar at the top of the pane — **Generic** (agent-neutral source skillspecs), **Claude** (compiled output for Claude Code), and **Kimi** (compiled output for Kimi CLI).
+The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the right working-surface slot (`Ctrl+L` to switch in). It surfaces four trees through a single tab bar at the top of the pane — **Generic** (agent-neutral source skillspecs), **Claude** (compiled output for Claude Code), **Kimi** (compiled output for Kimi CLI), and **OpenCode** (compiled output for OpenCode).
 
 ![Skills pane — skill sections with SKILL.md indices and body-file cards](../assets/screenshots/skills-pane-light.png#only-light)
 ![Skills pane — skill sections with SKILL.md indices and body-file cards](../assets/screenshots/skills-pane-dark.png#only-dark)
 
-## The three tabs
+## The four tabs
 
 | Tab | Reads from | Editable? | Notes |
 |---|---|---|---|
 | **Generic** | `<conception>/.agents/skills/` | Yes | Agent-neutral source — `.md` body files and `.yaml` spec / target overlays. |
 | **Claude** | `<conception>/<skills_path>` (default `.claude/skills/`) | Yes (but see warning) | Compiled output. Edits here are overwritten on the next `condash skills install`. |
 | **Kimi** | `<conception>/.kimi/skills/` | No | Compiled output. Always regenerated from source — buttons are hidden. |
+| **OpenCode** | `<conception>/.opencode/skills/` | No | Compiled output. Always regenerated from source — buttons are hidden. |
 
 The currently-selected tab is remembered per-machine in `settings.json` (`skillsActiveTab`), so the next launch reopens the same view. The first launch after the tabs ship defaults to **Claude** to match the pre-tabs behaviour.
 
@@ -40,6 +41,18 @@ Identical to the pre-tabs Skills pane:
 
 Same layout as Claude, but rooted at `.kimi/skills/` and without the synthetic `CLAUDE.md` injection (Kimi uses `AGENTS.md`, not `CLAUDE.md`). The tab is read-only: tree-mutation buttons are suppressed and the main-process resolver refuses to write under `.kimi/skills/`. Edit the matching source skillspec under `.agents/skills/` and re-run `condash skills install` to regenerate.
 
+### OpenCode (compiled)
+
+Same layout as Kimi, rooted at `.opencode/skills/`, with a synthetic `AGENTS.md` root entry. Read-only and regenerated from `.agents/skills/` on every `condash skills install`.
+
+**Telling OpenCode to read condash's config.** condash compiles the conception's agent config to `.opencode/AGENTS.md` (project scope) and `~/.config/opencode/AGENTS.md` (user scope, with `--user`). OpenCode reads the global `~/.config/opencode/AGENTS.md` automatically. It does **not** auto-discover the project-scope `.opencode/AGENTS.md` (condash never touches the conception-root `AGENTS.md`, which it manages separately), so point OpenCode at it from the project's `opencode.json`:
+
+```json
+{ "instructions": [".opencode/AGENTS.md"] }
+```
+
+Skills need no such step — OpenCode discovers `.opencode/skills/` (and `~/.config/opencode/skills/`) on its own. But OpenCode *also* scans `.claude/skills/` and `.agents/skills/`, and resolves a duplicate skill name by a non-deterministic race (no stable precedence), so run OpenCode with `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` to have it read only its own dirs and treat condash's `.opencode/` output as the single source.
+
 ## Editing skills
 
 Click any card to open the file in the note modal — the same editor used elsewhere in condash, with atomic-write save through `writeNote`. Wikilinks and relative markdown links route through the in-modal navigator just like Knowledge files.
@@ -53,6 +66,7 @@ Each tree carries its own `.condash-skills.json` manifest, populated by `condash
 - `<conception>/.agents/.condash-skills.json` — source refuse-on-edit tracking (CLI internal).
 - `<conception>/<skills_path>/.condash-skills.json` — Claude compiled tracking.
 - `<conception>/.kimi/skills/.condash-skills.json` — Kimi compiled tracking.
+- `<conception>/.opencode/skills/.condash-skills.json` — OpenCode compiled tracking.
 
 The pane uses each manifest to flag two states on the matching tab:
 
@@ -63,7 +77,7 @@ The flags are informational only — local edits are never blocked. They exist s
 
 ## Configuration
 
-`skills_path` controls only the **Claude** tab's root directory. The Generic and Kimi tabs always read from `.agents/skills/` and `.kimi/skills/` respectively — those paths are not user-configurable.
+`skills_path` controls only the **Claude** tab's root directory. The Generic, Kimi, and OpenCode tabs always read from `.agents/skills/`, `.kimi/skills/`, and `.opencode/skills/` respectively — those paths are not user-configurable.
 
 Set the Claude tab's directory by editing `.condash/settings.json` at the conception root (per-tree, per-host), or via **Settings → Workspace → Skills directory**. The value lives on the tree side; the global `settings.json` carries only defaults.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -187,19 +187,19 @@ The skills (`/projects index`, `/knowledge index`) clear these after they regene
 
 ### `skills`
 
-Manage Claude Code + Kimi skills. Two scopes:
+Manage Claude Code, Kimi, and OpenCode skills. Two scopes:
 
-- **Repo scope (default)** — installs the skills condash itself ships into a conception. Sources go to `<conception>/.agents/skills/<name>/`; compiled outputs to `<conception>/.claude/skills/<name>/` and `<conception>/.kimi/skills/<name>/`.
-- **User scope (`--user`)** — compiles skillspecs the user already owns at `~/.config/agents/skills/<name>/` into `~/.claude/skills/<name>/` + `~/.kimi/skills/<name>/`. Used by the ClaudeConfig sync flow that mirrors versioned user skills out to live.
+- **Repo scope (default)** — installs the skills condash itself ships into a conception. Sources go to `<conception>/.agents/skills/<name>/`; compiled outputs to `<conception>/.claude/skills/<name>/`, `<conception>/.kimi/skills/<name>/`, and `<conception>/.opencode/skills/<name>/`.
+- **User scope (`--user`)** — compiles skillspecs the user already owns at `~/.config/agents/skills/<name>/` into `~/.claude/skills/<name>/`, `~/.kimi/skills/<name>/`, and `~/.config/opencode/skills/<name>/` (OpenCode uses the XDG config dir, not `~/.opencode/`). Used by the ClaudeConfig sync flow that mirrors versioned user skills out to live.
 
 | Verb | Default scope | With `--user` |
 |---|---|---|
 | `list` | Print every skill condash ships | List user skillspecs under `~/.config/agents/skills/`, with host-filter status |
-| `install [<name>…]` | Copy shipped sources into the conception's `.agents/skills/`, then compile to `.claude/skills/` + `.kimi/skills/`. Refuses on local edits without `--force` | Compile user sources to `~/.claude/skills/` + `~/.kimi/skills/`. No source-copy pass; outputs always regenerated; no manifest |
+| `install [<name>…]` | Copy shipped sources into the conception's `.agents/skills/`, then compile to `.claude/skills/` + `.kimi/skills/` + `.opencode/skills/`. Refuses on local edits without `--force` | Compile user sources to `~/.claude/skills/` + `~/.kimi/skills/` + `~/.config/opencode/skills/`. No source-copy pass; outputs always regenerated; no manifest |
 | `status` | Compare sources against the recorded SHA256 manifest | Compare each compiled output against a fresh in-memory compile: `ok` / `stale` / `missing` / `skipped` |
 | `validate [<name>…]` | Lint each shipped skillspec | Lint each user skillspec |
 
-`--user` is incompatible with `--dest`. The user-source root, target roots, and host-label file are env-overridable for tests (`CONDASH_USER_SKILLS_ROOT`, `CONDASH_USER_CLAUDE_ROOT`, `CONDASH_USER_KIMI_ROOT`, `CONDASH_USER_HOST_FILE`).
+`--user` is incompatible with `--dest`. The user-source root, target roots, and host-label file are env-overridable for tests (`CONDASH_USER_SKILLS_ROOT`, `CONDASH_USER_CLAUDE_ROOT`, `CONDASH_USER_KIMI_ROOT`, `CONDASH_USER_OPENCODE_ROOT`, `CONDASH_USER_HOST_FILE`).
 
 A user skillspec's `spec.yaml` may carry a `hosts:` list — e.g. `hosts: [vcoeur]`. When present, condash reads the current host label from `~/.claude/.host` and skips any skill whose `hosts:` does not include that label. Absent `hosts:` means install everywhere. This replaces the multi-host filter previously enforced by ClaudeConfig's `/sync-config`.
 

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -81,6 +81,7 @@ Install or refresh the shipped skills. Use it after upgrading condash to pull up
 | `<conception>/.agents/.condash-skills.json` | Source refuse-on-edit (CLI internal) | `skills.<name>.source` |
 | `<conception>/.claude/skills/.condash-skills.json` | Claude compiled tracking | `skills.<name>.files` |
 | `<conception>/.kimi/skills/.condash-skills.json` | Kimi compiled tracking | `skills.<name>.files` |
+| `<conception>/.opencode/skills/.condash-skills.json` | OpenCode compiled tracking | `skills.<name>.files` |
 
 The source manifest moved from `.claude/skills/.condash-skills.json` to `.agents/.condash-skills.json` when the skillspec compiler shipped. `readManifest` migrates the legacy path on first read (one-shot, transparent — the legacy file is moved, not copied).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.22.1",
+      "version": "3.23.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/agents-md/compile.test.ts
+++ b/src/agents-md/compile.test.ts
@@ -86,4 +86,13 @@ describe('compileAgentConfig — variable substitution', () => {
     });
     expect(body(out)).toBe('custom/');
   });
+
+  it('substitutes OpenCode variables', () => {
+    expect(body(compileAgentConfig('{{ agent_name }}', '', 'opencode'))).toBe('OpenCode');
+    expect(body(compileAgentConfig('{{ skills_dir }}', '', 'opencode'))).toBe('.opencode/skills/');
+    expect(body(compileAgentConfig('{{ agent_config }}', '', 'opencode'))).toBe(
+      '.opencode/AGENTS.md',
+    );
+    expect(body(compileAgentConfig('{{ memory_dir }}', '', 'opencode'))).toBe('');
+  });
 });

--- a/src/agents-md/compile.ts
+++ b/src/agents-md/compile.ts
@@ -5,20 +5,32 @@
  *   - `.agents/agents/common.md`      — shared content (must contain `## Specifics`)
  *   - `.agents/agents/claude.md`      — Claude-only fragment
  *   - `.agents/agents/kimi.md`        — Kimi-only fragment
+ *   - `.agents/agents/opencode.md`    — OpenCode-only fragment
  *
  * The compile step inserts the agent-specific fragment into `common.md`
  * immediately before the `## Specifics` heading, then applies `{{ var }}`
  * variable substitution from the per-target map.
  */
 
-export type AgentsMdTarget = 'claude' | 'kimi';
+export type AgentsMdTarget = 'claude' | 'kimi' | 'opencode';
 
-export const AGENTS_MD_TARGETS: readonly AgentsMdTarget[] = ['claude', 'kimi'] as const;
+export const AGENTS_MD_TARGETS: readonly AgentsMdTarget[] = ['claude', 'kimi', 'opencode'] as const;
 
-/** Output path per target, relative to the conception root. */
+/**
+ * Output path per target, relative to the conception root.
+ *
+ * OpenCode's config lands inside its own `.opencode/` dir — **never** the
+ * conception-root `AGENTS.md`, which condash manages via the shipped-files
+ * migration (see `src/cli/commands/files.ts`). OpenCode does not
+ * auto-discover `.opencode/AGENTS.md`, so a project points to it with an
+ * `opencode.json` `instructions` entry (`[".opencode/AGENTS.md"]`) — see the
+ * skills-pane guide. User scope instead writes `~/.config/opencode/AGENTS.md`,
+ * which OpenCode reads natively as global config (`userAgentConfigOutput`).
+ */
 export const AGENTS_MD_OUTPUTS: Record<AgentsMdTarget, string> = {
   claude: '.claude/CLAUDE.md',
   kimi: '.kimi/AGENTS.md',
+  opencode: '.opencode/AGENTS.md',
 };
 
 /** Default variable map per target, applied via `{{ var }}` substitution. */
@@ -37,6 +49,14 @@ export function defaultVariables(target: AgentsMdTarget): Record<string, string>
         skills_dir: '.kimi/skills/',
         agent_config: 'AGENTS.md',
         // No native memory in Kimi — substitute empty.
+        memory_dir: '',
+      };
+    case 'opencode':
+      return {
+        agent_name: 'OpenCode',
+        skills_dir: '.opencode/skills/',
+        agent_config: '.opencode/AGENTS.md',
+        // No native curated memory in OpenCode — substitute empty.
         memory_dir: '',
       };
   }

--- a/src/cli/commands/skills-compile.ts
+++ b/src/cli/commands/skills-compile.ts
@@ -53,7 +53,11 @@ export async function compileAllSkillspecs(opts: CompileAllOptions): Promise<Com
     string,
     { files: Record<string, { sha256: string; shippedVersion: string }> }
   >;
-  const compiledManifests: Record<CompileTarget, CompiledManifest> = { claude: {}, kimi: {} };
+  const compiledManifests: Record<CompileTarget, CompiledManifest> = {
+    claude: {},
+    kimi: {},
+    opencode: {},
+  };
   const compiled: CompileAllResult['compiled'] = [];
 
   for (const skillName of skillNames) {

--- a/src/cli/commands/skills-install.ts
+++ b/src/cli/commands/skills-install.ts
@@ -164,6 +164,7 @@ export async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise
     outputs: {
       claude: join(dest, TARGET_RELPATHS.claude),
       kimi: join(dest, TARGET_RELPATHS.kimi),
+      opencode: join(dest, TARGET_RELPATHS.opencode),
     },
     copied: [],
     updated: [],
@@ -506,7 +507,11 @@ export async function installUserSkills(args: ParsedArgs, ctx: OutputContext): P
   const hostLabel = await readHostLabel();
   const report: UserInstallReport = {
     source: userSourceRoot(),
-    outputs: { claude: userTargetRoot('claude'), kimi: userTargetRoot('kimi') },
+    outputs: {
+      claude: userTargetRoot('claude'),
+      kimi: userTargetRoot('kimi'),
+      opencode: userTargetRoot('opencode'),
+    },
     hostLabel,
     skipped: [],
     compiled: [],
@@ -526,6 +531,7 @@ export async function installUserSkills(args: ParsedArgs, ctx: OutputContext): P
       outputs: {
         claude: userAgentConfigOutput('claude'),
         kimi: userAgentConfigOutput('kimi'),
+        opencode: userAgentConfigOutput('opencode'),
       },
       compiled: [],
     },
@@ -581,10 +587,12 @@ export async function installUserSkills(args: ParsedArgs, ctx: OutputContext): P
       });
       const outputPath = userAgentConfigOutput(target);
       if (!dryRun) {
-        if (target === 'claude') {
-          await writeFileMkdir(outputPath, Buffer.from(compiled, 'utf8'));
-        } else {
+        if (target === 'kimi') {
+          // Kimi has no standalone config file — write inline into global-agent.yaml.
           await writeKimiGlobalAgent(outputPath, compiled);
+        } else {
+          // Claude (CLAUDE.md) and OpenCode (AGENTS.md) are plain markdown files.
+          await writeFileMkdir(outputPath, Buffer.from(compiled, 'utf8'));
         }
       }
       report.agentConfigs.compiled.push({ target, path: outputPath });

--- a/src/cli/commands/skills-shipped.ts
+++ b/src/cli/commands/skills-shipped.ts
@@ -20,6 +20,7 @@ export const SOURCE_RELPATH = '.agents/skills';
 export const TARGET_RELPATHS: Record<CompileTarget, string> = {
   claude: '.claude/skills',
   kimi: '.kimi/skills',
+  opencode: '.opencode/skills',
 };
 
 export const KNOWN_FLAGS_LIST = ['dest', 'user'] as const;

--- a/src/cli/commands/skills-status.ts
+++ b/src/cli/commands/skills-status.ts
@@ -394,6 +394,7 @@ export async function listUser(args: ParsedArgs, ctx: OutputContext): Promise<vo
     outputs: {
       claude: userAgentConfigOutput('claude'),
       kimi: userAgentConfigOutput('kimi'),
+      opencode: userAgentConfigOutput('opencode'),
     },
   };
   emit(
@@ -434,6 +435,7 @@ export async function listUser(args: ParsedArgs, ctx: OutputContext): Promise<vo
         lines.push(`Agent configs: ${d.agentConfigs.source}`);
         lines.push(`  → ${d.agentConfigs.outputs.claude}  (claude)`);
         lines.push(`  → ${d.agentConfigs.outputs.kimi}  (kimi)`);
+        lines.push(`  → ${d.agentConfigs.outputs.opencode}  (opencode)`);
       }
       return lines.join('\n') + '\n';
     },
@@ -527,7 +529,8 @@ export async function userSkillsStatus(args: ParsedArgs, ctx: OutputContext): Pr
       });
       const outputPath = userAgentConfigOutput(target);
       let state: 'ok' | 'stale' | 'missing';
-      if (target === 'claude') {
+      if (target === 'claude' || target === 'opencode') {
+        // Claude (CLAUDE.md) and OpenCode (AGENTS.md) are plain markdown files.
         let onDisk: string | null = null;
         try {
           onDisk = await fs.readFile(outputPath, 'utf8');

--- a/src/cli/commands/skills-user-fs.ts
+++ b/src/cli/commands/skills-user-fs.ts
@@ -70,6 +70,12 @@ export function userSourceRoot(): string {
 }
 
 export function userTargetRoot(target: CompileTarget): string {
+  // OpenCode reads user skills from the XDG config dir, not `~/.opencode/skills`.
+  if (target === 'opencode') {
+    return (
+      process.env.CONDASH_USER_OPENCODE_ROOT ?? join(homedir(), '.config', 'opencode', 'skills')
+    );
+  }
   const envName = target === 'claude' ? 'CONDASH_USER_CLAUDE_ROOT' : 'CONDASH_USER_KIMI_ROOT';
   return process.env[envName] ?? join(homedir(), `.${target}`, 'skills');
 }
@@ -106,6 +112,13 @@ export function userAgentConfigRoot(): string {
 export function userAgentConfigOutput(target: AgentsMdTarget): string {
   if (target === 'claude') {
     return process.env.CONDASH_USER_CLAUDE_AGENT_OUTPUT ?? join(homedir(), '.claude', 'CLAUDE.md');
+  }
+  if (target === 'opencode') {
+    // OpenCode reads global rules from ~/.config/opencode/AGENTS.md.
+    return (
+      process.env.CONDASH_USER_OPENCODE_AGENT_OUTPUT ??
+      join(homedir(), '.config', 'opencode', 'AGENTS.md')
+    );
   }
   // Kimi: write inline into the global-agent.yaml's ROLE_ADDITIONAL field, not a standalone markdown file.
   return (

--- a/src/cli/commands/skills.user.test.ts
+++ b/src/cli/commands/skills.user.test.ts
@@ -35,6 +35,8 @@ let claudeScriptsTarget: string;
 let agentConfigRoot: string;
 let claudeAgentOutput: string;
 let kimiAgentOutput: string;
+let opencodeRoot: string;
+let opencodeAgentOutput: string;
 
 beforeEach(async () => {
   root = await fs.mkdtemp(join(tmpdir(), 'skills-user-'));
@@ -49,6 +51,8 @@ beforeEach(async () => {
   agentConfigRoot = join(root, 'agent-config-src');
   claudeAgentOutput = join(root, 'claude-CLAUDE.md');
   kimiAgentOutput = join(root, 'kimi-global-agent.yaml');
+  opencodeRoot = join(root, 'opencode');
+  opencodeAgentOutput = join(root, 'opencode-AGENTS.md');
   await fs.mkdir(sourceRoot, { recursive: true });
   process.env.CONDASH_USER_SKILLS_ROOT = sourceRoot;
   process.env.CONDASH_USER_CLAUDE_ROOT = claudeRoot;
@@ -61,6 +65,8 @@ beforeEach(async () => {
   process.env.CONDASH_USER_AGENT_CONFIG_ROOT = agentConfigRoot;
   process.env.CONDASH_USER_CLAUDE_AGENT_OUTPUT = claudeAgentOutput;
   process.env.CONDASH_USER_KIMI_AGENT_OUTPUT = kimiAgentOutput;
+  process.env.CONDASH_USER_OPENCODE_ROOT = opencodeRoot;
+  process.env.CONDASH_USER_OPENCODE_AGENT_OUTPUT = opencodeAgentOutput;
 });
 
 afterEach(async () => {
@@ -76,6 +82,8 @@ afterEach(async () => {
   delete process.env.CONDASH_USER_AGENT_CONFIG_ROOT;
   delete process.env.CONDASH_USER_CLAUDE_AGENT_OUTPUT;
   delete process.env.CONDASH_USER_KIMI_AGENT_OUTPUT;
+  delete process.env.CONDASH_USER_OPENCODE_ROOT;
+  delete process.env.CONDASH_USER_OPENCODE_AGENT_OUTPUT;
 });
 
 function ctx(): OutputContext {
@@ -710,9 +718,10 @@ describe('condash skills install --user (agent-config compile)', () => {
         ctx(),
       ),
     );
-    expect(env.data.agentConfigs.compiled).toHaveLength(2);
+    expect(env.data.agentConfigs.compiled).toHaveLength(3);
     await expect(fs.access(claudeAgentOutput)).rejects.toThrow();
     await expect(fs.access(kimiAgentOutput)).rejects.toThrow();
+    await expect(fs.access(opencodeAgentOutput)).rejects.toThrow();
   });
 
   it('status reports ok / stale / missing for agent configs', async () => {
@@ -733,7 +742,7 @@ describe('condash skills install --user (agent-config compile)', () => {
       ),
     );
     const agentRows = env.data.items.filter((r) => r.kind === 'agent-config');
-    expect(agentRows).toHaveLength(2);
+    expect(agentRows).toHaveLength(3);
     expect(agentRows.every((r) => r.state === 'ok')).toBe(true);
 
     // Tamper one.

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -99,6 +99,36 @@ export async function readKimiSkillsTree(conceptionPath: string): Promise<SkillN
 }
 
 /**
+ * Read the OpenCode skills tree at `<conceptionPath>/.opencode/skills/`.
+ * `.md`-only filter like the other compiled tabs. Injects a synthetic
+ * root-level entry for the conception's root `AGENTS.md` (OpenCode's context
+ * file, emitted by `condash skills install`) when present.
+ */
+export async function readOpencodeSkillsTree(conceptionPath: string): Promise<SkillNode | null> {
+  const root = join(conceptionPath, '.opencode', 'skills');
+  try {
+    await fs.access(root);
+  } catch {
+    return null;
+  }
+  const shipped = await buildShippedLookup(root);
+  const tree = await walk(
+    root,
+    '',
+    'skills',
+    new Set<string>(),
+    shipped,
+    root,
+    /* acceptYaml */ false,
+  );
+  const agentsEntries = await readConceptionOpencodeAgentsMd(conceptionPath);
+  if (agentsEntries.length > 0) {
+    tree.children = [...agentsEntries, ...(tree.children ?? [])];
+  }
+  return tree;
+}
+
+/**
  * Router that delegates to the tab-specific reader.
  */
 export async function readSkillsTreeForTab(
@@ -108,6 +138,7 @@ export async function readSkillsTreeForTab(
 ): Promise<SkillNode | null> {
   if (tab === 'generic') return readGenericSkillsTree(conceptionPath);
   if (tab === 'kimi') return readKimiSkillsTree(conceptionPath);
+  if (tab === 'opencode') return readOpencodeSkillsTree(conceptionPath);
   return readSkillsTree(conceptionPath, skillsRelPath);
 }
 
@@ -131,6 +162,15 @@ async function readConceptionAgentsMd(conceptionPath: string): Promise<SkillNode
   return readConceptionAgentConfig(conceptionPath, [
     { rel: '__kimi__/AGENTS.md', abs: join(conceptionPath, 'AGENTS.md') },
     { rel: '__kimi__/.kimi/AGENTS.md', abs: join(conceptionPath, '.kimi', 'AGENTS.md') },
+  ]);
+}
+
+/** Probe `<conceptionPath>/AGENTS.md` (OpenCode's root context file) and
+ *  return a synthetic SkillNode entry when it exists. Sentinel-prefixed
+ *  `__opencode__/` so it can't collide with a real skills-tree path. */
+async function readConceptionOpencodeAgentsMd(conceptionPath: string): Promise<SkillNode[]> {
+  return readConceptionAgentConfig(conceptionPath, [
+    { rel: '__opencode__/AGENTS.md', abs: join(conceptionPath, 'AGENTS.md') },
   ]);
 }
 

--- a/src/main/tree-mutations.ts
+++ b/src/main/tree-mutations.ts
@@ -33,6 +33,7 @@ async function resolveRoot(root: TreeRoot, skillTab?: SkillTab): Promise<string>
     if (tab === 'generic') return join(conceptionPath, '.agents', 'skills');
     if (tab === 'claude') return join(conceptionPath, skills);
     if (tab === 'kimi') throw new Error('Kimi skills tree is read-only');
+    if (tab === 'opencode') throw new Error('OpenCode skills tree is read-only');
     throw new Error(`unknown skill tab: ${tab}`);
   }
   throw new Error(`unknown tree root: ${root as string}`);

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -191,6 +191,11 @@ function App() {
       fetcher: () => window.condash.readSkillsTree('kimi'),
       key: 'relPath',
     }),
+    opencode: createTreeStore<SkillNode>({
+      conceptionPath,
+      fetcher: () => window.condash.readSkillsTree('opencode'),
+      key: 'relPath',
+    }),
   };
   const { skillsActiveTab, handleSkillsTabSelect, activeSkillsRoot } = useSkillsTab({
     skillsStores,

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -10,14 +10,14 @@ import {
 } from './tree-view';
 import './skills-pane.css';
 
-// Compiled tabs (Claude / Kimi) accept the same SKILL_AFFORDANCES as before;
-// the Generic tab also accepts source-edit mutations. The Kimi tab is
-// read-only because its content is regenerated on every `condash skills
-// install` — see notes/02-design.md §Q1.
+// Compiled tabs (Claude / Kimi / OpenCode) accept the same SKILL_AFFORDANCES
+// as before; the Generic tab also accepts source-edit mutations. The Kimi and
+// OpenCode tabs are read-only because their content is regenerated on every
+// `condash skills install` — see notes/02-design.md §Q1.
 //
 // Each compiled tab also surfaces the conception's agent-config file as a
-// synthetic root-level entry: CLAUDE.md on the Claude tab, AGENTS.md on
-// the Kimi tab (injected in src/main/skills.ts).
+// synthetic root-level entry: CLAUDE.md on the Claude tab, AGENTS.md on the
+// Kimi and OpenCode tabs (injected in src/main/skills.ts).
 const EDITABLE_AFFORDANCES: ReadonlyArray<TreeAffordance> = ['createMd', 'mkdir'];
 const READONLY_AFFORDANCES: ReadonlyArray<TreeAffordance> = [];
 
@@ -25,6 +25,7 @@ const TAB_LABELS: Record<SkillTab, string> = {
   generic: 'Generic',
   claude: 'Claude',
   kimi: 'Kimi',
+  opencode: 'OpenCode',
 };
 
 function isSkillIndex(node: SkillNode): boolean {
@@ -75,7 +76,7 @@ export function SkillsView(props: {
   const scrollRef = usePaneScrollMemory(() => `skills-${props.tab}`);
 
   const affordances = (): ReadonlyArray<TreeAffordance> =>
-    props.tab === 'kimi' ? READONLY_AFFORDANCES : EDITABLE_AFFORDANCES;
+    props.tab === 'kimi' || props.tab === 'opencode' ? READONLY_AFFORDANCES : EDITABLE_AFFORDANCES;
 
   // Memoise pane-level callbacks so prop identity stays stable across
   // unrelated parent re-runs (e.g. expanding one directory). Tracks
@@ -87,6 +88,7 @@ export function SkillsView(props: {
     return (file: SkillNode, dir: SkillNode): boolean => {
       if (dir.relPath === '' && tab === 'claude' && isClaudeMd(file)) return true;
       if (dir.relPath === '' && tab === 'kimi' && isAgentsMd(file)) return true;
+      if (dir.relPath === '' && tab === 'opencode' && isAgentsMd(file)) return true;
       if (tab !== 'generic' && dir.relPath !== '' && isSkillIndex(file)) return true;
       return false;
     };
@@ -209,6 +211,28 @@ export function SkillsView(props: {
           <p>
             Run <code>condash skills install</code> to compile bundled skills for Kimi under{' '}
             <code>.kimi/skills/</code>.
+          </p>
+          <div class="empty-actions">
+            <Show when={props.onCopyInstallCommand}>
+              <button
+                type="button"
+                class="empty-cta"
+                onClick={() => props.onCopyInstallCommand?.()}
+              >
+                Copy install command
+              </button>
+            </Show>
+          </div>
+        </div>
+      );
+    }
+    if (props.tab === 'opencode') {
+      return (
+        <div class="empty">
+          <p>No OpenCode skills installed.</p>
+          <p>
+            Run <code>condash skills install</code> to compile bundled skills for OpenCode under{' '}
+            <code>.opencode/skills/</code>.
           </p>
           <div class="empty-actions">
             <Show when={props.onCopyInstallCommand}>

--- a/src/renderer/tree-expansion.ts
+++ b/src/renderer/tree-expansion.ts
@@ -43,6 +43,9 @@ export function createTreeExpansion(deps: TreeExpansionDeps): TreeExpansion {
     new Set(),
   );
   const [skillsKimiExpanded, setSkillsKimiExpanded] = createSignal<ReadonlySet<string>>(new Set());
+  const [skillsOpencodeExpanded, setSkillsOpencodeExpanded] = createSignal<ReadonlySet<string>>(
+    new Set(),
+  );
 
   void window.condash.getTreeExpansion().then((prefs) => {
     setKnowledgeExpanded(new Set(prefs.knowledge));
@@ -50,6 +53,7 @@ export function createTreeExpansion(deps: TreeExpansionDeps): TreeExpansion {
     setSkillsGenericExpanded(new Set(prefs.skillsGeneric));
     setSkillsClaudeExpanded(new Set(prefs.skillsClaude));
     setSkillsKimiExpanded(new Set(prefs.skillsKimi));
+    setSkillsOpencodeExpanded(new Set(prefs.skillsOpencode));
   });
 
   const skillsGetter = (tab: SkillTab): Accessor<ReadonlySet<string>> =>
@@ -57,13 +61,17 @@ export function createTreeExpansion(deps: TreeExpansionDeps): TreeExpansion {
       ? skillsGenericExpanded
       : tab === 'kimi'
         ? skillsKimiExpanded
-        : skillsClaudeExpanded;
+        : tab === 'opencode'
+          ? skillsOpencodeExpanded
+          : skillsClaudeExpanded;
   const skillsSetter = (tab: SkillTab) =>
     tab === 'generic'
       ? setSkillsGenericExpanded
       : tab === 'kimi'
         ? setSkillsKimiExpanded
-        : setSkillsClaudeExpanded;
+        : tab === 'opencode'
+          ? setSkillsOpencodeExpanded
+          : setSkillsClaudeExpanded;
 
   /** Persist the union of every pane / tab set to settings.json.
    *  Fire-and-forget — a write failure surfaces as a toast but the
@@ -75,6 +83,7 @@ export function createTreeExpansion(deps: TreeExpansionDeps): TreeExpansion {
       skillsGeneric: Array.from(skillsGenericExpanded()),
       skillsClaude: Array.from(skillsClaudeExpanded()),
       skillsKimi: Array.from(skillsKimiExpanded()),
+      skillsOpencode: Array.from(skillsOpencodeExpanded()),
     };
     void window.condash.setTreeExpansion(prefs).catch((err) => {
       deps.flashToast(`Could not persist tree expansion: ${(err as Error).message}`, 'error');

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -183,9 +183,9 @@ export type WorkingSurface = 'code' | 'knowledge' | 'resources' | 'skills' | 'lo
 export type LeftView = 'projects' | 'deliverables';
 
 /** Active tab in the Skills pane. */
-export type SkillTab = 'generic' | 'claude' | 'kimi';
+export type SkillTab = 'generic' | 'claude' | 'kimi' | 'opencode';
 
-export const SKILL_TABS: readonly SkillTab[] = ['generic', 'claude', 'kimi'] as const;
+export const SKILL_TABS: readonly SkillTab[] = ['generic', 'claude', 'kimi', 'opencode'] as const;
 
 /** Composite-layout state. The unified window has a top band (Projects on
  * the left, working surface on the right) and a bottom band (Terminal).
@@ -271,6 +271,7 @@ export interface TreeExpansionPrefs {
   skillsGeneric?: string[];
   skillsClaude?: string[];
   skillsKimi?: string[];
+  skillsOpencode?: string[];
 }
 
 /** Discriminator for the three tree panes. Used by the `tree.*` IPC verbs

--- a/src/skillspec/compile.test.ts
+++ b/src/skillspec/compile.test.ts
@@ -89,4 +89,19 @@ describe('compileSkillspec', () => {
     // YAML lib should quote — we don't care about quote style, just that it parses back.
     expect(text).toMatch(/description: ['"]?Manage things: foo and bar['"]?/);
   });
+
+  it('emits OpenCode SKILL.md with compatibility + metadata pass-through', () => {
+    const out = compileSkillspec(
+      spec({
+        spec: { description: 'demo skill' },
+        targets: { opencode: { compatibility: 'opencode>=0.14', metadata: { x: 'y' } } },
+      }),
+      'opencode',
+    );
+    const text = out.files['SKILL.md'].toString('utf8');
+    expect(text).toContain('description: demo skill');
+    expect(text).toContain('compatibility: opencode>=0.14');
+    expect(text).toContain('metadata:');
+    expect(text).toContain('x: y');
+  });
 });

--- a/src/skillspec/decompile.test.ts
+++ b/src/skillspec/decompile.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { compileSkillspec } from './compile';
+import { decompileSkillMd } from './decompile';
+import { SkillspecError } from './parse';
+import type { Skillspec } from './types';
+
+describe('decompileSkillMd', () => {
+  it('splits frontmatter and body', () => {
+    const { frontmatter, body } = decompileSkillMd(
+      '---\nname: foo\ndescription: a skill\n---\n\n# Foo\n\nBody.\n',
+    );
+    expect(frontmatter).toEqual({ name: 'foo', description: 'a skill' });
+    expect(body).toBe('# Foo\n\nBody.\n');
+  });
+
+  it('round-trips a compiled SKILL.md (compile → decompile)', () => {
+    const spec: Skillspec = {
+      name: 'demo',
+      sourceDir: '/tmp/demo',
+      spec: { name: 'demo', description: 'demo skill', metadata: { opencode: { tags: ['x'] } } },
+      body: '# Demo\n\nHello.\n',
+      targets: {},
+      assets: {},
+    };
+    const skillMd = compileSkillspec(spec, 'opencode').files['SKILL.md'].toString('utf8');
+    const { frontmatter, body } = decompileSkillMd(skillMd);
+    expect(frontmatter).toEqual(spec.spec);
+    expect(body).toBe('# Demo\n\nHello.\n');
+  });
+
+  it('tolerates CRLF frontmatter fences', () => {
+    const { frontmatter, body } = decompileSkillMd('---\r\nname: foo\r\n---\r\n\r\nBody.\n');
+    expect(frontmatter).toEqual({ name: 'foo' });
+    expect(body).toBe('Body.\n');
+  });
+
+  it('throws when the frontmatter block is missing', () => {
+    expect(() => decompileSkillMd('# No frontmatter\n')).toThrow(SkillspecError);
+  });
+
+  it('throws when frontmatter is a sequence, not a mapping', () => {
+    expect(() => decompileSkillMd('---\n- a\n- b\n---\n\nBody.\n')).toThrow(SkillspecError);
+  });
+});

--- a/src/skillspec/decompile.ts
+++ b/src/skillspec/decompile.ts
@@ -1,0 +1,48 @@
+import { parse as parseYaml } from 'yaml';
+import { SkillspecError } from './parse';
+
+/** A `SKILL.md` split back into its agent-neutral parts. */
+export interface DecompiledSkill {
+  /** Parsed YAML frontmatter — the mapping between the leading `---` fences. */
+  frontmatter: Record<string, unknown>;
+  /** Markdown body after the closing `---`, with leading blank lines stripped. */
+  body: string;
+}
+
+/** Matches a leading `---\n…\n---` frontmatter block (CRLF tolerant). */
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+/**
+ * Split a compiled `SKILL.md` back into frontmatter + body — the inverse of
+ * the compiler's `renderSkillMd`. condash's compile path is otherwise one-way;
+ * this is the import direction, used to ingest an externally-authored
+ * `SKILL.md` (e.g. from `~/.config/opencode/skills/` or `~/.hermes/skills/`)
+ * into an agent-neutral skillspec source (`spec.yaml` + `body.md`).
+ *
+ * @param skillMd Full `SKILL.md` text (frontmatter fence + body).
+ * @returns The parsed frontmatter mapping and the body markdown.
+ * @throws SkillspecError if the leading `---` block is missing, empty, or not
+ *   a YAML mapping.
+ */
+export function decompileSkillMd(skillMd: string): DecompiledSkill {
+  const match = skillMd.match(FRONTMATTER_RE);
+  if (!match) {
+    throw new SkillspecError('SKILL.md is missing a leading `---` YAML frontmatter block');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(match[1]);
+  } catch (err) {
+    throw new SkillspecError(`Failed to parse SKILL.md frontmatter: ${(err as Error).message}`);
+  }
+  if (parsed === null || parsed === undefined) {
+    throw new SkillspecError('SKILL.md frontmatter is empty');
+  }
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new SkillspecError('SKILL.md frontmatter must be a YAML mapping');
+  }
+
+  const body = skillMd.slice(match[0].length).replace(/^\r?\n+/, '');
+  return { frontmatter: parsed as Record<string, unknown>, body };
+}

--- a/src/skillspec/index.ts
+++ b/src/skillspec/index.ts
@@ -1,4 +1,6 @@
 export { parseSkillspec, SkillspecError } from './parse';
 export { compileSkillspec } from './compile';
+export { decompileSkillMd } from './decompile';
+export type { DecompiledSkill } from './decompile';
 export type { CompileTarget, CompiledSkill, Skillspec } from './types';
 export { COMPILE_TARGETS } from './types';

--- a/src/skillspec/types.ts
+++ b/src/skillspec/types.ts
@@ -5,8 +5,9 @@
  * `<conception>/.agents/skills/<name>/` (or `~/.config/agents/skills/<name>/`)
  * that compiles into agent-native skill formats:
  *
- *   - Claude → `<conception>/.claude/skills/<name>/SKILL.md` + sibling assets
- *   - Kimi   → `<conception>/.kimi/skills/<name>/SKILL.md`   + sibling assets
+ *   - Claude   → `<conception>/.claude/skills/<name>/SKILL.md`   + sibling assets
+ *   - Kimi     → `<conception>/.kimi/skills/<name>/SKILL.md`     + sibling assets
+ *   - OpenCode → `<conception>/.opencode/skills/<name>/SKILL.md` + sibling assets
  *
  * Source layout:
  *
@@ -16,14 +17,15 @@
  *   ├── body.md                  # required — SKILL.md body without frontmatter
  *   ├── targets/                 # optional — per-target frontmatter overlays
  *   │   ├── claude.yaml
- *   │   └── kimi.yaml
+ *   │   ├── kimi.yaml
+ *   │   └── opencode.yaml
  *   └── …                        # any other file/dir is a sibling asset,
  *                                 #   copied verbatim under the same path.
  */
 
-export type CompileTarget = 'claude' | 'kimi';
+export type CompileTarget = 'claude' | 'kimi' | 'opencode';
 
-export const COMPILE_TARGETS: readonly CompileTarget[] = ['claude', 'kimi'] as const;
+export const COMPILE_TARGETS: readonly CompileTarget[] = ['claude', 'kimi', 'opencode'] as const;
 
 /**
  * Parsed source directory. `spec` and `targets[t]` carry frontmatter as parsed


### PR DESCRIPTION
## Summary

- condash now treats OpenCode as a first-class compile target: skillspecs and agent config compile for OpenCode the same way they do for Claude and Kimi.
- Skills compile to `.opencode/skills/`; agent config to `.opencode/AGENTS.md` (project) and `~/.config/opencode/AGENTS.md` (user); the Skills pane gains a read-only OpenCode tab.
- Ships as v3.23.0. An OpenCode session-export/visualization view and a global "show global/local/both" skills toggle are tracked as a separate follow-up (GUI-heavy, needs visual verification).

## Changes

- skillspec: `opencode` added to `CompileTarget` / `COMPILE_TARGETS`; compiles to `.opencode/skills/` (project) and `~/.config/opencode/skills/` (user scope — the XDG config dir, not `~/.opencode`).
- agents-md: `opencode` target compiles to `.opencode/AGENTS.md` (project) and `~/.config/opencode/AGENTS.md` (user). It never writes the conception-root `AGENTS.md`, which condash owns via its shipped-files migration.
- New `decompileSkillMd`: splits a `SKILL.md` back into frontmatter + body — the import direction; the compiler was previously one-way.
- Renderer: read-only "OpenCode" Skills sub-tab with the synthetic `AGENTS.md` badge, wired through `SkillTab` / `SKILL_TABS`, the per-tab expansion state and store, the read-only mutation guard, and the empty-state.
- Docs: the Skills-pane guide documents how a project points OpenCode at the project-scope config (`opencode.json` `instructions: [".opencode/AGENTS.md"]`) and the `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` guidance; CLI and skill references updated. Version bumped to 3.23.0.

## Impact

- Every `condash skills install` now also emits `.opencode/skills/`, and (for any conception with `.agents/agents/common.md`) a `.opencode/AGENTS.md`. Existing Claude/Kimi outputs are unchanged.
- OpenCode does not auto-discover `.opencode/AGENTS.md` — a project must add the `instructions` entry above. The user-scope `~/.config/opencode/AGENTS.md` is read natively as global config.
- OpenCode also scans `.claude/skills/` and `.agents/skills/` and resolves a duplicate skill name non-deterministically (no stable precedence); run it with `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` so `.opencode/` is the single source.

## Watchpoints

- The OpenCode Skills sub-tab was verified by typecheck and main-process unit tests, not in a running Electron window — eyeball the tab label, read-only affordances, `AGENTS.md` badge, and empty-state in a built app.
- Confirm the new `.opencode/AGENTS.md` emission on every install is acceptable for existing conceptions before tagging.
