### PR TITLE
Fix Settings save on legacy keys and gate task picker on promptFlags

### DIFF
--- a/docs/guides/tasks-pane.md
+++ b/docs/guides/tasks-pane.md
@@ -68,7 +68,7 @@ Run is disabled when the task's referenced agent is no longer defined (the card 
 Click **+ New task**, or **click a task card** to open the **editor popup** for an existing task:
 
 - **Name** — the card title. For a new task the **slug** auto-derives from the name until you hand-edit it.
-- **Agent** — pick an agent from the [`agents` settings list](agent-clis-and-models.md#register-it-as-a-condash-agent); the select shows the agent's `label` and stores its stable `id`.
+- **Agent** — pick an agent from the [`agents` settings list](agent-clis-and-models.md#register-it-as-a-condash-agent); the select shows the agent's `label` and stores its stable `id`. Only agents with [`promptFlags`](../reference/config.md#agents) are selectable — a task hands its filled prompt to the agent via `--prompt`/`--run`, which an opaque command can't accept. Agents without the flag are shown disabled (a new task defaults to the first prompt-seedable agent). A task already pointing at an opaque agent keeps that selection and still runs via the type-into-tab fallback.
 - **Submit** — press Enter after typing (on by default).
 - **Prompt** — markdown with `{MARKERS}`. The **Markers** chips below update live as you type so you can see the fields you're creating.
 

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import {
   configSchema,
+  globalSettingsSchema,
   migrateRawSettings,
   validateAndCanonicaliseConceptionConfig,
+  validateAndCanonicaliseGlobalSettings,
 } from './config-schema';
 
 describe('configSchema repoEntry', () => {
@@ -109,6 +111,62 @@ describe('configSchema dropped path keys', () => {
   it('rejects `skills_path` (no longer configurable)', () => {
     const result = configSchema.safeParse({ skills_path: '.claude/skills' });
     expect(result.success).toBe(false);
+  });
+});
+
+describe('migrateRawSettings — defunct top-level keys', () => {
+  // `resources_path` / `skills_path` were dropped by the reframe; `skillsActiveTab`
+  // is a defunct UI-state key. A real settings.json upgraded across those versions
+  // still carries them, and the strict schema rejects them — so without stripping,
+  // every Settings save throws `Unrecognized key`. (This was the reported bug.)
+  it('strips `resources_path`, `skills_path` and `skillsActiveTab`, keeping live keys', () => {
+    const migrated = migrateRawSettings({
+      resources_path: 'resources',
+      skills_path: '.claude/skills',
+      skillsActiveTab: 'generic',
+      workspace_path: '/home/alice/src/vcoeur',
+    }) as Record<string, unknown>;
+    expect('resources_path' in migrated).toBe(false);
+    expect('skills_path' in migrated).toBe(false);
+    expect('skillsActiveTab' in migrated).toBe(false);
+    expect(migrated.workspace_path).toBe('/home/alice/src/vcoeur');
+  });
+
+  it('lets a conception save round-trip a legacy resources_path / skills_path body', () => {
+    // Reproduces the reported failure: editing agents on the conception tab
+    // canonicalises `.condash/settings.json`, which carried these two keys.
+    const json = JSON.stringify({
+      workspace_path: '/home/alice/src/vcoeur',
+      resources_path: 'resources',
+      skills_path: '.claude/skills',
+      agents: [{ id: 'claude', label: 'Claude', command: 'agedum claude', promptFlags: true }],
+    });
+    const canon = validateAndCanonicaliseConceptionConfig(json);
+    const parsed = JSON.parse(canon);
+    expect('resources_path' in parsed).toBe(false);
+    expect('skills_path' in parsed).toBe(false);
+    expect(parsed.agents[0].promptFlags).toBe(true);
+  });
+
+  it('lets a global save keep `skillsActiveScope` while stripping defunct keys', () => {
+    // The global tab carries `skillsActiveScope` (live UI state) plus the
+    // orphaned `skillsActiveTab` and legacy `terminal.launcher_command`.
+    const json = JSON.stringify({
+      skillsActiveScope: 'user',
+      skillsActiveTab: 'generic',
+      terminal: { launcher_command: 'claude', shell: '/bin/bash' },
+    });
+    const canon = validateAndCanonicaliseGlobalSettings(json);
+    const parsed = JSON.parse(canon);
+    expect(parsed.skillsActiveScope).toBe('user');
+    expect('skillsActiveTab' in parsed).toBe(false);
+    expect('launcher_command' in parsed.terminal).toBe(false);
+    expect(parsed.terminal.shell).toBe('/bin/bash');
+  });
+
+  it('accepts a valid `skillsActiveScope` and rejects an invalid one', () => {
+    expect(globalSettingsSchema.safeParse({ skillsActiveScope: 'conception' }).success).toBe(true);
+    expect(globalSettingsSchema.safeParse({ skillsActiveScope: 'bogus' }).success).toBe(false);
   });
 });
 

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -396,6 +396,11 @@ export const globalSettingsSchema = z
   .object({
     ...sharedSchemaFields,
     ...pathTrackingFields,
+    /** Active scope toggle in the Skills pane (`conception` vs `user`).
+     *  Per-machine UI state written by `setSkillsActiveScope`; global-only, so
+     *  it is absent from `conceptionConfigSchema`. Mirrors `SkillScope` in
+     *  shared/types.ts. */
+    skillsActiveScope: z.enum(['conception', 'user']).optional(),
   })
   .strict();
 
@@ -436,6 +441,10 @@ export const DEFAULT_SKILLS_PATH = '.agents/skills';
  * the stale keys outright.
  *
  * Current rules:
+ * - `resources_path` / `skills_path` (top-level) — dropped by the reframe in
+ *   favour of the DEFAULT_RESOURCES_PATH / DEFAULT_SKILLS_PATH constants; and
+ *   `skillsActiveTab` — a defunct UI-state key. Stripped so older files keep
+ *   saving (otherwise every write fails with `Unrecognized key`).
  * - `terminal.launchers` / `terminal.launcher_command` — legacy tab-strip
  *   launcher keys. Removed silently so existing `settings.json` / `condash.json`
  *   files keep saving; the next write drops them from disk. (Their successor is
@@ -453,6 +462,15 @@ export const DEFAULT_SKILLS_PATH = '.agents/skills';
 export function migrateRawSettings(parsed: unknown): unknown {
   if (!parsed || typeof parsed !== 'object') return parsed;
   const root = parsed as Record<string, unknown>;
+  // The reframe dropped `resources_path` / `skills_path` in favour of the
+  // DEFAULT_RESOURCES_PATH / DEFAULT_SKILLS_PATH constants; `skillsActiveTab` is
+  // a defunct UI-state key with no remaining reader. Strip all three at the top
+  // level (before the terminal early-return below) so the strict schema accepts
+  // older files — otherwise every Settings save throws `Unrecognized key` and
+  // the user can't persist any change. The next write drops them from disk.
+  for (const defunctKey of ['resources_path', 'skills_path', 'skillsActiveTab']) {
+    if (defunctKey in root) delete root[defunctKey];
+  }
   // v3.20.0 → v3.21.0: the left-band pane was renamed Outputs → Deliverables.
   if (root.layout && typeof root.layout === 'object') {
     const layout = root.layout as Record<string, unknown>;

--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -49,11 +49,15 @@ interface FillState {
 }
 
 function blankDraft(agents: readonly Agent[]): Draft {
+  // Default a new task to the first prompt-seedable agent — tasks hand the
+  // filled prompt to the agent via `--prompt`/`--run` (see the agent picker's
+  // disabled rows), so an agent without `promptFlags` can't carry one.
+  const seedable = agents.find((a) => a.promptFlags === true) ?? agents[0];
   return {
     slug: '',
     slugDirty: false,
     name: '',
-    agent: agents[0]?.id ?? '',
+    agent: seedable?.id ?? '',
     submit: true,
     prompt: '',
     editingSlug: null,
@@ -492,14 +496,16 @@ function TaskEditor(props: {
   onMount(() => document.addEventListener('keydown', handleKey, true));
   onCleanup(() => document.removeEventListener('keydown', handleKey, true));
 
-  // Agent options keyed by id (the stored identity) with the display label.
-  // Includes the draft's current id when it dangles (renamed/removed) so editing
-  // doesn't silently drop the reference.
+  // Agent options keyed by id (the stored identity) with the display label and
+  // whether the agent is prompt-seedable. Includes the draft's current id when
+  // it dangles (renamed/removed) so editing doesn't silently drop the reference.
   const agentOptions = createMemo(() => {
-    const opts = props.agents().map((a) => ({ id: a.id, label: a.label }));
+    const opts = props
+      .agents()
+      .map((a) => ({ id: a.id, label: a.label, promptFlags: a.promptFlags === true }));
     const current = d().agent;
     if (current && !opts.some((o) => o.id === current)) {
-      return [{ id: current, label: `${current} (missing)` }, ...opts];
+      return [{ id: current, label: `${current} (missing)`, promptFlags: false }, ...opts];
     }
     return opts;
   });
@@ -554,7 +560,17 @@ function TaskEditor(props: {
                   <option value="">(no agents defined)</option>
                 </Match>
                 <Match when={agentOptions().length > 0}>
-                  <For each={agentOptions()}>{(o) => <option value={o.id}>{o.label}</option>}</For>
+                  <For each={agentOptions()}>
+                    {(o) => (
+                      // Only prompt-seedable agents can carry a task prompt. Show
+                      // the rest disabled (kept visible for context), except the
+                      // current selection, which must stay selectable so the bound
+                      // value never lands on a disabled option.
+                      <option value={o.id} disabled={!o.promptFlags && o.id !== d().agent}>
+                        {o.promptFlags ? o.label : `${o.label} — no prompt seeding`}
+                      </option>
+                    )}
+                  </For>
                 </Match>
               </Switch>
             </select>


### PR DESCRIPTION
## Summary

Saving any change in the Settings modal failed: the canonicalising write path validates the file against a strict zod schema, and real settings files carry keys the schema no longer lists. The conception tab choked on `resources_path` / `skills_path` (dropped by the reframe in favour of constants); the global tab choked on `skillsActiveScope` (a live UI-state key that was never added to the schema) and the orphaned `skillsActiveTab`. CLI reads were unaffected because they don't canonicalise — only GUI saves did.

This fixes the save path and, separately, restricts the Tasks agent picker to prompt-seedable agents.

## Changes

- `migrateRawSettings` strips the defunct top-level keys `resources_path`, `skills_path`, and `skillsActiveTab` before the strict parse, so older files keep saving and the next write removes them from disk.
- `globalSettingsSchema` gains the live `skillsActiveScope` key (`conception` | `user`) it was silently missing — it's written by `setSkillsActiveScope` and documented in the config reference, but absent from the schema.
- Tasks editor agent picker: only `promptFlags` agents are selectable; the rest are shown disabled (the current selection stays selectable so the bound value never lands on a disabled option). A new task defaults to the first prompt-seedable agent.
- Tests for the strip + `skillsActiveScope` round-trip; tasks-pane guide updated.

## Watchpoints

- A task already pointing at an opaque (non-`promptFlags`) agent keeps that selection and still runs via the type-into-tab fallback — only the picker is gated, not the run path.
- Companion change in agentsconf emits `promptFlags: true` for every synced agent so the flag survives a settings re-sync.