### PR TITLE
Add effort-level config to claude and opencode agents

### DIFF
--- a/docs/guides/agent-clis-and-models.md
+++ b/docs/guides/agent-clis-and-models.md
@@ -75,6 +75,11 @@ export CLAUDE_CODE_SUBAGENT_MODEL="kimi-k2.6"
 # --- Context window (drives the "% context left" display + compaction) ---
 export CLAUDE_CODE_MAX_CONTEXT_TOKENS=262144   # Kimi-k2.6 = 256K
 
+# --- Reasoning effort (optional) ---
+# Providers that map Claude Code's /effort onto their own reasoning budget
+# (e.g. DeepSeek) honour this; omit it to let the live session's /effort drive.
+export CLAUDE_CODE_EFFORT_LEVEL=max
+
 # --- Turn off Anthropic-only features the endpoint may not honour ---
 export DISABLE_PROMPT_CACHING=1                 # flip off if caching is confirmed
 export CLAUDE_CODE_DISABLE_1M_CONTEXT=1
@@ -115,6 +120,8 @@ opencode --model kimi-for-coding/kimi-k2-thinking
 ```
 
 Unlike `claude-kimi`, the credential is **not** in the wrapper. The model string is `<provider>/<model>`; the `kimi-for-coding` provider is registered once with `opencode auth login` and stored in OpenCode's auth file. The wrapper just selects the model and launches. (OpenCode is often installed as a self-contained binary, e.g. under `~/.opencode/bin` — make sure that directory is on your `PATH`.)
+
+To pin reasoning effort, add a top-level `"options": { "reasoningEffort": "max" }` to `opencode.json` — or set the agent's **Effort level** field in condash, which inlines the same key into `OPENCODE_CONFIG_CONTENT`. Providers that support a reasoning budget (e.g. DeepSeek) map it onto their `reasoning_effort`; leave it blank to omit.
 
 ### `aider-kimi` — Aider via an OpenAI-compatible endpoint
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "condash",
-  "version": "3.28.1",
+  "version": "3.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "condash",
-      "version": "3.28.1",
+      "version": "3.29.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "condash",
-  "version": "3.28.1",
+  "version": "3.29.0",
   "description": "Markdown project dashboard for the conception tree (Electron build)",
   "private": true,
   "main": "dist-electron/main/index.js",

--- a/src/main/agents.ts
+++ b/src/main/agents.ts
@@ -36,6 +36,8 @@ const claudeConfigSchema = z.object({
   opusAlias: z.string(),
   subagentModel: z.string(),
   maxContextTokens: z.number(),
+  // Default '' so agent JSON written before this field existed still validates.
+  effortLevel: z.string().default(''),
   disableCaching: z.boolean(),
   disable1M: z.boolean(),
   disableAdaptiveThinking: z.boolean(),
@@ -67,6 +69,7 @@ const opencodeConfigSchema = z.object({
   buildModel: z.string().optional(),
   planModel: z.string().optional(),
   disableExternalSkills: z.boolean(),
+  effortLevel: z.string().optional(),
   extraConfigJson: z
     .string()
     .optional()

--- a/src/renderer/panes/agents.tsx
+++ b/src/renderer/panes/agents.tsx
@@ -599,6 +599,19 @@ function AgentEditor(props: {
             }
           />
         </label>
+        <label>
+          <span>Effort level (options.reasoningEffort)</span>
+          <input
+            type="text"
+            placeholder="omit"
+            value={d().opencode.effortLevel ?? ''}
+            onInput={(e) =>
+              props.patch({
+                opencode: { ...d().opencode, effortLevel: e.currentTarget.value || undefined },
+              })
+            }
+          />
+        </label>
         <label class="agents-checkbox">
           <input
             type="checkbox"
@@ -667,6 +680,7 @@ function AgentEditor(props: {
                 ['sonnetAlias', 'sonnet alias'],
                 ['opusAlias', 'opus alias'],
                 ['subagentModel', 'Subagent model'],
+                ['effortLevel', 'Effort level (CLAUDE_CODE_EFFORT_LEVEL)'],
               ] as [keyof ClaudeAgentConfig, string][]
             }
           >

--- a/src/shared/harnesses.test.ts
+++ b/src/shared/harnesses.test.ts
@@ -12,6 +12,7 @@ import {
   isValidSlug,
   kimiAgentFileYaml,
   MissingAgentSecretError,
+  OPENCODE_PRESETS,
   previewCommandLine,
   slugify,
   suggestSlug,
@@ -248,5 +249,40 @@ describe('buildSpawn — kimi extra flags', () => {
       '--config',
       '{"a":1}',
     ]);
+  });
+});
+
+describe('buildSpawn — effort level', () => {
+  it('claude emits CLAUDE_CODE_EFFORT_LEVEL when set, omits it when blank', () => {
+    const base: AgentDef = {
+      harness: 'claude',
+      name: 'ds',
+      slug: 'claude-ds',
+      secretEnv: 'DEEPSEEK_API_KEY',
+      config: CLAUDE_PRESETS['deepseek-v4-pro'].config,
+    };
+    expect(buildSpawn(base, resolve({ DEEPSEEK_API_KEY: 'sk' })).env.CLAUDE_CODE_EFFORT_LEVEL).toBe(
+      'max',
+    );
+
+    const blank: AgentDef = { ...base, config: { ...base.config, effortLevel: '' } };
+    expect(buildSpawn(blank, resolve({ DEEPSEEK_API_KEY: 'sk' })).env).not.toHaveProperty(
+      'CLAUDE_CODE_EFFORT_LEVEL',
+    );
+  });
+
+  it('opencode sets options.reasoningEffort when set, omits options when blank', () => {
+    const set: AgentDef = {
+      harness: 'opencode',
+      name: 'oc',
+      slug: 'opencode-ds',
+      config: OPENCODE_PRESETS['deepseek-v4-pro'].config,
+    };
+    const setCfg = JSON.parse(buildSpawn(set, resolve({})).env.OPENCODE_CONFIG_CONTENT);
+    expect(setCfg.options.reasoningEffort).toBe('max');
+
+    const blank: AgentDef = { ...set, config: { ...set.config, effortLevel: undefined } };
+    const blankCfg = JSON.parse(buildSpawn(blank, resolve({})).env.OPENCODE_CONFIG_CONTENT);
+    expect(blankCfg).not.toHaveProperty('options');
   });
 });

--- a/src/shared/harnesses.ts
+++ b/src/shared/harnesses.ts
@@ -89,6 +89,10 @@ export interface ClaudeAgentConfig {
   opusAlias: string;
   subagentModel: string;
   maxContextTokens: number;
+  /** `CLAUDE_CODE_EFFORT_LEVEL` — reasoning-effort level handed to the harness
+   *  (e.g. `max` for alt-providers that map it onto their reasoning budget).
+   *  Blank = omit the var so the session's own `/effort` drives it. */
+  effortLevel: string;
   disableCaching: boolean;
   disable1M: boolean;
   disableAdaptiveThinking: boolean;
@@ -130,6 +134,9 @@ export interface OpencodeAgentConfig {
   planModel?: string;
   /** Sets `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` so only `.opencode/` skills load. */
   disableExternalSkills: boolean;
+  /** Top-level `options.reasoningEffort` in the inline config — reasoning-effort
+   *  level for the default model (e.g. `max`). Blank = omit. */
+  effortLevel?: string;
   /** Raw JSON merged into the inline config — escape hatch for any other
    *  opencode.json key (theme, provider, mcp, …). Blank = none. */
   extraConfigJson?: string;
@@ -310,6 +317,7 @@ function buildClaudeSpawn(
   env.ANTHROPIC_DEFAULT_OPUS_MODEL = cfg.opusAlias;
   env.CLAUDE_CODE_SUBAGENT_MODEL = cfg.subagentModel;
   env.CLAUDE_CODE_MAX_CONTEXT_TOKENS = String(cfg.maxContextTokens);
+  if (cfg.effortLevel.trim()) env.CLAUDE_CODE_EFFORT_LEVEL = cfg.effortLevel;
 
   if (cfg.disableCaching) env.DISABLE_PROMPT_CACHING = '1';
   if (cfg.disable1M) env.CLAUDE_CODE_DISABLE_1M_CONTEXT = '1';
@@ -370,6 +378,12 @@ function buildOpencodeSpawn(
     agent.plan = { ...((agent.plan as Record<string, unknown>) ?? {}), model: cfg.planModel };
   }
   if (Object.keys(agent).length > 0) config.agent = agent;
+  if (cfg.effortLevel?.trim()) {
+    config.options = {
+      ...((config.options as Record<string, unknown>) ?? {}),
+      reasoningEffort: cfg.effortLevel,
+    };
+  }
   env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);
 
   return { command: HARNESSES.opencode.binary, args: [], env, unsetEnv: [] };
@@ -415,6 +429,7 @@ export const CLAUDE_PRESETS: Record<string, ClaudePreset> = {
       opusAlias: '',
       subagentModel: '',
       maxContextTokens: 0,
+      effortLevel: '',
       disableCaching: false,
       disable1M: false,
       disableAdaptiveThinking: false,
@@ -435,6 +450,7 @@ export const CLAUDE_PRESETS: Record<string, ClaudePreset> = {
       opusAlias: 'deepseek-v4-pro',
       subagentModel: 'deepseek-v4-pro',
       maxContextTokens: 1000000,
+      effortLevel: 'max',
       ...CLAUDE_ALT_PROVIDER_TOGGLES,
     },
   },
@@ -450,6 +466,7 @@ export const CLAUDE_PRESETS: Record<string, ClaudePreset> = {
       opusAlias: 'deepseek-v4-flash',
       subagentModel: 'deepseek-v4-flash',
       maxContextTokens: 1000000,
+      effortLevel: 'max',
       ...CLAUDE_ALT_PROVIDER_TOGGLES,
     },
   },
@@ -465,6 +482,7 @@ export const CLAUDE_PRESETS: Record<string, ClaudePreset> = {
       opusAlias: 'deepseek-v4-pro',
       subagentModel: 'deepseek-v4-flash',
       maxContextTokens: 1000000,
+      effortLevel: 'max',
       ...CLAUDE_ALT_PROVIDER_TOGGLES,
     },
   },
@@ -480,6 +498,7 @@ export const CLAUDE_PRESETS: Record<string, ClaudePreset> = {
       opusAlias: 'kimi-k2.6',
       subagentModel: 'kimi-k2.6',
       maxContextTokens: 262144,
+      effortLevel: 'max',
       ...CLAUDE_ALT_PROVIDER_TOGGLES,
     },
   },
@@ -523,11 +542,15 @@ export interface OpencodePreset {
 export const OPENCODE_PRESETS: Record<string, OpencodePreset> = {
   'deepseek-v4-pro': {
     secretEnv: '',
-    config: { model: 'deepseek/deepseek-v4-pro', disableExternalSkills: true },
+    config: { model: 'deepseek/deepseek-v4-pro', disableExternalSkills: true, effortLevel: 'max' },
   },
   'deepseek-v4-flash': {
     secretEnv: '',
-    config: { model: 'deepseek/deepseek-v4-flash', disableExternalSkills: true },
+    config: {
+      model: 'deepseek/deepseek-v4-flash',
+      disableExternalSkills: true,
+      effortLevel: 'max',
+    },
   },
   'deepseek-auto': {
     secretEnv: '',
@@ -536,10 +559,15 @@ export const OPENCODE_PRESETS: Record<string, OpencodePreset> = {
       buildModel: 'deepseek/deepseek-v4-pro',
       planModel: 'deepseek/deepseek-v4-pro',
       disableExternalSkills: true,
+      effortLevel: 'max',
     },
   },
   kimi: {
     secretEnv: '',
-    config: { model: 'kimi-for-coding/kimi-k2-thinking', disableExternalSkills: true },
+    config: {
+      model: 'kimi-for-coding/kimi-k2-thinking',
+      disableExternalSkills: true,
+      effortLevel: 'max',
+    },
   },
 };


### PR DESCRIPTION
## Summary

- Agents can pin reasoning effort per agent instead of relying on per-session `/effort`: claude exports `CLAUDE_CODE_EFFORT_LEVEL`, opencode sets a top-level `options.reasoningEffort` in its inline config — for DeepSeek/Kimi alt-provider agents.
- New `effortLevel` field on both harness configs, editable in the Agents pane.

## Changes

- `src/shared/harnesses.ts`: `effortLevel` on `ClaudeAgentConfig` (required) and `OpencodeAgentConfig` (optional); `buildClaudeSpawn` emits `CLAUDE_CODE_EFFORT_LEVEL` when non-blank; `buildOpencodeSpawn` merges `options.reasoningEffort` into `OPENCODE_CONFIG_CONTENT`; presets default alt-providers to `max`, native to blank.
- `src/main/agents.ts`: zod schema gains `effortLevel` (claude `.default('')` for back-compat; opencode `.optional()`).
- `src/renderer/panes/agents.tsx`: effort-level input in the claude and opencode config forms.
- `src/shared/harnesses.test.ts`: covers env emission, blank-omit, and the opencode `options` merge.
- `docs/guides/agent-clis-and-models.md`: documents both levers.
- Bump 3.29.0.

## Impact

- Additive: existing agent JSON without the field still loads (claude defaults to `''`, opencode omits it); older condash ignores the unknown key.

## Watchpoints

- The `CLAUDE_CODE_EFFORT_LEVEL` env var and opencode `options.reasoningEffort` key come from provider integration notes not verified against the live `claude` / `opencode` binaries in-session. condash emits them faithfully; confirm DeepSeek/Kimi honour them before relying on pinned effort.