### PR TITLE
Add per-minute timestamp markers to transcript logs

### DIFF
--- a/src/main/osc-transcript.test.ts
+++ b/src/main/osc-transcript.test.ts
@@ -99,3 +99,67 @@ describe('OscTranscriptExtractor', () => {
     term.dispose();
   });
 });
+
+describe('OscTranscriptExtractor timestamp markers', () => {
+  /** Feed one complete `msg` frame with a unique frameId. */
+  function feedMsg(ex: OscTranscriptExtractor, role: string, text: string, id: string): void {
+    ex.feed(packets(id, { v: 1, t: 'msg', role, text }));
+  }
+
+  it('emits no marker for messages within the same minute', () => {
+    const clock = new Date(2026, 4, 30, 20, 15, 0);
+    const ex = new OscTranscriptExtractor(() => clock);
+    feedMsg(ex, 'user', 'hi', 'a');
+    feedMsg(ex, 'assistant', 'hey', 'b');
+    expect(ex.render()).toBe('[user] hi\n\n[assistant] hey');
+  });
+
+  it('never emits a marker before the first message', () => {
+    const ex = new OscTranscriptExtractor(() => new Date(2026, 4, 30, 9, 5, 0));
+    feedMsg(ex, 'user', 'only', 'a');
+    expect(ex.render()).toBe('[user] only');
+  });
+
+  it('inserts a marker when the minute rolls over', () => {
+    let clock = new Date(2026, 4, 30, 20, 15, 30);
+    const ex = new OscTranscriptExtractor(() => clock);
+    feedMsg(ex, 'user', 'first', 'a');
+    clock = new Date(2026, 4, 30, 20, 16, 5);
+    feedMsg(ex, 'assistant', 'second', 'b');
+    expect(ex.render()).toBe('[user] first\n\n<!-- 2026-05-30:20:16 -->\n\n[assistant] second');
+  });
+
+  it('emits exactly one marker per minute even with several messages', () => {
+    let clock = new Date(2026, 4, 30, 20, 15, 0);
+    const ex = new OscTranscriptExtractor(() => clock);
+    feedMsg(ex, 'user', 'm1', 'a');
+    clock = new Date(2026, 4, 30, 20, 16, 0);
+    feedMsg(ex, 'assistant', 'm2', 'b');
+    feedMsg(ex, 'user', 'm3', 'c');
+    expect(ex.render()).toBe(
+      '[user] m1\n\n<!-- 2026-05-30:20:16 -->\n\n[assistant] m2\n\n[user] m3',
+    );
+  });
+
+  it('emits a marker for each successive minute rollover', () => {
+    let clock = new Date(2026, 11, 1, 0, 0, 0);
+    const ex = new OscTranscriptExtractor(() => clock);
+    feedMsg(ex, 'user', 'a', '1');
+    clock = new Date(2026, 11, 1, 0, 1, 0);
+    feedMsg(ex, 'assistant', 'b', '2');
+    clock = new Date(2026, 11, 1, 0, 2, 0);
+    feedMsg(ex, 'assistant', 'c', '3');
+    expect(ex.render()).toBe(
+      '[user] a\n\n<!-- 2026-12-01:00:01 -->\n\n[assistant] b\n\n<!-- 2026-12-01:00:02 -->\n\n[assistant] c',
+    );
+  });
+
+  it('zero-pads month, day, hour, and minute', () => {
+    let clock = new Date(2026, 0, 3, 4, 5, 0);
+    const ex = new OscTranscriptExtractor(() => clock);
+    feedMsg(ex, 'user', 'x', 'a');
+    clock = new Date(2026, 0, 3, 4, 6, 0);
+    feedMsg(ex, 'assistant', 'y', 'b');
+    expect(ex.render()).toContain('<!-- 2026-01-03:04:06 -->');
+  });
+});

