### PR TITLE
Ship root opencode.json so OpenCode loads project AGENTS.md

### DIFF
--- a/conception-template/_gitignore
+++ b/conception-template/_gitignore
@@ -38,6 +38,11 @@ projects/**/local/**
 .kimi/AGENTS.md
 .opencode/AGENTS.md
 
+# NOT ignored on purpose: the conception-root `opencode.json`. `condash skills
+# install` writes/merges only its `instructions` entry (pointing OpenCode at the
+# compiled `.opencode/AGENTS.md`) and never clobbers other keys, so it's a
+# versioned pointer you can commit and extend — do not add it here.
+
 # condash workspace state (per-host: settings.json + terminal logs).
 # Note: ignoring the dir contents with `.condash/*` (not the dir itself)
 # is what lets the negation re-include the starter example. A bare

--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -54,11 +54,13 @@ Same layout as Claude, rooted at the Kimi skills dir. The config callout is `AGE
 
 Same layout as Kimi, rooted at the OpenCode skills dir, with an `AGENTS.md` config callout.
 
-**Telling OpenCode to read condash's config.** condash compiles the conception's agent config to `.opencode/AGENTS.md` (project scope) and `~/.config/opencode/AGENTS.md` (user scope, with `--user`). OpenCode reads the global `~/.config/opencode/AGENTS.md` automatically. It does **not** auto-discover the project-scope `.opencode/AGENTS.md` (condash never touches the conception-root `AGENTS.md`, which it manages separately), so point OpenCode at it from the project's `opencode.json`:
+**Telling OpenCode to read condash's config.** condash compiles the conception's agent config to `.opencode/AGENTS.md` (project scope) and `~/.config/opencode/AGENTS.md` (user scope, with `--user`). OpenCode reads the global `~/.config/opencode/AGENTS.md` automatically. It does **not** auto-discover the project-scope `.opencode/AGENTS.md` (condash never touches the conception-root `AGENTS.md`, which it manages separately) — OpenCode only finds an `AGENTS.md` by walking up from the working directory, never inside `.opencode/`. So `condash skills install` points OpenCode at it for you, by writing the conception-root `opencode.json`:
 
 ```json
-{ "instructions": [".opencode/AGENTS.md"] }
+{ "$schema": "https://opencode.ai/config.json", "instructions": [".opencode/AGENTS.md"] }
 ```
+
+The `instructions` paths resolve relative to the config file, so this lives at the conception **root** (not `.opencode/opencode.json`, which OpenCode doesn't read). If you already have an `opencode.json`, condash **merges** the `instructions` entry in and leaves every other key (`model`, `theme`, `mcp`, …) untouched. Unlike the compiled `.opencode/AGENTS.md` (gitignored, regenerated each install), `opencode.json` is a versioned pointer you can commit and extend — condash only ever adds the one entry.
 
 Skills need no such step — OpenCode discovers `.opencode/skills/` (and `~/.config/opencode/skills/`) on its own. But OpenCode *also* scans `.claude/skills/` and `.agents/skills/`, and resolves a duplicate skill name by a non-deterministic race (no stable precedence), so run OpenCode with `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` to have it read only its own dirs and treat condash's `.opencode/` output as the single source.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.26.2",
+  "version": "3.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.26.2",
+      "version": "3.27.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.26.2",
+  "version": "3.27.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/agents-md/compile.ts
+++ b/src/agents-md/compile.ts
@@ -26,10 +26,12 @@ export const AGENTS_MD_TARGETS: readonly AgentsMdTarget[] = HARNESS_IDS;
  * OpenCode's config lands inside its own `.opencode/` dir — **never** the
  * conception-root `AGENTS.md`, which condash manages via the shipped-files
  * migration (see `src/cli/commands/files.ts`). OpenCode does not
- * auto-discover `.opencode/AGENTS.md`, so a project points to it with an
- * `opencode.json` `instructions` entry (`[".opencode/AGENTS.md"]`) — see the
- * skills-pane guide. User scope instead writes `~/.config/opencode/AGENTS.md`,
- * which OpenCode reads natively as global config (`userAgentConfigOutput`).
+ * auto-discover `.opencode/AGENTS.md`, so `condash skills install` writes (or
+ * merges) the pointer into the conception-root `opencode.json`
+ * (`instructions: [".opencode/AGENTS.md"]`) — see `ensureOpencodeConfig` in
+ * `src/cli/commands/files.ts`. User scope instead writes
+ * `~/.config/opencode/AGENTS.md`, which OpenCode reads natively as global
+ * config (`userAgentConfigOutput`).
  */
 export const AGENTS_MD_OUTPUTS: Record<AgentsMdTarget, string> = {
   claude: HARNESSES.claude.agentsMdOutput,

--- a/src/cli/commands/files.install.test.ts
+++ b/src/cli/commands/files.install.test.ts
@@ -8,7 +8,12 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { runSkills } from './skills';
-import { AGENT_CONFIG_COMMON, SHIPPED_FILES, statusShippedFile } from './files';
+import {
+  AGENT_CONFIG_COMMON,
+  SHIPPED_FILES,
+  ensureOpencodeConfig,
+  statusShippedFile,
+} from './files';
 import { MANIFEST_RELPATH, readManifest } from './install-shared';
 import type { OutputContext } from '../output';
 
@@ -51,6 +56,34 @@ describe('condash skills install — top-level files', () => {
     expect(kimi).toContain('.kimi/skills/projects/SKILL.md');
     // Claude fragment excluded from Kimi output.
     expect(kimi).not.toContain('Auto-memory opt-out');
+  });
+
+  it('writes a conception-root opencode.json pointing at the compiled .opencode/AGENTS.md', async () => {
+    await install();
+    const cfg = JSON.parse(await fs.readFile(join(dest, 'opencode.json'), 'utf8'));
+    expect(cfg.$schema).toBe('https://opencode.ai/config.json');
+    expect(cfg.instructions).toContain('.opencode/AGENTS.md');
+  });
+
+  it('merges into an existing opencode.json without clobbering other keys', async () => {
+    await fs.writeFile(
+      join(dest, 'opencode.json'),
+      JSON.stringify({
+        $schema: 'https://opencode.ai/config.json',
+        model: 'deepseek/deepseek-v4-pro',
+      }),
+    );
+    await install();
+    const cfg = JSON.parse(await fs.readFile(join(dest, 'opencode.json'), 'utf8'));
+    expect(cfg.model).toBe('deepseek/deepseek-v4-pro');
+    expect(cfg.instructions).toEqual(['.opencode/AGENTS.md']);
+  });
+
+  it('is idempotent — a second install does not duplicate the instructions entry', async () => {
+    await install();
+    await install();
+    const cfg = JSON.parse(await fs.readFile(join(dest, 'opencode.json'), 'utf8'));
+    expect(cfg.instructions).toEqual(['.opencode/AGENTS.md']);
   });
 
   it('writes .gitignore with region replacement', async () => {
@@ -247,5 +280,59 @@ describe('condash skills install — top-level files', () => {
 
     const manifest = await readManifest(dest);
     expect(manifest!.files!['CLAUDE.md']).toBeUndefined();
+  });
+});
+
+describe('ensureOpencodeConfig', () => {
+  it('creates opencode.json with the schema + instructions entry when absent', async () => {
+    const outcome = await ensureOpencodeConfig(dest, false);
+    expect(outcome.state).toBe('created');
+    const cfg = JSON.parse(await fs.readFile(join(dest, 'opencode.json'), 'utf8'));
+    expect(cfg).toEqual({
+      $schema: 'https://opencode.ai/config.json',
+      instructions: ['.opencode/AGENTS.md'],
+    });
+  });
+
+  it('merges the entry into an existing config, preserving other keys + entries', async () => {
+    await fs.writeFile(
+      join(dest, 'opencode.json'),
+      JSON.stringify({ model: 'x', instructions: ['docs/extra.md'] }),
+    );
+    const outcome = await ensureOpencodeConfig(dest, false);
+    expect(outcome.state).toBe('merged');
+    const cfg = JSON.parse(await fs.readFile(join(dest, 'opencode.json'), 'utf8'));
+    expect(cfg.model).toBe('x');
+    expect(cfg.instructions).toEqual(['docs/extra.md', '.opencode/AGENTS.md']);
+  });
+
+  it('is a no-op when the entry is already present', async () => {
+    await fs.writeFile(
+      join(dest, 'opencode.json'),
+      JSON.stringify({ instructions: ['.opencode/AGENTS.md'] }),
+    );
+    const before = await fs.readFile(join(dest, 'opencode.json'), 'utf8');
+    const outcome = await ensureOpencodeConfig(dest, false);
+    expect(outcome.state).toBe('unchanged');
+    expect(await fs.readFile(join(dest, 'opencode.json'), 'utf8')).toBe(before);
+  });
+
+  it('skips a malformed existing opencode.json instead of clobbering it', async () => {
+    await fs.writeFile(join(dest, 'opencode.json'), '{ not valid json ');
+    const outcome = await ensureOpencodeConfig(dest, false);
+    expect(outcome.state).toBe('skipped');
+    expect(await fs.readFile(join(dest, 'opencode.json'), 'utf8')).toBe('{ not valid json ');
+  });
+
+  it('skips when "instructions" exists but is not an array', async () => {
+    await fs.writeFile(join(dest, 'opencode.json'), JSON.stringify({ instructions: 'oops' }));
+    const outcome = await ensureOpencodeConfig(dest, false);
+    expect(outcome.state).toBe('skipped');
+  });
+
+  it('writes nothing in dry-run', async () => {
+    const outcome = await ensureOpencodeConfig(dest, true);
+    expect(outcome.state).toBe('created');
+    await expect(fs.access(join(dest, 'opencode.json'))).rejects.toThrow();
   });
 });

--- a/src/cli/commands/files.ts
+++ b/src/cli/commands/files.ts
@@ -372,6 +372,92 @@ export async function compileAgentConfigs(
   return written;
 }
 
+/** The `instructions` entry pointing OpenCode at condash's compiled config. */
+const OPENCODE_INSTRUCTIONS_ENTRY = AGENTS_MD_OUTPUTS.opencode;
+/** OpenCode's published config schema URL — set on a freshly-created file. */
+const OPENCODE_CONFIG_SCHEMA = 'https://opencode.ai/config.json';
+
+export interface OpencodeConfigOutcome {
+  /** Always `opencode.json` (conception root). */
+  path: string;
+  /**
+   * `created` — wrote a fresh file. `merged` — added the instructions entry to
+   * an existing file, preserving every other key. `unchanged` — entry already
+   * present. `skipped` — existing file is malformed / unexpectedly shaped and
+   * was left untouched so the user's content isn't clobbered (see `reason`).
+   */
+  state: 'created' | 'merged' | 'unchanged' | 'skipped';
+  /** Human-readable explanation, set only for `skipped`. */
+  reason?: string;
+}
+
+/**
+ * Ensure the conception-root `opencode.json` points OpenCode at the compiled
+ * `.opencode/AGENTS.md`.
+ *
+ * OpenCode auto-discovers an `AGENTS.md` only by walking *up* from the working
+ * directory — it never looks inside `.opencode/` — so without this entry the
+ * project-scope agent config condash compiles is silently ignored. The
+ * `instructions` paths resolve relative to the config-file directory, so the
+ * file must sit at the conception root (not `.opencode/opencode.json`, which
+ * OpenCode does not read).
+ *
+ * Merge-not-clobber: an existing file keeps every other key (`$schema`,
+ * `model`, `theme`, `mcp`, …); only the missing instructions entry is added.
+ * Idempotent. A malformed or unexpectedly-shaped existing file is left
+ * untouched and reported as `skipped`.
+ */
+export async function ensureOpencodeConfig(
+  dest: string,
+  dryRun: boolean,
+): Promise<OpencodeConfigOutcome> {
+  const path = 'opencode.json';
+  const targetPath = join(dest, path);
+
+  let onDisk: string | null = null;
+  try {
+    onDisk = await fs.readFile(targetPath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  if (onDisk === null) {
+    const content =
+      JSON.stringify(
+        { $schema: OPENCODE_CONFIG_SCHEMA, instructions: [OPENCODE_INSTRUCTIONS_ENTRY] },
+        null,
+        2,
+      ) + '\n';
+    if (!dryRun) await writeFileMkdir(targetPath, Buffer.from(content, 'utf8'));
+    return { path, state: 'created' };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(onDisk);
+  } catch {
+    return { path, state: 'skipped', reason: 'existing opencode.json is not valid JSON' };
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return { path, state: 'skipped', reason: 'existing opencode.json is not a JSON object' };
+  }
+
+  const config = parsed as Record<string, unknown>;
+  const existing = config.instructions;
+  if (existing !== undefined && !Array.isArray(existing)) {
+    return { path, state: 'skipped', reason: 'existing "instructions" is not an array' };
+  }
+  const list = (existing as unknown[] | undefined) ?? [];
+  if (list.includes(OPENCODE_INSTRUCTIONS_ENTRY)) {
+    return { path, state: 'unchanged' };
+  }
+
+  config.instructions = [...list, OPENCODE_INSTRUCTIONS_ENTRY];
+  const content = JSON.stringify(config, null, 2) + '\n';
+  if (!dryRun) await writeFileMkdir(targetPath, Buffer.from(content, 'utf8'));
+  return { path, state: 'merged' };
+}
+
 export type FileStatusState =
   | 'unchanged'
   | 'edited'

--- a/src/cli/commands/skills-install.ts
+++ b/src/cli/commands/skills-install.ts
@@ -37,11 +37,13 @@ import {
 import {
   SHIPPED_FILES,
   compileAgentConfigs,
+  ensureOpencodeConfig,
   installAgentConfigSources,
   installShippedFile,
   pruneSourceMissingFileEntries,
   sourceMissingFileRows,
   type FileInstallOutcome,
+  type OpencodeConfigOutcome,
   type ShippedFile,
 } from './files';
 import {
@@ -91,6 +93,7 @@ export interface InstallReport {
     sourceMissing: { path: string; region: string; shippedVersion: string }[];
   };
   agentsMdCompiled: { target: AgentsMdTarget; path: string }[];
+  opencodeConfig: OpencodeConfigOutcome | null;
   agentConfigsCopied: string[];
   pruned?: {
     skills: { skill: string; relPath: string; shippedVersion: string }[];
@@ -181,6 +184,7 @@ export async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise
       sourceMissing: [],
     },
     agentsMdCompiled: [],
+    opencodeConfig: null,
     agentConfigsCopied: [],
     diffs: showDiff ? [] : undefined,
   };
@@ -307,6 +311,12 @@ export async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise
 
   // Pass 2b: compile .agents/agents/ → per-target outputs (no-op if source tree isn't on disk).
   report.agentsMdCompiled = await compileAgentConfigs(dest, dryRun);
+
+  // Pass 2c: when an OpenCode config was compiled, ensure the conception-root
+  // opencode.json points OpenCode at it (it does not auto-discover `.opencode/`).
+  if (report.agentsMdCompiled.some((c) => c.target === 'opencode')) {
+    report.opencodeConfig = await ensureOpencodeConfig(dest, dryRun);
+  }
 
   // --prune: drop manifest entries whose shipped source is gone.
   if (prune) {
@@ -474,6 +484,11 @@ function formatInstallHuman(report: InstallReport): string {
   if (report.agentsMdCompiled.length > 0) {
     lines.push(`Compiled agent configs (${report.agentsMdCompiled.length}):`);
     for (const c of report.agentsMdCompiled) lines.push(`  → ${c.path}  (${c.target})`);
+  }
+  if (report.opencodeConfig && report.opencodeConfig.state !== 'unchanged') {
+    const o = report.opencodeConfig;
+    const suffix = o.reason ? ` — ${o.reason}` : '';
+    lines.push(`OpenCode config (${o.state}): ${o.path}${suffix}`);
   }
   if (report.diffs && report.diffs.length > 0) {
     for (const d of report.diffs) {


### PR DESCRIPTION
## Summary

- OpenCode auto-discovers an `AGENTS.md` only by walking up from the working directory — never inside `.opencode/` — so the project agent config condash compiles to `.opencode/AGENTS.md` was silently ignored.
- `condash skills install` now writes (or merges) a conception-root `opencode.json` with `instructions: [".opencode/AGENTS.md"]`, so the compiled project config actually reaches OpenCode.

## Changes

- New `ensureOpencodeConfig()` in `src/cli/commands/files.ts`: merge-not-clobber — preserves `$schema` / `model` / `theme` / `mcp` and any existing `instructions`, idempotent, and skips a malformed or wrong-shaped file rather than overwriting it. Wired into `skills install` (gated on the OpenCode compile target) and surfaced in the install report as `created` / `merged` / `unchanged` / `skipped`.
- Docs: the Skills-pane guide now describes this as automatic (was a manual step); the `compile.ts` comment and a note in the shipped `_gitignore` record that `opencode.json` is a versioned pointer, kept out of the ignore list unlike the compiled `.opencode/AGENTS.md`.
- Tests: 9 new (3 integration through `install`, 6 unit). Full unit suite green; typecheck and format clean.
- Version bump to 3.27.0.

## Impact

- Existing conceptions gain a root `opencode.json` on their next `condash skills install`; one already present is merged into, never clobbered.
- The pointer must live at the conception **root** — OpenCode does not read `.opencode/opencode.json`.

## Watchpoints

- Behavior verified against OpenCode's documented config-discovery rules, not yet against a live OpenCode session restart.