### PR TITLE
Document skill provenance in AGENTS.md General template

### DIFF
--- a/conception-template/.agents/agents/common.md
+++ b/conception-template/.agents/agents/common.md
@@ -10,6 +10,7 @@ This section is shipped by condash and refreshed by `condash skills install`. Ed
 
 - Tree roots: [`projects/index.md`](projects/index.md), [`knowledge/index.md`](knowledge/index.md).
 - Workflow skills: [`{{ skills_dir }}projects/SKILL.md`]({{ skills_dir }}projects/SKILL.md) drives every project / incident / document mutation; [`{{ skills_dir }}knowledge/SKILL.md`]({{ skills_dir }}knowledge/SKILL.md) drives durable reference material.
+- Skill provenance: skills under `{{ skills_dir }}` are conception-scoped (not user-scoped). condash ships and refreshes a fixed set on `condash skills install` — `projects`, `knowledge`, `pr`, `skills`, `tidy`, sourced from `.agents/skills/<name>/` — so to change one of those, edit it in condash. A conception may also carry additional skills here that condash does **not** ship; condash leaves them untouched, and `## Specifics` records where they come from.
 - [`condash.json`](condash.json) — per-conception overrides read by condash. Top-level keys here replace the matching keys in `~/.config/condash/settings.json`. Legacy filename `configuration.json` is still read as a fallback.
 
 ### Workflow


### PR DESCRIPTION
## Summary

- The shipped AGENTS.md General section never said where the skills in a conception come from, so an agent looking for a skill's source couldn't tell condash-owned skills from local ones.
- Adds one Pointers bullet making that explicit, without assuming any particular install layout.

## Changes

- `conception-template/.agents/agents/common.md`: new "Skill provenance" bullet in the General/Pointers list — skills under the skills dir are conception-scoped (not user-scoped); condash ships and refreshes a fixed set (`projects`, `knowledge`, `pr`, `skills`, `tidy`) from `.agents/skills/`; a conception may carry additional skills condash does not ship, with their source recorded under `## Specifics`.

## Impact

- Ships to every conception's AGENTS.md on the next `condash skills install` (the General section is overwritten on install).