### PR TITLE
Cancel superseded pages deploys to prevent apt-repo queue jams

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,11 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  # Cancel a still-pending pages deploy when a newer run supersedes it. The apt
+  # index + mkdocs site are rebuilt deterministically from scratch every run, so
+  # the latest run always wins; a stale queued/in-progress run must not block or
+  # clobber it. (Previously false, which let a wedged run jam the whole group.)
+  cancel-in-progress: true
 
 env:
   APT_SIGNING_KEY_FPR: BC6C98E8D6D80FFBC408057FD1D69E3E4A005621

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.26.0",
+  "version": "3.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.26.0",
+      "version": "3.26.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.26.0",
+  "version": "3.26.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",


### PR DESCRIPTION
## Summary

- A wedged or queued Pages deploy in the `pages` concurrency group (`cancel-in-progress: false`) blocks every later deploy, so the apt repo cannot update until GitHub clears the stuck run.
- Flip the group to `cancel-in-progress: true` so a newer run cancels a superseded pending one. The apt index and mkdocs site are rebuilt deterministically from scratch each run, so latest-wins is safe.
- Bump the patch version to ship the fix.

## Changes

- `.github/workflows/docs.yml`: set `concurrency.cancel-in-progress` to true (was false), with a rationale comment.
- `package.json` and `package-lock.json`: version 3.26.0 to 3.26.1.

## Impact

- Overlapping Pages deploys now serialize by cancellation instead of queueing; a stale pending run no longer holds the `pages` lock and stalls releases.

## Watchpoints

- After a release publishes, confirm the Pages deploy completes and the apt repo serves the new version, and that a rapid second release cancels the first in-flight deploy rather than both running.