### PR TITLE
Drop stale .gitignore-shipping refs from skills skill + docs

### DIFF
--- a/conception-template/.agents/skills/skills/SKILL.md
+++ b/conception-template/.agents/skills/skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skills
-description: Install or update condash-shipped artefacts in this conception — agent skills under `.agents/skills/` and top-level files like `AGENTS.md` and `.gitignore`. Wraps `condash skills {status,install}` and walks edited items one-by-one so local customisations don't get clobbered. Use after upgrading condash to pull updated content, or for the first-time install.
+description: Install or update condash-shipped artefacts in this conception — agent skills under `.agents/skills/` and the `AGENTS.md` marker region. Wraps `condash skills {status,install}` and walks edited items one-by-one so local customisations don't get clobbered. Use after upgrading condash to pull updated content, or for the first-time install.
 ---
 
 # /skills — install and update condash-shipped artefacts
@@ -11,10 +11,9 @@ condash ships two kinds of artefacts into a conception tree:
   (`SKILL.md` + optional task `.md` files + optional `SKILL.<harness>.md`
   overlay). condash no longer compiles them to per-harness dirs; the harness
   launcher renders them per agent at run time.
-- **Top-level files** at the conception root. `.gitignore` ships a
-  heading-delimited region; `AGENTS.md` ships a marker-bounded head — every
-  line from the top through `<!-- end condash agents -->` is regenerated on
-  install, and everything after the marker is user-owned and never touched.
+- **The root `AGENTS.md`** — a marker-bounded head: every line from the top
+  through `<!-- end condash agents -->` is regenerated on install, and
+  everything after the marker is user-owned and never touched.
 
 Both kinds flow through a single CLI surface — `condash skills {list,status,install}` —
 and a single manifest namespace. This skill is the user-facing wrapper for
@@ -45,7 +44,7 @@ there are local edits to triage.
 
 `<name-or-path>` accepts either a shipped skill name (`knowledge`, `pr`,
 `projects`, `skills`, `tidy`, …) or a top-level destination path
-(`AGENTS.md`, `.gitignore`, …). No positionals = everything.
+(`AGENTS.md`). No positionals = everything.
 
 ## Procedure (`/skills update`)
 

--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -56,7 +56,7 @@ The pane never writes. To change a shipped skill, edit it at its source under `.
 
 The conception's source tree carries a single manifest populated by `condash skills install`:
 
-- `<conception>/.agents/.condash-skills.json` — refuse-on-edit tracking for the shipped skill sources (and the `.gitignore` region), keyed by SHA256 + shipped version.
+- `<conception>/.agents/.condash-skills.json` — refuse-on-edit tracking for the shipped skill sources, keyed by SHA256 + shipped version.
 
 The pane uses it to flag two states on the **Generic** tab:
 

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -74,7 +74,7 @@ Install or refresh the shipped skills. Use it after upgrading condash to pull up
 | `status` | `/skills status` | `condash skills status` (compare local vs shipped via SHA256) |
 | `install` | `/skills install` | `condash skills install` (per-file diff + confirmation walk) |
 
-`condash skills install` records what it shipped in one manifest at `<conception>/.agents/.condash-skills.json` (v3 schema: a `skills.<name>` namespace for skill sources plus a `files.<path>` namespace for the region-delimited `.gitignore`). Each tracked file carries its shipped version + SHA256, so a re-install can tell an unchanged file from a locally-edited one and refuse to clobber edits without `--force`. `AGENTS.md` is **not** manifest-tracked — its marker line is the boundary, so there's no hash to reconcile.
+`condash skills install` records what it shipped in one manifest at `<conception>/.agents/.condash-skills.json` (v3 schema: a `skills.<name>` namespace for skill sources plus a `files.<path>` namespace retained to reconcile top-level files condash ≤ 4.0.1 shipped — e.g. a legacy region-delimited `.gitignore`; condash no longer ships any top-level file). Each tracked file carries its shipped version + SHA256, so a re-install can tell an unchanged file from a locally-edited one and refuse to clobber edits without `--force`. `AGENTS.md` is **not** manifest-tracked — its marker line is the boundary, so there's no hash to reconcile.
 
 ### The skill source is committed; nothing is compiled
 


### PR DESCRIPTION
## Summary

- condash v4.1.0 (`ee7df60`) stopped shipping `.gitignore` — a conception's `.gitignore` is now fully user-owned — but the shipped `skills` skill text and two doc pages still claimed condash ships/tracks it. This corrects those leftovers.

## Changes

- `conception-template/.agents/skills/skills/SKILL.md`: condash ships agent skills + the `AGENTS.md` marker region only. Removed `.gitignore` from the skill description, the top-level-files bullet (now just the `AGENTS.md` marker head), and the `<name-or-path>` example. Kept the `Source-missing: .gitignore (recommend --prune)` example — it illustrates a file condash *used to* ship reconciling as source-missing, which the retained region-merge machinery supports.
- `docs/guides/skills-pane.md`: dropped the "`.gitignore` region" from the manifest-tracking line.
- `docs/reference/skill.md`: reworded the `files.<path>` manifest namespace as retained to reconcile top-level files condash ≤ 4.0.1 shipped, rather than a currently-shipped `.gitignore`.