### PR TITLE
Wrap project card app pills instead of overflowing

### DIFF
--- a/src/renderer/panes/projects-pane.css
+++ b/src/renderer/panes/projects-pane.css
@@ -612,12 +612,16 @@ body[data-dragging='project'] .row {
 
 /* Apps row now hosts one .app-pill per app — kill the meta-icon's own
  * padding/spacing so the pills sit flush, and bump the inter-pill gap
- * a touch so adjacent pills don't merge visually. */
+ * a touch so adjacent pills don't merge visually. `flex-wrap: wrap`
+ * lets a long apps list spill onto a second row inside the card
+ * instead of clipping pills at the right edge (issue #258). */
 .row .meta-icon.apps {
   padding: 0;
   margin: 0;
-  gap: 6px;
+  gap: 4px 6px;
   font-family: var(--font-ui);
+  flex-wrap: wrap;
+  min-width: 0;
 }
 
 /* Bottom-of-card row: slug (left) + date range (right). Same height


### PR DESCRIPTION
## Summary

- Fixes #258. Project cards with 5+ apps had the trailing pills clipped at the card's right edge — the inline-flex apps span never wrapped, and the row gained no scroll affordance.
- Add `flex-wrap: wrap` (with a 4px row-gap) to the apps meta-icon so a long list spills onto a second row inside the card.

## Changes

- `src/renderer/panes/projects-pane.css` — `.row .meta-icon.apps` gains `flex-wrap: wrap`, `min-width: 0`, and a two-axis gap (4px between rows / 6px between pills).