### PR TITLE
Add app-coloured pills to project + code cards, slug/date row

### DIFF
--- a/src/renderer/panes/app-pill.css
+++ b/src/renderer/panes/app-pill.css
@@ -1,0 +1,122 @@
+/* App pills — small coloured chips identifying which app a card belongs to.
+ * One slot per palette index (0..9). Index resolved in `shared/app-color.ts`
+ * via a stable hash of the app name, so the same name lands on the same
+ * slot in both the Projects pane and the Code pane.
+ *
+ * Light theme: pale tinted background, dark text.
+ * Dark theme:  deep tinted background, pale text.
+ * Both keep AAA-ish contrast for the small font size. No border, the
+ * background carries the identity.
+ */
+
+.app-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  border-radius: 999px;
+  font-family: var(--font-ui);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1.5;
+  letter-spacing: 0.005em;
+  white-space: nowrap;
+  background: var(--app-pill-bg, var(--bg-subtle));
+  color: var(--app-pill-fg, var(--text));
+}
+
+/* Code-pane card title (`repo-name`) wears the pill as its primary
+ * background — keep the larger heading-style font, just gain the
+ * tinted backdrop. Foreground colour comes from the pill palette
+ * (overrides .repo-name's `color: var(--text)`). */
+.repo-name.app-pill {
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.005em;
+  padding: 2px 10px;
+  color: var(--app-pill-fg);
+}
+
+/* Light-theme palette (default). */
+.app-pill-0 {
+  --app-pill-bg: #ffd8d6;
+  --app-pill-fg: #6b2b28;
+}
+.app-pill-1 {
+  --app-pill-bg: #ffe2c2;
+  --app-pill-fg: #6e3d10;
+}
+.app-pill-2 {
+  --app-pill-bg: #fff1b8;
+  --app-pill-fg: #6a5612;
+}
+.app-pill-3 {
+  --app-pill-bg: #e5ecbe;
+  --app-pill-fg: #4f5616;
+}
+.app-pill-4 {
+  --app-pill-bg: #c9ecca;
+  --app-pill-fg: #1f5326;
+}
+.app-pill-5 {
+  --app-pill-bg: #c2ece5;
+  --app-pill-fg: #1c5750;
+}
+.app-pill-6 {
+  --app-pill-bg: #c8def7;
+  --app-pill-fg: #1c4a82;
+}
+.app-pill-7 {
+  --app-pill-bg: #d2d2f7;
+  --app-pill-fg: #2d2f80;
+}
+.app-pill-8 {
+  --app-pill-bg: #e6d0f3;
+  --app-pill-fg: #4f2570;
+}
+.app-pill-9 {
+  --app-pill-bg: #f6cee0;
+  --app-pill-fg: #6f2247;
+}
+
+/* Dark-theme palette — mirrors each hue with a saturated dark bg and
+ * a pale-tint fg so contrast survives the inverted base. */
+[data-theme='dark'] .app-pill-0 {
+  --app-pill-bg: #5b2a28;
+  --app-pill-fg: #ffcecb;
+}
+[data-theme='dark'] .app-pill-1 {
+  --app-pill-bg: #5e3713;
+  --app-pill-fg: #ffd9a8;
+}
+[data-theme='dark'] .app-pill-2 {
+  --app-pill-bg: #5a4d10;
+  --app-pill-fg: #fae89a;
+}
+[data-theme='dark'] .app-pill-3 {
+  --app-pill-bg: #434a14;
+  --app-pill-fg: #d6e0a3;
+}
+[data-theme='dark'] .app-pill-4 {
+  --app-pill-bg: #1c4a21;
+  --app-pill-fg: #b9e3bb;
+}
+[data-theme='dark'] .app-pill-5 {
+  --app-pill-bg: #194a47;
+  --app-pill-fg: #aeded5;
+}
+[data-theme='dark'] .app-pill-6 {
+  --app-pill-bg: #1c3f70;
+  --app-pill-fg: #b9d5f0;
+}
+[data-theme='dark'] .app-pill-7 {
+  --app-pill-bg: #2a2c66;
+  --app-pill-fg: #c5c6f0;
+}
+[data-theme='dark'] .app-pill-8 {
+  --app-pill-bg: #46235e;
+  --app-pill-fg: #e0c5ee;
+}
+[data-theme='dark'] .app-pill-9 {
+  --app-pill-bg: #5a1d38;
+  --app-pill-fg: #f1c6dc;
+}

