### PR TITLE
Polish the code-card @handle: compact rectangular pill + path

### DIFF
--- a/src/renderer/code-runs.tsx
+++ b/src/renderer/code-runs.tsx
@@ -86,10 +86,8 @@ function repoMeta(
       branch = worktrees.find((w) => w.primary)?.branch ?? undefined;
     }
   }
-  // Prefer the configured label (`condash.json`) so the active-run
-  // row matches the title used on the repo card; fall back to the repo
-  // directory name when no label is set.
-  const displayName = repo.label ?? repo.name;
+  // The `@handle` titles the active-run row, matching the repo card.
+  const displayName = `@${repo.handle}`;
   return { repo, branch, displayName };
 }
 

--- a/src/renderer/panes/app-pill.css
+++ b/src/renderer/panes/app-pill.css
@@ -25,14 +25,16 @@
 }
 
 /* Code-pane card title (`repo-name`) wears the pill as its primary
- * background — keep the larger heading-style font, just gain the
- * tinted backdrop. Foreground colour comes from the pill palette
- * (overrides .repo-name's `color: var(--text)`). */
+ * background. A compact rectangular chip — smaller than the old capsule
+ * heading — so the `@handle` reads as a tag, not a banner. Foreground
+ * colour comes from the pill palette (overrides .repo-name's
+ * `color: var(--text)`). */
 .repo-name.app-pill {
-  font-size: 15px;
-  font-weight: 650;
+  font-size: 13px;
+  font-weight: 600;
   letter-spacing: -0.005em;
-  padding: 2px 10px;
+  padding: 1px 7px;
+  border-radius: 4px;
   color: var(--app-pill-fg);
 }
 

--- a/src/renderer/panes/code-parts/repo-row.tsx
+++ b/src/renderer/panes/code-parts/repo-row.tsx
@@ -29,25 +29,14 @@ export function RepoRow(props: {
   onRun: (repo: RepoEntry, worktree?: Worktree) => void;
   onOpenInTerm: (repo: RepoEntry, worktree: Worktree) => void;
 }) {
-  const displayName = (): string => {
-    if (props.repo.parent && props.repo.name.startsWith(`${props.repo.parent}/`)) {
-      return props.repo.name.slice(props.repo.parent.length + 1);
-    }
-    return props.repo.name;
-  };
-
   /** Primary pill — always the canonical `@handle`, so a code card and a
    * project card naming the same app read identically. */
   const handlePill = (): string => appPillText(props.repo.handle);
 
-  /** Secondary subtitle: the friendly `label` when set, otherwise the
-   * directory name when it differs from the handle (e.g. handle `@kasten`,
-   * directory `notes.vcoeur.com`). Null when the two already match. */
-  const secondaryName = (): string | null => {
-    if (props.repo.label) return props.repo.label;
-    const name = displayName();
-    return name === props.repo.handle ? null : name;
-  };
+  /** Secondary subtitle: the on-disk location, with the home directory
+   * collapsed to `~`. The path is the useful per-card fact the handle hides;
+   * the configured `label` still titles the active-run row (`code-runs.tsx`). */
+  const repoPath = (): string => props.repo.path.replace(/^\/home\/[^/]+\//, '~/');
 
   const isPlainDirectory = (): boolean => !props.repo.missing && props.repo.isGit === false;
 
@@ -92,15 +81,13 @@ export function RepoRow(props: {
         <span style={{ display: 'flex', 'align-items': 'center', gap: '8px', 'flex-wrap': 'wrap' }}>
           <span
             class={`repo-name app-pill ${appColorClass(props.repo.handle)}`}
-            title={`Directory: ${displayName()}`}
+            title={props.repo.path}
           >
             {handlePill()}
           </span>
-          <Show when={secondaryName()}>
-            <span class="repo-dirname" title={`Directory: ${displayName()}`}>
-              {secondaryName()}
-            </span>
-          </Show>
+          <span class="repo-dirname" title={props.repo.path}>
+            {repoPath()}
+          </span>
           <Show when={liveBranchLabel()}>
             <span
               class="repo-live-branch"


### PR DESCRIPTION
## Summary

Follow-up polish to the `@handle` rollout (PR #261), addressing card-design feedback: the code-pane handle pill was too large and capsule-shaped, and the secondary line showed the configured `label` rather than the more useful repo path.

## Changes

- **Compact rectangular pill.** `.repo-name.app-pill` drops from a 15px/650 capsule (999px radius) to a 13px/600 rectangular tag (4px radius) — the `@handle` reads as a tag, not a banner.
- **Path instead of label** on the card's secondary line, with the home directory collapsed to `~`. The path is the per-card fact the handle hides.
- **Active-run row titles on `@handle`** too (`code-runs.tsx`), matching the card.
- `label` is consequently no longer displayed anywhere. It stays accepted in `condash.json` (non-breaking) but is now display-dead — a candidate for full removal in a later pass.

## Watchpoints

- `label` is now vestigial: configurable but never shown. If we want it gone for good, that's a follow-up (schema removal + a `migrateRawSettings` strip so existing configs don't break).

🤖 Generated with [Claude Code](https://claude.com/claude-code)