### PR TITLE
Capture in-band agent transcript over a neutral OSC protocol

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -221,6 +221,16 @@ The writer treats the pty `output` stream as the source of truth. Typed keystrok
 
 Long-running streams (`tail -f`, full-screen TUIs like `vim` / `htop` / Claude Code) are bounded by the xterm scrollback: bytes that scroll past the scrollback window are dropped, exactly as they would be in the live terminal pane. The on-disk `.txt` therefore self-bounds to roughly *scrollback × line width* and never grows beyond that.
 
+##### In-band transcript capture (alternate-screen TUIs) { #in-band-transcript }
+
+A full-screen, alternate-screen TUI (e.g. an agent CLI) only ever paints the current viewport — its scrolled-off conversation is repainted on demand, never retained — so the rendered-buffer snapshot above captures just the last frame. To recover a clean transcript without parsing escape-sequence redraws, a cooperating program may emit its transcript **in-band** as an OSC escape the terminal ignores for display:
+
+```
+ESC ] 7373 ; agent-transcript ; <frameId> ; <i> ; <n> ; <base64piece> BEL
+```
+
+`src/main/osc-transcript.ts` (`OscTranscriptExtractor`) taps the pty stream in `SessionLogger.output`, strips these sequences (so the grid render stays clean), reassembles the base64 pieces per `frameId`, and decodes JSON frames (`{v,t:"msg",sid,mid,role,text}` / `{v,t:"end"}`). When a session emits the protocol, the `.txt` body becomes the decoded transcript instead of the grid snapshot. This is **harness-blind** — condash implements only the generic OSC protocol and never special-cases a program; any tool that speaks it is captured cleanly.
+
 ### Tuning capture
 
 The `terminal.logging` block in `.condash/settings.json` (or in the global `settings.json` for cross-conception defaults) carries the knobs:

--- a/src/main/osc-transcript.test.ts
+++ b/src/main/osc-transcript.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { Terminal } from '@xterm/headless';
+import { OscTranscriptExtractor } from './osc-transcript';
+
+const BEL = '\x07';
+const PREFIX = '\x1b]7373;agent-transcript;';
+
+/** Build the OSC packets for one frame, splitting the base64 into `pieces`. */
+function packets(id: string, frame: unknown, pieces = 1): string {
+  const b64 = Buffer.from(JSON.stringify(frame), 'utf8').toString('base64');
+  const size = Math.ceil(b64.length / pieces);
+  const n = Math.ceil(b64.length / size) || 1;
+  let out = '';
+  for (let i = 0; i < n; i++) {
+    out += `${PREFIX}${id};${i};${n};${b64.slice(i * size, (i + 1) * size)}${BEL}`;
+  }
+  return out;
+}
+
+describe('OscTranscriptExtractor', () => {
+  it('passes ordinary terminal output through untouched', () => {
+    const ex = new OscTranscriptExtractor();
+    const data = 'hello \x1b[31mworld\x1b[0m\r\n$ ';
+    expect(ex.feed(data)).toBe(data);
+    expect(ex.hasTranscript()).toBe(false);
+  });
+
+  it('extracts a single-packet message frame and strips it from the stream', () => {
+    const ex = new OscTranscriptExtractor();
+    const pkt = packets('0', {
+      v: 1,
+      t: 'msg',
+      sid: 's',
+      mid: 'm',
+      role: 'user',
+      text: 'hi there',
+    });
+    const clean = ex.feed(`before${pkt}after`);
+    expect(clean).toBe('beforeafter');
+    expect(ex.hasTranscript()).toBe(true);
+    expect(ex.render()).toBe('[user] hi there');
+  });
+
+  it('reassembles a frame split across multiple pieces', () => {
+    const ex = new OscTranscriptExtractor();
+    const long = 'x'.repeat(5000);
+    const pkt = packets('1', { v: 1, t: 'msg', role: 'assistant', text: long }, 6);
+    expect(pkt.split(PREFIX).length - 1).toBeGreaterThan(1); // really chunked
+    ex.feed(pkt);
+    expect(ex.render()).toBe(`[assistant] ${long}`);
+  });
+
+  it('reassembles a frame whose packets arrive across feed boundaries', () => {
+    const ex = new OscTranscriptExtractor();
+    const pkt = packets('2', { v: 1, t: 'msg', role: 'assistant', text: 'split me' });
+    const mid = Math.floor(pkt.length / 2);
+    let clean = ex.feed('a' + pkt.slice(0, mid));
+    clean += ex.feed(pkt.slice(mid) + 'b');
+    expect(clean).toBe('ab');
+    expect(ex.render()).toBe('[assistant] split me');
+  });
+
+  it('orders multiple messages and joins them', () => {
+    const ex = new OscTranscriptExtractor();
+    ex.feed(packets('0', { v: 1, t: 'msg', role: 'user', text: 'q' }));
+    ex.feed(packets('1', { v: 1, t: 'msg', role: 'assistant', text: 'a' }));
+    ex.feed(packets('2', { v: 1, t: 'end', sid: 's' }));
+    expect(ex.render()).toBe('[user] q\n\n[assistant] a');
+  });
+
+  it('ignores malformed packets without breaking', () => {
+    const ex = new OscTranscriptExtractor();
+    const clean = ex.feed(`${PREFIX}bad;packet${BEL}tail`);
+    expect(clean).toBe('tail');
+    expect(ex.hasTranscript()).toBe(false);
+  });
+
+  it('display-safety: the OSC is not rendered by xterm', async () => {
+    // condash's headless logger and the live renderer both parse the stream
+    // through @xterm/headless; an unknown OSC must be swallowed, never shown.
+    const term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+    const pkt = packets('0', { v: 1, t: 'msg', role: 'assistant', text: 'SECRET_PAYLOAD' });
+    await new Promise<void>((resolve) => term.write(`visible${pkt}`, () => resolve()));
+    let rendered = '';
+    for (let y = 0; y < term.buffer.active.length; y++) {
+      rendered += term.buffer.active.getLine(y)?.translateToString(true) ?? '';
+    }
+    expect(rendered).toContain('visible');
+    expect(rendered).not.toContain('SECRET_PAYLOAD');
+    expect(rendered).not.toContain('agent-transcript');
+    term.dispose();
+  });
+});