--- a/src/main/osc-transcript.ts
+++ b/src/main/osc-transcript.ts
@@ -52,6 +52,17 @@ export class OscTranscriptExtractor {
   private pieces = new Map<string, { n: number; got: Map<number, string> }>();
   private lines: string[] = [];
   private captured = false;
+  /** `YYYY-MM-DD:HH:MM` of the last minute a message landed in. A timestamp
+   * marker line is pushed only when a later message falls in a different
+   * minute, so the body is time-anchored without one marker per write. The
+   * first message just seeds this without emitting a marker. */
+  private lastMinute: string | null = null;
+
+  /**
+   * @param now Clock used to stamp timestamp markers between messages.
+   *   Injectable so tests can drive minute rollover deterministically.
+   */
+  constructor(private readonly now: () => Date = () => new Date()) {}
 
   /** Feed a raw pty chunk. Returns the chunk with our OSC sequences stripped,
    * for the caller to forward to the grid renderer. Incomplete sequences are
@@ -125,12 +136,27 @@ export class OscTranscriptExtractor {
   private applyFrame(frame: TranscriptFrame): void {
     if (frame.t === 'msg' && typeof frame.text === 'string') {
       this.captured = true;
+      this.maybePushTimestampMarker();
       const who =
         frame.role === 'user' ? 'user' : frame.role === 'reasoning' ? 'reasoning' : 'assistant';
       this.lines.push(`[${who}] ${frame.text}`);
     } else if (frame.t === 'end') {
       this.captured = true;
     }
+  }
+
+  /** Push a `<!-- YYYY-MM-DD:HH:MM -->` marker line before the next message when
+   * the wall-clock minute has rolled over since the previous one. The first
+   * message only seeds the minute (no marker — the log header already records
+   * the session start time). The HTML-comment form stays invisible when the
+   * `.txt` is viewed as rendered markdown and is trivially skippable by a
+   * parser; local time matches the log filename's `HHMMSS`. */
+  private maybePushTimestampMarker(): void {
+    const minute = formatMinute(this.now());
+    if (this.lastMinute !== null && minute !== this.lastMinute) {
+      this.lines.push(`<!-- ${minute} -->`);
+    }
+    this.lastMinute = minute;
   }
 
   /** True once any protocol frame has been decoded — the caller should then
@@ -143,6 +169,16 @@ export class OscTranscriptExtractor {
   render(): string {
     return this.lines.join('\n\n');
   }
+}
+
+/** Format a local-time `Date` as `YYYY-MM-DD:HH:MM` for a timestamp marker. */
+function formatMinute(when: Date): string {
+  const yyyy = String(when.getFullYear());
+  const mm = String(when.getMonth() + 1).padStart(2, '0');
+  const dd = String(when.getDate()).padStart(2, '0');
+  const hh = String(when.getHours()).padStart(2, '0');
+  const mi = String(when.getMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}:${hh}:${mi}`;
 }
 
 /** Length of the longest suffix of `buf` that is a proper prefix of the marker


### PR DESCRIPTION
## Summary

Insert per-minute timestamp markers into the in-band transcript body so a reader (and the future terminal-monitor) can anchor when each message arrived. Part of making `condash logs` readable + time-anchored across harnesses; the companion agedum PR makes Claude sessions emit a transcript so they benefit from this here.

## Changes

- `OscTranscriptExtractor` now takes an injectable `now: () => Date` clock and pushes a `<!-- YYYY-MM-DD:HH:MM -->` marker line before a message whenever the wall-clock minute has rolled over since the previous one. The first message only seeds the minute (no marker — the log header already records the session start). Local time, matching the `.txt` filename's `HHMMSS`.
- Markers live on the **transcript** path only (append-only, one frame = one timed event); the grid snapshot is a repaint with no per-write boundary and is unchanged.
- `docs/reference/cli.md`: note the marker lines on `transcript` bodies.

## Impact

- Pays down the deferred "rendered `.txt` not safely re-segmentable" note from the logs-cli-completeness work: a per-minute marker gives the terminal-monitor reliable "summarize what's new since T" split points.
- The HTML-comment form is invisible in rendered markdown and trivially skippable by a parser.

## Tests

- +6 unit tests (no-marker within a minute, never before first message, rollover insertion, one-per-minute, successive rollovers, zero-padding). Full unit suite green (725).