### PR TITLE
Fix tag-version injection on Windows (shell: bash)

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -40,7 +40,10 @@ jobs:
       # bump. `_build.yml` runs only from release.yml (tag push), so ref_name is
       # the tag. electron-builder reads this version into installers + latest*.yml.
       - name: Set version from tag
+        # shell: bash so the ${VAR#v} stripping works on Windows too (default
+        # shell there is PowerShell, which doesn't do bash parameter expansion).
         run: npm pkg set version="${GITHUB_REF_NAME#v}"
+        shell: bash
         env:
           GITHUB_REF_NAME: ${{ github.ref_name }}
 


### PR DESCRIPTION
## Summary

- The v3.29.2 release failed on the `build / Build (windows-latest)` leg at the new 'Set version from tag' step: `${GITHUB_REF_NAME#v}` is bash parameter expansion, but GitHub's default shell on Windows is PowerShell. Linux + macOS passed; Windows failed, and `publish` was correctly skipped — so nothing shipped.
- Pin the step to `shell: bash` (Git Bash is present on the Windows runner) so injection works on all three OS legs.

## Changes

- `.github/workflows/_build.yml`: add `shell: bash` to the 'Set version from tag' step.

## Impact

- Unblocks the tag-derived release on Windows. Re-release as v3.29.3 after merge (v3.29.2's tag published nothing).

## Watchpoints

- Confirm the v3.29.3 `windows-latest` leg passes 'Set version from tag' and the published Windows installer reports 3.29.3.