### PR TITLE
Fix stale Skills-pane Playwright specs from the #260 reframe

### DIFF
--- a/tests/global-skills.spec.ts
+++ b/tests/global-skills.spec.ts
@@ -5,14 +5,13 @@ import { join, resolve } from 'node:path';
 import { bootApp } from './fixtures/electron-app';
 
 /**
- * End-to-end for the Skills pane's local/global scope toggle (+ refresh + the
- * Generic agent-config sources). Boots a fixture conception for the local
+ * End-to-end for the Skills pane's conception/user scope toggle (+ refresh).
+ * Boots a fixture conception with a `.agents/skills/` skill for the conception
  * scope and a separate temp tree wired in via the `CONDASH_USER_*` overrides
- * for the global scope, then drives the two-row header.
+ * for the user scope, then verifies flipping the scope swaps the tree.
  *
  * Vitest (`src/main/skills.test.ts`) already covers the reader logic; this
- * spec verifies the renderer ↔ IPC ↔ FS round-trip and that flipping the
- * scope actually swaps the tree. Screenshots land in
+ * spec verifies the renderer ↔ IPC ↔ FS round-trip. Screenshots land in
  * `tests/screenshots-out/global-skills/` for visual review (gitignored).
  */
 
@@ -26,45 +25,31 @@ async function shoot(window: import('@playwright/test').Page, name: string): Pro
     .catch((err) => console.error(`[shoot] ${name}: ${(err as Error).message}`));
 }
 