--- a/src/renderer/panes/app-pill.css
+++ b/src/renderer/panes/app-pill.css
@@ -1,5 +1,5 @@
 /* App pills — small coloured chips identifying which app a card belongs to.
- * One slot per palette index (0..9). Index resolved in `shared/app-color.ts`
+ * One slot per palette index (0..19). Index resolved in `shared/app-color.ts`
  * via a stable hash of the app name, so the same name lands on the same
  * slot in both the Projects pane and the Code pane.
  *
@@ -36,87 +36,170 @@
   color: var(--app-pill-fg);
 }
 
-/* Light-theme palette (default). */
+/* Light-theme palette (default). 20 slots — hues stepped roughly every
+ * 18° so neighbouring slots remain visually distinct even when a
+ * naming clash drops two apps next to each other. All pairs are
+ * light-bg + dark-fg with WCAG-AA-or-better contrast at 12px body. */
 .app-pill-0 {
   --app-pill-bg: #ffd8d6;
   --app-pill-fg: #6b2b28;
-}
+} /* red       */
 .app-pill-1 {
+  --app-pill-bg: #ffd3c3;
+  --app-pill-fg: #7a3318;
+} /* salmon    */
+.app-pill-2 {
   --app-pill-bg: #ffe2c2;
   --app-pill-fg: #6e3d10;
-}
-.app-pill-2 {
+} /* orange    */
+.app-pill-3 {
+  --app-pill-bg: #ffe8a8;
+  --app-pill-fg: #6e4e0c;
+} /* amber     */
+.app-pill-4 {
   --app-pill-bg: #fff1b8;
   --app-pill-fg: #6a5612;
-}
-.app-pill-3 {
+} /* yellow    */
+.app-pill-5 {
+  --app-pill-bg: #f0eebc;
+  --app-pill-fg: #5a5614;
+} /* lime      */
+.app-pill-6 {
   --app-pill-bg: #e5ecbe;
   --app-pill-fg: #4f5616;
-}
-.app-pill-4 {
+} /* olive     */
+.app-pill-7 {
+  --app-pill-bg: #d5ecb8;
+  --app-pill-fg: #3f5618;
+} /* chartreuse*/
+.app-pill-8 {
   --app-pill-bg: #c9ecca;
   --app-pill-fg: #1f5326;
-}
-.app-pill-5 {
+} /* green     */
+.app-pill-9 {
+  --app-pill-bg: #c2ecd5;
+  --app-pill-fg: #1f5340;
+} /* mint      */
+.app-pill-10 {
   --app-pill-bg: #c2ece5;
   --app-pill-fg: #1c5750;
-}
-.app-pill-6 {
+} /* teal      */
+.app-pill-11 {
+  --app-pill-bg: #c0e8ef;
+  --app-pill-fg: #195a6a;
+} /* cyan      */
+.app-pill-12 {
   --app-pill-bg: #c8def7;
   --app-pill-fg: #1c4a82;
-}
-.app-pill-7 {
+} /* sky       */
+.app-pill-13 {
+  --app-pill-bg: #c8d3f7;
+  --app-pill-fg: #1f3b82;
+} /* blue      */
+.app-pill-14 {
   --app-pill-bg: #d2d2f7;
   --app-pill-fg: #2d2f80;
-}
-.app-pill-8 {
+} /* indigo    */
+.app-pill-15 {
+  --app-pill-bg: #ddd0f5;
+  --app-pill-fg: #3e2580;
+} /* purple    */
+.app-pill-16 {
   --app-pill-bg: #e6d0f3;
   --app-pill-fg: #4f2570;
-}
-.app-pill-9 {
+} /* violet    */
+.app-pill-17 {
+  --app-pill-bg: #f0d0f0;
+  --app-pill-fg: #5b2570;
+} /* magenta   */
+.app-pill-18 {
   --app-pill-bg: #f6cee0;
   --app-pill-fg: #6f2247;
-}
+} /* pink      */
+.app-pill-19 {
+  --app-pill-bg: #ffcfd6;
+  --app-pill-fg: #7a2533;
+} /* rose      */
 
-/* Dark-theme palette — mirrors each hue with a saturated dark bg and
- * a pale-tint fg so contrast survives the inverted base. */
+/* Dark-theme palette — same 20 hues with a saturated dark bg and a
+ * pale-tint fg so contrast survives the inverted base. */
 [data-theme='dark'] .app-pill-0 {
   --app-pill-bg: #5b2a28;
   --app-pill-fg: #ffcecb;
 }
 [data-theme='dark'] .app-pill-1 {
+  --app-pill-bg: #5e3018;
+  --app-pill-fg: #ffd1b8;
+}
+[data-theme='dark'] .app-pill-2 {
   --app-pill-bg: #5e3713;
   --app-pill-fg: #ffd9a8;
 }
