### PR TITLE
Add AGENTS.md column to generated Apps table

### DIFF
--- a/docs/reference/agents-md-style.md
+++ b/docs/reference/agents-md-style.md
@@ -20,7 +20,7 @@ Open `## Specifics` with the **Apps** table — one row per app the conception c
 | **App** | Logical name prefixed with `#` (e.g. `#alicepeintures.com`). Lower-case, kebab-or-dot, matching the repo basename when possible. The slug used in cross-references everywhere. |
 | **Purpose** | One line in plain English — what the app *is*. Lets a reader skim "what's in this conception" without opening anything. |
 | **Repo** | Absolute path on this host (e.g. `~/src/<workspace>/<repo>`). |
-| **Config** | Path to the app's own agent-config file (typically `<repo>/AGENTS.md`). Spell it out when it lives elsewhere. |
+| **AGENTS.md** | Absolute path to the app's own agent-config file. `sync-docs` resolves it per checkout with the fallback `AGENTS.md` → `CLAUDE.md` → `.claude/CLAUDE.md`, so the cell always points at the file that actually exists; empty when the checkout carries none. (Formerly labelled **Config**.) |
 | **Knowledge** | Path to the per-app knowledge entry-point in this conception (e.g. `knowledge/internal/<slug>.md`). The entry point is where deep details live — Config is the navigation layer. |
 
 Keep the table tight: navigation fields only. Operational config (formatter, port, base branch, …) belongs in `.condash/settings.json`, not here.