-test('Skills pane: local/global scope toggle, Generic sources, refresh', async () => {
-  // Global-scope fixture tree, pointed at by the CONDASH_USER_* overrides.
-  const globalDir = await mkdtemp(join(tmpdir(), 'condash-global-skills-'));
-  await mkdir(join(globalDir, 'g-skills', 'pr'), { recursive: true });
-  await writeFile(join(globalDir, 'g-skills', 'pr', 'spec.yaml'), 'description: global pr\n', 'utf8');
-  await mkdir(join(globalDir, 'g-agents'), { recursive: true });
-  await writeFile(join(globalDir, 'g-agents', 'common.md'), '# Global common\n\nGlobal base.\n', 'utf8');
-  await writeFile(join(globalDir, 'g-agents', 'claude.md'), '# Global claude overlay\n', 'utf8');
-  await mkdir(join(globalDir, 'c-skills', 'commit'), { recursive: true });
-  await writeFile(join(globalDir, 'c-skills', 'commit', 'SKILL.md'), '# Global commit\n\nx\n', 'utf8');
-  await mkdir(join(globalDir, 'k-skills'), { recursive: true });
-  await mkdir(join(globalDir, 'o-skills'), { recursive: true });
-  await mkdir(join(globalDir, 'claude-out'), { recursive: true });
-  await writeFile(join(globalDir, 'claude-out', 'CLAUDE.md'), '# Global CLAUDE\n\nGlobal rules.\n', 'utf8');
+test('Skills pane: conception/user scope toggle + refresh', async () => {
+  // User-scope fixture tree, pointed at by the CONDASH_USER_* overrides the
+  // reframed pane reads (just the skills root + the AGENTS.md path now).
+  const globalDir = await mkdtemp(join(tmpdir(), 'condash-user-skills-'));
+  await mkdir(join(globalDir, 'g-skills', 'usertool'), { recursive: true });
+  await writeFile(
+    join(globalDir, 'g-skills', 'usertool', 'SKILL.md'),
+    '# User tool\n\nUser-scope skill.\n',
+    'utf8',
+  );
+  await writeFile(join(globalDir, 'AGENTS.md'), '# User AGENTS\n\nUser base.\n', 'utf8');
 
   const booted = await bootApp({
     env: {
       CONDASH_USER_SKILLS_ROOT: join(globalDir, 'g-skills'),
-      CONDASH_USER_AGENT_CONFIG_ROOT: join(globalDir, 'g-agents'),
-      CONDASH_USER_CLAUDE_ROOT: join(globalDir, 'c-skills'),
-      CONDASH_USER_KIMI_ROOT: join(globalDir, 'k-skills'),
-      CONDASH_USER_OPENCODE_ROOT: join(globalDir, 'o-skills'),
-      CONDASH_USER_CLAUDE_AGENT_OUTPUT: join(globalDir, 'claude-out', 'CLAUDE.md'),
+      CONDASH_USER_AGENTS_MD: join(globalDir, 'AGENTS.md'),
     },
     prepare: async (conceptionDir) => {
-      // Local Claude skill + the conception's own CLAUDE.md.
-      await mkdir(join(conceptionDir, '.claude', 'skills', 'projects'), { recursive: true });
+      // A conception-scope skill under `.agents/skills/` (the reframed source).
+      await mkdir(join(conceptionDir, '.agents', 'skills', 'conctool'), { recursive: true });
       await writeFile(
-        join(conceptionDir, '.claude', 'skills', 'projects', 'SKILL.md'),
-        '# Projects skill\n\nLead.\n',
+        join(conceptionDir, '.agents', 'skills', 'conctool', 'SKILL.md'),
+        '# Conception tool\n\nConception-scope skill.\n',
         'utf8',
       );
-      await writeFile(join(conceptionDir, 'CLAUDE.md'), '# Local project CLAUDE\n\nLocal rules.\n', 'utf8');
-      // Local Generic agent-config sources.
-      await mkdir(join(conceptionDir, '.agents', 'agents'), { recursive: true });
-      await writeFile(join(conceptionDir, '.agents', 'agents', 'common.md'), '# Local common\n\nBase.\n', 'utf8');
-      await writeFile(join(conceptionDir, '.agents', 'agents', 'claude.md'), '# Local claude overlay\n', 'utf8');
-      await mkdir(join(conceptionDir, '.agents', 'skills', 'foo'), { recursive: true });
-      await writeFile(join(conceptionDir, '.agents', 'skills', 'foo', 'spec.yaml'), 'description: local foo\n', 'utf8');
     },
   });
   const { window, cleanup } = booted;
@@ -72,51 +57,29 @@ test('Skills pane: local/global scope toggle, Generic sources, refresh', async (
     await window.locator('.edge-strip-right .edge-handle').filter({ hasText: 'Skills' }).click();
     await expect(window.locator('.skills-pane')).toBeVisible();
 
-    // Row 1 renders both scope buttons; Local is the default + active.
-    const localBtn = window.locator('.skills-scope-btn', { hasText: 'Local' });
-    const globalBtn = window.locator('.skills-scope-btn', { hasText: 'Global' });
-    await expect(localBtn).toBeVisible();
-    await expect(globalBtn).toBeVisible();
-    await expect(localBtn).toHaveAttribute('aria-pressed', 'true');
+    // Both scope buttons render; Conception is the default + active.
+    const conceptionBtn = window.locator('.skills-scope-btn', { hasText: 'Conception' });
+    const userBtn = window.locator('.skills-scope-btn', { hasText: 'User' });
+    await expect(conceptionBtn).toBeVisible();
+    await expect(userBtn).toBeVisible();
+    await expect(conceptionBtn).toHaveAttribute('aria-pressed', 'true');
 
-    // Default Claude tab: the conception's CLAUDE.md callout, badged CLAUDE.
-    await expect(
-      window.locator('.tree-special-file', { hasText: 'Local project CLAUDE' }),
-    ).toBeVisible();
-    await expect(window.locator('.tree-special-badge', { hasText: 'CLAUDE' }).first()).toBeVisible();
-    await shoot(window, 'local-claude');
+    // Conception scope shows the conception skill, not the user one.
+    const conctool = window.locator('.tree-dir-name', { hasText: /^conctool$/i });
+    await expect(conctool).toBeVisible();
+    await expect(window.locator('.tree-dir-name', { hasText: /^usertool$/i })).toHaveCount(0);
+    await shoot(window, 'conception-scope');
 
-    // Generic tab: common.md + every <model>.md source render as read-only
-    // callouts in the config band (not as plain cards) — common.md AND
-    // claude.md must both be callouts.
-    await window.locator('.skills-tab', { hasText: 'Generic' }).click();
-    await expect(window.locator('.tree-special-badge', { hasText: 'COMMON' })).toBeVisible();
-    await expect(window.locator('.skills-config-band .tree-special-file')).toHaveCount(2);
-    await expect(
-      window.locator('.skills-config-band .tree-special-file', { hasText: 'Local common' }),
-    ).toBeVisible();
-    await expect(
-      window.locator('.skills-config-band .tree-special-file', { hasText: 'Local claude overlay' }),
-    ).toBeVisible();
-    await shoot(window, 'local-generic');
-
-    // Flip to Global — the tree must swap (Local common → Global common).
-    await globalBtn.click();
-    await expect(globalBtn).toHaveAttribute('aria-pressed', 'true');
-    await expect(
-      window.locator('.tree-special-file', { hasText: 'Global common' }),
-    ).toBeVisible();
-    await expect(window.locator('.tree-special-file', { hasText: 'Local common' })).toHaveCount(0);
-    await shoot(window, 'global-generic');
-
-    // Global Claude tab: the compiled ~/.claude/CLAUDE.md + the global skill.
-    await window.locator('.skills-tab', { hasText: 'Claude' }).click();
-    await expect(window.locator('.tree-special-file', { hasText: 'Global CLAUDE' })).toBeVisible();
-    await shoot(window, 'global-claude');
+    // Flip to User — the tree swaps to the user-scope skill.
+    await userBtn.click();
+    await expect(userBtn).toHaveAttribute('aria-pressed', 'true');
+    await expect(window.locator('.tree-dir-name', { hasText: /^usertool$/i })).toBeVisible();
+    await expect(window.locator('.tree-dir-name', { hasText: /^conctool$/i })).toHaveCount(0);
+    await shoot(window, 'user-scope');
 
     // Refresh re-reads the active tree without blowing up the pane.
     await window.locator('.skills-refresh').click();
-    await expect(window.locator('.tree-special-file', { hasText: 'Global CLAUDE' })).toBeVisible();
+    await expect(window.locator('.tree-dir-name', { hasText: /^usertool$/i })).toBeVisible();
   } finally {
     await cleanup();
     await rm(globalDir, { recursive: true, force: true });

--- a/tests/resources-skills.spec.ts
+++ b/tests/resources-skills.spec.ts
@@ -83,18 +83,22 @@ test('Skills pane: SKILL.md badge + shipped chip + diverged warning', async () =
     // CI's xvfb — events for the inner SKILL.md were occasionally
     // dropped when the inotify hook hadn't attached to the new dir yet.
     prepare: async (conceptionDir) => {
-      const skillsRoot = join(conceptionDir, '.claude', 'skills');
+      // Post-reframe the Skills pane reads `.agents/skills/` (the multi-harness
+      // `.claude/skills` fan-out was dropped); the shipped manifest lives there.
+      const skillsRoot = join(conceptionDir, '.agents', 'skills');
       await mkdir(join(skillsRoot, 'projects'), { recursive: true });
       // Manifest first, then the `.md` files. The watcher classifies only
       // `.md` paths (and unlinks) under the skills root as `skills` events,
-      // so the manifest write itself never triggers a refetch.
+      // so the manifest write itself never triggers a refetch. Post-reframe
+      // the manifest lives at `.agents/.condash-skills.json` (one level above
+      // the skills dir) and keys files under `source`, not `files`.
       await writeFile(
-        join(skillsRoot, '.condash-skills.json'),
+        join(conceptionDir, '.agents', '.condash-skills.json'),
         JSON.stringify({
           version: 1,
           skills: {
             projects: {
-              files: {
+              source: {
                 'SKILL.md': { sha256: skillSha, shippedVersion: '2.10.15' },
                 'create.md': { sha256: 'deadbeef', shippedVersion: '2.10.15' },
               },

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -71,7 +71,7 @@ test('settings modal: tabs swap panels and badges reflect inheritance', async ()
 
 test('settings modal: reset-to-global drops the override key from condash.json', async () => {
   const booted = await bootApp({
-    extraConfig: { skills_path: 'some/custom/skills' },
+    extraConfig: { worktrees_path: '/tmp/some-custom-worktrees' },
   });
   try {
     await booted.app.evaluate(({ BrowserWindow }) => {
@@ -86,11 +86,11 @@ test('settings modal: reset-to-global drops the override key from condash.json',
     const conceptionPanel = modal.locator('#settings-panel-conception');
     await expect(conceptionPanel).toBeVisible();
 
-    // Find the `skills_path` field by label. Settings.json doesn't
-    // declare skills_path, so the conception override (`some/custom/
-    // skills`) shows "Overridden" — distinct from the absent global.
+    // Find the `worktrees_path` field by label. settings.json doesn't declare
+    // worktrees_path in the test's isolated global, so the conception override
+    // shows "Overridden" — distinct from the absent global.
     const skillsField = conceptionPanel
-      .locator('.settings-field-with-badge', { hasText: 'Skills directory' })
+      .locator('.settings-field-with-badge', { hasText: 'Worktrees path' })
       .first();
     await expect(skillsField.locator('.settings-badge--overridden')).toBeVisible();
 
@@ -108,7 +108,7 @@ test('settings modal: reset-to-global drops the override key from condash.json',
       .poll(async () => {
         const text = await readFile(condashPath, 'utf8');
         const parsed = JSON.parse(text) as Record<string, unknown>;
-        return Object.prototype.hasOwnProperty.call(parsed, 'skills_path');
+        return Object.prototype.hasOwnProperty.call(parsed, 'worktrees_path');
       })
       .toBe(false);
   } finally {


### PR DESCRIPTION
## Summary

The v4.5.0 release tag failed at the Playwright gate — not because of the `@handle` work (PR #261/#262), but because three Skills-pane/settings e2e specs still assert the **old** Skills pane that PR #260 (Markdown-viewer reframe) intentionally replaced. They merged undetected because the PR `ci` gate doesn't run the full Playwright suite — only the release workflow does, so this was the first full run since #260.

Verified the three failed at `0e17400` (before #261), confirming they pre-date this feature.

## Changes

- **`global-skills.spec.ts`** — rewritten from the removed local/global + agent-tab + multi-harness-roots model to the reframed **conception/user** scope toggle (sources via `CONDASH_USER_SKILLS_ROOT` / `CONDASH_USER_AGENTS_MD`); asserts the tree swaps on scope flip + refresh.
- **`resources-skills.spec.ts`** — fixture now writes to `.agents/skills/` (the `.claude/skills` fan-out was dropped) and the shipped manifest to `.agents/.condash-skills.json` keyed by `source` (was `files`).
- **`settings-tabs.spec.ts`** — the reset-to-global override test now exercises `worktrees_path`; `skills_path` was dropped by the reframe.

Full Playwright suite green (40 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)