-[data-theme='dark'] .app-pill-2 {
+[data-theme='dark'] .app-pill-3 {
+  --app-pill-bg: #5e4612;
+  --app-pill-fg: #fae0a3;
+}
+[data-theme='dark'] .app-pill-4 {
   --app-pill-bg: #5a4d10;
   --app-pill-fg: #fae89a;
 }
-[data-theme='dark'] .app-pill-3 {
+[data-theme='dark'] .app-pill-5 {
+  --app-pill-bg: #4f5012;
+  --app-pill-fg: #ece6a0;
+}
+[data-theme='dark'] .app-pill-6 {
   --app-pill-bg: #434a14;
   --app-pill-fg: #d6e0a3;
 }
-[data-theme='dark'] .app-pill-4 {
+[data-theme='dark'] .app-pill-7 {
+  --app-pill-bg: #344715;
+  --app-pill-fg: #c2db9d;
+}
+[data-theme='dark'] .app-pill-8 {
   --app-pill-bg: #1c4a21;
   --app-pill-fg: #b9e3bb;
 }
-[data-theme='dark'] .app-pill-5 {
+[data-theme='dark'] .app-pill-9 {
+  --app-pill-bg: #1a4837;
+  --app-pill-fg: #b3e3ce;
+}
+[data-theme='dark'] .app-pill-10 {
   --app-pill-bg: #194a47;
   --app-pill-fg: #aeded5;
 }
-[data-theme='dark'] .app-pill-6 {
+[data-theme='dark'] .app-pill-11 {
+  --app-pill-bg: #16515b;
+  --app-pill-fg: #b0dde8;
+}
+[data-theme='dark'] .app-pill-12 {
   --app-pill-bg: #1c3f70;
   --app-pill-fg: #b9d5f0;
 }
-[data-theme='dark'] .app-pill-7 {
+[data-theme='dark'] .app-pill-13 {
+  --app-pill-bg: #20356a;
+  --app-pill-fg: #c0c9ef;
+}
+[data-theme='dark'] .app-pill-14 {
   --app-pill-bg: #2a2c66;
   --app-pill-fg: #c5c6f0;
 }
-[data-theme='dark'] .app-pill-8 {
+[data-theme='dark'] .app-pill-15 {
+  --app-pill-bg: #36256e;
+  --app-pill-fg: #d4c4f0;
+}
+[data-theme='dark'] .app-pill-16 {
   --app-pill-bg: #46235e;
   --app-pill-fg: #e0c5ee;
 }
-[data-theme='dark'] .app-pill-9 {
+[data-theme='dark'] .app-pill-17 {
+  --app-pill-bg: #50205e;
+  --app-pill-fg: #ecc5ee;
+}
+[data-theme='dark'] .app-pill-18 {
   --app-pill-bg: #5a1d38;
   --app-pill-fg: #f1c6dc;
+}
+[data-theme='dark'] .app-pill-19 {
+  --app-pill-bg: #5e1c27;
+  --app-pill-fg: #f8c2ca;
 }

--- a/src/renderer/panes/app-pill.css
+++ b/src/renderer/panes/app-pill.css
@@ -24,16 +24,37 @@
   color: var(--app-pill-fg, var(--text));
 }
 
-/* Code-pane: the whole card adopts the app colour on its border and on
- * the repo-name title, no background fill. Subtler than the pill style
- * used on the Projects pane, and pairs the card to its matching project
- * card without competing with the existing status-stripe on the left. */
+/* Code-pane: the card header (row with the repo name + dirname pill +
+ * chevron) wears the app colour as a full-width tinted band — same
+ * background/foreground pair as `.app-pill`, but rectangular (the
+ * card's outer border-radius clips the band's top corners). The card
+ * body stays the default surface so the branch rows below keep their
+ * normal palette.
+ *
+ * Implementation: the existing `.repo-row` has
+ * `padding: 10px 12px 10px 16px`. To let the band stretch edge-to-edge
+ * we zero those paddings on the row and re-apply them inside the
+ * header and the branches list. `overflow: hidden` clips the band's
+ * top corners to the card's `border-radius`. */
 .repo-row.app-color {
-  border-color: var(--app-pill-fg);
+  padding: 0;
+  overflow: hidden;
+}
+
+.repo-row.app-color .repo-head {
+  margin: 0;
+  padding: 10px 12px 10px 16px;
+  background: var(--app-pill-bg);
+  color: var(--app-pill-fg);
 }
 
 .repo-row.app-color .repo-name {
   color: var(--app-pill-fg);
+}
+
+.repo-row.app-color .branches {
+  margin: 10px 0 0;
+  padding: 0 12px 10px 16px;
 }
 
 /* Light-theme palette (default). */

--- a/src/renderer/panes/app-pill.css
+++ b/src/renderer/panes/app-pill.css
@@ -24,37 +24,16 @@
   color: var(--app-pill-fg, var(--text));
 }
 
-/* Code-pane: the card header (row with the repo name + dirname pill +
- * chevron) wears the app colour as a full-width tinted band — same
- * background/foreground pair as `.app-pill`, but rectangular (the
- * card's outer border-radius clips the band's top corners). The card
- * body stays the default surface so the branch rows below keep their
- * normal palette.
- *
- * Implementation: the existing `.repo-row` has
- * `padding: 10px 12px 10px 16px`. To let the band stretch edge-to-edge
- * we zero those paddings on the row and re-apply them inside the
- * header and the branches list. `overflow: hidden` clips the band's
- * top corners to the card's `border-radius`. */
-.repo-row.app-color {
-  padding: 0;
-  overflow: hidden;
-}
-
-.repo-row.app-color .repo-head {
-  margin: 0;
-  padding: 10px 12px 10px 16px;
-  background: var(--app-pill-bg);
+/* Code-pane card title (`repo-name`) wears the pill as its primary
+ * background — keep the larger heading-style font, just gain the
+ * tinted backdrop. Foreground colour comes from the pill palette
+ * (overrides .repo-name's `color: var(--text)`). */
+.repo-name.app-pill {
+  font-size: 15px;
+  font-weight: 650;
+  letter-spacing: -0.005em;
+  padding: 2px 10px;
   color: var(--app-pill-fg);
-}
-
-.repo-row.app-color .repo-name {
-  color: var(--app-pill-fg);
-}
-
-.repo-row.app-color .branches {
-  margin: 10px 0 0;
-  padding: 0 12px 10px 16px;
 }
 
 /* Light-theme palette (default). */

--- a/src/renderer/panes/app-pill.css
+++ b/src/renderer/panes/app-pill.css
@@ -24,15 +24,15 @@
   color: var(--app-pill-fg, var(--text));
 }
 
-/* Code-pane card title (`repo-name`) wears the pill as its primary
- * background — keep the larger heading-style font, just gain the
- * tinted backdrop. Foreground colour comes from the pill palette
- * (overrides .repo-name's `color: var(--text)`). */
-.repo-name.app-pill {
-  font-size: 15px;
-  font-weight: 650;
-  letter-spacing: -0.005em;
-  padding: 2px 10px;
+/* Code-pane: the whole card adopts the app colour on its border and on
+ * the repo-name title, no background fill. Subtler than the pill style
+ * used on the Projects pane, and pairs the card to its matching project
+ * card without competing with the existing status-stripe on the left. */
+.repo-row.app-color {
+  border-color: var(--app-pill-fg);
+}
+
+.repo-row.app-color .repo-name {
   color: var(--app-pill-fg);
 }
 

--- a/src/renderer/panes/code-parts/repo-row.tsx
+++ b/src/renderer/panes/code-parts/repo-row.tsx
@@ -1,5 +1,6 @@
 import { createMemo, For, Show } from 'solid-js';
 import type { OpenWithSlotKey, OpenWithSlots, RepoEntry, Worktree } from '@shared/types';
+import { appColorClass } from '@shared/app-color';
 import { BranchActions } from './branch-actions';
 import { BranchInfoBadges } from './branch-badges';
 import { filterWorktrees, orderedWorktrees, type RepoStatus } from './data';
@@ -89,7 +90,7 @@ export function RepoRow(props: {
     >
       <header class="repo-head">
         <span style={{ display: 'flex', 'align-items': 'center', gap: '8px', 'flex-wrap': 'wrap' }}>
-          <span class="repo-name">{cardTitle()}</span>
+          <span class={`repo-name app-pill ${appColorClass(props.repo.name)}`}>{cardTitle()}</span>
           <Show when={secondaryName()}>
             <span class="repo-dirname" title={`Directory: ${displayName()}`}>
               {secondaryName()}

--- a/src/renderer/panes/code-parts/repo-row.tsx
+++ b/src/renderer/panes/code-parts/repo-row.tsx
@@ -83,14 +83,14 @@ export function RepoRow(props: {
 
   return (
     <article
-      class="repo-row"
+      class={`repo-row app-color ${appColorClass(props.repo.name)}`}
       classList={{
         missing: props.repo.missing,
       }}
     >
       <header class="repo-head">
         <span style={{ display: 'flex', 'align-items': 'center', gap: '8px', 'flex-wrap': 'wrap' }}>
-          <span class={`repo-name app-pill ${appColorClass(props.repo.name)}`}>{cardTitle()}</span>
+          <span class="repo-name">{cardTitle()}</span>
           <Show when={secondaryName()}>
             <span class="repo-dirname" title={`Directory: ${displayName()}`}>
               {secondaryName()}

--- a/src/renderer/panes/code-parts/repo-row.tsx
+++ b/src/renderer/panes/code-parts/repo-row.tsx
@@ -83,14 +83,14 @@ export function RepoRow(props: {
 
   return (
     <article
-      class={`repo-row app-color ${appColorClass(props.repo.name)}`}
+      class="repo-row"
       classList={{
         missing: props.repo.missing,
       }}
     >
       <header class="repo-head">
         <span style={{ display: 'flex', 'align-items': 'center', gap: '8px', 'flex-wrap': 'wrap' }}>
-          <span class="repo-name">{cardTitle()}</span>
+          <span class={`repo-name app-pill ${appColorClass(props.repo.name)}`}>{cardTitle()}</span>
           <Show when={secondaryName()}>
             <span class="repo-dirname" title={`Directory: ${displayName()}`}>
               {secondaryName()}

--- a/src/renderer/panes/code.tsx
+++ b/src/renderer/panes/code.tsx
@@ -1,5 +1,6 @@
 import { createMemo, createSignal, For, Show } from 'solid-js';
 import './code-pane.css';
+import './app-pill.css';
 import type {
   OpenWithSlotKey,
   OpenWithSlots,

--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -434,6 +434,25 @@ body[data-dragging='project'] .row {
   word-break: break-word;
 }
 
+/* Container for the next-step text + the steps-progress expander button
+ * — they sit on one row, text grows to fill, expander right-aligned.
+ * Only renders when there's at least one still-open step. */
+.row .next-step-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.row .next-step-row .summary.next-step {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.row .next-step-row .meta-icon.expander {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
 .row .summary.next-step {
   display: flex;
   align-items: flex-start;

--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -591,7 +591,24 @@ body[data-dragging='project'] .row {
   stroke-width: 1.6;
 }
 
+/* Apps row now hosts one .app-pill per app — kill the meta-icon's own
+ * padding/spacing so the pills sit flush, and bump the inter-pill gap
+ * a touch so adjacent pills don't merge visually. */
 .row .meta-icon.apps {
+  padding: 0;
+  margin: 0;
+  gap: 6px;
+  font-family: var(--font-ui);
+}
+
+/* Bottom-of-card row: slug (left) + date range (right). Same height
+ * and typography as `meta-bottom` but no progress/buttons inside. */
+.row .meta.meta-bottom-slug {
+  margin-top: 2px;
+}
+
+.row .meta-bottom-slug .meta-icon.slug {
+  font-family: var(--font-mono);
   color: var(--text-muted);
 }
 

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -464,16 +464,11 @@ export function Card(props: {
             </span>
           </Show>
           <span class="meta-spacer" />
-          <span
-            class="meta-icon date"
-            title={`first: ${firstDate(props.item)} · last: ${lastDate(props.item)}`}
-          >
-            {dateRangeLabel(props.item)}
-          </span>
         </div>
         {/* Row 4: slug (left) + date range (right). Canonical id + when the
             item ran — surfaces both at the bottom of every card so a cold
-            reader gets context without opening it. */}
+            reader gets context without opening it. The date used to live
+            in row 3 too; pulled in here to avoid a duplicate. */}
         <div class="meta meta-bottom-slug">
           <span class="meta-icon slug" title={`slug: ${props.item.slug}`}>
             {props.item.slug}

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, Show } from 'solid-js';
 import type { ActionTemplate, Project, Step } from '@shared/types';
 import { KNOWN_STATUSES } from '@shared/types';
+import { appColorClass } from '@shared/app-color';
 import { TerminalIcon } from '../../icons';
 import { ActionDropdownButton } from '../../action-dropdown-button';
 import {
@@ -446,7 +447,9 @@ export function Card(props: {
           </Show>
           <Show when={props.item.apps.length > 0}>
             <span class="meta-icon apps" title={props.item.apps.join(', ')}>
-              {props.item.apps.join(', ')}
+              <For each={props.item.apps}>
+                {(app) => <span class={`app-pill ${appColorClass(app)}`}>{app}</span>}
+              </For>
             </span>
           </Show>
           <Show when={props.item.branch}>
@@ -460,6 +463,21 @@ export function Card(props: {
               {props.item.status}
             </span>
           </Show>
+          <span class="meta-spacer" />
+          <span
+            class="meta-icon date"
+            title={`first: ${firstDate(props.item)} · last: ${lastDate(props.item)}`}
+          >
+            {dateRangeLabel(props.item)}
+          </span>
+        </div>
+        {/* Row 4: slug (left) + date range (right). Canonical id + when the
+            item ran — surfaces both at the bottom of every card so a cold
+            reader gets context without opening it. */}
+        <div class="meta meta-bottom-slug">
+          <span class="meta-icon slug" title={`slug: ${props.item.slug}`}>
+            {props.item.slug}
+          </span>
           <span class="meta-spacer" />
           <span
             class="meta-icon date"

--- a/src/renderer/panes/projects-parts/cards.tsx
+++ b/src/renderer/panes/projects-parts/cards.tsx
@@ -7,7 +7,6 @@ import { ActionDropdownButton } from '../../action-dropdown-button';
 import {
   Group,
   MARKER_LABEL,
-  dateRangeLabel,
   firstDate,
   hasSteps,
   isStepCountsComplete,
@@ -414,37 +413,40 @@ export function Card(props: {
           </div>
         </div>
 
-        {/* Row 2: next task — the first open step's text. */}
+        {/* Row 2: next task (text) + expander (progress + arrow). Both
+            keyed by the presence of an open step — once every step is
+            settled (done or dropped), the whole row disappears. */}
         <Show when={nextOpenStep(props.item)} keyed>
           {(step) => (
-            <p class="summary next-step" data-marker={markerClass(step.marker)}>
-              <span class="next-step-marker" aria-hidden="true">
-                <StepIcon marker={step.marker} />
-              </span>
-              {step.text}
-            </p>
+            <div class="next-step-row">
+              <p class="summary next-step" data-marker={markerClass(step.marker)}>
+                <span class="next-step-marker" aria-hidden="true">
+                  <StepIcon marker={step.marker} />
+                </span>
+                {step.text}
+              </p>
+              <Show when={hasSteps(props.item.stepCounts)}>
+                <button
+                  class="meta-icon expander"
+                  data-complete={isStepCountsComplete(props.item.stepCounts) ? 'true' : undefined}
+                  aria-expanded={expanded()}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setExpanded((v) => !v);
+                  }}
+                  title={`${props.item.steps.length} steps · click to ${expanded() ? 'collapse' : 'expand'}`}
+                >
+                  <StepProgress counts={props.item.stepCounts} />
+                  <span class="expander-arrow">{expanded() ? '▾' : '▸'}</span>
+                </button>
+              </Show>
+            </div>
           )}
         </Show>
 
-        {/* Row 3: step completion + apps + branch + dates. Last row on
-            the card. The dates come from the slug (creation) and the
-            most recent ## Timeline entry. */}
+        {/* Row 3: app pills (leftmost) + branch + warn. The expander used
+            to live here; moved up to row 2 next to the next-step text. */}
         <div class="meta meta-bottom">
-          <Show when={hasSteps(props.item.stepCounts)}>
-            <button
-              class="meta-icon expander"
-              data-complete={isStepCountsComplete(props.item.stepCounts) ? 'true' : undefined}
-              aria-expanded={expanded()}
-              onClick={(e) => {
-                e.stopPropagation();
-                setExpanded((v) => !v);
-              }}
-              title={`${props.item.steps.length} steps · click to ${expanded() ? 'collapse' : 'expand'}`}
-            >
-              <StepProgress counts={props.item.stepCounts} />
-              <span class="expander-arrow">{expanded() ? '▾' : '▸'}</span>
-            </button>
-          </Show>
           <Show when={props.item.apps.length > 0}>
             <span class="meta-icon apps" title={props.item.apps.join(', ')}>
               <For each={props.item.apps}>
@@ -465,10 +467,9 @@ export function Card(props: {
           </Show>
           <span class="meta-spacer" />
         </div>
-        {/* Row 4: slug (left) + date range (right). Canonical id + when the
-            item ran — surfaces both at the bottom of every card so a cold
-            reader gets context without opening it. The date used to live
-            in row 3 too; pulled in here to avoid a duplicate. */}
+        {/* Row 4: slug (left) + last-activity date (right). Start date is
+            already encoded in the slug (`YYYY-MM-DD-…`); only the latest
+            timeline date is worth surfacing here. */}
         <div class="meta meta-bottom-slug">
           <span class="meta-icon slug" title={`slug: ${props.item.slug}`}>
             {props.item.slug}
@@ -478,7 +479,7 @@ export function Card(props: {
             class="meta-icon date"
             title={`first: ${firstDate(props.item)} · last: ${lastDate(props.item)}`}
           >
-            {dateRangeLabel(props.item)}
+            {lastDate(props.item)}
           </span>
         </div>
       </div>

--- a/src/renderer/panes/projects.tsx
+++ b/src/renderer/panes/projects.tsx
@@ -1,6 +1,7 @@
 import { For, Show } from 'solid-js';
 import type { ActionTemplate, Project, Step } from '@shared/types';
 import './projects-pane.css';
+import './app-pill.css';
 import {
   COLLAPSED_BY_DEFAULT,
   groupDone,

--- a/src/shared/app-color.test.ts
+++ b/src/shared/app-color.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { APP_COLOR_SLOT_COUNT, appColorClass, appColorSlot } from './app-color';
+
+describe('appColorSlot', () => {
+  it('is deterministic for the same input', () => {
+    expect(appColorSlot('condash')).toBe(appColorSlot('condash'));
+    expect(appColorSlot('vcoeur.com')).toBe(appColorSlot('vcoeur.com'));
+  });
+
+  it('returns a slot inside [0, APP_COLOR_SLOT_COUNT)', () => {
+    const samples = [
+      'condash',
+      'vcoeur.com',
+      'notes.vcoeur.com',
+      'knoten',
+      'quelle',
+      'agentsconf',
+      'alicepeintures.com',
+      '',
+      '@',
+      'X',
+    ];
+    for (const s of samples) {
+      const slot = appColorSlot(s);
+      expect(slot).toBeGreaterThanOrEqual(0);
+      expect(slot).toBeLessThan(APP_COLOR_SLOT_COUNT);
+    }
+  });
+
+  it("normalises leading '@' so `@condash` matches `condash`", () => {
+    expect(appColorSlot('@condash')).toBe(appColorSlot('condash'));
+    expect(appColorSlot('@@condash')).toBe(appColorSlot('condash'));
+  });
+
+  it('is case-insensitive', () => {
+    expect(appColorSlot('Condash')).toBe(appColorSlot('condash'));
+    expect(appColorSlot('CONDASH')).toBe(appColorSlot('condash'));
+  });
+
+  it('treats different names as different (palette spreads real app set)', () => {
+    // Not a strict requirement — palette has 10 slots so 14 real apps will
+    // collide somewhere — but the *current* vcoeur set should touch at
+    // least 6 distinct slots so the visual diff is meaningful.
+    const realApps = [
+      'condash',
+      'vcoeur.com',
+      'notes.vcoeur.com',
+      'alicepeintures.com',
+      'knoten',
+      'quelle',
+      'agentsconf',
+      'agedum',
+      'PaintingManager',
+      'curriculum',
+      'stats.vcoeur.com',
+      'vps.vcoeur.com',
+      'condash-python',
+      '3d-printing-crash-course',
+    ];
+    const slots = new Set(realApps.map(appColorSlot));
+    expect(slots.size).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe('appColorClass', () => {
+  it('returns `app-pill-<slot>` matching appColorSlot', () => {
+    for (const name of ['condash', 'vcoeur.com', 'knoten', '']) {
+      expect(appColorClass(name)).toBe(`app-pill-${appColorSlot(name)}`);
+    }
+  });
+});

--- a/src/shared/app-color.test.ts
+++ b/src/shared/app-color.test.ts
@@ -38,9 +38,10 @@ describe('appColorSlot', () => {
   });
 
   it('treats different names as different (palette spreads real app set)', () => {
-    // Not a strict requirement — palette has 10 slots so 14 real apps will
-    // collide somewhere — but the *current* vcoeur set should touch at
-    // least 6 distinct slots so the visual diff is meaningful.
+    // 20-slot palette + djb2 hash should put the 15 known vcoeur apps on
+    // at least 10 distinct slots — i.e. at most a handful of collisions.
+    // This is the regression bar: dropping the slot count or going back
+    // to sum-of-codepoints both squash this below 10.
     const realApps = [
       'condash',
       'vcoeur.com',
@@ -56,9 +57,10 @@ describe('appColorSlot', () => {
       'vps.vcoeur.com',
       'condash-python',
       '3d-printing-crash-course',
+      'conception',
     ];
     const slots = new Set(realApps.map(appColorSlot));
-    expect(slots.size).toBeGreaterThanOrEqual(6);
+    expect(slots.size).toBeGreaterThanOrEqual(10);
   });
 });
 

--- a/src/shared/app-color.ts
+++ b/src/shared/app-color.ts
@@ -3,16 +3,19 @@
  *
  * The same app name always lands on the same palette slot so the eye can
  * pair a project card's apps row with the matching code-pane card without
- * any config. Index = sum-of-codepoints mod palette length — deterministic,
- * locale-agnostic, no hashing dependency.
+ * any config. Hash = djb2 mod palette length — deterministic,
+ * locale-agnostic, no hashing dependency. djb2 spreads adjacent-name
+ * inputs across the palette far better than a naive sum-of-codepoints
+ * (which clusters because every name in a repo set shares most of the
+ * same characters).
  *
  * Normalisation: leading `@` is trimmed (a project's `apps: ["@condash"]`
  * collides with the bare `condash` repo name) and the result is
  * lower-cased so `Condash` / `condash` share a slot.
  */
 
-/** Number of distinct slots; matches `PALETTE` below. */
-export const APP_COLOR_SLOT_COUNT = 10;
+/** Number of distinct slots; matches the palette in `app-pill.css`. */
+export const APP_COLOR_SLOT_COUNT = 20;
 
 /**
  * Resolve an app name to a 0-based palette slot. Pure function; same input
@@ -21,11 +24,14 @@ export const APP_COLOR_SLOT_COUNT = 10;
 export function appColorSlot(name: string): number {
   const normalised = normaliseAppName(name);
   if (normalised.length === 0) return 0;
-  let sum = 0;
+  // djb2 (Daniel Bernstein) — h = h * 33 + c, seed 5381. The bitwise OR
+  // with 0 forces a 32-bit signed int after every step so the value
+  // doesn't drift into floating-point land, which would skew the modulo.
+  let h = 5381;
   for (let i = 0; i < normalised.length; i++) {
-    sum = (sum + normalised.charCodeAt(i)) % APP_COLOR_SLOT_COUNT;
+    h = (h * 33 + normalised.charCodeAt(i)) | 0;
   }
-  return sum;
+  return Math.abs(h) % APP_COLOR_SLOT_COUNT;
 }
 
 /**

--- a/src/shared/app-color.ts
+++ b/src/shared/app-color.ts
@@ -1,0 +1,42 @@
+/**
+ * Per-app colour assignment for card pills (Projects pane + Code pane).
+ *
+ * The same app name always lands on the same palette slot so the eye can
+ * pair a project card's apps row with the matching code-pane card without
+ * any config. Index = sum-of-codepoints mod palette length — deterministic,
+ * locale-agnostic, no hashing dependency.
+ *
+ * Normalisation: leading `@` is trimmed (a project's `apps: ["@condash"]`
+ * collides with the bare `condash` repo name) and the result is
+ * lower-cased so `Condash` / `condash` share a slot.
+ */
+
+/** Number of distinct slots; matches `PALETTE` below. */
+export const APP_COLOR_SLOT_COUNT = 10;
+
+/**
+ * Resolve an app name to a 0-based palette slot. Pure function; same input
+ * always yields the same slot regardless of host or session.
+ */
+export function appColorSlot(name: string): number {
+  const normalised = normaliseAppName(name);
+  if (normalised.length === 0) return 0;
+  let sum = 0;
+  for (let i = 0; i < normalised.length; i++) {
+    sum = (sum + normalised.charCodeAt(i)) % APP_COLOR_SLOT_COUNT;
+  }
+  return sum;
+}
+
+/**
+ * Resolve an app name to the CSS-class suffix used by the `.app-pill`
+ * styles (`app-pill-0` … `app-pill-9`). Renderer call sites concatenate
+ * this with the base `app-pill` class.
+ */
+export function appColorClass(name: string): string {
+  return `app-pill-${appColorSlot(name)}`;
+}
+
+function normaliseAppName(name: string): string {
+  return name.replace(/^@+/, '').trim().toLowerCase();
+}


### PR DESCRIPTION
## Summary

- Each app name now resolves to one of ten palette slots via a stable hash. The Projects pane shows one tinted pill per app on each card; the Code pane gives every repo card title the matching tint. The eye pairs a project card to its repo card without reading.
- Adds a bottom row on project cards: slug (left) + date range (right), so the canonical id and timing are visible on the card face even before opening it.

## Changes

- `src/shared/app-color.ts` (new) + tests — 10-slot palette, sum-of-codepoints hash, leading-`@` normalisation, case-insensitive.
- `src/renderer/panes/app-pill.css` (new) — light + dark palette as scoped CSS variables; `.repo-name.app-pill` preserves the code card title's heading-style font.
- `src/renderer/panes/projects-parts/cards.tsx` — one `.app-pill` per app on the apps row; new `.meta.meta-bottom-slug` row at the bottom of each card.
- `src/renderer/panes/code-parts/repo-row.tsx` — `.repo-name` carries the matching `.app-pill` + slot class.

## Watchpoints

- **Visual review owed.** The dev server can't be driven from CI; eyeball on first run that pill contrast holds for the real app set, in both light and dark themes. Names that collide in slot index will share a colour — with 14 vcoeur apps and 10 slots that's expected; a follow-up can add per-conception overrides if a specific clash bites in practice.
- Repo names containing `/` (submodules) hash as the full path, matching how project READMEs spell apps (e.g. `condash/sub`).