### PR TITLE
Logs: label reasoning transcript frames as [reasoning]

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -229,7 +229,7 @@ A full-screen, alternate-screen TUI (e.g. an agent CLI) only ever paints the cur
 ESC ] 7373 ; agent-transcript ; <frameId> ; <i> ; <n> ; <base64piece> BEL
 ```
 
-`src/main/osc-transcript.ts` (`OscTranscriptExtractor`) taps the pty stream in `SessionLogger.output`, strips these sequences (so the grid render stays clean), reassembles the base64 pieces per `frameId`, and decodes JSON frames (`{v,t:"msg",sid,mid,role,text}` / `{v,t:"end"}`). When a session emits the protocol, the `.txt` body becomes the decoded transcript instead of the grid snapshot. This is **harness-blind** — condash implements only the generic OSC protocol and never special-cases a program; any tool that speaks it is captured cleanly.
+`src/main/osc-transcript.ts` (`OscTranscriptExtractor`) taps the pty stream in `SessionLogger.output`, strips these sequences (so the grid render stays clean), reassembles the base64 pieces per `frameId`, and decodes JSON frames (`{v,t:"msg",sid,mid,role,text}` / `{v,t:"end"}`; `role` ∈ `user` / `assistant` / `reasoning`, rendered as `[user]` / `[assistant]` / `[reasoning]`). When a session emits the protocol, the `.txt` body becomes the decoded transcript instead of the grid snapshot. This is **harness-blind** — condash implements only the generic OSC protocol and never special-cases a program; any tool that speaks it is captured cleanly.
 
 ### Tuning capture
 

--- a/src/main/osc-transcript.test.ts
+++ b/src/main/osc-transcript.test.ts
@@ -68,6 +68,14 @@ describe('OscTranscriptExtractor', () => {
     expect(ex.render()).toBe('[user] q\n\n[assistant] a');
   });
 
+  it('labels reasoning frames distinctly from the assistant response', () => {
+    const ex = new OscTranscriptExtractor();
+    ex.feed(packets('0', { v: 1, t: 'msg', role: 'user', text: 'why?' }));
+    ex.feed(packets('1', { v: 1, t: 'msg', role: 'reasoning', text: 'thinking…' }));
+    ex.feed(packets('2', { v: 1, t: 'msg', role: 'assistant', text: 'because' }));
+    expect(ex.render()).toBe('[user] why?\n\n[reasoning] thinking…\n\n[assistant] because');
+  });
+
   it('ignores malformed packets without breaking', () => {
     const ex = new OscTranscriptExtractor();
     const clean = ex.feed(`${PREFIX}bad;packet${BEL}tail`);

--- a/src/main/osc-transcript.ts
+++ b/src/main/osc-transcript.ts
@@ -125,7 +125,8 @@ export class OscTranscriptExtractor {
   private applyFrame(frame: TranscriptFrame): void {
     if (frame.t === 'msg' && typeof frame.text === 'string') {
       this.captured = true;
-      const who = frame.role === 'user' ? 'user' : 'assistant';
+      const who =
+        frame.role === 'user' ? 'user' : frame.role === 'reasoning' ? 'reasoning' : 'assistant';
       this.lines.push(`[${who}] ${frame.text}`);
     } else if (frame.t === 'end') {
       this.captured = true;


### PR DESCRIPTION
## Summary

Paired with the agedum fidelity follow-up: the OSC transcript protocol now carries `role: "reasoning"` for model reasoning parts (alongside `user`/`assistant`). Render it distinctly.

## Changes

- `src/main/osc-transcript.ts` — `applyFrame` renders `reasoning` as `[reasoning]` (was folded into `[assistant]`).
- `src/main/osc-transcript.test.ts` — covers user / reasoning / assistant ordering + labels.
- `docs/guides/terminal.md` — documents the role set.

## Impact

- Backward-compatible: unknown/old roles still render as `[assistant]`; `user` unchanged. Shipped extractor (v4.11.0) already handled user/assistant.