### PR TITLE
Materialise conception agent body as common.md, drop body.md

### DIFF
--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -38,7 +38,7 @@ The Generic tab walks the skills root and surfaces both `.md` and `.yaml` files:
 - `body.md` and sibling markdown files (`index.md`, `retrieve.md`, …) render as standard cards. Title is pulled from the first H1.
 - `spec.yaml` and `targets/<agent>.yaml` render as cards with a `YAML` badge — title falls back to the filename when no H1 is present (YAML has none).
 
-Above the tree, the agent-config **sources** render as read-only callouts: `condash.md` (the shipped `## General` head), `conception.md` (your `## Specifics`), and each present `<model>.md` overlay (`claude.md`, `kimi.md`, `opencode.md`), badged by name. (A pre-split tree still shows the legacy `common.md` until the next install migrates it.) These are the inputs `condash skills install` joins + splices into each agent's compiled `CLAUDE.md` / `AGENTS.md` — there is no single "generic" compiled config, so the Generic tab shows the sources instead.
+Above the tree, the agent-config **sources** render as read-only callouts: `condash.md` (the shipped `## General` head), `conception.md` (your `## Specifics`), the combined `common.md` body, and each present `<model>.md` overlay (`claude.md`, `kimi.md`, `opencode.md`), badged by name. (`common.md` is materialised from `condash.md` + `conception.md` on every install — and is the file you author directly in the user scope, which has no split.) These are the inputs `condash skills install` joins + splices into each agent's compiled `CLAUDE.md` / `AGENTS.md` — there is no single "generic" compiled config, so the Generic tab shows the sources instead.
 
 ### Claude (compiled)
 

--- a/docs/reference/agents-md-style.md
+++ b/docs/reference/agents-md-style.md
@@ -7,7 +7,7 @@ description: How to write the per-conception ## Specifics section and durable te
 
 > **Audience.** Conception maintainers — anyone who edits the `AGENTS.md` at the root of a conception tree.
 
-Each conception's agent config is compiled from two source files under `.agents/agents/`: `condash.md` (the `## General` section) is shipped by condash and refreshed on every `condash skills install`; `conception.md` (the `## Specifics` section) is yours — it describes the apps, repositories, and team rules for this workspace, and condash never overwrites it. The two are concatenated, the per-agent fragment (`claude.md` / `kimi.md`) is spliced in, and the result compiles to each agent's `CLAUDE.md` / `AGENTS.md`.
+Each conception's agent config is compiled from two source files under `.agents/agents/`: `condash.md` (the `## General` section) is shipped by condash and refreshed on every `condash skills install`; `conception.md` (the `## Specifics` section) is yours — it describes the apps, repositories, and team rules for this workspace, and condash never overwrites it. The two are concatenated, the per-agent fragment (`claude.md` / `kimi.md`) is spliced in, and the result compiles to each agent's `CLAUDE.md` / `AGENTS.md`. Each install also materialises the concatenation as a committed `common.md` — the agent-neutral body, mirroring the user-scope agentspec at `~/.config/agents/agents/common.md`.
 
 This guide covers the shape of `conception.md` (the `## Specifics` section).
 

--- a/src/agents-md/compile.ts
+++ b/src/agents-md/compile.ts
@@ -8,13 +8,14 @@
  *   - `.agents/agents/kimi.md`        — Kimi-only fragment
  *   - `.agents/agents/opencode.md`    — OpenCode-only fragment
  *
- * `condash.md` + `conception.md` concatenated reproduce the legacy single-file
- * `common.md` (head before `## Specifics`, then the Specifics tail), so the
+ * `condash.md` + `conception.md` concatenated form the combined `common.md`
+ * body (head before `## Specifics`, then the Specifics tail), so the
  * orchestrator (`compileAgentConfigs` in `files.ts`) joins them via
  * `combineAgentSource` and feeds the result to the unchanged `compileAgentConfig`:
  * the agent fragment is spliced in just before the `## Specifics` heading and
- * `{{ var }}` substitution runs over the merge. A legacy tree that still has
- * only `common.md` is handled by `splitLegacyCommon` (read + migrate).
+ * `{{ var }}` substitution runs over the merge. A conception authored as a
+ * single `common.md` (no split) is read back via `splitLegacyCommon` — a
+ * non-destructive read, never an on-disk rewrite.
  */
 
 import { type CompileHarnessId, COMPILE_HARNESS_IDS, HARNESSES } from '../shared/harnesses';