--- a/src/main/applications.test.ts
+++ b/src/main/applications.test.ts
@@ -134,14 +134,47 @@ describe('validateApplications', () => {
 });
 
 describe('renderAppsTable', () => {
-  it('renders #handle / path / knowledge rows for live apps only', async () => {
+  it('renders #handle / path / AGENTS.md / knowledge rows for live apps only', async () => {
     writeConfig({
       repositories: [{ handle: 'kasten', path: 'notes.vcoeur.com', label: 'Kasten' }],
       retired_apps: [{ handle: 'kasten-manager' }],
     });
-    const table = renderAppsTable(await listApplications(tmp, emptyGlobal));
-    expect(table).toContain('| `#kasten` | `notes.vcoeur.com` | `knowledge/internal/kasten.md` |');
+    // No checkout on disk → the AGENTS.md cell is empty.
+    const table = await renderAppsTable(await listApplications(tmp, emptyGlobal));
+    expect(table).toContain('| App | Repo | AGENTS.md | Knowledge |');
+    expect(table).toContain(
+      '| `#kasten` | `notes.vcoeur.com` |  | `knowledge/internal/kasten.md` |',
+    );
     expect(table).not.toContain('kasten-manager');
+  });
+
+  it('points the AGENTS.md cell at the resolved instruction file', async () => {
+    writeConfig({ repositories: [{ handle: 'kasten', path: 'notes.vcoeur.com' }] });
+    const checkout = join(tmp, 'notes.vcoeur.com');
+    mkdirSync(checkout, { recursive: true });
+    writeFileSync(join(checkout, 'AGENTS.md'), '# A\n');
+    const table = await renderAppsTable(await listApplications(tmp, emptyGlobal));
+    expect(table).toContain(`\`${join(checkout, 'AGENTS.md')}\``);
+  });
+
+  it('falls back AGENTS.md → CLAUDE.md → .claude/CLAUDE.md', async () => {
+    writeConfig({ repositories: [{ handle: 'kasten', path: 'notes.vcoeur.com' }] });
+    const checkout = join(tmp, 'notes.vcoeur.com');
+    mkdirSync(join(checkout, '.claude'), { recursive: true });
+    writeFileSync(join(checkout, '.claude', 'CLAUDE.md'), '# legacy\n');
+    expect(await renderAppsTable(await listApplications(tmp, emptyGlobal))).toContain(
+      `\`${join(checkout, '.claude', 'CLAUDE.md')}\``,
+    );
+    // A top-level CLAUDE.md outranks the nested one.
+    writeFileSync(join(checkout, 'CLAUDE.md'), '# legacy\n');
+    expect(await renderAppsTable(await listApplications(tmp, emptyGlobal))).toContain(
+      `\`${join(checkout, 'CLAUDE.md')}\``,
+    );
+    // AGENTS.md outranks both.
+    writeFileSync(join(checkout, 'AGENTS.md'), '# canonical\n');
+    expect(await renderAppsTable(await listApplications(tmp, emptyGlobal))).toContain(
+      `\`${join(checkout, 'AGENTS.md')}\``,
+    );
   });
 });
 

--- a/src/main/applications.ts
+++ b/src/main/applications.ts
@@ -254,19 +254,44 @@ export async function fixAppsReferences(
 const APPS_TABLE_START = '<!-- condash:apps:start -->';
 const APPS_TABLE_END = '<!-- condash:apps:end -->';
 
+/** Instruction-file candidates per app checkout, in fallback order. The first
+ *  that exists wins; AGENTS.md is canonical, the CLAUDE.md forms are legacy. */
+const INSTRUCTION_FILES = ['AGENTS.md', 'CLAUDE.md', '.claude/CLAUDE.md'];
+
+/**
+ * Absolute path to an app's instruction file, resolving the
+ * `AGENTS.md` → `CLAUDE.md` → `.claude/CLAUDE.md` fallback against its checkout.
+ * Returns `''` when the checkout is unknown (retired) or carries none of them.
+ */
+async function instructionsFile(cwd: string | undefined): Promise<string> {
+  if (!cwd) return '';
+  for (const candidate of INSTRUCTION_FILES) {
+    const abs = resolve(cwd, candidate);
+    if (await pathExists(abs)) return abs;
+  }
+  return '';
+}
+
 /**
  * Render the Apps table markdown from the live registry. Columns: the
- * `#handle`, the repo path (as configured), and the conventional knowledge
- * file `knowledge/internal/<handle>.md`. Retired apps are omitted — the table
+ * `#handle`, the repo path (as configured), the absolute path to the app's
+ * instruction file (`AGENTS.md`, else the legacy `CLAUDE.md` forms — so an
+ * agent can open it directly), and the conventional knowledge file
+ * `knowledge/internal/<handle>.md`. Retired apps are omitted — the table
  * documents live apps only.
  */
-export function renderAppsTable(records: AppRecord[]): string {
+export async function renderAppsTable(records: AppRecord[]): Promise<string> {
   const live = records.filter((r) => !r.retired);
-  const lines = ['| App | Repo | Knowledge |', '|-----|------|-----------|'];
+  const lines = [
+    '| App | Repo | AGENTS.md | Knowledge |',
+    '|-----|------|-----------|-----------|',
+  ];
   for (const record of live) {
     const repo = record.path ?? '';
+    const agents = await instructionsFile(record.cwd);
+    const agentsCell = agents ? `\`${agents}\`` : '';
     lines.push(
-      `| \`#${record.handle}\` | \`${repo}\` | \`knowledge/internal/${record.handle}.md\` |`,
+      `| \`#${record.handle}\` | \`${repo}\` | ${agentsCell} | \`knowledge/internal/${record.handle}.md\` |`,
     );
   }
   return lines.join('\n');
@@ -301,7 +326,7 @@ export async function syncAppsDocs(conceptionPath: string): Promise<SyncDocsResu
     return { changed: false, missingSentinels: true, file };
   }
   const records = await listApplications(conceptionPath);
-  const table = renderAppsTable(records);
+  const table = await renderAppsTable(records);
   const before = raw.slice(0, startIdx + APPS_TABLE_START.length);
   const after = raw.slice(endIdx);
   const next = `${before}\n\n${table}\n\n${after}`;


### PR DESCRIPTION
## Summary

`condash applications sync-docs` regenerates the Apps table in a conception's `AGENTS.md`. It gains a fourth column, **AGENTS.md**, holding the absolute path to each app's own instruction file so an agent reading the table can open it directly.

## Changes

- `renderAppsTable` (`src/main/applications.ts`) emits the new column. It resolves the file per checkout with the fallback `AGENTS.md` → `CLAUDE.md` → `.claude/CLAUDE.md` (first existing wins; empty cell when none exists); becomes async to probe the filesystem via the existing `pathExists` helper. `syncAppsDocs` awaits it.
- `docs/reference/agents-md-style.md`: the documented **Config** column is renamed **AGENTS.md** and its description updated to match the generated output (absolute path + fallback).
- `applications.test.ts`: updated the header/row assertions and added coverage for the resolved path and the full fallback ordering.

## Impact

- Verified against real conception data (worktree CLI, then reverted): all 15 apps resolve — `AGENTS.md` for condash/conception/agedum, `CLAUDE.md` or `.claude/CLAUDE.md` for the rest. 650 unit tests + typecheck + prettier clean.
- The live conception table only picks up the column after this releases and condash is reinstalled.

## Watchpoints

- **Absolute paths** bake the host path into the versioned table. Chosen for direct openability, consistent with the style guide ("the Apps table is the only place the absolute path appears"). Trivial to switch to workspace-relative if cross-machine churn appears.
- Column header is `AGENTS.md` (as requested); the style guide previously called it `Config`. Guide updated to match.