### PR TITLE
Fix opencode initial-prompt launch; show logs newest-first

### DIFF
--- a/src/main/ipc/logs.test.ts
+++ b/src/main/ipc/logs.test.ts
@@ -121,7 +121,7 @@ describe('logsListSessions', () => {
     await expect(handlers.logsListSessions({}, 'not-a-day')).rejects.toThrow(/invalid day/);
   });
 
-  it('returns per-session metadata parsed from header + footer, sorted by time', async () => {
+  it('returns per-session metadata parsed from header + footer, most recent first', async () => {
     writeSession(
       '2026-05-13',
       '142207',
@@ -145,11 +145,11 @@ describe('logsListSessions', () => {
       exitCode?: number;
       cmd?: string;
     }>;
-    expect(result.map((r) => r.sid)).toEqual(['t-bbb', 't-aaa']); // 09:30 before 14:22
-    expect(result[0].repo).toBe('condash');
-    expect(result[0].exitCode).toBe(0);
-    expect(result[0].cmd).toBe('make dev');
-    expect(result[1].exitCode).toBeUndefined(); // still running
+    expect(result.map((r) => r.sid)).toEqual(['t-aaa', 't-bbb']); // 14:22 before 09:30 — most recent first
+    expect(result[0].exitCode).toBeUndefined(); // 14:22 still running
+    expect(result[1].repo).toBe('condash');
+    expect(result[1].exitCode).toBe(0);
+    expect(result[1].cmd).toBe('make dev');
   });
 
   it('returns an empty list for an empty day', async () => {

--- a/src/main/ipc/logs.ts
+++ b/src/main/ipc/logs.ts
@@ -94,8 +94,8 @@ async function listSessionsForDay(day: string): Promise<TermLogSessionMeta[]> {
     const meta = await readSessionMetaSummary(fullPath, day, name);
     if (meta) metas.push(meta);
   }
-  // Sort by HHMMSS — chronological within a day.
-  metas.sort((a, b) => (a.time < b.time ? -1 : 1));
+  // Sort by HHMMSS descending — most recent first within a day.
+  metas.sort((a, b) => (a.time < b.time ? 1 : -1));
   return metas;
 }
 

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -120,7 +120,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
    *  unit tests (jsdom env has no rAF).
    *
    *  When `initialPrompt` is set, it passes the prompt as a CLI argument to the
-   *  agent harness (claude: positional arg; opencode: `tui --prompt`). The settle
+   *  agent harness (claude: positional arg; opencode: `--prompt`). The settle
    *  delay is skipped in that case — the prompt is in argv, not typed via pty. */
   const spawnAgentTab = async (
     agent: AgentListItem,

--- a/src/shared/harnesses.test.ts
+++ b/src/shared/harnesses.test.ts
@@ -178,7 +178,7 @@ describe('buildSpawn — opencode', () => {
     });
   });
 
-  it('appends tui --prompt with initialPrompt', () => {
+  it('appends --prompt with initialPrompt', () => {
     const def: AgentDef = {
       harness: 'opencode',
       name: 'deepseek-v4-pro',
@@ -186,7 +186,7 @@ describe('buildSpawn — opencode', () => {
       config: defaultOpencodeConfig('deepseek/deepseek-v4-pro'),
     };
     const spec = buildSpawn(def, resolve({}), 'explain this code');
-    expect(spec.args).toEqual(['tui', '--prompt', 'explain this code']);
+    expect(spec.args).toEqual(['--prompt', 'explain this code']);
   });
 
   it('routes build/plan overrides and merges extra config underneath', () => {

--- a/src/shared/harnesses.ts
+++ b/src/shared/harnesses.ts
@@ -244,7 +244,7 @@ export class MissingAgentSecretError extends Error {
  * `initialPrompt` is an optional first user message injected as a CLI argument
  * so the prompt lands as part of the spawn command rather than via pty.write()
  * after a blind settle delay. Supported by claude (positional arg) and opencode
- * (`tui --prompt`); ignored by kimi (no interactive initial-prompt support).
+ * (`--prompt`); ignored by kimi (no interactive initial-prompt support).
  */
 export function buildSpawn(
   def: AgentDef,
@@ -395,7 +395,7 @@ function buildOpencodeSpawn(
   }
   env.OPENCODE_CONFIG_CONTENT = JSON.stringify(config);
 
-  const extraArgs = initialPrompt ? ['tui', '--prompt', initialPrompt] : [];
+  const extraArgs = initialPrompt ? ['--prompt', initialPrompt] : [];
   return { command: HARNESSES.opencode.binary, args: extraArgs, env, unsetEnv: [] };
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -560,7 +560,7 @@ export interface TermSpawnRequest {
    *  `agents/.env`) and spawns that. Mutually exclusive with `repo` / `command`. */
   agentSlug?: string;
   /** When set, passes the initial prompt as a CLI argument to the agent
-   *  (claude: positional arg; opencode: `tui --prompt <text>`; kimi: ignored).
+   *  (claude: positional arg; opencode: `--prompt <text>`; kimi: ignored).
    *  Only meaningful with `agentSlug`; the prompt is added to argv directly,
    *  removing the race between process-start and pty.write(). */
   initialPrompt?: string;


### PR DESCRIPTION
## Summary

- `opencode --prompt <text>` is the correct way to launch the TUI with an initial prompt; the previous `opencode tui --prompt <text>` aborted because opencode has no `tui` subcommand — it read `tui` as the project directory and failed to cd into it. Regression from the initial-prompt CLI-flags work shipped in v3.29.1.
- The logs pane now lists sessions newest-first within each day, matching the existing newest-first day ordering.

## Changes

- `harnesses.ts` — `buildOpencodeSpawn()` drops the leading `tui` arg; the initial-prompt spawn is now `['--prompt', prompt]`.
- `logs.ts` — `listSessionsForDay()` sorts sessions by timestamp descending (most recent first).
- Corrected `tui --prompt` doc comments in `harnesses.ts`, `types.ts`, `terminal-bridge.ts`.
- Updated tests: `harnesses.test.ts` (opencode arg assertion) and `logs.test.ts` (session order).

## Impact

- opencode agents launched with an initial prompt now start correctly instead of erroring on spawn.
- The logs pane reads newest→oldest throughout (day and session level).