### PR TITLE
Skip dropped [-] steps in project-card next-step selector

### DIFF
--- a/src/renderer/panes/projects-parts/data.test.ts
+++ b/src/renderer/panes/projects-parts/data.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import type { Project, Step, StepMarker } from '../../../shared/types';
+import { nextOpenStep } from './data';
+
+function step(marker: StepMarker, text: string, lineIndex = 0): Step {
+  return { lineIndex, marker, text, section: 'Steps' };
+}
+
+function project(steps: Step[]): Project {
+  return {
+    slug: '2026-05-28-x',
+    path: '/p',
+    title: 'x',
+    kind: 'project',
+    status: 'now',
+    apps: [],
+    branch: null,
+    base: null,
+    steps,
+    stepCounts: { todo: 0, doing: 0, done: 0, blocked: 0, dropped: 0 },
+    deliverables: [],
+    deliverableCount: 0,
+    closedAt: null,
+    timeline: [],
+  } as Project;
+}
+
+describe('nextOpenStep', () => {
+  it('returns the first todo step when nothing has started', () => {
+    const a = step(' ', 'a', 0);
+    expect(nextOpenStep(project([a, step(' ', 'b', 1)]))?.text).toBe('a');
+  });
+
+  it('skips past done [x] steps', () => {
+    expect(
+      nextOpenStep(project([step('x', 'a', 0), step('~', 'b', 1), step(' ', 'c', 2)]))?.text,
+    ).toBe('b');
+  });
+
+  it('skips past dropped [-] steps so the in-progress step surfaces instead', () => {
+    // Repro from vcoeur/condash#247: in-progress [~] step C must surface,
+    // not the earlier abandoned [-] step B.
+    const steps = [
+      step('x', 'A', 0),
+      step('-', 'B', 1),
+      step('~', 'C', 2),
+      step('-', 'D', 3),
+      step(' ', 'E', 4),
+    ];
+    expect(nextOpenStep(project(steps))?.text).toBe('C');
+  });
+
+  it('returns undefined when every step is either done or dropped', () => {
+    expect(
+      nextOpenStep(project([step('x', 'a', 0), step('-', 'b', 1), step('x', 'c', 2)])),
+    ).toBeUndefined();
+  });
+
+  it('still surfaces a blocked [!] step', () => {
+    expect(nextOpenStep(project([step('-', 'a', 0), step('!', 'b', 1)]))?.text).toBe('b');
+  });
+});

--- a/src/renderer/panes/projects-parts/data.ts
+++ b/src/renderer/panes/projects-parts/data.ts
@@ -211,10 +211,11 @@ export function isStepCountsComplete(c: StepCounts): boolean {
   return total > 0 && c.todo === 0 && c.doing === 0 && c.blocked === 0;
 }
 
-/** First step whose marker is not 'x' (done). Returns undefined if every step
- * is done — the card body collapses in that case. */
+/** First *actionable* step — skips both `x` (done) and `-` (dropped/abandoned),
+ * matching how `countSteps` treats `-` as settled. Returns undefined if every
+ * step has been decided one way or the other. */
 export function nextOpenStep(item: Project): Step | undefined {
-  return item.steps.find((s) => s.marker !== 'x');
+  return item.steps.find((s) => s.marker !== 'x' && s.marker !== '-');
 }
 
 export function groupByStatus(items: Project[]): Map<string, Project[]> {


### PR DESCRIPTION
## Summary

- Fixes #247: the Projects-pane card's "next step" line could surface an abandoned [-] step instead of the next actionable one when an in-progress [~] (or todo [ ]) step sat below it.
- The progress counter already treats [-] as settled — the selector now matches it.

## Changes

- `src/renderer/panes/projects-parts/data.ts` — `nextOpenStep` now skips both `x` (done) and `-` (dropped); doc comment rewritten to reflect the rule.
- `src/renderer/panes/projects-parts/data.test.ts` (new) — unit tests covering the repro from the issue, plus the "every step settled" and "blocked still surfaces" cases.

## Impact

- Card UI only: cards whose Steps mix [-] and active markers will now show the correct in-progress / todo step on the next-step line. No data, IPC, or persisted-state change.