### PR TITLE
Fix condash skills install crash on legacy per-skill manifests

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -203,7 +203,7 @@ It also ships one region-delimited top-level file, `.gitignore` (its `# General`
 
 Install flags: `--dest <path>` (retarget the install dir; default the resolved conception or cwd), `--force` (override refuse-on-edit), `--diff` (show a unified diff per refused item), `--dry-run` (report without writing), `--prune` (drop manifest entries whose shipped source has been removed).
 
-Skill sources and `.gitignore` flow through one manifest at `.agents/.condash-skills.json` (v3 schema: `skills.<name>` + `files.<path>`), tracking the shipped version and SHA256 per file so a re-install can detect local edits. `AGENTS.md` is deterministic (the marker is the boundary) and not manifest-tracked.
+Skill sources and `.gitignore` flow through one manifest at `.agents/.condash-skills.json` (v3 schema: `skills.<name>.source` per source file + `files.<path>` per top-level region), tracking the shipped version and SHA256 per file so a re-install can detect local edits. A per-skill entry left by an earlier schema (one with no `source` map) is re-seeded on read, so upgrading condash never crashes the install. `AGENTS.md` is deterministic (the marker is the boundary) and not manifest-tracked.
 
 ### `config`
 

--- a/src/cli/commands/install-shared.ts
+++ b/src/cli/commands/install-shared.ts
@@ -163,6 +163,17 @@ export async function readManifest(dest: string): Promise<Manifest | null> {
   }
   if (!parsed.skills) parsed.skills = {};
 
+  // Coerce every per-skill entry to the canonical `{ source: {...} }` shape.
+  // A v3 manifest written before the source/compiled-output split (the pre-v4
+  // schema tracked compiled outputs under a `files` key) carries entries with
+  // no `source` map under the same version number. Install, prune, and the
+  // source-missing walk all index `entry.source`, so a stale entry would crash
+  // with "Cannot set properties of undefined". Discard the stale keys and
+  // re-seed empty — the next install repopulates from the shipped sources.
+  for (const [name, entry] of Object.entries(parsed.skills)) {
+    if (!entry || !entry.source) parsed.skills[name] = { source: {} };
+  }
+
   // One-time transparent migration: legacy path → new path.
   if (path === legacyPath) {
     await fs.mkdir(dirname(newPath), { recursive: true });

--- a/src/cli/commands/skills.test.ts
+++ b/src/cli/commands/skills.test.ts
@@ -151,4 +151,34 @@ describe('condash skills install (verbatim placement)', () => {
     expect(manifest!.files!['AGENTS.md']).toBeTruthy();
     expect((manifest as unknown as { templates?: unknown }).templates).toBeUndefined();
   });
+
+  it('normalizes a v3 manifest whose per-skill entry predates the source split', async () => {
+    // The pre-v4 v3 schema tracked compiled outputs under a per-skill `files`
+    // key with no `source` map. Reusing version 3 across the schema change,
+    // this used to crash install with "Cannot set properties of undefined
+    // (setting 'SKILL.claude.md')" — the first source file written for a skill.
+    const manifestPath = join(dest, '.agents', MANIFEST_RELPATH);
+    await fs.mkdir(dirname(manifestPath), { recursive: true });
+    await fs.writeFile(
+      manifestPath,
+      JSON.stringify(
+        {
+          version: 3,
+          skills: {
+            knowledge: {
+              files: { 'SKILL.md': { sha256: 'a'.repeat(64), shippedVersion: '3.1.0' } },
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    await install(); // must not throw
+    const manifest = await readManifest(dest);
+    expect(manifest!.version).toBe(3);
+    // The stale `files` map is discarded; the entry is re-seeded from sources.
+    expect(manifest!.skills.knowledge.source['SKILL.md']).toBeTruthy();
+    expect((manifest!.skills.knowledge as unknown as { files?: unknown }).files).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- `condash skills install` (v4.0.0) crashes with "Cannot set properties of undefined (setting 'SKILL.claude.md')" when a conception still carries a manifest whose per-skill entries use the pre-v4 shape, and never reaches the step that writes `AGENTS.md`.
- The per-skill schema changed (compiled-output `files` map → source `source` map) while keeping manifest version 3, so `readManifest` passed the stale shape through untouched and the install loop dereferenced `undefined.source` on the first source file written.

## Changes

- `readManifest` (`install-shared.ts`): normalize every per-skill entry to the canonical `{ source: {} }` shape on read, discarding stale keys. This covers install, `--prune`, and the source-missing walk, all of which index `entry.source`.
- Add a regression test feeding a v3 manifest with a legacy per-skill `files` entry, asserting install completes and re-seeds `source`.
- `docs/reference/cli.md`: document the canonical `skills.<name>.source` schema and the re-seed-on-upgrade behaviour.

## Impact

- Conceptions upgrading from a pre-v4 condash now install cleanly instead of erroring; the stale per-skill tracking is dropped and re-seeded from shipped sources on the next install. No user action required.