--- a/src/main/osc-transcript.ts
+++ b/src/main/osc-transcript.ts
@@ -1,0 +1,155 @@
+/**
+ * Extractor for a **neutral "agent transcript over OSC"** protocol.
+ *
+ * Some full-screen TUIs (anything on the alternate screen) never leave their
+ * conversation in the terminal grid — only the current frame is ever on
+ * screen, so the rendered-buffer snapshot the SessionLogger writes is just the
+ * last viewport. To capture a clean transcript without parsing escape-sequence
+ * redraws, a cooperating program may emit its transcript **in-band** as an OSC
+ * escape the terminal ignores for display:
+ *
+ *   ESC ] 7373 ; agent-transcript ; <frameId> ; <i> ; <n> ; <base64piece> BEL
+ *   (BEL = 0x07; the ST form `ESC \` is also accepted as the terminator)
+ *
+ * A frame's base64 payload may be split across `n` pieces (indices `0..n-1`)
+ * to keep each OSC write small; this extractor reassembles them per
+ * `frameId`, base64-decodes the concatenation, and parses a JSON frame:
+ *
+ *   { "v":1, "t":"msg", "sid":string, "mid":string,
+ *     "role":"user"|"assistant", "text":string }
+ *   { "v":1, "t":"end", "sid":string }
+ *
+ * This module is deliberately **harness-blind**: it knows only the generic OSC
+ * protocol, never which program produced it. Any tool that speaks the protocol
+ * gets a clean transcript captured; condash never special-cases a harness.
+ *
+ * Usage: feed every raw pty chunk through `feed()`, which returns the chunk
+ * with our OSC sequences removed (so the remainder still drives the grid
+ * render). If `hasTranscript()` is true at flush time, prefer `render()` over
+ * the grid snapshot for the log body.
+ */
+
+/** Marker prefix every protocol packet starts with. */
+const PREFIX = '\x1b]7373;agent-transcript;';
+const BEL = '\x07';
+const ST = '\x1b\\';
+
+/** One decoded transcript frame. */
+export interface TranscriptFrame {
+  v: number;
+  t: string;
+  sid?: string;
+  mid?: string;
+  role?: string;
+  text?: string;
+}
+
+export class OscTranscriptExtractor {
+  /** Unconsumed tail — holds an incomplete sequence (or a partial PREFIX) that
+   * spans feed boundaries. */
+  private buf = '';
+  /** Reassembly state per frameId: how many pieces and which we've seen. */
+  private pieces = new Map<string, { n: number; got: Map<number, string> }>();
+  private lines: string[] = [];
+  private captured = false;
+
+  /** Feed a raw pty chunk. Returns the chunk with our OSC sequences stripped,
+   * for the caller to forward to the grid renderer. Incomplete sequences are
+   * buffered until the rest arrives. */
+  feed(data: string): string {
+    this.buf += data;
+    let clean = '';
+    for (;;) {
+      const start = this.buf.indexOf(PREFIX);
+      if (start === -1) {
+        // No complete marker. Hold back only a possible partial PREFIX at the
+        // tail so a marker split across feeds isn't emitted as visible text.
+        const keep = partialPrefixLen(this.buf);
+        clean += this.buf.slice(0, this.buf.length - keep);
+        this.buf = this.buf.slice(this.buf.length - keep);
+        break;
+      }
+      clean += this.buf.slice(0, start);
+      this.buf = this.buf.slice(start);
+      const afterPrefix = PREFIX.length;
+      const bel = this.buf.indexOf(BEL, afterPrefix);
+      const st = this.buf.indexOf(ST, afterPrefix);
+      let end = -1;
+      let termLen = 0;
+      if (bel !== -1 && (st === -1 || bel < st)) {
+        end = bel;
+        termLen = BEL.length;
+      } else if (st !== -1) {
+        end = st;
+        termLen = ST.length;
+      }
+      if (end === -1) {
+        // Incomplete sequence; keep it (starts with PREFIX) for the next feed.
+        break;
+      }
+      this.ingest(this.buf.slice(afterPrefix, end));
+      this.buf = this.buf.slice(end + termLen);
+    }
+    return clean;
+  }
+
+  /** Parse one packet body: `<frameId>;<i>;<n>;<base64piece>`. */
+  private ingest(body: string): void {
+    const sep1 = body.indexOf(';');
+    const sep2 = body.indexOf(';', sep1 + 1);
+    const sep3 = body.indexOf(';', sep2 + 1);
+    if (sep1 === -1 || sep2 === -1 || sep3 === -1) return;
+    const id = body.slice(0, sep1);
+    const i = Number(body.slice(sep1 + 1, sep2));
+    const n = Number(body.slice(sep2 + 1, sep3));
+    const piece = body.slice(sep3 + 1);
+    if (!Number.isInteger(i) || !Number.isInteger(n) || n <= 0 || i < 0 || i >= n) return;
+    let entry = this.pieces.get(id);
+    if (!entry) {
+      entry = { n, got: new Map() };
+      this.pieces.set(id, entry);
+    }
+    entry.got.set(i, piece);
+    if (entry.got.size !== entry.n) return;
+    this.pieces.delete(id);
+    let b64 = '';
+    for (let k = 0; k < entry.n; k++) b64 += entry.got.get(k) ?? '';
+    try {
+      const frame = JSON.parse(Buffer.from(b64, 'base64').toString('utf8')) as TranscriptFrame;
+      this.applyFrame(frame);
+    } catch {
+      /* malformed frame — ignore, never break capture */
+    }
+  }
+
+  private applyFrame(frame: TranscriptFrame): void {
+    if (frame.t === 'msg' && typeof frame.text === 'string') {
+      this.captured = true;
+      const who = frame.role === 'user' ? 'user' : 'assistant';
+      this.lines.push(`[${who}] ${frame.text}`);
+    } else if (frame.t === 'end') {
+      this.captured = true;
+    }
+  }
+
+  /** True once any protocol frame has been decoded — the caller should then
+   * prefer `render()` over the grid snapshot. */
+  hasTranscript(): boolean {
+    return this.captured;
+  }
+
+  /** The accumulated transcript as plain text. */
+  render(): string {
+    return this.lines.join('\n\n');
+  }
+}
+
+/** Length of the longest suffix of `buf` that is a proper prefix of the marker
+ * PREFIX — i.e. a marker possibly split across the feed boundary. */
+function partialPrefixLen(buf: string): number {
+  const max = Math.min(buf.length, PREFIX.length - 1);
+  for (let k = max; k > 0; k--) {
+    if (PREFIX.startsWith(buf.slice(buf.length - k))) return k;
+  }
+  return 0;
+}

