### PR TITLE
Resolve worktree apps by handle and alias, not just repo name

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -171,6 +171,8 @@ Worktree-centric operations on top of the conception's configured repositories (
 | `setup <branch> [--repo <r>...] [--copy-env] [--no-env] [--no-install] [--base <ref>]` | Create the worktree for `<branch>` in every primary (or the listed `--repo` subset). `--copy-env` copies `.env*` from the main checkout; `--no-env` skips env wiring; `--no-install` skips the per-repo `install:` hook; `--base <ref>` branches off `<ref>` instead of the repo's default branch |
 | `remove <branch> [--repo <r>...] [--force] [--force-rm]` | Tear down `<branch>` worktrees and (if safe) the local branch. `--force` passes through to `git worktree remove --force` (deletes even if dirty); `--force-rm` implies `--force` and `rm -rf`'s the leftover dir if git deregistered the worktree but left files behind (typical with `node_modules`). Without `--force-rm`, half-removed entries are reported under `partiallyRemoved[]` so the caller can distinguish them from genuinely protected repos |
 
+A declaring item's `apps:` tokens and explicit `--repo` values resolve to a repo by its `#handle`, its directory name, or a configured alias — so a repo whose handle differs from its directory (e.g. `#vcoeur` → `vcoeur.com`) is matched either way. The worktree directory is always named after the canonical directory name, so every spelling lands on the same `<worktrees_path>/<branch>/<dir>/`.
+
 ### `audit`
 
 Tree-wide health checks. Bundles the same passes the GUI exposes via the gear modal's "Audit" button.

