### PR TITLE
Fix tasks Playwright spec for #handle sigil

### DIFF
--- a/tests/tasks.spec.ts
+++ b/tests/tasks.spec.ts
@@ -86,9 +86,9 @@ test('tasks pane lists a task and fills its markers', async () => {
     // {APP} is unfilled → left verbatim until an app is picked.
     await expect(preview).toContainText('{APP}');
 
-    // Pick the seeded app → bare {APP} resolves to its @alias in the preview.
-    await window.locator('.tasks-fill select').first().selectOption('@condash');
-    await expect(preview).toContainText('Review @condash');
+    // Pick the seeded app → bare {APP} resolves to its #alias in the preview.
+    await window.locator('.tasks-fill select').first().selectOption('#condash');
+    await expect(preview).toContainText('Review #condash');
 
     await window.screenshot({ path: join(outDir, 'tasks-fill.png') });
   } finally {


### PR DESCRIPTION
## Summary

- The v4.8.0 sigil switch (#268, PR #269) changed the `{APP}` picker option value and preview to `#handle`, but the tasks e2e spec still selected `@condash` and asserted `Review @condash`, failing the release Playwright gate (build + publish were skipped, so nothing shipped).

## Changes

- `tests/tasks.spec.ts`: select `#condash` and assert `Review #condash`.

## Watchpoints

- Verified locally: full Playwright suite (40 tests) green under xvfb.