### PR TITLE
Pass initial prompt via CLI arg (claude/opencode), detect kimi readiness

### DIFF
--- a/src/main/agents.ts
+++ b/src/main/agents.ts
@@ -294,11 +294,15 @@ export async function deleteAgent(conceptionPath: string, slug: string): Promise
  * from `agents/.env`. Throws `MissingAgentSecretError` (from buildSpawn) when a
  * declared secret is unresolved, and a plain error when the agent is unknown.
  */
-export async function resolveAgentSpawn(conceptionPath: string, slug: string): Promise<SpawnSpec> {
+export async function resolveAgentSpawn(
+  conceptionPath: string,
+  slug: string,
+  initialPrompt?: string,
+): Promise<SpawnSpec> {
   const def = await readAgent(conceptionPath, slug);
   if (!def) throw new Error(`unknown agent: ${slug}`);
   const env = await readEnv(conceptionPath);
-  const spec = buildSpawn(def, (key) => env[key] || undefined);
+  const spec = buildSpawn(def, (key) => env[key] || undefined, initialPrompt);
   // kimi: inject instructions at spawn by wrapping the plain instructions file
   // (default ~/.kimi/AGENTS.md) into a transient `--agent-file` YAML.
   if (def.harness === 'kimi' && def.config.instructionsFile?.trim()) {

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -200,7 +200,7 @@ export async function spawnTerminal(
     // Resolve the agent slug to its binary + args + env (token injected from
     // agents/.env). Run it through the login shell so PATH and `~` expansion
     // match a hand-typed invocation.
-    agentSpec = await resolveAgentSpawn(conceptionPath, request.agentSlug);
+    agentSpec = await resolveAgentSpawn(conceptionPath, request.agentSlug, request.initialPrompt);
     const parts = [agentSpec.command, ...agentSpec.args.map((a) => quoteArg(expandHome(a)))];
     program = shell;
     argv = wrapForShell(shell, parts.join(' '));

--- a/src/renderer/terminal-bridge.test.ts
+++ b/src/renderer/terminal-bridge.test.ts
@@ -11,6 +11,8 @@ type FakeHandle = {
   moveActiveTab: ReturnType<typeof vi.fn>;
   typeIntoActive: ReturnType<typeof vi.fn>;
   hasActive: ReturnType<typeof vi.fn>;
+  getActiveSessionId: ReturnType<typeof vi.fn>;
+  waitForReady: ReturnType<typeof vi.fn>;
 };
 
 function makeFakeHandle(): FakeHandle {
@@ -21,6 +23,8 @@ function makeFakeHandle(): FakeHandle {
     moveActiveTab: vi.fn(),
     typeIntoActive: vi.fn(),
     hasActive: vi.fn().mockReturnValue(true),
+    getActiveSessionId: vi.fn().mockReturnValue('session-1'),
+    waitForReady: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -42,6 +46,14 @@ const claudeAgent: AgentListItem = {
   secretEnv: 'DEEPSEEK_API_KEY',
   tokenPresent: true,
   command: 'claude',
+};
+const opencodeAgent: AgentListItem = {
+  slug: 'opencode-deepseek-v4-pro',
+  name: 'deepseek-v4-pro',
+  harness: 'opencode',
+  secretEnv: 'DEEPSEEK_API_KEY',
+  tokenPresent: true,
+  command: 'opencode',
 };
 const kimiAgent: AgentListItem = {
   slug: 'kimi-cli-native',
@@ -181,7 +193,7 @@ describe('handleNewProjectAction', () => {
     // Drain the agent-spawn settle delay (~350 ms).
     await vi.advanceTimersByTimeAsync(400);
     await promise;
-    expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my');
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my', undefined);
     expect(handle.typeIntoActive).toHaveBeenCalledWith('Start new project ');
     vi.useRealTimers();
   });
@@ -214,21 +226,21 @@ describe('handleProjectAction with agent binding', () => {
     const promise = bridge.handleProjectAction(sampleProject, action);
     await vi.advanceTimersByTimeAsync(400);
     await promise;
-    expect(handle.spawnUserShell).toHaveBeenCalledWith(claudeAgent, 'my');
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(claudeAgent, 'my', undefined);
     expect(handle.typeIntoActive).toHaveBeenCalledWith('review foo-bar');
     vi.useRealTimers();
   });
 });
 
 describe('runTask', () => {
-  it('spawns the task agent, types the filled prompt, and submits', async () => {
+  it('kimi + submit=true spawns, settles, types via pty, and submits', async () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
-    const bridge = createTerminalBridge(makeDeps(handle, [claudeAgent]));
-    const promise = bridge.runTask('claude-deepseek-v4-pro', 'review the docs', true);
-    await vi.advanceTimersByTimeAsync(400);
+    const bridge = createTerminalBridge(makeDeps(handle, [kimiAgent]));
+    const promise = bridge.runTask('kimi-cli-native', 'review the docs', true);
+    await vi.advanceTimersByTimeAsync(600);
     await promise;
-    expect(handle.spawnUserShell).toHaveBeenCalledWith(claudeAgent, 'my');
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my', undefined);
     expect(handle.typeIntoActive).toHaveBeenCalledWith('review the docs');
     expect(handle.typeIntoActive).toHaveBeenLastCalledWith('\r');
     vi.useRealTimers();
@@ -257,5 +269,82 @@ describe('runTask', () => {
     );
     expect(handle.spawnUserShell).not.toHaveBeenCalled();
     expect(handle.typeIntoActive).not.toHaveBeenCalled();
+  });
+
+  it('claude + submit=true passes initialPrompt to spawnUserShell, skips typeIntoActive', async () => {
+    const handle = makeFakeHandle();
+    const bridge = createTerminalBridge(makeDeps(handle, [claudeAgent]));
+    await bridge.runTask('claude-deepseek-v4-pro', 'review the docs', true);
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(claudeAgent, 'my', 'review the docs');
+    expect(handle.typeIntoActive).not.toHaveBeenCalled();
+    expect(handle.waitForReady).not.toHaveBeenCalled();
+  });
+
+  it('opencode + submit=true passes initialPrompt to spawnUserShell, skips typeIntoActive', async () => {
+    const handle = makeFakeHandle();
+    const bridge = createTerminalBridge(makeDeps(handle, [opencodeAgent]));
+    await bridge.runTask('opencode-deepseek-v4-pro', 'explain this', true);
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(opencodeAgent, 'my', 'explain this');
+    expect(handle.typeIntoActive).not.toHaveBeenCalled();
+    expect(handle.waitForReady).not.toHaveBeenCalled();
+  });
+
+  it('claude + submit=false falls back to pty path (no initialPrompt, settles, types)', async () => {
+    vi.useFakeTimers();
+    const handle = makeFakeHandle();
+    const bridge = createTerminalBridge(makeDeps(handle, [claudeAgent]));
+    const promise = bridge.runTask('claude-deepseek-v4-pro', 'just type this', false);
+    await vi.advanceTimersByTimeAsync(400);
+    await promise;
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(claudeAgent, 'my', undefined);
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('just type this');
+    expect(handle.typeIntoActive).toHaveBeenCalledTimes(1);
+    expect(handle.waitForReady).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('waits for kimi prompt marker before typing', async () => {
+    vi.useFakeTimers();
+    const handle = makeFakeHandle();
+    // Simulate waitForReady resolving after a short delay.
+    handle.waitForReady.mockImplementation(
+      () => new Promise<void>((resolve) => setTimeout(resolve, 200)),
+    );
+    const bridge = createTerminalBridge(makeDeps(handle, [kimiAgent]));
+    const promise = bridge.runTask('kimi-cli-native', 'review the docs', true);
+    // Drain settle delay + waitForReady resolve.
+    await vi.advanceTimersByTimeAsync(600);
+    await promise;
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my', undefined);
+    expect(handle.waitForReady).toHaveBeenCalledWith('session-1', /▸/);
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('review the docs');
+    expect(handle.typeIntoActive).toHaveBeenLastCalledWith('\r');
+    vi.useRealTimers();
+  });
+
+  it('types anyway when kimi readiness times out', async () => {
+    vi.useFakeTimers();
+    const handle = makeFakeHandle();
+    handle.waitForReady.mockRejectedValue(new Error('Timed out'));
+    const bridge = createTerminalBridge(makeDeps(handle, [kimiAgent]));
+    const promise = bridge.runTask('kimi-cli-native', 'text', false);
+    await vi.advanceTimersByTimeAsync(400);
+    await promise;
+    expect(handle.waitForReady).toHaveBeenCalled();
+    // Still types despite the timeout.
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('text');
+    vi.useRealTimers();
+  });
+
+  it('skips readiness wait for non-kimi agents', async () => {
+    vi.useFakeTimers();
+    const handle = makeFakeHandle();
+    const bridge = createTerminalBridge(makeDeps(handle, [claudeAgent]));
+    const promise = bridge.runTask('claude-deepseek-v4-pro', 'text', false);
+    await vi.advanceTimersByTimeAsync(400);
+    await promise;
+    expect(handle.waitForReady).not.toHaveBeenCalled();
+    expect(handle.typeIntoActive).toHaveBeenCalledWith('text');
+    vi.useRealTimers();
   });
 });

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -117,8 +117,15 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
    *  its prompt before it will accept typed input — typing during init drops
    *  characters or lands in a not-yet-ready REPL. AGENT_SPAWN_SETTLE_MS covers
    *  both. setTimeout (not requestAnimationFrame) so this stays callable in
-   *  unit tests (jsdom env has no rAF). */
-  const spawnAgentTab = async (agent: AgentListItem): Promise<TerminalPaneHandle | null> => {
+   *  unit tests (jsdom env has no rAF).
+   *
+   *  When `initialPrompt` is set, it passes the prompt as a CLI argument to the
+   *  agent harness (claude: positional arg; opencode: `tui --prompt`). The settle
+   *  delay is skipped in that case — the prompt is in argv, not typed via pty. */
+  const spawnAgentTab = async (
+    agent: AgentListItem,
+    initialPrompt?: string,
+  ): Promise<TerminalPaneHandle | null> => {
     if (!deps.terminalHandle()) {
       deps.ensureTerminalOpen();
       await waitForTerminalHandle(deps);
@@ -127,12 +134,14 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     if (!handle) return null;
     deps.ensureTerminalOpen();
     try {
-      await handle.spawnUserShell(agent, 'my');
+      await handle.spawnUserShell(agent, 'my', initialPrompt);
     } catch (err) {
       deps.flashToast(`Could not spawn ${agent.name}: ${(err as Error).message}`, 'error');
       return null;
     }
-    await new Promise<void>((resolve) => setTimeout(resolve, AGENT_SPAWN_SETTLE_MS));
+    if (!initialPrompt) {
+      await new Promise<void>((resolve) => setTimeout(resolve, AGENT_SPAWN_SETTLE_MS));
+    }
     return handle;
   };
 
@@ -255,14 +264,42 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     handle.typeIntoActive(text);
   };
 
+  /** Harnesses whose CLI accepts an initial prompt as an argument, removing
+   *  the need to type into the pty after spawn. */
+  const NATIVE_INITIAL_PROMPT_HARNESSES = new Set(['claude', 'opencode']);
+
   const runTask = async (agentSlug: string, text: string, submit: boolean): Promise<void> => {
     const agent = findAgentBySlug(deps.agents(), agentSlug);
     if (!agent) {
       deps.flashToast(`Task agent not found: ${agentSlug}`, 'error');
       return;
     }
+
+    // When the harness supports it and submit is true, pass the prompt as a
+    // CLI argument in argv. The agent executes it on startup — no pty.write,
+    // no settle delay, no race.
+    if (submit && NATIVE_INITIAL_PROMPT_HARNESSES.has(agent.harness)) {
+      const handle = await spawnAgentTab(agent, text);
+      if (!handle) return;
+      return;
+    }
+
     const handle = await spawnAgentTab(agent);
     if (!handle) return;
+    // Kimi has no CLI flag for an initial prompt in interactive mode, so we
+    // must still type via the pty. Replace the blind 350 ms settle delay
+    // (built into spawnAgentTab) with a prompt-marker watch so we never
+    // send text before kimi is ready to read it.
+    if (agent.harness === 'kimi') {
+      const sessionId = handle.getActiveSessionId();
+      if (sessionId) {
+        try {
+          await handle.waitForReady(sessionId, /▸/);
+        } catch {
+          // Timeout — fall through and type anyway (best-effort).
+        }
+      }
+    }
     handle.typeIntoActive(text);
     if (submit) {
       // Small delay so the terminal has time to ingest the typed text

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -57,14 +57,23 @@ export interface TerminalPaneHandle {
   spawn(request: TermSpawnRequest, label: string, opts?: SpawnOptions): Promise<string>;
   switchTo(side: TermSide, id?: string): void;
   /** Add a fresh user shell tab to "My terms". `agent` may be an
-   *  `AgentListItem` to pin and run that agent, or `null` for a plain shell. */
-  spawnUserShell(agent?: AgentChoice, side?: TermSide): Promise<string>;
+   *  `AgentListItem` to pin and run that agent, or `null` for a plain shell.
+   *  `initialPrompt` is passed through to `TermSpawnRequest` so harnesses that
+   *  support it (claude, opencode) receive the prompt as a CLI argument. */
+  spawnUserShell(agent?: AgentChoice, side?: TermSide, initialPrompt?: string): Promise<string>;
   /** Move the active tab within its column strip. */
   moveActiveTab(direction: -1 | 1): void;
   /** Type a literal string into the active terminal (no shell parsing). */
   typeIntoActive(text: string): void;
   /** True when there is an active session in the active column. */
   hasActive(): boolean;
+  /** Return the active session ID for the active column, or null. */
+  getActiveSessionId(): string | null;
+  /** Wait until the accumulated output for `sessionId` matches `pattern`,
+   *  or reject after `timeoutMs` (default 15 s). Resolves immediately if
+   *  the pattern already matches. ANSI escape sequences are stripped before
+   *  matching so patterns can target visible text only. */
+  waitForReady(sessionId: string, pattern: RegExp, timeoutMs?: number): Promise<void>;
 }
 
 export function TerminalPane(props: {
@@ -110,6 +119,45 @@ export function TerminalPane(props: {
   // user-initiated close (× button) and process-exit close don't race.
   const closingTabs = new Set<string>();
 
+  // Accumulated raw pty output per session (ANSI codes included). Used by
+  // waitForReady to detect agent prompt markers without re-parsing xterm buffers.
+  const sessionData = new Map<string, string>();
+
+  // Pending readiness waiters keyed by session id.
+  const readyWaiters = new Map<
+    string,
+    {
+      pattern: RegExp;
+      resolve: () => void;
+      reject: (err: Error) => void;
+      timer: ReturnType<typeof setTimeout>;
+    }[]
+  >();
+
+  const stripAnsi = (text: string): string =>
+    text.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '').replace(/\x1b\][0-9;]*[^\x07]*\x07/g, '');
+
+  const checkReadyWaiters = (sessionId: string): void => {
+    const waiters = readyWaiters.get(sessionId);
+    if (!waiters || waiters.length === 0) return;
+    const raw = sessionData.get(sessionId) || '';
+    const cleaned = stripAnsi(raw);
+    const remaining = waiters.filter((w) => {
+      if (w.pattern.test(cleaned)) {
+        clearTimeout(w.timer);
+        w.resolve();
+        return false;
+      }
+      return true;
+    });
+    if (remaining.length === 0) {
+      readyWaiters.delete(sessionId);
+      sessionData.delete(sessionId);
+    } else {
+      readyWaiters.set(sessionId, remaining);
+    }
+  };
+
   const xterms = new Map<
     string,
     {
@@ -146,6 +194,10 @@ export function TerminalPane(props: {
     element.style.display = 'none';
     const host = hostFor(column);
     if (host) host.appendChild(element);
+    if (replay) {
+      const prev = sessionData.get(id) || '';
+      sessionData.set(id, prev + replay);
+    }
     const mounted = mountXterm(element, id, {
       replay,
       prefs: props.xtermPrefs,
@@ -314,6 +366,15 @@ export function TerminalPane(props: {
       handle?.mounted.dispose();
       handle?.element.remove();
       xterms.delete(id);
+      sessionData.delete(id);
+      const waiters = readyWaiters.get(id);
+      if (waiters) {
+        for (const w of waiters) {
+          clearTimeout(w.timer);
+          w.reject(new Error('Session closed'));
+        }
+        readyWaiters.delete(id);
+      }
     }
     if (toDrop.length > 0) {
       setTabs((prev) => prev.filter((t) => !toDrop.includes(t.id)));
@@ -366,6 +427,7 @@ export function TerminalPane(props: {
   const spawnUserShell = async (
     agent: AgentChoice = null,
     sd: TermSide = 'my',
+    initialPrompt?: string,
   ): Promise<string> => {
     const label = uniqueLabel(agent?.name || 'shell');
     // Pin the label only when the caller picked an agent. The bare "New shell"
@@ -376,6 +438,7 @@ export function TerminalPane(props: {
         side: sd,
         agentSlug: agent?.slug,
         cwd: props.cwd ?? undefined,
+        initialPrompt,
       },
       label,
       { pinned: agent !== null },
@@ -392,6 +455,9 @@ export function TerminalPane(props: {
 
   // ---- live data + exit notification ----
   const offTermData = window.condash.onTermData(({ id, data }) => {
+    const prev = sessionData.get(id) || '';
+    sessionData.set(id, prev + data);
+    checkReadyWaiters(id);
     const handle = xterms.get(id);
     handle?.term.write(data);
   });
@@ -412,6 +478,14 @@ export function TerminalPane(props: {
       element.remove();
     }
     xterms.clear();
+    for (const waiters of readyWaiters.values()) {
+      for (const w of waiters) {
+        clearTimeout(w.timer);
+        w.reject(new Error('Pane closed'));
+      }
+    }
+    readyWaiters.clear();
+    sessionData.clear();
   });
 
   const closeTab = (id: string) => {
@@ -520,6 +594,27 @@ export function TerminalPane(props: {
       queueMicrotask(focusActive);
     },
     hasActive: () => Boolean(activeIdIn(activeColumn())),
+    getActiveSessionId: () => activeIdIn(activeColumn()),
+    waitForReady: (sessionId, pattern, timeoutMs = 15000) =>
+      new Promise<void>((resolve, reject) => {
+        const raw = sessionData.get(sessionId) || '';
+        if (pattern.test(stripAnsi(raw))) {
+          resolve();
+          return;
+        }
+        const timer = setTimeout(() => {
+          const waiters = readyWaiters.get(sessionId);
+          if (waiters) {
+            const filtered = waiters.filter((w) => w.resolve !== resolve);
+            if (filtered.length === 0) readyWaiters.delete(sessionId);
+            else readyWaiters.set(sessionId, filtered);
+          }
+          reject(new Error(`Timed out waiting for agent prompt (${timeoutMs}ms)`));
+        }, timeoutMs);
+        const entry = { pattern, resolve, reject, timer };
+        const existing = readyWaiters.get(sessionId) || [];
+        readyWaiters.set(sessionId, [...existing, entry]);
+      }),
   };
   onMount(() => props.registerHandle(handle));
   onCleanup(() => props.registerHandle(null));

--- a/src/shared/harnesses.test.ts
+++ b/src/shared/harnesses.test.ts
@@ -100,6 +100,20 @@ describe('buildSpawn — claude', () => {
     const spec = buildSpawn(native, resolve({}));
     expect(spec).toEqual({ command: 'claude', args: [], env: {}, unsetEnv: [] });
   });
+
+  it('appends initialPrompt as a positional argument', () => {
+    const spec = buildSpawn(def, resolve({ DEEPSEEK_API_KEY: 'sk-test' }), 'fix the bug');
+    expect(spec.args).toEqual(['fix the bug']);
+    // Native path also works.
+    const native: AgentDef = {
+      harness: 'claude',
+      name: 'native',
+      slug: 'claude-native',
+      config: CLAUDE_PRESETS.native.config,
+    };
+    const nativeSpec = buildSpawn(native, resolve({}), 'review PR');
+    expect(nativeSpec.args).toEqual(['review PR']);
+  });
 });
 
 describe('buildSpawn — kimi-cli', () => {
@@ -163,6 +177,17 @@ describe('buildSpawn — opencode', () => {
     });
   });
 
+  it('appends tui --prompt with initialPrompt', () => {
+    const def: AgentDef = {
+      harness: 'opencode',
+      name: 'deepseek-v4-pro',
+      slug: 'opencode-deepseek-v4-pro',
+      config: defaultOpencodeConfig('deepseek/deepseek-v4-pro'),
+    };
+    const spec = buildSpawn(def, resolve({}), 'explain this code');
+    expect(spec.args).toEqual(['tui', '--prompt', 'explain this code']);
+  });
+
   it('routes build/plan overrides and merges extra config underneath', () => {
     const spec = buildSpawn(
       {
@@ -187,6 +212,19 @@ describe('buildSpawn — opencode', () => {
         plan: { model: 'deepseek/deepseek-v4-pro' },
       },
     });
+  });
+});
+
+describe('buildSpawn — kimi ignores initialPrompt', () => {
+  it('does not add initialPrompt to args (no interactive support)', () => {
+    const def: AgentDef = {
+      harness: 'kimi',
+      name: 'native',
+      slug: 'kimi-cli-native',
+      config: defaultKimiConfig(),
+    };
+    const spec = buildSpawn(def, resolve({}), 'some prompt');
+    expect(spec.args).toEqual([]);
   });
 });
 

--- a/src/shared/harnesses.ts
+++ b/src/shared/harnesses.ts
@@ -233,18 +233,24 @@ export class MissingAgentSecretError extends Error {
  * Build the spawn spec for an agent. `resolveSecret` looks a name up in the
  * conception's `agents/.env`; it returns `undefined` for an absent/blank key.
  * Throws `MissingAgentSecretError` when a declared secret is unresolved.
+ *
+ * `initialPrompt` is an optional first user message injected as a CLI argument
+ * so the prompt lands as part of the spawn command rather than via pty.write()
+ * after a blind settle delay. Supported by claude (positional arg) and opencode
+ * (`tui --prompt`); ignored by kimi (no interactive initial-prompt support).
  */
 export function buildSpawn(
   def: AgentDef,
   resolveSecret: (name: string) => string | undefined,
+  initialPrompt?: string,
 ): SpawnSpec {
   switch (def.harness) {
     case 'claude':
-      return buildClaudeSpawn(def, resolveSecret);
+      return buildClaudeSpawn(def, resolveSecret, initialPrompt);
     case 'kimi':
       return buildKimiSpawn(def, resolveSecret);
     case 'opencode':
-      return buildOpencodeSpawn(def, resolveSecret);
+      return buildOpencodeSpawn(def, resolveSecret, initialPrompt);
   }
 }
 
@@ -274,14 +280,16 @@ export function previewCommandLine(def: AgentDef): string {
 function buildClaudeSpawn(
   def: Extract<AgentDef, { harness: 'claude' }>,
   resolveSecret: (name: string) => string | undefined,
+  initialPrompt?: string,
 ): SpawnSpec {
   const cfg = def.config;
+  const extraArgs = initialPrompt ? [initialPrompt] : [];
 
   // Native claude (no provider remap): an empty baseUrl means "run bare
   // `claude`" — claude uses the user's own Anthropic login + model config, so
   // condash sets nothing.
   if (!cfg.baseUrl.trim()) {
-    return { command: HARNESSES.claude.binary, args: [], env: {}, unsetEnv: [] };
+    return { command: HARNESSES.claude.binary, args: extraArgs, env: {}, unsetEnv: [] };
   }
 
   const env: Record<string, string> = {};
@@ -326,7 +334,7 @@ function buildClaudeSpawn(
     'CLAUDE_CODE_USE_MANTLE',
   );
 
-  return { command: HARNESSES.claude.binary, args: [], env, unsetEnv };
+  return { command: HARNESSES.claude.binary, args: extraArgs, env, unsetEnv };
 }
 
 function buildKimiSpawn(
@@ -351,6 +359,7 @@ function buildKimiSpawn(
 function buildOpencodeSpawn(
   def: Extract<AgentDef, { harness: 'opencode' }>,
   resolveSecret: (name: string) => string | undefined,
+  initialPrompt?: string,
 ): SpawnSpec {
   const cfg = def.config;
   const env: Record<string, string> = {};
@@ -372,7 +381,8 @@ function buildOpencodeSpawn(
   if (Object.keys(agent).length > 0) config.agent = agent;
   env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);
 
-  return { command: HARNESSES.opencode.binary, args: [], env, unsetEnv: [] };
+  const extraArgs = initialPrompt ? ['tui', '--prompt', initialPrompt] : [];
+  return { command: HARNESSES.opencode.binary, args: extraArgs, env, unsetEnv: [] };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -559,6 +559,11 @@ export interface TermSpawnRequest {
    *  main process resolves it to the harness binary + args + env (token from
    *  `agents/.env`) and spawns that. Mutually exclusive with `repo` / `command`. */
   agentSlug?: string;
+  /** When set, passes the initial prompt as a CLI argument to the agent
+   *  (claude: positional arg; opencode: `tui --prompt <text>`; kimi: ignored).
+   *  Only meaningful with `agentSlug`; the prompt is added to argv directly,
+   *  removing the race between process-start and pty.write(). */
+  initialPrompt?: string;
   /** Override the cwd; defaults to $HOME (or the resolved repo cwd). */
   cwd?: string;
   cols?: number;


### PR DESCRIPTION
## Summary

- Tasks pane prompts were pty.write()'d after a blind 350ms delay — the agent process wasn't always ready, causing dropped characters.
- Claude and opencode now receive the prompt as a CLI argument, eliminating the race entirely.
- Kimi has no interactive initial-prompt flag, so readiness detection watches pty output for the prompt marker before injecting text.

## Changes

- **TermSpawnRequest.initialPrompt** — new field threading the prompt through the spawn pipeline
- **buildSpawn()** — accepts optional initialPrompt; claude passes as positional arg, opencode as tui --prompt
- **runTask()** — harness-aware branching: claude/opencode + submit=true → prompt in argv (no settle, no pty.write); kimi → settle + waitForReady + pty.write
- **TerminalPaneHandle** — new getActiveSessionId() and waitForReady() methods with session-level ANSI-stripped output accumulation
- **spawnAgentTab()** — skips the 350ms settle delay when initialPrompt is set
- Tests cover all paths: native argv (claude/opencode submit=true/false), kimi readiness wait, readiness timeout fallback

## Impact

- No breaking changes — existing agent configs and task definitions are unaffected
- The settle delay is skipped only when the harness supports native initial-prompt and submit is true

## Watchpoints

- Monitor kimi task launches for prompt marker detection reliability across kimi versions; the timeout fallback ensures tasks still run even if the marker format changes