### PR TITLE
Complete and de-stale the shipped docs for v4.9.0

### DIFF
--- a/docs/get-started/releases.md
+++ b/docs/get-started/releases.md
@@ -21,6 +21,29 @@ Tags follow `vMAJOR.MINOR.PATCH`:
 
 Patches are the norm. Most weeks there's at least one; MINOR bumps are rarer, MAJOR is a special event.
 
+## Major versions
+
+condash's history spans three implementations and four major lines. Only the Electron line (`2.x`–`4.x`) is current; `0.x` (Python) and `1.x` (Rust/Tauri) are frozen in separate repos.
+
+| Major | What it was |
+|---|---|
+| `0.x` | Python (NiceGUI + FastAPI). Frozen at [`vcoeur/condash-python`](https://github.com/vcoeur/condash-python). |
+| `1.x` | Rust + Tauri rewrite. Frozen at [`vcoeur/condash-tauri`](https://github.com/vcoeur/condash-tauri). |
+| `2.x`–`4.x` | Electron rewrite — the current canonical build. |
+
+### Migrating from condash 3.x → 4.x
+
+**v4.0.0 narrowed what condash does with agent config.** Earlier 3.x builds compiled per-agent instruction files for you; 4.0.0 removed that pipeline entirely. If you used any of the following, it is gone:
+
+- The `.agents/agents/` source tree (`common.md` / `condash.md` / `conception.md` / `claude.md` / `kimi.md`) — no longer read.
+- The root `opencode.json` pointer condash used to write — no longer written.
+- `condash project build` — removed.
+- `condash skills install --user` — removed (condash no longer writes `~/.claude/skills/` or `~/.kimi/skills/`).
+
+What `condash skills install` does now is just two things: ship your `.agents/skills/<name>/` sources **verbatim**, and maintain condash's marker region inside `AGENTS.md`. Rendering `AGENTS.md` into per-agent views (`.claude/CLAUDE.md`, `.kimi/AGENTS.md`, …) is now the job of your harness launcher, not condash — those files are produced at launch and are never written to disk by condash. If you have leftover `.agents/agents/` or a condash-written `opencode.json`, they are simply inert; delete them at your convenience.
+
+Agent launchers also changed shape in this line: they are now a flat `{ id, label, command }` list under the `agents` config key, edited in the **[Settings modal](../guides/settings-modal.md)** — see **[Agent CLIs and model providers](../guides/agent-clis-and-models.md)**.
+
 ## Finding the latest
 
 Three paths:

--- a/docs/guides/applications-and-handles.md
+++ b/docs/guides/applications-and-handles.md
@@ -1,0 +1,90 @@
+---
+title: Applications and handles · condash guide
+description: How condash identifies each app by one canonical #handle, where the registry lives, and how to manage it from the CLI.
+---
+
+# Applications and handles
+
+> **Audience.** Daily user managing more than one repo.
+
+**When to read this.** A project README's `apps:` value shows up wrong on the card, you renamed a repo and old references broke, or you're adding a new app and want it to read consistently everywhere.
+
+## One app, one `#handle`
+
+Every app condash knows about has exactly one canonical **`#handle`** — a short, lowercase token (`#condash`, `#kasten`, `#painting-manager`). The handle is the single identity used in:
+
+- the coloured pill on Code-pane and project cards (always rendered as `#handle`, coloured by a stable hash of the handle),
+- a project README's `apps:` list,
+- the generated Apps table in `AGENTS.md`,
+- cross-tree search.
+
+!!! note "The sigil is `#`, not `@`"
+    Earlier versions used `@handle`. condash switched to `#` in v4.8.0 because a leading `@` triggers file-path autocompletion in agent CLIs, which mangled handles mid-prompt; `#` is unbound. A stray `@`-prefixed value no longer resolves and `validate` flags it. In a YAML `apps:` list a `#` value **must be quoted** (an unquoted leading `#` is a YAML comment):
+
+    ```yaml
+    apps:
+      - "#condash"
+      - "#kasten"
+      - "~/src/other/Thing"   # unregistered repo → absolute path
+    ```
+
+## Where the registry lives
+
+The registry is your config's **`repositories[]`** array (`settings.json` defaults, overridable per tree in `.condash/settings.json`). Each entry's `handle` defaults to the directory name — sigil-stripped and lowercased — so simple repos need set nothing. Domain-style or camelCase repos should pin one explicitly:
+
+```json
+{
+  "repositories": [
+    "condash",
+    { "handle": "kasten", "path": "notes.vcoeur.com" },
+    { "handle": "painting-manager", "path": "PaintingManager", "aliases": ["PaintingManager"] }
+  ]
+}
+```
+
+- **`handle`** — the canonical identity. Omit it and you get `appHandle(name)` (directory name, sigil-stripped + lowercased).
+- **`aliases`** — legacy spellings that still resolve to this handle. `validate` flags a README `apps:` value matching an alias and suggests the `#handle` rewrite; `rename` records the old handle here for you.
+- **`label`** — an optional human title rendered as a secondary subtitle; the primary pill is always the `#handle`.
+
+### Retired apps
+
+A repo that no longer exists but is still referenced by closed-project READMEs goes in the top-level **`retired_apps`** list:
+
+```json
+{ "retired_apps": [{ "handle": "kasten-manager", "label": "KastenManager", "aliases": ["KastenManager"] }] }
+```
+
+Retired handles **resolve** (so history stays valid) but are never rendered as cards and never appear in the generated Apps table. A handle is either live (in `repositories`) or retired (here) — never both.
+
+## How `apps:` values resolve
+
+A project README's `apps:` entry must be one of:
+
+- a live `#handle` (in `repositories`),
+- a retired `#handle` (in `retired_apps`),
+- or an absolute path to an unregistered repo outside the workspace (`~/src/other/Thing`).
+
+A bare directory name, a domain (`notes.vcoeur.com`), a label, or a sub-path are **legacy forms** — `condash applications validate` flags each and suggests the canonical `#handle`.
+
+## Managing it from the CLI
+
+```bash
+condash applications list                # every app, live + retired
+condash applications add fovea --path fovea --label "Fovea"
+condash applications set kasten --label "Kasten"
+condash applications rename fovea fovea-web   # cascades into README apps: refs
+condash applications validate            # exit 3 on an unresolved reference
+condash applications validate --fix      # canonicalise every resolvable value
+condash applications sync-docs           # regenerate the AGENTS.md Apps table
+```
+
+| Verb | What it does |
+|------|--------------|
+| `list` | List every registered app (live + retired) with handle, label, path. |
+| `add <handle> --path <p> [--label <l>]` | Register a new live app. |
+| `set <handle> [--label <l>] [--path <p>]` | Update a registered app. |
+| `rename <old> <new>` | Rename a handle; records the old as an alias **and** rewrites every project README `apps:` reference that pointed at it. |
+| `sync-docs` | Regenerate the Apps table in `AGENTS.md` between the `condash:apps` sentinels from the registry. (Agent-specific files like `CLAUDE.md` are virtual renders of `AGENTS.md` and are never written to disk.) |
+| `validate [--fix]` | Check every README `apps:` value resolves to a known `#handle` or existing path. `--fix` canonicalises every resolvable value (bare names and aliases alike), leaving only the unresolvable ones for a human. |
+
+→ Schema details for `repositories[]` and `retired_apps` are in **[Config files → repositories](../reference/config.md#repositories)**. The full CLI surface is in **[CLI → applications](../reference/cli.md#applications)**. How handles read inside an `AGENTS.md` `## Specifics` section: **[AGENTS.md style guide](../reference/agents-md-style.md)**.

--- a/docs/guides/deliverables-pane.md
+++ b/docs/guides/deliverables-pane.md
@@ -1,6 +1,6 @@
 # The Deliverables pane
 
-The Deliverables pane is a **separate left-band pane with its own edge-strip handle**, peer to Projects — *not* a tab inside the Projects pane, and *not* in the right working-surface slot with Code / Knowledge / Resources / Skills / Agents / Logs. The left edge strip carries three stacked handles, **Projects**, **[Tasks](tasks-pane.md)**, and **Deliverables**; click a handle to fill the left band with that pane (clicking the active one hides the band). Which view was last shown is remembered across launches (the `leftView` layout field).
+The Deliverables pane is a **separate left-band pane with its own edge-strip handle**, peer to Projects — *not* a tab inside the Projects pane, and *not* in the right working-surface slot with Code / Knowledge / Resources / Skills / Logs. The left edge strip carries three stacked handles, **Projects**, **[Tasks](tasks-pane.md)**, and **Deliverables**; click a handle to fill the left band with that pane (clicking the active one hides the band). Which view was last shown is remembered across launches (the `leftView` layout field).
 
 ## What it shows
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -11,6 +11,8 @@ Each guide answers one specific question.
 
 - **[Configure the conception path](configure-conception-path.md)** — change the folder condash renders, with the menu, the CLI, or by editing `settings.json`.
 - **[Repositories and open-with buttons](repositories-and-open-with.md)** — populate the Code pane and wire IDE/terminal launch slots.
+- **[The Settings modal](settings-modal.md)** — the two-tab modal, what each section writes, and how per-conception overrides inherit from your machine defaults.
+- **[Applications and handles](applications-and-handles.md)** — identify each app by one canonical `#handle`, manage the registry, keep `apps:` references resolving.
 
 **Daily**
 
@@ -21,7 +23,7 @@ Each guide answers one specific question.
 - **[The knowledge tree](knowledge-tree.md)** — your reference notes, organised as cards.
 - **[The Resources pane](resources-pane.md)** — every file under `resources/` as a card with copy / open / paste-to-term actions.
 - **[The Deliverables pane](deliverables-pane.md)** — every project's `## Deliverables`, aggregated and grouped by project, in a separate left-band pane next to Projects.
-- **[The Skills pane](skills-pane.md)** — markdown skills under `.claude/skills/`, edited in place, with shipped/diverged chips.
+- **[The Skills pane](skills-pane.md)** — browse the markdown skills condash ships under `.agents/skills/`, with shipped/diverged chips.
 - **[Troubleshooting](troubleshooting.md)** — Wayland blur, dirty caches, app won't launch.
 
 **More**

--- a/docs/guides/settings-modal.md
+++ b/docs/guides/settings-modal.md
@@ -1,0 +1,58 @@
+---
+title: The Settings modal · condash guide
+description: Where condash keeps its configuration — the two-tab modal, what each section writes, and how per-conception overrides inherit from your per-machine defaults.
+---
+
+# The Settings modal
+
+> **Audience.** Daily user.
+
+**When to read this.** You want to change something — your theme, your shell, the repos on the Code pane, an agent launcher — and you'd rather click than hand-edit JSON. Or you set a value and it didn't take, and you need to understand which file won.
+
+Open it from **File → Settings** (or `Ctrl+,`). It's a full-viewport modal, not a popover. Everything it edits is plain JSON on disk — the modal is a convenience over the same two files documented in **[Config files](../reference/config.md)**; nothing here is exclusive to the UI.
+
+## Two tabs, two files
+
+The modal has exactly two tabs, and the tab you're on decides **which file** your edits land in:
+
+| Tab | Writes to | Holds |
+|-----|-----------|-------|
+| **Global** | `settings.json` in the OS user-data directory (per-machine) | Your machine-wide defaults + the active conception path and recents list. |
+| **This conception** | `<conception>/.condash/settings.json` (per-tree, per-host) | Overrides for *this* conception only. |
+
+Both files share the **same schema**. The active conception path and the recents list are Global-only — they describe your machine, not any one tree.
+
+## Which sections live where
+
+The left rail lists the sections of the current tab:
+
+- **Global** — Recent conceptions · Appearance · Terminal · Agents
+- **This conception** — Workspace · Repositories · Open with · Appearance · Terminal · Agents
+
+Three sections — **Appearance**, **Terminal**, **Agents** — appear on *both* tabs. Those are the **inheritable** ones: set a default on Global, override it per tree on This conception. The conception-only sections (Workspace, Repositories, Open with) appear on This conception because overriding them per machine makes no sense.
+
+| Section | Tab(s) | Config key(s) | Guide |
+|---------|--------|---------------|-------|
+| Recent conceptions | Global | *(managed outside the file)* | [Configure the conception path](configure-conception-path.md) |
+| Workspace | This conception | `workspace_path`, `worktrees_path` | [Repositories and open-with buttons](repositories-and-open-with.md) |
+| Repositories | This conception | `repositories` | [Repositories and open-with buttons](repositories-and-open-with.md) |
+| Open with | This conception | `open_with` | [Repositories and open-with buttons](repositories-and-open-with.md) |
+| Appearance | Both | `theme`, `cardMinWidth` | — |
+| Terminal | Both | `terminal` | [Embedded terminal](terminal.md) |
+| Agents | Both | `agents` | [Agent CLIs and model providers](agent-clis-and-models.md) |
+
+App identity (`#handle`, `retired_apps`, `aliases`) is edited inline in the **Repositories** section — see **[Applications and handles](applications-and-handles.md)**.
+
+## How inheritance works
+
+For an inheritable key, the rule is **top-level replace**: if This conception sets the key, its value replaces the Global value wholesale — arrays replace arrays, objects replace objects, no deep merge. The one documented exception is `terminal`, which merges one level deep so a conception that customises `terminal.logging` keeps your per-machine `terminal.screenshot_dir` and shortcuts (see [Config files → terminal](../reference/config.md#terminal)).
+
+On the **This conception** tab, each inheritable control carries a badge telling you whether the value is **inherited** from Global or **overridden** here. A per-conception diff view collapses the sections that fully inherit, so you see at a glance what this tree actually changes.
+
+A small **dirty pip** next to a section label means you have unsaved edits in it. The modal remembers the last tab and section you were on, so reopening lands you where you left off.
+
+## What it does *not* edit
+
+Layout state (`leftView`, branch filters, tree-expansion), the welcome-screen dismissal, and the recents list are written by the app as you use it — they live in the same files but have no Settings section. For the exhaustive key list, see **[Config files → All config keys](../reference/config.md#all-config-keys)**.
+
+→ Prefer editing the JSON directly? Every key, with defaults and the override model, is in **[Config files](../reference/config.md)**.

--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -1,56 +1,51 @@
+---
+title: The Skills pane · condash guide
+description: Browse the markdown skills condash ships — the conception's .agents/skills/ tree and your user-scope sources — read-only, with shipped/diverged chips.
+---
+
 # The Skills pane
 
-The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the right working-surface slot (`Ctrl+L` to switch in). Its header has two rows: a **Local / Global** scope toggle (with a refresh button on the right), and below it a tab bar selecting one of four trees — **Generic** (the agent-neutral source skills under `.agents/skills/`), **Claude**, **Kimi**, and **OpenCode** (each harness's skills directory, when one exists). The pane is **read-only**: it surfaces skills for browsing. Edit a skill at its source under `.agents/skills/` and re-run `condash skills install` to refresh it.
+> **Audience.** Daily user.
+
+**When to read this.** You want to see which management skills are installed in this conception (or globally on your machine), and whether any have drifted from what condash shipped.
+
+The Skills pane sits alongside **Code**, **Knowledge**, and **Resources** in the right working-surface slot (`Ctrl+L` to switch in). It is **read-only**: it surfaces skills for browsing. The source of truth is your agedum config, edited through its own flow — condash places the sources and never compiles or rewrites them.
 
 ![Skills pane — skill sections with SKILL.md indices and body-file cards](../assets/screenshots/skills-pane-light.png#only-light)
 ![Skills pane — skill sections with SKILL.md indices and body-file cards](../assets/screenshots/skills-pane-dark.png#only-dark)
 
-## Scope: Local vs Global
+## Two scopes
 
-The first header row toggles which scope the pane reads:
+The header carries a segmented control with two scopes (and a **refresh** button on the right):
 
-- **Local** (default) — the active conception's skills.
-- **Global** — the per-machine user scope under `~/.config/agents/`, `~/.claude/`, `~/.kimi/`, and `~/.config/opencode/`. condash does not write these; they're laid down by whatever user-scoped tooling owns your machine's agent config.
+| Scope | `AGENTS.md` pinned at top | Skills tree |
+|-------|---------------------------|-------------|
+| **Conception** (default) | `<conception>/AGENTS.md` | `<conception>/.agents/skills/` |
+| **User** | `~/.config/agents/AGENTS.md` | `~/.agents/skills/` |
 
-The selected scope is remembered per-machine in `settings.json` (`skillsActiveScope`); flipping it re-reads the active tab's tree. The **refresh** button on the right of the scope row re-reads the current tree on demand — useful in the Global scope, whose paths aren't watched for changes the way the conception tree is.
+Both are **agedum sources**. condash never reads the compiled per-harness outputs (`.claude/`, `.kimi/`, `.opencode/`, …) — only the agent-neutral source tree. Each scope pins its `AGENTS.md` as a read-only callout at the top of the tree, then lists the skills below.
 
-## The four tabs
+The selected scope is remembered per-machine in `settings.json` (`skillsActiveScope`) and each scope keeps its own scroll position. The **refresh** button re-reads the active scope on demand — useful for the User scope, whose paths aren't watched the way the conception tree is.
 
-Each tab reads a skills directory:
+## What the tree shows
 
-| Tab | Local reads | Global reads |
-|---|---|---|
-| **Generic** | `<conception>/.agents/skills/` | `~/.config/agents/skills/` |
-| **Claude** | `<conception>/<skills_path>` (default `.claude/skills/`) | `~/.claude/skills/` |
-| **Kimi** | `<conception>/.kimi/skills/` | `~/.kimi/skills/` |
-| **OpenCode** | `<conception>/.opencode/skills/` | `~/.config/opencode/skills/` |
+Each subdirectory under `.agents/skills/` is a skill:
 
-condash ships only the **Generic** source tree (`.agents/skills/`); the other three directories appear only if some other tool put them there. The currently-selected tab is remembered per-machine in `settings.json` (`skillsActiveTab`), so the next launch reopens the same view. The first launch after the tabs ship defaults to **Claude** to match the pre-tabs behaviour.
+- Its `SKILL.md` (minimal `name` + `description` frontmatter plus the skill body) renders as a badged callout at the top of the expanded skill.
+- Task `.md` files (`create.md`, `close.md`, …) and any `SKILL.<harness>.md` overlay render as cards underneath. The walker recurses to any depth; a card's title comes from the first H1, falling back to the filename.
 
-Each tab maintains its own directory expansion state and scroll position. Switching tabs within a scope is paint-only — all four trees are loaded eagerly when a conception is opened (and re-fetched on a scope flip or refresh).
+These sources are placed verbatim by `condash skills install`; condash does not compile them. Your harness launcher (agedum, shipped separately) reads the source and renders each skill per agent at run time.
 
-## What each tab shows
+If a scope has no skills yet, the pane shows an empty state:
 
-### Generic (sources)
-
-The Generic tab walks the `.agents/skills/` root — the agent-neutral source skills condash ships:
-
-- Each subdirectory is a skill. Its `SKILL.md` (minimal `name` + `description` frontmatter plus the skill body) renders as a badged callout at the top of the expanded body.
-- Task `.md` files (`create.md`, `close.md`, …) and any `SKILL.<harness>.md` overlay render as cards underneath. The walker recurses to any depth. Title is pulled from the first H1, falling back to the filename.
-
-These sources are placed verbatim by `condash skills install`; condash does not compile them. A harness launcher (shipped separately) reads the source and renders each skill per agent at run time.
-
-### Claude / Kimi / OpenCode
-
-Same layout as the Generic tab, each rooted at the matching harness skills directory (`<skills_path>`, default `.claude/skills/`, for Claude; `.kimi/skills/` for Kimi; `.opencode/skills/` for OpenCode). condash does **not** write these directories — they appear only when another tool installs per-harness skills there. With nothing in them, the tab shows its empty state.
-
-OpenCode discovers `.opencode/skills/` (and `~/.config/opencode/skills/`) on its own, but it *also* scans `.claude/skills/` and `.agents/skills/` and resolves a duplicate skill name by a non-deterministic race (no stable precedence). Launch OpenCode with `OPENCODE_DISABLE_EXTERNAL_SKILLS=1` to have it read only its own dirs.
+- **Conception** — *"Run `condash skills install` to lay down the shipped skills under `.agents/skills/`,"* with a **Copy install command** button.
+- **User** — *"User-scope skills live at `~/.agents/skills/`. Edit them via your agedum sources."*
 
 ## Viewing files
 
-Click any card to open the file in the note modal — the same viewer used elsewhere in condash, opened **read-only**. Wikilinks and relative markdown links route through the in-modal navigator just like Knowledge files. Global-scope files live outside the conception, so the pane reads them through a dedicated `readSkillFile` IPC bounded to the user-scope skill locations (never their parent dirs).
+Click any card to open the file in the note modal — the same viewer used elsewhere, opened **read-only**. Wikilinks and relative markdown links route through the in-modal navigator just like Knowledge files. User-scope files live outside the conception, so the pane reads them through a dedicated `readSkillFile` IPC bounded to the user-scope skill locations (never their parent dirs).
 
-The pane never writes. To change a shipped skill, edit it at its source under `.agents/skills/` (`~/.config/agents/skills/...` for the global scope, owned by your user-scoped tooling) — then re-run `condash skills install`, which refuses to clobber the edit unless you pass `--force`.
+The pane never writes. To change a shipped skill, edit it at its source under `.agents/skills/` (`~/.config/agents/skills/...` for the User scope, owned by your user-scoped tooling) — then re-run `condash skills install`, which refuses to clobber the edit unless you pass `--force`.
 
 ## Shipped-skill tracking
 
@@ -58,23 +53,11 @@ The conception's source tree carries a single manifest populated by `condash ski
 
 - `<conception>/.agents/.condash-skills.json` — refuse-on-edit tracking for the shipped skill sources, keyed by SHA256 + shipped version.
 
-The pane uses it to flag two states on the **Generic** tab:
+The pane uses it to flag two states:
 
 - **shipped** — the on-disk content matches the version condash shipped. Cards display a `shipped` chip; the `SKILL` callout carries the same flag.
-- **shipped · diverged** — the file is shipped but locally edited. Cards display an amber `shipped · diverged` chip; the `SKILL` callout switches to amber. Opening the file shows a banner: *"Shipped by condash, but locally edited. Running `condash skills install` will flag this divergence."*
+- **shipped · diverged** — the file is shipped but locally edited. Cards display an amber `shipped · diverged` chip, and opening the file shows a banner: *"Shipped by condash, but locally edited. Running `condash skills install` will flag this divergence."*
 
-The flags are informational only — local edits are never blocked. They exist so a quick scan tells you where your customisations are and warns you before an upstream re-install reverts them.
+The flags are informational only — local edits are never blocked. They exist so a quick scan tells you where your customisations are and warns you before an upstream re-install would revert them.
 
-## Configuration
-
-`skills_path` controls only the **Claude** tab's root directory. The Generic, Kimi, and OpenCode tabs always read from `.agents/skills/`, `.kimi/skills/`, and `.opencode/skills/` respectively — those paths are not user-configurable.
-
-Set the Claude tab's directory by editing `.condash/settings.json` at the conception root (per-tree, per-host), or via **Settings → Workspace → Skills directory**. The value lives on the tree side; the global `settings.json` carries only defaults.
-
-```json
-{
-  "skills_path": ".claude/skills"
-}
-```
-
-The value is relative to the conception root. Absolute paths and `..` segments are rejected by the schema.
+→ The CLI that lays these down: **[CLI → skills](../reference/cli.md)**. What condash ships and how installs behave: **[Extend the management skill](skill-extensions.md)**.

--- a/docs/help/configuration.md
+++ b/docs/help/configuration.md
@@ -40,12 +40,12 @@ writes always target `.condash/settings.json`.
 |---|---|
 | `workspace_path` | Where condash scans for git repos. |
 | `worktrees_path` | Sandbox for the "Open in IDE" buttons. |
-| `skills_path` | Folder backing the Skills pane. Default `.claude/skills`. |
-
-The Resources pane is hard-coded to `<conception>/resources/` — no
-override is available since the reframe.
 | `repositories` | Ordered list of repos to surface on the Code pane. Each entry is a string, a `{name, …}` object (optional `submodules`, `run`, `force_stop`, `label`, `install`, `env`, `pinned_branch`), or a `{"section": "<heading>"}` marker that groups every following repo under a header — see [Reference → Configuration → `repositories`](../reference/config.md#repositories) for the full table. |
 | `open_with` | Three launcher slots (`main_ide`, `secondary_ide`, `terminal`). `{path}` is replaced with the absolute target path. |
+
+The Skills pane (`<conception>/.agents/skills/`) and Resources pane
+(`<conception>/resources/`) read hard-coded folders — no override is
+available since the reframe.
 
 A repo entry's `run` wires up an inline dev-server runner; `force_stop`
 gives a kill button that frees a stuck port (e.g. `fuser -k 8200/tcp`).
@@ -104,7 +104,7 @@ its own form control.
 legacy `condash.json` and `configuration.json` are read but never
 written to):
 
-- **Workspace** — `workspace_path`, `worktrees_path`, `skills_path`.
+- **Workspace** — `workspace_path`, `worktrees_path`.
 - **Repositories** — ordered repo list, per-repo `run` / `force_stop`.
 - **Open with** — slot labels and commands.
 - **Appearance** — theme + card-grid min-widths overridden for this
@@ -158,7 +158,7 @@ condash config set theme dark --global    # write to settings.json
 | Change | Effect |
 |---|---|
 | `open_with`, `terminal`, repo `run` / `force_stop`, `cardMinWidth`, theme | Live, no restart |
-| `workspace_path`, `worktrees_path`, `skills_path`, repository list | Restart required |
+| `workspace_path`, `worktrees_path`, repository list | Restart required |
 
 ## More
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -16,13 +16,13 @@ condash reads two JSON files. Both share **the same schema**. The per-machine `s
 | `settings.json`          | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux) · `~/Library/Application Support/condash/settings.json` (macOS) · `%APPDATA%\condash\settings.json` (Windows) | Per-user, per-machine                     | `lastConceptionPath`, `recentConceptionPaths` (cap 5) |
 | `.condash/settings.json` | `<conception_path>/.condash/settings.json` (legacy fallbacks: `condash.json`, `configuration.json`)                                                                         | Per-conception, **per-host** (gitignored) | (none — every key here also accepts a global default) |
 
-Both files share the **same schema** modulo the two path-tracking keys above. Any other top-level key — `workspace_path`, `worktrees_path`, `skills_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal`, `theme`, `layout`, `welcome`, `cardMinWidth`, `treeExpansion`, `selectedBranches` — may live in either file. When the same key appears in both, the conception's value **replaces** the global one entirely (top-level replace; arrays replace, objects replace whole, no deep merge).
+Both files share the **same schema** modulo the two path-tracking keys above. Every other top-level key (`workspace_path`, `worktrees_path`, `repositories`, `retired_apps`, `agents`, `open_with`, `pdf_viewer`, `terminal`, `theme`, `layout`, `welcome`, `cardMinWidth`, `treeExpansion`, `selectedBranches`, `branchFilterStickyAll`) may live in either file — see the [full table](#all-config-keys) below. When the same key appears in both, the conception's value **replaces** the global one entirely (top-level replace; arrays replace, objects replace whole, no deep merge — the one exception is `terminal`, below).
 
 **Exception: `terminal` merges one level deep.** Its sub-schema straddles per-machine input / device prefs (`shell`, `shortcut`, `screenshot_dir`, `xterm`, `screenshot_paste_shortcut`, `move_tab_{left,right}_shortcut`) and per-tree retention policy (`logging.{enabled, retentionDays, maxDirMb, scrollback}`). A pure replace meant any conception that customised `terminal.logging` silently lost every per-machine terminal pref — the screenshot-paste shortcut toasted "no screenshot directory". Conception sub-keys win at the first level; sub-keys absent from the conception fall through to the global block. Nested values inside `terminal.xterm` and `terminal.logging` still replace whole — only the immediate sub-keys of `terminal` merge.
 
 ### The `.condash/` workspace directory
 
-`.condash/` is condash's per-conception state directory — the home of `settings.json` plus terminal logs at `.condash/logs/YYYY/MM/DD/HHMMSS-<sid>.jsonl`. **The whole directory is gitignored by default** (the auto-migrator appends a `.condash/` line to your `.gitignore` on first run when the conception is a git repo), so settings + logs are per-host state with no commit-leak risk. Teams that want to share a baseline config either commit `condash.json` alongside (legacy path still reads) or manually un-ignore `settings.json` in their `.gitignore`.
+`.condash/` is condash's per-conception state directory — the home of `settings.json` plus terminal logs at `.condash/logs/YYYY/MM/DD/HHMMSS-<sid>.txt`. **The whole directory is gitignored by default** (the auto-migrator appends a `.condash/` line to your `.gitignore` on first run when the conception is a git repo), so settings + logs are per-host state with no commit-leak risk. Teams that want to share a baseline config either commit `condash.json` alongside (legacy path still reads) or manually un-ignore `settings.json` in their `.gitignore`.
 
 ### Reading and writing
 
@@ -30,6 +30,32 @@ Both files share the **same schema** modulo the two path-tracking keys above. An
 - **Write target**: every save through the GUI or `condash config set` writes to `.condash/settings.json`. The auto-migrator copies the legacy content into the new path on first open, tombstones the source file (so accidental edits don't drift), and appends `.condash/` to `.gitignore`. Run `condash config migrate` to invoke it explicitly.
 - **Override scope**: a conception's `settings.json` is forbidden from setting `lastConceptionPath` or `recentConceptionPaths` — a tree cannot describe its own location, by design.
 - **Environment override**: `CONDASH_CONCEPTION_PATH` still wins for the session, matching the legacy behaviour.
+
+## All config keys { #all-config-keys }
+
+Every top-level key, in one place. **Scope** is which file the key is valid in: *both* keys act as a per-machine default in `settings.json` and a per-conception override in `.condash/settings.json`; *global-only* keys are rejected in a conception file (a tree cannot describe its own location).
+
+| Key | Scope | Type | Default | What it does |
+|-----|-------|------|---------|--------------|
+| `workspace_path` | both | string | — | Root condash resolves repo paths against; populates the Code pane. Unset hides the pane. [↓](#workspace-keys) |
+| `worktrees_path` | both | string | — | Extra sandbox root accepted by the "open in IDE" launchers. [↓](#workspace-keys) |
+| `repositories` | both | array | `[]` | Ordered Code-pane repo list; also the app registry (`#handle`, `label`, `aliases`, `run`, `submodules`, `section`). [↓](#repositories) |
+| `retired_apps` | both | array | `[]` | Defunct `#handle`s still referenced by closed projects — resolve, never rendered. [↓](#retired_apps) |
+| `agents` | both | array | `[]` | Flat `{id,label,command}` terminal-launcher list shown in the tab-strip spawn dropdown. [↓](#agents) |
+| `open_with` | both | object | — | The three IDE/terminal launch slots (`main_ide`, `secondary_ide`, `terminal`). [↓](#open_with) |
+| `pdf_viewer` | both | array | — | Ordered fallback chain of external PDF viewers. |
+| `terminal` | both | object | — | Shell, shortcuts, screenshot dir, `xterm` theming, `logging`. **Merges one level deep** (the sole exception to top-level replace). [↓](#terminal) |
+| `theme` | both | enum | `system` | `light` \| `dark` \| `system`. |
+| `layout` | both | object | — | Persisted pane layout, including `leftView` (`projects` \| `tasks` \| `deliverables`). [↓](#layoutstate) |
+| `welcome` | both | object | — | `{ dismissed }` — first-launch welcome-screen state. |
+| `cardMinWidth` | both | object | — | Per-surface minimum card width. [↓](#cardminwidth) |
+| `treeExpansion` | both | object | — | Remembered expand/collapse state of the tree panes. |
+| `selectedBranches` | both | array | `[]` | Code-pane branch-filter selection. |
+| `branchFilterStickyAll` | both | boolean | `true` | Branch filter "All (sticky)" mode — show every branch and auto-pin new ones. |
+| `lastConceptionPath` | global-only | string\|null | `null` | Currently-open conception path. |
+| `recentConceptionPaths` | global-only | array | `[]` | Most-recently-opened paths, newest first (cap 5). |
+
+Tasks are **not** a config key — they live on disk at `<conception>/tasks/<slug>/` (see [Tasks](#tasks)). condash also persists a few small UI-state fields it manages itself (e.g. `skillsActiveScope`, the last-active Settings tab) in `settings.json`; you don't edit those by hand. Strict-mode validation rejects any unknown top-level key on save.
 
 ## `.condash/settings.json` (per-conception, per-host)
 
@@ -41,7 +67,6 @@ Lives at `<conception_path>/.condash/settings.json`. Don't commit it — the aut
 {
   "workspace_path": "/home/you/src",
   "worktrees_path": "/home/you/src/worktrees",
-  "skills_path": ".agents/skills",
   "repositories": [
     "condash",
     {
@@ -103,9 +128,11 @@ Legacy formats — JSONL event streams from condash ≤ 2.22, compressed `.txt.g
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `workspace_path` | Directory condash resolves relative repo paths against. Every direct subdirectory containing a `.git/` shows up in the **Code** pane. If unset, the pane is hidden. Repos with an explicit `path` may live outside this root.                                                    |
 | `worktrees_path` | Additional sandbox for the "open in IDE" buttons. Paths outside `workspace_path` and `worktrees_path` are rejected before the shell sees them.                                                                                                                                   |
-| `skills_path`    | Directory backing the **Skills** pane's **Claude** tab. Relative paths are resolved against `<conception_path>`; default `".claude/skills"`. Markdown only. Each skill renders as a section with its `SKILL.md` body. Unset = same as default. The pane's other two tabs (**Generic**, **Kimi**) read from fixed paths — `.agents/skills/` and `.kimi/skills/` respectively — and are not user-configurable. See [Skills pane guide](../guides/skills-pane.md). |
 
-The **Resources** pane is hard-coded to `<conception_path>/resources/` since the reframe — no key controls it.
+Since the reframe, two panes read **hard-coded** directories — no config key controls either:
+
+- The **Skills** pane reads the agedum sources at `<conception_path>/.agents/skills/` (and `~/.agents/skills/` for the User scope). The former `skills_path` key was dropped; condash never reads compiled per-harness outputs (`.claude/`, `.kimi/`, …). See the [Skills pane guide](../guides/skills-pane.md).
+- The **Resources** pane reads `<conception_path>/resources/`.
 
 ### `repositories`
 
@@ -374,13 +401,11 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
   "treeExpansion": {
     "knowledge": ["topics", "topics/security"],
     "resources": [],
-    "skillsGeneric": [],
-    "skillsClaude": ["pr"],
-    "skillsKimi": []
+    "skills": ["pr"]
   },
   "selectedBranches": ["feature-foo", "release-2026-05"],
   "branchFilterStickyAll": false,
-  "skillsActiveTab": "claude"
+  "skillsActiveScope": "conception"
 }
 ```
 
@@ -393,12 +418,12 @@ Lives at `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` on Linux (the mat
 | `layout`                | Composite-layout state. See [LayoutState](#layoutstate) below.                                                                                                                                                                                             |
 | `welcome`               | First-launch state. `welcome.dismissed: true` hides the Welcome screen even when both Projects and Knowledge are empty.                                                                                                                                    |
 | `cardMinWidth`          | Per-pane card grid min-width. See [CardMinWidth](#cardminwidth) below.                                                                                                                                                                                     |
-| `treeExpansion`         | Per-pane set of expanded directory `relPath`s for the Knowledge / Resources / Skills tree panes. Skills carries three independent sets — `skillsGeneric`, `skillsClaude`, `skillsKimi` — one per tab. Empty (or missing) means everything is collapsed — the on-purpose first-load state per #89. The legacy `skills` key is migrated into `skillsClaude` on first read and never written back. |
+| `treeExpansion`         | Per-pane set of expanded directory `relPath`s for the Knowledge / Resources / Skills tree panes (`knowledge`, `resources`, `skills`). Empty (or missing) means everything is collapsed — the on-purpose first-load state per #89. |
 | `selectedBranches`      | Branches pinned by the Code-pane top-of-pane filter. The primary worktree row is always rendered; this set is additive on top of it. Honoured only when `branchFilterStickyAll` is false.                                                                  |
 | `branchFilterStickyAll` | True ⇒ Code-pane filter is in **All (sticky)** mode: every branch is shown and new ones auto-pin. False ⇒ honour `selectedBranches` exactly (empty = main only). Defaults to true on first read when no explicit selection was ever made, false otherwise. |
-| `skillsActiveTab`       | Active tab in the Skills pane — `generic`, `claude`, or `kimi`. Defaults to `claude` (preserves pre-tabs behaviour for users without an explicit selection). Persisted on every tab switch.                                                                |
+| `skillsActiveScope`     | Active scope in the Skills pane — `conception` or `user`. Defaults to `conception`. Persisted on every scope switch.                                                                                                                                       |
 
-Workspace-shape keys (`workspace_path`, `worktrees_path`, `skills_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal`) are also valid in `settings.json` — they act as global defaults that any conception's `.condash/settings.json` may override. The reverse direction is forbidden: a conception's `settings.json` cannot set `lastConceptionPath` or `recentConceptionPaths`, since those describe the tree's own location and the user's machine-local recents list.
+Workspace-shape keys (`workspace_path`, `worktrees_path`, `repositories`, `open_with`, `pdf_viewer`, `terminal`) are also valid in `settings.json` — they act as global defaults that any conception's `.condash/settings.json` may override. The reverse direction is forbidden: a conception's `settings.json` cannot set `lastConceptionPath` or `recentConceptionPaths`, since those describe the tree's own location and the user's machine-local recents list.
 
 ### LayoutState
 
@@ -454,7 +479,7 @@ The file is created on demand: the first-launch folder picker writes it; you can
 
 **This conception** tab (writes to `.condash/settings.json`; the legacy `condash.json` and `configuration.json` are read but never written to):
 
-- **Workspace** — `workspace_path`, `worktrees_path`, `skills_path`.
+- **Workspace** — `workspace_path`, `worktrees_path`.
 - **Repositories** — ordered repo list, per-repo `run` / `force_stop`.
 - **Open with** — slot labels and commands.
 - **Appearance** — theme + card-grid min-widths overridden for this conception only.

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -165,7 +165,7 @@ Per-path tree events for projects + knowledge + resources + skills + logs + conf
 - `project` — `projects/<month>/<slug>/README.md` add/change/unlink. Renderer patches the project list in place via `getProject`.
 - `knowledge` — any `.md` under `knowledge/`. Coarse — renderer bumps `refreshKey`.
 - `resources` — any file under `<conception>/resources/`. Coarse.
-- `skills` — any file under the configured `skills_path` (or the sibling `.agents/skills/` and `.kimi/skills/` roots backing the Generic / Kimi tabs). Coarse.
+- `skills` — any file under `<conception>/.agents/skills/`, the agedum source tree the Skills pane reads. Coarse.
 - `logs` — any session file under `.condash/logs/`. Drives the Logs pane's live refresh.
 - `config` — `.condash/settings.json` (canonical), `condash.json` (legacy), or `configuration.json` (legacy²) at the conception root. Same coarse handling.
 - `unknown` — any classification failure. Forces a full re-render.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,8 @@ nav:
     - guides/index.md
     - Configure the conception path: guides/configure-conception-path.md
     - Repositories and open-with buttons: guides/repositories-and-open-with.md
+    - The Settings modal: guides/settings-modal.md
+    - Applications and handles: guides/applications-and-handles.md
     - Embedded terminal: guides/terminal.md
     - Agent CLIs and model providers: guides/agent-clis-and-models.md
     - The Tasks pane: guides/tasks-pane.md
@@ -104,6 +106,7 @@ nav:
     - Keyboard shortcuts: reference/shortcuts.md
     - README format: reference/readme-format.md
     - Status, steps, deliverables: reference/conception-convention.md
+    - AGENTS.md style guide: reference/agents-md-style.md
     - Advanced:
       - Mutation model: reference/mutations.md
       - Inline dev-server runner: reference/inline-runner.md


### PR DESCRIPTION
## Summary

- An audit of `docs/` against v4.9.0 found the tree mostly current, but with stale configuration references (a removed key, a reframed pane) and two missing user guides.
- This brings the public site and the in-app Help back in sync with the shipped app and fills the coverage gaps.

## Changes

- Remove the dropped `skills_path` key across `reference/config.md`, in-app `help/configuration.md`, and `reference/ipc-api.md`. Since the reframe the Skills pane reads a hard-coded `.agents/skills/` and the key is no longer in the (strict) schema.
- Rewrite `guides/skills-pane.md` for the current two-scope **Conception / User** model, replacing the retired four-tab Generic/Claude/Kimi/OpenCode UI.
- Update the `settings.json` reference: `treeExpansion.skills` is a single array, and `skillsActiveScope` replaces `skillsActiveTab`.
- Add `reference/agents-md-style.md` to the mkdocs nav — it was linked from the Reference index but missing from the sidebar.
- Drop the stale "Agents" entry from the working-surface list in `guides/deliverables-pane.md` (there is no Agents pane; agents live in the Settings modal).
- Fix a table broken by an interleaved paragraph in `help/configuration.md`, and a `.jsonl`->`.txt` log-path typo in `reference/config.md`.
- Add two guides: `guides/settings-modal.md` (the two-tab modal + inheritance model) and `guides/applications-and-handles.md` (the `#handle` registry, `retired_apps`, `apps:` resolution, the `condash applications` CLI). Both wired into the Guides index and nav.
- Add a 3.x->4.x migration note in `get-started/releases.md` and a consolidated **All config keys** table in `reference/config.md`.

## Watchpoints

- mkdocs isn't installed in the authoring environment, so the site was not built here. Validated `mkdocs.yml` YAML, every nav entry's file existence, and internal `.md` link targets by script; CI builds the site on release.
- The Settings "This conception" tab hint string still tells users it writes to `condash.json`, but the canonical write target is `.condash/settings.json`. That is a renderer-code string (`src/renderer/settings-modal-parts/data.ts`), out of scope for this docs PR — worth a one-line follow-up.