--- a/src/main/worktree/inspect.ts
+++ b/src/main/worktree/inspect.ts
@@ -15,7 +15,7 @@ import {
   findItemsDeclaringBranch,
   readConfig,
   repoLookupMap,
-  rootRepoFromApp,
+  resolveAppRepo,
 } from './shared';
 
 export interface BranchRepoState {
@@ -60,12 +60,16 @@ export async function checkBranchState(
 
   // Union of Apps from declaring items (active items only — done items don't
   // need worktrees but still surface their previous claims so the user can
-  // see them).
+  // see them). Each token resolves to its canonical repo directory name so a
+  // `#vcoeur`-style handle (≠ the `vcoeur.com` directory) maps correctly.
+  const reposByName = repoLookupMap(config);
   const wantedRepos = new Set<string>();
   for (const item of declaringItems) {
-    for (const app of item.apps) wantedRepos.add(rootRepoFromApp(app));
+    for (const app of item.apps) {
+      const repo = resolveAppRepo(app, reposByName);
+      if (repo) wantedRepos.add(repo.name);
+    }
   }
-  const reposByName = repoLookupMap(config);
 
   const repos: BranchRepoState[] = [];
   for (const name of [...wantedRepos].sort()) {

--- a/src/main/worktree/remove.ts
+++ b/src/main/worktree/remove.ts
@@ -13,7 +13,7 @@ import {
   findItemsDeclaringBranch,
   readConfig,
   repoLookupMap,
-  rootRepoFromApp,
+  resolveAppRepo,
   validateBranchName,
 } from './shared';
 
@@ -69,13 +69,16 @@ export async function removeBranchWorktrees(
   // Resolve target repos: explicit list, or the union of Apps across items
   // declaring the branch. Then remove the protected set (repos still claimed
   // by *other active* items so we don't yank a worktree out from under them).
+  // Resolve every token to its canonical repo directory name so a `#vcoeur`
+  // handle and a literal `--repo vcoeur.com` both target the same worktree.
   const requested =
     options.repos && options.repos.length > 0
-      ? new Set(options.repos)
+      ? new Set(options.repos.map((token) => resolveAppRepo(token, reposByName)?.name ?? token))
       : new Set(
           (await findItemsDeclaringBranch(conceptionPath, branch))
             .flatMap((i) => i.apps)
-            .map(rootRepoFromApp),
+            .map((app) => resolveAppRepo(app, reposByName)?.name)
+            .filter((name): name is string => Boolean(name)),
         );
   // Compute the protected set from active items declaring this branch *that
   // were not in the explicit override*. The skill is responsible for excluding
@@ -84,8 +87,8 @@ export async function removeBranchWorktrees(
   for (const item of await findItemsDeclaringBranch(conceptionPath, branch)) {
     if (item.status === 'done') continue;
     for (const app of item.apps) {
-      const repo = rootRepoFromApp(app);
-      if (!requested.has(repo)) protectedSet.add(repo);
+      const repo = resolveAppRepo(app, reposByName)?.name;
+      if (repo && !requested.has(repo)) protectedSet.add(repo);
     }
   }
 

--- a/src/main/worktree/setup.test.ts
+++ b/src/main/worktree/setup.test.ts
@@ -197,6 +197,87 @@ describe('implicit-mode resolution with `#`-prefixed apps', () => {
   });
 });
 
+describe('apps handle differs from the repo directory name', () => {
+  // `#vcoeur` is the canonical handle of a repo whose directory is `vcoeur.com`.
+  // Before the fix, the apps→repo lookup keyed only on the directory name, so
+  // `#vcoeur` resolved to nothing and worktrees needed an explicit
+  // `--repo vcoeur.com`. All three operations must now resolve `#vcoeur` to the
+  // `vcoeur.com` worktree directory.
+  const branch = 'handle-ne-name';
+  const repoDir = 'vcoeur.com';
+
+  async function setupVcoeurRepo(): Promise<void> {
+    writeFileSync(
+      join(conception, 'condash.json'),
+      JSON.stringify(
+        {
+          workspace_path: join(tmp, 'workspace'),
+          worktrees_path: worktreesRoot,
+          repositories: [{ handle: 'vcoeur', path: repoDir, aliases: [repoDir] }],
+        },
+        null,
+        2,
+      ),
+    );
+    await git(join(tmp, 'workspace'), 'init', '-q', '-b', 'main', repoDir);
+    const r = join(tmp, 'workspace', repoDir);
+    await git(r, 'config', 'user.email', 'test@example.com');
+    await git(r, 'config', 'user.name', 'Test');
+    await git(r, 'commit', '-q', '--allow-empty', '-m', 'init');
+    const projectDir = join(conception, 'projects/2026-05/2026-05-30-vcoeur');
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, 'README.md'),
+      [
+        '---',
+        'date: 2026-05-30',
+        'kind: project',
+        'status: now',
+        'apps:',
+        '  - "#vcoeur"',
+        `branch: ${branch}`,
+        '---',
+        '',
+        '# Test',
+      ].join('\n'),
+    );
+  }
+
+  it('setup resolves `#vcoeur` to the `vcoeur.com` worktree directory', async () => {
+    await setupVcoeurRepo();
+    const result = await setupBranchWorktrees(conception, branch);
+    expect(result.created).toEqual([{ repo: repoDir, path: join(worktreesRoot, branch, repoDir) }]);
+    expect(result.blocked).toEqual([]);
+    expect(existsSync(join(worktreesRoot, branch, repoDir))).toBe(true);
+  });
+
+  it('check enumerates `vcoeur.com` with no false orphan', async () => {
+    await setupVcoeurRepo();
+    await setupBranchWorktrees(conception, branch);
+    const state = await checkBranchState(conception, branch);
+    expect(state.repos).toHaveLength(1);
+    expect(state.repos[0].name).toBe(repoDir);
+    expect(state.repos[0].worktreeExists).toBe(true);
+    expect(state.missing).toEqual([]);
+    expect(state.orphan).toEqual([]);
+  });
+
+  it('remove resolves `#vcoeur` and cleans the worktree', async () => {
+    await setupVcoeurRepo();
+    await setupBranchWorktrees(conception, branch);
+    const result = await removeBranchWorktrees(conception, branch);
+    expect(result.removed).toEqual([{ repo: repoDir, path: join(worktreesRoot, branch, repoDir) }]);
+    expect(result.notPresent).toEqual([]);
+    expect(existsSync(join(worktreesRoot, branch, repoDir))).toBe(false);
+  });
+
+  it('an explicit `--repo vcoeur` handle maps to the same `vcoeur.com` worktree', async () => {
+    await setupVcoeurRepo();
+    const result = await setupBranchWorktrees(conception, branch, { repos: ['vcoeur'] });
+    expect(result.created).toEqual([{ repo: repoDir, path: join(worktreesRoot, branch, repoDir) }]);
+  });
+});
+
 process.on('exit', () => {
   if (prevXdgConfigHome === undefined) delete process.env.XDG_CONFIG_HOME;
   else process.env.XDG_CONFIG_HOME = prevXdgConfigHome;

--- a/src/main/worktree/shared.test.ts
+++ b/src/main/worktree/shared.test.ts
@@ -6,7 +6,7 @@
  * top-level repo, so both layers are stripped.
  */
 import { describe, expect, it } from 'vitest';
-import { rootRepoFromApp } from './shared';
+import { repoLookupMap, resolveAppRepo, rootRepoFromApp, type ConfigWithPaths } from './shared';
 
 describe('rootRepoFromApp', () => {
   it('returns the bare name when already canonical', () => {
@@ -26,5 +26,49 @@ describe('rootRepoFromApp', () => {
 
   it('strips both `#` and sub-path together', () => {
     expect(rootRepoFromApp('#condash/frontend')).toBe('condash');
+  });
+});
+
+describe('repoLookupMap + resolveAppRepo (handle/alias resolution)', () => {
+  // A repo whose `#handle` (`vcoeur`) differs from its directory name
+  // (`vcoeur.com`) — the only shape that breaks a name-only lookup.
+  const config: ConfigWithPaths = {
+    workspace_path: '/ws',
+    repositories: [
+      { handle: 'vcoeur', path: 'vcoeur.com', aliases: ['vcoeur.com'] },
+      { name: 'condash' },
+      // Collision: this repo's handle equals the *name* of the next repo.
+      { handle: 'foo', name: 'bar' },
+      { name: 'foo' },
+    ],
+  };
+
+  it('indexes a repo by directory name, handle, and alias', () => {
+    const map = repoLookupMap(config);
+    expect(map.get('vcoeur.com')?.name).toBe('vcoeur.com'); // directory name
+    expect(map.get('vcoeur')?.name).toBe('vcoeur.com'); // #handle
+  });
+
+  it('resolves a `#handle` token to the canonical directory name', () => {
+    const map = repoLookupMap(config);
+    expect(resolveAppRepo('#vcoeur', map)?.name).toBe('vcoeur.com');
+    expect(resolveAppRepo('vcoeur', map)?.name).toBe('vcoeur.com');
+  });
+
+  it('resolves a directory-name or alias token too', () => {
+    const map = repoLookupMap(config);
+    expect(resolveAppRepo('#vcoeur.com', map)?.name).toBe('vcoeur.com');
+    expect(resolveAppRepo('vcoeur.com', map)?.name).toBe('vcoeur.com');
+    expect(resolveAppRepo('#condash', map)?.name).toBe('condash');
+  });
+
+  it('lets a real directory name win over another repo’s handle on collision', () => {
+    const map = repoLookupMap(config);
+    expect(resolveAppRepo('foo', map)?.name).toBe('foo');
+  });
+
+  it('returns null for a token that names no configured repo', () => {
+    const map = repoLookupMap(config);
+    expect(resolveAppRepo('#nope', map)).toBeNull();
   });
 });

--- a/src/main/worktree/shared.ts
+++ b/src/main/worktree/shared.ts
@@ -38,7 +38,18 @@ export function repoLookupMap(config: ConfigWithPaths): Map<string, RepoLookupEx
   const map = new Map<string, RepoLookupExtended>();
   walkRepos(config, (entry) => {
     if (entry.parent) return; // ignore submodules — worktrees are per top-level repo
-    map.set(entry.name, { name: entry.name, cwd: entry.cwd });
+    const lookup: RepoLookupExtended = { name: entry.name, cwd: entry.cwd };
+    map.set(entry.name, lookup);
+    // Also index by the canonical `#handle` and any configured aliases, so an
+    // `apps:` token resolves even when the handle differs from the directory
+    // name (e.g. `#vcoeur` → repo `vcoeur.com`). The directory name always
+    // wins on collision (set first, and alias keys are skipped when taken),
+    // so a handle/alias never shadows a real repo directory. Every key points
+    // at the same lookup object, whose `.name` stays the canonical directory
+    // name callers use for the worktree path.
+    for (const key of [entry.handle, ...(entry.aliases ?? [])]) {
+      if (key && !map.has(key)) map.set(key, lookup);
+    }
   });
   // Re-walk the raw config to pick up `pinned_branch`, `install`, and `env`
   // (those aren't currently in the RepoLookup shape).
@@ -66,16 +77,38 @@ export async function resolveTargetRepos(
   override: string[] | undefined,
   reposByName: Map<string, RepoLookupExtended>,
 ): Promise<string[]> {
-  if (override && override.length > 0) return override;
+  // Normalise to canonical directory names so the worktree path is stable
+  // regardless of which spelling (name, `#handle`, or alias) named the repo.
+  if (override && override.length > 0) {
+    // Unknown tokens pass through unchanged so the caller still reports them
+    // as "not configured".
+    return [
+      ...new Set(override.map((token) => resolveAppRepo(token, reposByName)?.name ?? token)),
+    ].sort();
+  }
   const items = await findItemsDeclaringBranch(conceptionPath, branch);
   const set = new Set<string>();
   for (const item of items) {
     for (const app of item.apps) {
-      const root = rootRepoFromApp(app);
-      if (reposByName.has(root)) set.add(root);
+      const repo = resolveAppRepo(app, reposByName);
+      if (repo) set.add(repo.name);
     }
   }
   return [...set].sort();
+}
+
+/**
+ * Resolve an `apps:` token to its canonical top-level repo descriptor,
+ * matching by directory name, `#handle`, or a configured alias. Returns null
+ * when the token names no configured repo. The returned `.name` is the
+ * canonical directory name — callers use it for the worktree path and labels
+ * so `#vcoeur`, `#vcoeur.com`, and `--repo vcoeur.com` all map to one worktree.
+ */
+export function resolveAppRepo(
+  app: string,
+  repos: Map<string, RepoLookupExtended>,
+): RepoLookupExtended | null {
+  return repos.get(rootRepoFromApp(app)) ?? null;
 }
 
 export async function findItemsDeclaringBranch(


### PR DESCRIPTION
## Summary

- `condash worktrees check/setup/remove` derived no repo for a project whose `apps:` token uses a `#handle` that differs from the repo's directory name — today the only such case resolves `#vcoeur` to the `vcoeur.com` directory. Setting up a worktree needed an explicit `--repo` to work around it.
- The lookup now resolves a token by handle, alias, or directory name, and always names the worktree directory after the canonical repo directory, so every spelling lands on one worktree.

## Changes

- `repoLookupMap` now indexes each repo by its `#handle` and configured aliases in addition to its directory name; the directory name wins on collision so a handle/alias never shadows a real repo directory.
- Added `resolveAppRepo`, a single token to repo resolver, and routed `resolveTargetRepos`, `checkBranchState`, and `removeBranchWorktrees` through it so they emit canonical directory names (fixing both the empty repo list and false orphan reports).
- Explicit `--repo` values are normalised the same way, so `--repo vcoeur` and `--repo vcoeur.com` target the same worktree.
- Added unit tests for handle/alias resolution and collision precedence, and integration tests covering setup/check/remove plus an explicit-handle `--repo`, for a repo whose handle differs from its directory name.
- Documented the resolution rule in the CLI reference.

## Impact

- A project README using the canonical `#handle` now sets up worktrees with no `--repo` workaround. Behaviour is unchanged for every repo whose handle equals its directory name.