### PR TITLE
Fix terminal external paste by reading clipboard in main process

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -143,7 +143,7 @@ Press `Ctrl+Shift+V` (configurable as `terminal.screenshot_paste_shortcut`) anyw
 
 Typical use: take a screenshot of a failing test → `Ctrl+Shift+V` → the path appears → prefix with `cat ` or drop into a `gh issue create --body-file ` command.
 
-Clipboard-based paste (`Ctrl+V`) also works for regular text, and uses the OS clipboard via a server-side bridge because xterm.js can't read the browser clipboard directly. Both `Ctrl+V` (paste) and `Ctrl+C` (copy) flow through this bridge.
+Regular text paste (`Ctrl+V`) reads the system clipboard in the main process (`clipboardReadText` IPC) and feeds it through `term.paste()`, so bracketed-paste mode is honoured — agent TUIs (e.g. opencode) see a multi-line paste as a single block. Copy (`Ctrl+C`, when there's a selection) writes the clipboard via the renderer's `navigator.clipboard`. Paste doesn't use the renderer clipboard because `navigator.clipboard.readText()` is permission-gated and unreliable in Electron.
 
 ## Configuration surface
 

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -81,6 +81,7 @@ The terminal pane spawns and drives node-pty sessions. Lifecycle: `termSpawn` �
 |---|---|
 | `termSpawn(request)` | Allocate a pty (setsid → own process group), return session id and resolved cwd. |
 | `termWrite(id, data)` | Forward stdin bytes. |
+| `clipboardReadText()` | Read the system clipboard via the main-process Electron `clipboard`. Backs the terminal's `Ctrl+V` handler — the renderer's `navigator.clipboard.readText()` is permission-gated and unreliable. |
 | `termResize(id, cols, rows)` | `TIOCSWINSZ` on the pty. |
 | `termClose(id)` | Run the kill pipeline: `SIGTERM` → optional `force_stop` → 500ms wait → `SIGKILL` on the process group. |
 | `termList()` | Snapshot of live (or recently-exited) sessions. Used by the panel rebuild on pane switch. |
@@ -199,7 +200,7 @@ Every entry maps one-to-one to a menu item — see [Keyboard shortcuts — Appli
 
 ## What is intentionally **not** here
 
-- **No HTTP fallback.** No clipboard endpoint, no asset routes, no embedded server. The renderer reads the system clipboard through the browser's native [`navigator.clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard_API) API.
+- **No HTTP fallback.** No clipboard endpoint, no asset routes, no embedded server. Copy writes the clipboard through the browser's native [`navigator.clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard_API) API; paste reads it through the `clipboardReadText` IPC (main-process Electron `clipboard`), since `navigator.clipboard.readText()` is permission-gated in the renderer.
 - **No vendored CDN bundles.** Electron ships Chromium directly; assets are bundled into the asar at package time.
 - **No auth layer.** condash is single-user, local-only.
 - **No `step set`-style verbs.** Step markers cycle only through `toggleStep`; there is no "set marker to X" verb. Use the cycle.

--- a/docs/reference/shortcuts.md
+++ b/docs/reference/shortcuts.md
@@ -131,12 +131,13 @@ These live inside xterm's `attachCustomKeyEventHandler` and only fire while a te
 |---|---|
 | `Ctrl+C` | Copy the selection if there is one; otherwise send `SIGINT` to the foreground process. |
 | `Ctrl+Shift+C` | Always copy (no-op with no selection). |
-| `Ctrl+V` / `Ctrl+Shift+V` | Paste from the system clipboard via the renderer's `navigator.clipboard` API. `Ctrl+Shift+V` is intercepted by the screenshot-paste handler unless rebound. |
+| `Ctrl+V` | Paste from the system clipboard. The clipboard is read in the main process (`clipboardReadText` IPC) and fed through `term.paste()`, which applies bracketed-paste wrapping when the program has that mode on. |
+| `Ctrl+Shift+V` | Paste the path of the newest screenshot — intercepted by the screenshot-paste handler unless rebound. |
 | `Ctrl+F` | Open the in-tab **search bar** (xterm search addon). `Esc` closes it. |
 | `Ctrl+Up` / `Ctrl+Down` | Jump to the previous / next OSC 133 prompt boundary in the active tab. Requires the [shell integration snippet](../guides/terminal.md#shell-integration); without it, the keys fall through to the shell. |
 | `Ctrl+Left` / `Ctrl+Right` | Same as the pane-level move-tab shortcuts — intercepted here because xterm consumes arrow keys. |
 
-Clipboard plumbing reads and writes the system clipboard through the browser's native [`navigator.clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard_API) API. There is no HTTP endpoint and no native bridge.
+Copy writes the system clipboard through the browser's native [`navigator.clipboard`](https://developer.mozilla.org/docs/Web/API/Clipboard_API) API. Paste reads it through the `clipboardReadText` IPC (main-process Electron `clipboard`), because `navigator.clipboard.readText()` is permission-gated and unreliable in the renderer. There is no HTTP endpoint.
 
 ## Input focus rules
 

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron';
+import { clipboard, ipcMain } from 'electron';
 import {
   attachTerminal,
   closeSession,
@@ -25,6 +25,12 @@ export function registerTerminalIpc(): void {
   ipcMain.handle('termWrite', (_, id: string, data: string) => {
     writeTerminal(id, data);
   });
+
+  // Read the system clipboard from the main process. The renderer's
+  // navigator.clipboard.readText() is permission-gated (no clipboard-read
+  // permission handler is wired) and unreliable in Electron, so terminal
+  // paste reads through here instead. See xterm-mount.ts's Ctrl+V handler.
+  ipcMain.handle('clipboardReadText', () => clipboard.readText());
 
   ipcMain.handle('termResize', (_, id: string, cols: number, rows: number) => {
     resizeTerminal(id, cols, rows);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -96,6 +96,7 @@ const api: CondashApi = {
   },
   termSpawn: (request) => ipcRenderer.invoke('termSpawn', request),
   termWrite: (id, data) => ipcRenderer.invoke('termWrite', id, data),
+  clipboardReadText: () => ipcRenderer.invoke('clipboardReadText'),
   termResize: (id, cols, rows) => ipcRenderer.invoke('termResize', id, cols, rows),
   termClose: (id) => ipcRenderer.invoke('termClose', id),
   termGetPrefs: () => ipcRenderer.invoke('termGetPrefs'),

--- a/src/renderer/xterm-mount.ts
+++ b/src/renderer/xterm-mount.ts
@@ -182,10 +182,7 @@ export function mountXterm(
     /* image addon optional */
   }
 
-  // ---- write/data wiring + clipboard copy (Ctrl+C) ----
-  // Ctrl+V is intentionally left to xterm.js's native paste via the browser's
-  // paste event on its hidden textarea. The previous navigator.clipboard.readText()
-  // fallback silently failed for external clipboard content in Electron.
+  // ---- write/data wiring + clipboard copy/paste (Ctrl+C / Ctrl+V) ----
   term.attachCustomKeyEventHandler((ev) => {
     if (ev.type !== 'keydown') return true;
     const ctrl = ev.ctrlKey && !ev.metaKey;
@@ -198,6 +195,23 @@ export function mountXterm(
         return false;
       }
       return true;
+    }
+    // Ctrl+V: read the system clipboard in the main process and paste through
+    // term.paste(), which applies bracketed-paste wrapping when the program
+    // has that mode on (opencode's TUI relies on it to treat a multi-line
+    // paste as one block). We can't lean on xterm.js's native paste here —
+    // the Electron menu's paste role does not reliably deliver a paste event
+    // to the hidden textarea, and navigator.clipboard.readText() is
+    // permission-gated in the renderer. See the clipboardReadText IPC.
+    if (ctrl && !ev.shiftKey && !ev.altKey && (ev.key === 'v' || ev.key === 'V')) {
+      ev.preventDefault();
+      void window.condash
+        .clipboardReadText()
+        .then((text) => {
+          if (text) term.paste(text);
+        })
+        .catch(() => undefined);
+      return false;
     }
     if (options.onCustomKey) return options.onCustomKey(ev);
     return true;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -273,6 +273,10 @@ export interface CondashApi {
 
   termSpawn(request: TermSpawnRequest): Promise<{ id: string; cwd: string }>;
   termWrite(id: string, data: string): Promise<void>;
+  /** Read the system clipboard via the main process. Used by the terminal's
+   * Ctrl+V handler — the renderer's navigator.clipboard.readText() is
+   * permission-gated and unreliable in Electron. */
+  clipboardReadText(): Promise<string>;
   termResize(id: string, cols: number, rows: number): Promise<void>;
   termClose(id: string): Promise<void>;
   termGetPrefs(): Promise<TerminalPrefs>;


### PR DESCRIPTION
## Summary

- After the previous attempt removed the custom Ctrl+V handler, external clipboard text still would not paste into the terminal. This restores paste by reading the clipboard reliably.
- The clipboard is read in the Electron main process and pasted via xterm's `term.paste()`, so bracketed-paste mode is preserved for agent TUIs like opencode.

## Changes

- Add a `clipboardReadText` IPC handler in `src/main/ipc/terminal.ts` that returns Electron's main-process `clipboard.readText()`.
- Expose `clipboardReadText` on the preload bridge (`src/preload/index.ts`) and the `CondashApi` type (`src/shared/api.ts`).
- Re-add a Ctrl+V handler in `src/renderer/xterm-mount.ts` that reads via the IPC and feeds the text through `term.paste()`.
- Update terminal/clipboard docs: `docs/reference/ipc-api.md`, `docs/reference/shortcuts.md`, `docs/guides/terminal.md`.

## Impact

- Paste now depends on the main-process clipboard rather than the renderer's `navigator.clipboard.readText()` (permission-gated, no `clipboard-read` handler is wired) or the Electron menu paste role (does not reliably deliver a paste event to xterm's hidden textarea). Copy (Ctrl+C) is unchanged.

## Watchpoints

- Manual paste could not be verified in a headless environment. Confirm Ctrl+V pastes external text into a terminal tab, and that a multi-line paste lands as a single block in opencode's input (bracketed paste wrapping).