--- a/src/main/terminal-logger.ts
+++ b/src/main/terminal-logger.ts
@@ -4,6 +4,7 @@ import { Terminal } from '@xterm/headless';
 import type { TermSide, TerminalLoggingPrefs } from '../shared/types';
 import { condashLogsRoot } from './condash-dir';
 import { META_LINE_PREFIX } from './logs-format';
+import { OscTranscriptExtractor } from './osc-transcript';
 
 /**
  * Single-session writer. One instance per pty spawn; lives from `open()`
@@ -149,6 +150,11 @@ export class SessionLogger {
   private paused = false;
   private dirty = false;
   private readonly flushMs: number;
+  /** Pulls any in-band "agent transcript over OSC" frames out of the pty
+   * stream. Harness-blind: it knows the generic protocol, not the program.
+   * When a session speaks it, the log body becomes the clean transcript
+   * instead of the grid snapshot. */
+  private readonly oscTranscript = new OscTranscriptExtractor();
 
   constructor(
     conceptionPath: string,
@@ -201,7 +207,10 @@ export class SessionLogger {
 
   output(data: string): void {
     if (!this.isEnabled() || data.length === 0) return;
-    this.term.write(data);
+    // Strip any in-band transcript OSC out of the stream first, so the grid
+    // render never carries it; feed only the remainder to xterm.
+    const clean = this.oscTranscript.feed(data);
+    if (clean.length > 0) this.term.write(clean);
     this.dirty = true;
     this.scheduleFlush();
   }
@@ -270,7 +279,11 @@ export class SessionLogger {
     // otherwise the buffer may not reflect the most recent `output` call.
     await new Promise<void>((resolve) => this.term.write('', () => resolve()));
     if (this.closed) return;
-    const body = renderBufferAsPlainText(this.term);
+    // A session that emitted an in-band transcript gets the clean transcript
+    // as its body; everything else falls back to the rendered grid.
+    const body = this.oscTranscript.hasTranscript()
+      ? this.oscTranscript.render()
+      : renderBufferAsPlainText(this.term);
     const text = this.composeFileContent(body);
     try {
       await mkdir(dirname(this.txtPath), { recursive: true });


### PR DESCRIPTION
## Summary

Full-screen, alternate-screen TUIs (agent CLIs like opencode) only ever paint the current viewport, so the rendered-buffer session log captures just the last frame, not the conversation. This adds a **harness-blind** way to recover a clean transcript: a cooperating program emits its transcript in-band as a neutral OSC escape the terminal ignores for display, and condash extracts it from the pty stream it already reads.

condash implements only the generic protocol — it never special-cases a program or names a harness.

## Changes

- `src/main/osc-transcript.ts` — `OscTranscriptExtractor`: parses `ESC ] 7373 ; agent-transcript ; <frameId> ; <i> ; <n> ; <base64piece> BEL`, reassembles chunks per frame, decodes JSON frames (`{v,t:"msg",sid,mid,role,text}` / `{v,t:"end"}`), and accumulates a transcript.
- `src/main/terminal-logger.ts` — `SessionLogger.output` feeds the stream through the extractor and forwards only the stripped remainder to xterm (grid stays clean); `flushNow` uses the decoded transcript as the `.txt` body when a session spoke the protocol, else the grid snapshot (unchanged behavior).
- `src/main/osc-transcript.test.ts` — extraction, chunk reassembly, split-across-feeds, malformed-input, and **display-safety** (xterm swallows the OSC).
- `docs/guides/terminal.md` — documents the protocol.

## Impact

- No behavior change for sessions that don't emit the protocol — they still get the grid snapshot.
- The OSC is stripped before the grid render and (verified) ignored by xterm, so the live terminal and the `.txt` stay clean.

## Watchpoints

- v1 renders `[role] text` blocks; tool-call/reasoning rendering can be added later.
- The producing side (an opencode plugin) ships separately (agentsconf); end-to-end verified against opencode 1.15.12.