### PR TITLE
Launch tasks and agent actions interactively via --prompt

### DIFF
--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -271,8 +271,8 @@ const actionTemplateSchema = z
  *  strings so a freshly-added blank row in the Settings editor survives the
  *  round-trip to disk and stays visible for the user to fill in; `listAgents`
  *  skips entries whose `id` or `command` is blank. Optional `promptFlags` opts
- *  the agent into argv prompt-seeding (`--run` / `--prompt`) instead of the
- *  keystroke path — see the `Agent` type. */
+ *  the agent into argv prompt-seeding (`--prompt`) instead of the keystroke
+ *  path — see the `Agent` type. */
 const agentSchema = z
   .object({
     id: z.string(),

--- a/src/main/tasks.test.ts
+++ b/src/main/tasks.test.ts
@@ -42,7 +42,6 @@ const task: TaskDef = {
   // `agent` references the agent by its stable id from the `agents` list.
   name: 'Refresh app docs',
   agent: 'claude-deepseek-v4-pro',
-  submit: true,
   prompt: 'Review {APP} and update its docs. Focus: {AREA:CLAUDE.md and docs/}',
 };
 
@@ -57,7 +56,7 @@ describe('task storage round-trip', () => {
     expect(back).toEqual(task);
   });
 
-  it('stores only name/agent/submit in task.json (prose stays in prompt.md)', async () => {
+  it('stores only name/agent in task.json (prose stays in prompt.md)', async () => {
     await writeTask(dir, 'refresh-app-docs', task);
     const config = JSON.parse(
       await fs.readFile(join(dir, 'tasks', 'refresh-app-docs', 'task.json'), 'utf8'),
@@ -65,18 +64,20 @@ describe('task storage round-trip', () => {
     expect(config).toEqual({
       name: 'Refresh app docs',
       agent: 'claude-deepseek-v4-pro',
-      submit: true,
     });
     expect(config).not.toHaveProperty('prompt');
   });
 
-  it('defaults submit to true when task.json omits it', async () => {
-    const tasksDir = join(dir, 'tasks', 'no-submit');
+  it('ignores a legacy submit key in task.json', async () => {
+    const tasksDir = join(dir, 'tasks', 'legacy-submit');
     await fs.mkdir(tasksDir, { recursive: true });
-    await fs.writeFile(join(tasksDir, 'task.json'), JSON.stringify({ name: 'X', agent: 'a' }));
+    await fs.writeFile(
+      join(tasksDir, 'task.json'),
+      JSON.stringify({ name: 'X', agent: 'a', submit: true }),
+    );
     await fs.writeFile(join(tasksDir, 'prompt.md'), 'hello');
-    const back = await readTask(dir, 'no-submit');
-    expect(back).toEqual({ name: 'X', agent: 'a', submit: true, prompt: 'hello' });
+    const back = await readTask(dir, 'legacy-submit');
+    expect(back).toEqual({ name: 'X', agent: 'a', prompt: 'hello' });
   });
 });
 

--- a/src/main/tasks.ts
+++ b/src/main/tasks.ts
@@ -2,7 +2,7 @@
  * Task storage (main process only).
  *
  * Tasks live as one directory each at `<conception>/tasks/<slug>/`, holding a
- * `task.json` (`name` / `agent` / `submit`) plus a hand-editable `prompt.md`.
+ * `task.json` (`name` / `agent`) plus a hand-editable `prompt.md`.
  * ENOENT-tolerant `listTasks`, derived-filename writes, idempotent delete. The
  * slug is the directory name (regex `^[a-z0-9-]+$`, same family as projects).
  * The referenced `agent` is an agent `id` from the `agents` settings list and
@@ -23,7 +23,6 @@ const PROMPT_FILENAME = 'prompt.md';
 const taskConfigSchema = z.object({
   name: z.string().min(1),
   agent: z.string(),
-  submit: z.boolean().optional(),
 });
 
 function tasksDir(conceptionPath: string): string {
@@ -54,7 +53,7 @@ async function readTaskDir(conceptionPath: string, slug: string): Promise<TaskDe
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
   }
-  return { name: config.name, agent: config.agent, submit: config.submit ?? true, prompt };
+  return { name: config.name, agent: config.agent, prompt };
 }
 
 /**
@@ -115,7 +114,7 @@ export async function writeTask(
   if (previousSlug && previousSlug !== safe && (await readTaskDir(conceptionPath, safe)) !== null) {
     throw new Error(`a task "${safe}" already exists — rename it or pick another slug`);
   }
-  const config = taskConfigSchema.parse({ name: def.name, agent: def.agent, submit: def.submit });
+  const config = taskConfigSchema.parse({ name: def.name, agent: def.agent });
   const dir = join(tasksDir(conceptionPath), safe);
   await fs.mkdir(dir, { recursive: true });
   await fs.writeFile(join(dir, CONFIG_FILENAME), `${JSON.stringify(config, null, 2)}\n`, 'utf8');

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -525,9 +525,7 @@ function App() {
                           projects={() => projects() ?? []}
                           apps={appOptions}
                           flashToast={flashToast}
-                          onRun={(agentId, text, submit) =>
-                            void bridge.runTask(agentId, text, submit)
-                          }
+                          onRun={(agentId, text) => void bridge.runTask(agentId, text)}
                         />
                       </Match>
                       <Match when={layout().leftView === 'projects'}>

--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -32,7 +32,6 @@ interface Draft {
   slugDirty: boolean;
   name: string;
   agent: string;
-  submit: boolean;
   prompt: string;
   editingSlug: string | null;
 }
@@ -50,15 +49,14 @@ interface FillState {
 
 function blankDraft(agents: readonly Agent[]): Draft {
   // Default a new task to the first prompt-seedable agent — tasks hand the
-  // filled prompt to the agent via `--prompt`/`--run` (see the agent picker's
-  // disabled rows), so an agent without `promptFlags` can't carry one.
+  // filled prompt to the agent via `--prompt` (see the agent picker's disabled
+  // rows), so an agent without `promptFlags` can't carry one.
   const seedable = agents.find((a) => a.promptFlags === true) ?? agents[0];
   return {
     slug: '',
     slugDirty: false,
     name: '',
     agent: seedable?.id ?? '',
-    submit: true,
     prompt: '',
     editingSlug: null,
   };
@@ -87,9 +85,9 @@ export function TasksView(props: {
   /** Apps available to the `{APP}` picker. */
   apps: () => readonly AppOption[];
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
-  /** Run a filled task: spawn the agent (by id), type the substituted prompt,
-   *  submit. */
-  onRun: (agentId: string, text: string, submit: boolean) => void;
+  /** Run a filled task: spawn the agent (by id) and deliver the substituted
+   *  prompt. Always launches interactively. */
+  onRun: (agentId: string, text: string) => void;
 }): JSX.Element {
   const [draft, setDraft] = createSignal<Draft | null>(null);
   const [fill, setFill] = createSignal<FillState | null>(null);
@@ -117,7 +115,6 @@ export function TasksView(props: {
       slugDirty: true,
       name: def.name,
       agent: def.agent,
-      submit: def.submit,
       prompt: def.prompt,
       editingSlug: slug,
     });
@@ -156,7 +153,6 @@ export function TasksView(props: {
     const def: TaskDef = {
       name: d.name.trim(),
       agent: d.agent,
-      submit: d.submit,
       prompt: d.prompt,
     };
     try {
@@ -330,7 +326,7 @@ function TaskFill(props: {
   projects: () => readonly Project[];
   conceptionPath: () => string | null;
   agentExists: (name: string) => boolean;
-  onRun: (agentName: string, text: string, submit: boolean) => void;
+  onRun: (agentName: string, text: string) => void;
 }): JSX.Element {
   const markers = createMemo(() => extractMarkers(props.fill().def.prompt));
   const textMarkers = createMemo(() =>
@@ -368,7 +364,7 @@ function TaskFill(props: {
 
   const run = (): void => {
     const f = props.fill();
-    props.onRun(f.def.agent, substitute(f.def.prompt, ctx()), f.def.submit);
+    props.onRun(f.def.agent, substitute(f.def.prompt, ctx()));
     close();
   };
 
@@ -390,7 +386,7 @@ function TaskFill(props: {
           </header>
           <p class="tasks-editor-note">
             Agent: <code>{props.fill().def.agent}</code>
-            {props.fill().def.submit ? ' · submits on run' : ' · types without submitting'}
+            {' · runs interactively'}
           </p>
 
           <Show when={needsApp()}>
@@ -574,15 +570,6 @@ function TaskEditor(props: {
                 </Match>
               </Switch>
             </select>
-          </label>
-
-          <label class="tasks-checkbox">
-            <input
-              type="checkbox"
-              checked={d().submit}
-              onChange={(e) => props.patch({ submit: e.currentTarget.checked })}
-            />
-            <span>Press Enter after typing (submit)</span>
           </label>
 
           <label>

--- a/src/renderer/terminal-bridge.test.ts
+++ b/src/renderer/terminal-bridge.test.ts
@@ -237,7 +237,7 @@ describe('handleProjectAction with agent binding', () => {
     await vi.advanceTimersByTimeAsync(400);
     await promise;
     expect(handle.spawnUserShell).toHaveBeenCalledWith(
-      { ...agedumAgent, command: "agedum claude --run 'review foo-bar'" },
+      { ...agedumAgent, command: "agedum claude --prompt 'review foo-bar'" },
       'my',
     );
     expect(handle.typeIntoActive).not.toHaveBeenCalled();
@@ -246,11 +246,11 @@ describe('handleProjectAction with agent binding', () => {
 });
 
 describe('runTask', () => {
-  it('spawns the agent, settles, types via pty, and submits when submit=true', async () => {
+  it('spawns an opaque agent, settles, types via pty, and submits', async () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
     const bridge = createTerminalBridge(makeDeps(handle, [kimiAgent]));
-    const promise = bridge.runTask('kimi-cli-native', 'review the docs', true);
+    const promise = bridge.runTask('kimi-cli-native', 'review the docs');
     await vi.advanceTimersByTimeAsync(600);
     await promise;
     expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my');
@@ -259,24 +259,11 @@ describe('runTask', () => {
     vi.useRealTimers();
   });
 
-  it('types without Enter when submit is false', async () => {
-    vi.useFakeTimers();
-    const handle = makeFakeHandle();
-    const bridge = createTerminalBridge(makeDeps(handle, [claudeAgent]));
-    const promise = bridge.runTask('claude-deepseek-v4-pro', 'just type this', false);
-    await vi.advanceTimersByTimeAsync(400);
-    await promise;
-    expect(handle.spawnUserShell).toHaveBeenCalledWith(claudeAgent, 'my');
-    expect(handle.typeIntoActive).toHaveBeenCalledWith('just type this');
-    expect(handle.typeIntoActive).toHaveBeenCalledTimes(1);
-    vi.useRealTimers();
-  });
-
   it('toasts and does nothing when the agent is unknown', async () => {
     const handle = makeFakeHandle();
     const deps = makeDeps(handle, [claudeAgent]);
     const bridge = createTerminalBridge(deps);
-    await bridge.runTask('does-not-exist', 'text', true);
+    await bridge.runTask('does-not-exist', 'text');
     expect(deps.flashToast).toHaveBeenCalledWith(
       expect.stringContaining('Task agent not found'),
       'error',
@@ -287,30 +274,15 @@ describe('runTask', () => {
 });
 
 describe('runTask with promptFlags agent', () => {
-  it('spawns `<command> --run <quoted>` and does not type when submit=true', async () => {
+  it('seeds `<command> --prompt <quoted>` interactively and does not type', async () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
     const bridge = createTerminalBridge(makeDeps(handle, [agedumAgent]));
-    const promise = bridge.runTask('agedum-claude', 'review the docs', true);
+    const promise = bridge.runTask('agedum-claude', 'review the docs');
     await vi.advanceTimersByTimeAsync(400);
     await promise;
     expect(handle.spawnUserShell).toHaveBeenCalledWith(
-      { ...agedumAgent, command: "agedum claude --run 'review the docs'" },
-      'my',
-    );
-    expect(handle.typeIntoActive).not.toHaveBeenCalled();
-    vi.useRealTimers();
-  });
-
-  it('spawns `<command> --prompt <quoted>` when submit=false', async () => {
-    vi.useFakeTimers();
-    const handle = makeFakeHandle();
-    const bridge = createTerminalBridge(makeDeps(handle, [agedumAgent]));
-    const promise = bridge.runTask('agedum-claude', 'seed me', false);
-    await vi.advanceTimersByTimeAsync(400);
-    await promise;
-    expect(handle.spawnUserShell).toHaveBeenCalledWith(
-      { ...agedumAgent, command: "agedum claude --prompt 'seed me'" },
+      { ...agedumAgent, command: "agedum claude --prompt 'review the docs'" },
       'my',
     );
     expect(handle.typeIntoActive).not.toHaveBeenCalled();
@@ -321,11 +293,11 @@ describe('runTask with promptFlags agent', () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
     const bridge = createTerminalBridge(makeDeps(handle, [agedumAgent]));
-    const promise = bridge.runTask('agedum-claude', "it's a $PATH; rm -rf", true);
+    const promise = bridge.runTask('agedum-claude', "it's a $PATH; rm -rf");
     await vi.advanceTimersByTimeAsync(400);
     await promise;
     expect(handle.spawnUserShell).toHaveBeenCalledWith(
-      { ...agedumAgent, command: "agedum claude --run 'it'\\''s a $PATH; rm -rf'" },
+      { ...agedumAgent, command: "agedum claude --prompt 'it'\\''s a $PATH; rm -rf'" },
       'my',
     );
     vi.useRealTimers();

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -48,10 +48,12 @@ export interface TerminalBridge {
    *  "Paste path → Term" button — re-uses the same "open pane, spawn
    *  shell if needed" dance as `handleWorkOn`. Does not press Enter. */
   handlePasteToTerm: (text: string) => Promise<void>;
-  /** Run a Tasks-pane task: spawn a fresh tab running the agent with `agentId`,
-   *  type the already-substituted `text`, and press Enter when `submit` is true.
-   *  Same spawn-and-type path as an agent-bound project action. */
-  runTask: (agentId: string, text: string, submit: boolean) => Promise<void>;
+  /** Run a Tasks-pane task: spawn a fresh tab running the agent with `agentId`
+   *  and deliver the already-substituted `text`. Tasks always launch
+   *  interactively — a `promptFlags` agent is seeded with `--prompt` (the
+   *  session stays open after the prompt runs); an opaque agent is spawned bare,
+   *  then the prompt is keystroke-injected and submitted once the TUI settles. */
+  runTask: (agentId: string, text: string) => Promise<void>;
 }
 
 /** Upper bound on animation frames waited for the pane to mount after
@@ -146,17 +148,17 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     return handle;
   };
 
-  /** Run `text` through `agent` in a fresh tab. When the agent opts into agedum
-   *  prompt flags (`promptFlags`), fold the prompt into argv — `--run` when
-   *  `submit` (non-interactive, exits), `--prompt` otherwise (interactive,
-   *  seeded) — and spawn that; the prompt is delivered at launch, so nothing is
-   *  typed. Otherwise spawn the bare command, let the TUI settle, and
-   *  keystroke-inject `text` (plus Enter when `submit`) — the generic path for an
-   *  opaque agent. */
+  /** Run `text` through `agent` in a fresh tab, always interactively so the
+   *  session stays open after the prompt runs (a one-shot `--run` would exit and
+   *  tear the tab down). When the agent opts into agedum prompt flags
+   *  (`promptFlags`), seed the prompt via `--prompt` in argv and spawn that; the
+   *  prompt is delivered at launch, so nothing is typed. Otherwise spawn the bare
+   *  command, let the TUI settle, and keystroke-inject `text` (plus Enter when
+   *  `submit`) — the generic path for an opaque agent. `submit` only governs that
+   *  keystroke Enter; a `promptFlags` agent is always seeded interactively. */
   const runAgentTask = async (agent: Agent, text: string, submit: boolean): Promise<void> => {
     if (agent.promptFlags) {
-      const flag = submit ? '--run' : '--prompt';
-      const command = `${agent.command} ${flag} ${shellSingleQuote(text)}`;
+      const command = `${agent.command} --prompt ${shellSingleQuote(text)}`;
       await spawnAgentTab({ ...agent, command });
       return;
     }
@@ -289,16 +291,16 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     handle.typeIntoActive(text);
   };
 
-  const runTask = async (agentId: string, text: string, submit: boolean): Promise<void> => {
+  const runTask = async (agentId: string, text: string): Promise<void> => {
     const agent = findAgentById(deps.agents(), agentId);
     if (!agent) {
       deps.flashToast(`Task agent not found: ${agentId}`, 'error');
       return;
     }
-    // Spawn a fresh tab for the agent and deliver the prompt: via argv flags
-    // when the agent opts in (`promptFlags`), otherwise by keystroke-injecting
-    // it once the TUI settles — an opaque agent has no flag to carry the prompt.
-    await runAgentTask(agent, text, submit);
+    // Same interactive spawn-and-deliver path as an agent-bound project action.
+    // `submit: true` presses Enter on the opaque keystroke path; a promptFlags
+    // agent is seeded with `--prompt` (interactive) regardless.
+    await runAgentTask(agent, text, true);
   };
 
   return {

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -12,16 +12,14 @@
  */
 import { MARKER_RE, projectContext, type ProjectLike } from './action-template';
 
-/** On-disk task definition: `task.json` config (`name` / `agent` / `submit`)
- *  plus the raw `prompt.md` body. The slug is the directory name, carried
- *  separately by the IPC verbs (it is not stored inside `task.json`). */
+/** On-disk task definition: `task.json` config (`name` / `agent`) plus the raw
+ *  `prompt.md` body. The slug is the directory name, carried separately by the
+ *  IPC verbs (it is not stored inside `task.json`). */
 export interface TaskDef {
   name: string;
   /** Referenced agent — its stable `slug` (the agent's filename/IPC key). May
    *  dangle if the agent was renamed/removed. */
   agent: string;
-  /** Press Enter after typing the filled prompt. Default true. */
-  submit: boolean;
   /** Raw markdown prompt with `{markers}`. */
   prompt: string;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -501,10 +501,9 @@ export interface Agent {
   label: string;
   /** Shell command run when the agent is launched. */
   command: string;
-  /** When true, `command` understands agedum's prompt-seeding flags
-   *  (`--prompt` / `--run`), so a task or agent-bound action passes the prompt in
-   *  argv — `<command> --run "<text>"` when submitting (non-interactive, exits),
-   *  `<command> --prompt "<text>"` otherwise (interactive, seeded) — instead of
+  /** When true, `command` understands agedum's `--prompt` flag, so a task or
+   *  agent-bound action passes the prompt in argv — `<command> --prompt "<text>"`
+   *  (interactive: the prompt runs and the session stays open) — instead of
    *  spawning the bare command and keystroke-injecting the prompt into the live
    *  TUI. Omit for an opaque agent: the default keystroke path works for any
    *  harness but races the TUI's boot. */


### PR DESCRIPTION
## Summary

Tasks and agent-bound project actions delivered a `promptFlags` agent's prompt with agedum `--run` whenever `submit` was set. `--run` runs the prompt non-interactively and **exits**, which tears the terminal tab down the moment the agent finishes (or errors). Tasks should stay open so the user can keep working in the seeded session. This switches that path to always seed `--prompt` (interactive: the prompt runs and the session stays open).

## Changes

- `src/renderer/terminal-bridge.ts` — `runAgentTask` (the shared path for tasks **and** project / new-project actions) always builds `<command> --prompt <quoted>`; the `--run` branch is gone. `runTask` delegates to it instead of carrying its own logic.
- `src/main/tasks.ts`, `src/shared/tasks.ts` — drop `submit` from the task config schema and `TaskDef`. A legacy `submit` key in an existing `task.json` is silently ignored on read.
- `src/renderer/panes/tasks.tsx` — remove the "Press Enter after typing (submit)" checkbox and the draft field; the fill view now reads "· runs interactively".
- `src/shared/types.ts`, `src/main/config-schema.ts` — `promptFlags` docs updated to `--prompt` only.
- Tests updated to match. `ActionTemplate.submit` (a separate keystroke-path feature, unrelated to tasks) is left untouched.

## Impact

Tasks and agent-bound actions now keep their terminal tab open after the prompt runs. The opaque (non-`promptFlags`) keystroke path is unchanged — it still types the prompt and presses Enter.

## Watchpoints

Pre-existing `task.json` files keep working (the stale `submit` key is ignored). A separate agedum `--run` issue remains under investigation and is unrelated to this UI change.