### PR TITLE
Fix stale spawn-dropdown e2e to unblock the release gate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.28.0",
+  "version": "3.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.28.0",
+      "version": "3.28.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.28.0",
+  "version": "3.28.1",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/tests/terminal-tab-titles.spec.ts
+++ b/tests/terminal-tab-titles.spec.ts
@@ -17,7 +17,8 @@ test('terminal pane: New shell spawns an unpinned shell; agents populate the spa
         join(dir, 'agents', 'opencode-demo.json'),
         JSON.stringify({
           harness: 'opencode',
-          modelVariant: 'demo',
+          name: 'opencode-demo',
+          slug: 'opencode-demo',
           config: { model: 'deepseek/demo', disableExternalSkills: true },
         }),
         'utf8',


### PR DESCRIPTION
## Summary

- The agent name/slug split (#224) made the terminal spawn dropdown list agents by **display name**, but `terminal-tab-titles.spec.ts` still seeded a legacy `modelVariant`-only agent and asserted the old harness-prefixed name — so it failed the **tag-time** Playwright gate (which, post-#221, doesn't run on PRs, so #224 never exercised it).
- Modernises the fixture to the current `{name, slug}` shape. This unblocks the release that ships the Tasks pane (already merged to `main`); cut as **v3.28.1**.

## Changes

- `tests/terminal-tab-titles.spec.ts` — seed `agents/opencode-demo.json` with `{ name: 'opencode-demo', slug: 'opencode-demo' }` instead of the legacy `{ modelVariant: 'demo' }`, so the agent's display name matches the dropdown label and the existing assertions.
- Version bumped to 3.28.1 (final commit).

## Impact

- Restores a green tag-time Playwright gate (the prior `v3.28.0` tag failed here and published nothing). Full Playwright suite verified green locally with CI retries enabled (39 passed).