### PR TITLE
Spell out project folder root layout in projects SKILL

### DIFF
--- a/conception-template/.agents/skills/projects/SKILL.md
+++ b/conception-template/.agents/skills/projects/SKILL.md
@@ -109,5 +109,6 @@ When no `branch` field is set, the main checkouts at `<workspace_path>/<repo>/` 
 - **Transfer stamps** (`**Transferred:** YYYY-MM-DD → <knowledge-path>`) mark passages promoted to `knowledge/`. Historical, never expire.
 - Status markers in checklists: `[ ]`, `[~]`, `[x]`, `[!]`, `[-]`.
 - Each item may have an optional `local/` directory next to `notes/` — gitignored, for raw inputs and intermediate renders that are useful while active but not versioned.
+- **Project folder root**: the only file at the root of an item folder is `README.md` — everything else lives in a subdirectory. `notes/` holds the narrative content (numbered `NN-*.md` notes, plus `.pdf` / images when they support a note). `local/` is gitignored, for raw inputs and intermediate renders. **Sibling directories** alongside `notes/` and `local/` (`scripts/`, `pictures/`, `files/`, `deliverables/`, …) are fine when they organise topic-specific assets that don't fit `notes/` — keep them flat next to `notes/`, don't fold them under it. A loose file at the root (a stray `rapport.md` / `rapport.pdf` pair, a deliverable PDF, …) belongs in `notes/`, or in a sibling like `deliverables/` if that's where it actually lives — not at the root.
 
 $ARGUMENTS


### PR DESCRIPTION
## Summary

- Fixes #255. The projects skill's Shared rules covered what goes inside `notes/` and `local/` but never said what's allowed at the item folder *root* — leading to two failure modes from agents reading the rules literally: loose `rapport.md` / `rapport.pdf` pairs dropped at the root, and over-correction that folds existing sibling dirs (`scripts/`, `pictures/`, `files/`, …) into `notes/`.
- The new bullet pins the convention: `README.md` is the only file at the root, `notes/` and `local/` keep their existing semantics, and arbitrary sibling dirs are fine when they organise topic-specific assets.

## Changes

- `conception-template/.agents/skills/projects/SKILL.md` — one new bullet at the bottom of the Shared rules list.

## Impact

- Skill content is re-shipped via `condash skills install`, so the rule reaches every conception on the next install. The region-aware installer flags hand-edits without `--force`, so any conception that had locally modified the bullet list gets a clean refusal rather than a silent overwrite.