--- a/src/cli/commands/files.install.test.ts
+++ b/src/cli/commands/files.install.test.ts
@@ -62,17 +62,28 @@ describe('condash skills install — top-level files', () => {
     expect(kimi).toContain('Kimi Code CLI');
   });
 
-  it('materialises body.md = condash.md + conception.md in the source dir', async () => {
+  it('materialises common.md = condash.md + conception.md in the source dir', async () => {
     await install();
     const agentsDir = join(dest, '.agents/agents');
     const condash = await fs.readFile(join(agentsDir, 'condash.md'), 'utf8');
     const conception = await fs.readFile(join(agentsDir, 'conception.md'), 'utf8');
-    const body = await fs.readFile(join(agentsDir, 'body.md'), 'utf8');
-    // body.md is the agent-neutral combined source: the condash.md head then
+    const common = await fs.readFile(join(agentsDir, 'common.md'), 'utf8');
+    // common.md is the agent-neutral combined body: the condash.md head then
     // the conception.md tail, placeholders intact (not substituted).
-    expect(body).toBe(combineAgentSource(condash, conception));
-    expect(body.indexOf('## General')).toBeLessThan(body.indexOf('## Specifics'));
-    expect(body).toContain('{{ skills_dir }}');
+    expect(common).toBe(combineAgentSource(condash, conception));
+    expect(common.indexOf('## General')).toBeLessThan(common.indexOf('## Specifics'));
+    expect(common).toContain('{{ skills_dir }}');
+  });
+
+  it('removes a stale body.md left by a pre-rename install', async () => {
+    await install();
+    const agentsDir = join(dest, '.agents/agents');
+    // An older condash materialised the combined body as body.md; the rename
+    // to common.md must clean it up so the source dir keeps a single body file.
+    await fs.writeFile(join(agentsDir, 'body.md'), 'stale\n');
+    await install();
+    await expect(fs.access(join(agentsDir, 'body.md'))).rejects.toThrow();
+    expect(await fs.readFile(join(agentsDir, 'common.md'), 'utf8')).toContain('## General');
   });
 
   it('writes a conception-root opencode.json pointing at the compiled .opencode/AGENTS.md', async () => {
@@ -239,42 +250,6 @@ describe('condash skills install — top-level files', () => {
     await install();
     const conception = await fs.readFile(join(dest, '.agents/agents/conception.md'), 'utf8');
     expect(conception).toContain('## Specifics');
-  });
-
-  it('migrates a legacy common.md into condash.md + conception.md, preserving Specifics', async () => {
-    // Scaffold the split tree, then reconstruct a pre-split state: a single
-    // common.md (head + a user Specifics), manifest tracking common.md, and
-    // the split files removed.
-    await install();
-    const agentsDir = join(dest, '.agents/agents');
-    const head = await fs.readFile(join(agentsDir, 'condash.md'), 'utf8');
-    const userSpecifics = '## Specifics\n\n- Team rule: always do X.\n';
-    await fs.writeFile(join(agentsDir, 'common.md'), `${head.trimEnd()}\n\n${userSpecifics}`);
-    await fs.rm(join(agentsDir, 'condash.md'));
-    await fs.rm(join(agentsDir, 'conception.md'));
-    // Re-point the manifest entry at the legacy common.md path.
-    const manifestPath = join(dest, '.agents', MANIFEST_RELPATH);
-    const m = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
-    m.files['.agents/agents/common.md'] = m.files[AGENT_CONFIG_COMMON.path];
-    delete m.files[AGENT_CONFIG_COMMON.path];
-    await fs.writeFile(manifestPath, JSON.stringify(m, null, 2));
-
-    await install();
-
-    // common.md is split + removed; the split files exist.
-    await expect(fs.access(join(agentsDir, 'common.md'))).rejects.toThrow();
-    expect(await fs.readFile(join(agentsDir, 'condash.md'), 'utf8')).toContain('## General');
-    expect(await fs.readFile(join(agentsDir, 'conception.md'), 'utf8')).toContain(
-      'Team rule: always do X',
-    );
-    // The compiled output keeps the user's Specifics.
-    expect(await fs.readFile(join(dest, '.claude/CLAUDE.md'), 'utf8')).toContain(
-      'Team rule: always do X',
-    );
-    // Manifest entry carried forward to condash.md; stale common.md entry gone.
-    const manifest = await readManifest(dest);
-    expect(manifest!.files![AGENT_CONFIG_COMMON.path]).toBeTruthy();
-    expect(manifest!.files!['.agents/agents/common.md']).toBeUndefined();
   });
 
   it('--prune does not drop the .agents/agents/condash.md manifest entry', async () => {

--- a/src/cli/commands/files.ts
+++ b/src/cli/commands/files.ts
@@ -315,15 +315,20 @@ export async function installShippedFile(
 const AGENTS_SOURCE_RELPATH = '.agents/agents';
 
 /** Source filenames in `.agents/agents/`. `condash.md` is the shipped head
- *  (H1 + `## General`); `conception.md` is the user-owned tail (`## Specifics`).
- *  `common.md` is the pre-split single file, kept only for migration. */
+ *  (H1 + `## General`); `conception.md` is the user-owned tail (`## Specifics`). */
 const CONDASH_SOURCE = 'condash.md';
 const CONCEPTION_SOURCE = 'conception.md';
-const LEGACY_COMMON_SOURCE = 'common.md';
-/** Derived combined source `condash.md` + `conception.md`, materialised in the
- *  source dir on every install. Committed (not gitignored) and not a compile
- *  input or manifest entry — staged for a future single-body change. */
-const BODY_OUTPUT = 'body.md';
+/** The combined agent body — `condash.md` + `conception.md` materialised in the
+ *  source dir on every install. Committed (not gitignored), not manifest-tracked.
+ *  This is the agent-neutral body launchers read; it mirrors the user-scope
+ *  agentspec at `~/.config/agents/agents/common.md`. A conception may instead be
+ *  authored as a single `common.md` (no `condash.md` split, like the user scope);
+ *  `compileAgentConfigs` then reads it back as the source, so the materialise is
+ *  idempotent. The body is never split or deleted on disk. */
+const COMMON_OUTPUT = 'common.md';
+/** Pre-rename name of the materialised body. Removed on install so switching to
+ *  `common.md` doesn't leave a stale `body.md` duplicate behind. */
+const STALE_BODY_OUTPUT = 'body.md';
 
 /**
  * `condash.md` is the condash-shipped head — an H1/tagline preamble plus the
@@ -366,25 +371,27 @@ export async function compileAgentConfigs(
 ): Promise<{ target: AgentsMdTarget; path: string }[]> {
   const sourceDir = join(dest, AGENTS_SOURCE_RELPATH);
 
-  // Head = condash.md; tail = conception.md. A pre-split tree that still has
-  // only common.md is handled by splitting it (compile stays correct even if
-  // the on-disk migration in installAgentConfigSources hasn't run yet).
+  // Head = condash.md; tail = conception.md. A conception authored as a single
+  // common.md (no split — the user-scope agentspec shape) is read back and
+  // split so compile stays correct either way.
   let head = await readFileOrNull(join(sourceDir, CONDASH_SOURCE));
   let tail = (await readFileOrNull(join(sourceDir, CONCEPTION_SOURCE))) ?? '';
   if (head === null) {
-    const legacy = await readFileOrNull(join(sourceDir, LEGACY_COMMON_SOURCE));
-    if (legacy === null) return [];
-    const split = splitLegacyCommon(legacy);
+    const single = await readFileOrNull(join(sourceDir, COMMON_OUTPUT));
+    if (single === null) return [];
+    const split = splitLegacyCommon(single);
     head = split.head;
     if (!tail) tail = split.tail;
   }
   const combined = combineAgentSource(head, tail);
 
-  // Materialise the combined source (condash.md + conception.md) as body.md in
-  // the source dir. Committed (not gitignored), not a compile input and not
-  // manifest-tracked — staged for a future single-body change.
+  // Materialise the combined body (condash.md + conception.md) as common.md in
+  // the source dir — the agent-neutral body launchers read, matching the
+  // user-scope `~/.config/agents/agents/common.md`. Committed (not gitignored),
+  // not manifest-tracked. Drop the pre-rename body.md so it doesn't linger.
   if (!dryRun) {
-    await writeFileMkdir(join(sourceDir, BODY_OUTPUT), Buffer.from(combined, 'utf8'));
+    await writeFileMkdir(join(sourceDir, COMMON_OUTPUT), Buffer.from(combined, 'utf8'));
+    await fs.rm(join(sourceDir, STALE_BODY_OUTPUT), { force: true });
   }
 
   // Per-conception identity variables for the shipped condash.md preamble
@@ -676,56 +683,15 @@ export interface AgentConfigInstallResult {
   /** Per-agent fragment paths (relative to `.agents/agents/`) that were written. */
   copied: string[];
   /**
-   * Outcome of the region-aware install for `common.md`. `null` only when the
+   * Outcome of the region-aware install for `condash.md`. `null` only when the
    * shipped agent-config tree is missing from the bundle (returns early).
    */
   commonOutcome: FileInstallOutcome | null;
 }
 
 /**
- * One-time migration of a pre-split conception. An existing tree has
- * `.agents/agents/common.md` (H1 + `## General` + `## Specifics`). Split it into
- * `condash.md` (the head, condash-owned) + `conception.md` (the `## Specifics`
- * tail, user-owned), drop `common.md`, and carry the manifest region entry
- * forward from `common.md` to `condash.md` (the General body is unchanged, so
- * the recorded hash stays valid — and without the carry-forward the freshly
- * written `condash.md` would be refused as "present but not tracked"). No-op
- * once `condash.md` exists. Returns true when a migration was performed.
- */
-async function migrateLegacyCommonMd(
-  dest: string,
-  manifest: Manifest,
-  dryRun: boolean,
-): Promise<boolean> {
-  const sourceDir = join(dest, AGENTS_SOURCE_RELPATH);
-  if ((await readFileOrNull(join(sourceDir, CONDASH_SOURCE))) !== null) return false;
-  const common = await readFileOrNull(join(sourceDir, LEGACY_COMMON_SOURCE));
-  if (common === null) return false;
-
-  const { head, tail } = splitLegacyCommon(common);
-  if (!dryRun) {
-    await writeFileMkdir(join(sourceDir, CONDASH_SOURCE), Buffer.from(head, 'utf8'));
-    if (tail) {
-      await writeFileMkdir(join(sourceDir, CONCEPTION_SOURCE), Buffer.from(tail, 'utf8'));
-    }
-    await fs.rm(join(sourceDir, LEGACY_COMMON_SOURCE), { force: true });
-  }
-  if (manifest.files) {
-    const legacyKey = `${AGENTS_SOURCE_RELPATH}/${LEGACY_COMMON_SOURCE}`;
-    const entry = manifest.files[legacyKey];
-    if (entry && !manifest.files[AGENT_CONFIG_COMMON.path]) {
-      manifest.files[AGENT_CONFIG_COMMON.path] = entry;
-    }
-    delete manifest.files[legacyKey];
-  }
-  return true;
-}
-
-/**
  * Install the `.agents/agents/` source tree from the shipped template:
  *
- * - Legacy `common.md` is first split into `condash.md` + `conception.md` (see
- *   `migrateLegacyCommonMd`).
  * - `condash.md` ships through `installShippedFile` so the `## General` body
  *   gets refreshed (refused without `--force` when hand-edited) while the
  *   H1/tagline preamble is preserved.
@@ -740,7 +706,7 @@ async function migrateLegacyCommonMd(
 export async function installAgentConfigSources(
   params: FileInstallParams,
 ): Promise<AgentConfigInstallResult> {
-  const { dest, dryRun, manifest } = params;
+  const { dest, dryRun } = params;
   const shippedDir = join(locateShippedFilesRoot(), '.agents', 'agents');
   const targetDir = join(dest, '.agents', 'agents');
   const copied: string[] = [];
@@ -755,9 +721,6 @@ export async function installAgentConfigSources(
   }
 
   if (!dryRun) await fs.mkdir(targetDir, { recursive: true });
-
-  // Split a pre-split common.md before the region-aware install runs.
-  await migrateLegacyCommonMd(dest, manifest, dryRun);
 
   // condash.md: region-aware install via the same machinery as `.gitignore`.
   const commonOutcome = await installShippedFile(AGENT_CONFIG_COMMON, params);
@@ -774,13 +737,9 @@ export async function installAgentConfigSources(
 
   // Per-agent fragments + any future nested files: full-overwrite. condash.md
   // (region-aware above) and conception.md (user-owned, scaffolded above) are
-  // both excluded; legacy common.md is gone after migration but guarded too.
-  const ownedAtRoot = new Set([
-    CONDASH_SOURCE,
-    CONCEPTION_SOURCE,
-    LEGACY_COMMON_SOURCE,
-    BODY_OUTPUT,
-  ]);
+  // excluded, as is common.md — it's materialised by compileAgentConfigs, not
+  // shipped from the template.
+  const ownedAtRoot = new Set([CONDASH_SOURCE, CONCEPTION_SOURCE, COMMON_OUTPUT]);
   async function walk(src: string, dst: string, prefix: string): Promise<void> {
     const entries = await fs.readdir(src, { withFileTypes: true });
     for (const entry of entries) {

--- a/src/cli/commands/skills-install.ts
+++ b/src/cli/commands/skills-install.ts
@@ -5,8 +5,9 @@
  * file regions with refuse-on-edit semantics; pass 2 compiles everything on
  * disk (via `compileAllSkillspecs`) so a refused source still propagates
  * through to the per-target trees. Pass 1c copies the agent-config sources
- * (region-aware for `common.md`, overwrite for the per-agent fragments);
- * pass 2b compiles them to `CLAUDE.md` / `AGENTS.md`.
+ * (region-aware for the `condash.md` head, overwrite for the per-agent
+ * fragments); pass 2b compiles them to `CLAUDE.md` / `AGENTS.md` and
+ * materialises the combined body as `common.md`.
  *
  * User scope (`installUserSkills`): no shipped tree, no manifest. Compile
  * the user's own skillspecs straight to `~/.claude/skills/` + `~/.kimi/skills/`,
@@ -295,9 +296,10 @@ export async function installRepo(args: ParsedArgs, ctx: OutputContext): Promise
   });
   report.compiled = compileResult.compiled;
 
-  // Pass 1c: copy agent-config sources. `common.md` goes through the
-  // region-aware install path so a user-customised `## Specifics` survives;
-  // the per-agent fragments (`claude.md`, `kimi.md`) overwrite in full.
+  // Pass 1c: copy agent-config sources. The `condash.md` head goes through the
+  // region-aware install path (the user-owned `conception.md` `## Specifics` is
+  // scaffold-once); the per-agent fragments (`claude.md`, `kimi.md`) overwrite
+  // in full. Pass 2b then materialises the combined body as `common.md`.
   const agentInstall = await installAgentConfigSources({
     dest,
     shippedVersion,

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -10,10 +10,11 @@ import { userAgentConfigOutput, userAgentConfigRoot, userSkillsRoot } from './us
 const HIDDEN_PREFIX = /^\./;
 
 /** Agent-config source files surfaced (read-only) on the Generic tab — the
- *  `condash.md` (shipped) + `conception.md` (user-owned) + per-model
- *  `<model>.md` inputs that `condash skills install` compiles into each agent's
- *  CLAUDE.md / AGENTS.md. `common.md` is listed for pre-split trees that
- *  haven't been migrated yet. */
+ *  `condash.md` (shipped) + `conception.md` (user-owned) split sources and the
+ *  per-model `<model>.md` inputs that `condash skills install` compiles into
+ *  each agent's CLAUDE.md / AGENTS.md. `common.md` is the combined body —
+ *  materialised from the split in a conception, hand-authored in the user
+ *  scope (`~/.config/agents/agents/`). */
 const GENERIC_AGENT_SOURCES = [
   'condash.md',
   'conception.md',


### PR DESCRIPTION
## Summary

- The combined agent body (`condash.md` + `conception.md`) is now materialised as `.agents/agents/common.md` instead of `body.md`, so a conception and the user-scope agentspec (`~/.config/agents/agents/common.md`) expose the same single `common.md` body that launchers read.
- The destructive legacy-`common.md` on-disk migration (split + delete) is retired: the split has already landed everywhere, and it conflicted with `common.md` now being the materialised body.

## Changes

- `files.ts`: `BODY_OUTPUT` → `COMMON_OUTPUT` (`body.md` → `common.md`); compile materialises `common.md` and removes any stale `body.md`; the single-file read fallback now reads `common.md`.
- `files.ts`: remove `migrateLegacyCommonMd` and its install-time call; drop the now-unused `manifest` binding; simplify the owned-at-root exclusion set.
- `skills-install.ts`, `compile.ts`, `main/skills.ts`: comment updates for the new body name and the retired migration.
- Docs: `agents-md-style.md` and `skills-pane.md` describe `common.md` as the materialised body.
- Tests: assert `common.md` is materialised and a stale `body.md` is cleaned up; drop the obsolete migration test.

## Impact

- On the next `condash skills install`, each conception's `.agents/agents/body.md` is replaced by `common.md` (committed, not gitignored). Compiled `CLAUDE.md` / `AGENTS.md` outputs are byte-identical — only the materialised source-dir filename changes.

## Watchpoints

- A pre-split conception (a bare `common.md`, no `condash.md`) is no longer auto-split-and-preserved on install: the migration that carried its `## Specifics` into `conception.md` is gone. No such tree exists today, but a tree restored from an old backup would need a manual split before install. The non-destructive compile/build fallback still reads a single `common.md` correctly.
- The Generic-tab source callouts now surface the materialised `common.md` alongside `condash.md` / `conception.md` (previously shown only for unmigrated trees) — cosmetic, no behaviour change.