### PR TITLE
Harmonize modal widths and keep popups clear of the terminal

### DIFF
--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -126,6 +126,13 @@ The terminal pane loads `@xterm/addon-image` (`src/renderer/xterm-mount.ts`) to 
 
 The renderer CSP (`src/renderer/index.html`) therefore carries `'wasm-unsafe-eval'` in `script-src`. That CSP3 keyword permits WebAssembly compilation **only** — it does not re-enable JS `eval` / `new Function`, so it is strictly narrower than `'unsafe-eval'`. Keep it; a CSP audit that strips it re-breaks every inline-image-emitting CLI.
 
+### 10. Modal sizing tiers + the terminal-aware backdrop
+
+Every modal shares the `.modal` / `.modal-backdrop` chrome in `src/renderer/modal-base.css` and maps its width onto one of three tokens — `--modal-w-sm` (dialogs), `--modal-w-md` (forms/tools), `--modal-w-lg` (content viewers) — declared once in that file. Two cascade rules make this work:
+
+- The base size **defaults** live in `:where(.modal) { width; max-height }`, **not** `.modal { … }`. Each per-modal stylesheet (`note-modal.css`, `tasks-pane.css`, …) is imported by its own component, so it is bundled *before* `modal-base.css`; a plain `.modal { width }` at equal specificity would win by source order and pin every popup to one width. `:where()` has zero specificity, so each `.<name>-modal { width: var(--modal-w-*) }` (one class) always wins regardless of bundle order. Set per-modal sizes with a single-class selector and never add `width` back to bare `.modal`.
+- The backdrop stops at the top of the terminal pane instead of covering the whole window: `.modal-backdrop` uses `bottom: var(--terminal-pane-height, 0px)`, and `TerminalPane` (`src/renderer/terminal-pane.tsx`) publishes its own rendered height to that custom property from a `ResizeObserver` (covering open/close, resize-drag, split, window-resize uniformly). The terminal stays visible and usable while any popup — Settings included — is open.
+
 ## Environment hygiene { #environment-hygiene }
 
 condash spawns subprocesses (terminals, runners, `force_stop` commands, open-with launchers). The main process scrubs the environment before each spawn to avoid leaking interpreter-specific vars into unrelated child programs:

--- a/src/renderer/about-modal.css
+++ b/src/renderer/about-modal.css
@@ -3,8 +3,7 @@
  * to the upstream repo. Same modal shell vocabulary as the help / search
  * modals; just a leaner body. */
 .about-modal {
-  width: 360px;
-  max-width: calc(100vw - 32px);
+  width: var(--modal-w-sm);
 }
 
 .about-modal-body {

--- a/src/renderer/confirm-modal.css
+++ b/src/renderer/confirm-modal.css
@@ -2,7 +2,7 @@
  * language of the quit-confirm but lives in its own component so callers
  * can pass arbitrary body content. */
 .confirm-modal {
-  width: min(460px, 90vw);
+  width: var(--modal-w-sm);
 }
 
 .confirm-body {

--- a/src/renderer/html-modal.css
+++ b/src/renderer/html-modal.css
@@ -1,7 +1,7 @@
 /* ---- HTML preview modal ------------------------------------------------ */
 
 .html-modal {
-  width: min(1100px, 100%);
+  width: var(--modal-w-lg);
   height: 100%;
 }
 

--- a/src/renderer/logs-modal.css
+++ b/src/renderer/logs-modal.css
@@ -3,7 +3,7 @@
  * the log viewer (search row, virtualised transcript). */
 
 .logs-modal {
-  width: min(1400px, 96vw);
+  width: var(--modal-w-lg);
   height: 90vh;
   max-height: 90vh;
   display: flex;

--- a/src/renderer/modal-base.css
+++ b/src/renderer/modal-base.css
@@ -5,9 +5,29 @@
  * may override individual rules (e.g. `.note-modal { width: … }`).
  */
 
+/* Shared modal width scale. Every modal maps its width onto one of these three
+ * tiers instead of carrying a bespoke pixel value, so popups take generous,
+ * harmonized horizontal space:
+ *   sm — compact dialogs (confirm / about / quit / prompt)
+ *   md — forms + tools    (tasks / search / shortcuts / help / new-project)
+ *   lg — content viewers  (note / project card / html / pdf / logs)
+ * Settings keeps its own full-bleed width. */
+:root {
+  --modal-w-sm: min(520px, 92vw);
+  --modal-w-md: min(1040px, 92vw);
+  --modal-w-lg: min(88vw, 1680px);
+}
+
 .modal-backdrop {
   position: fixed;
-  inset: 0;
+  /* Stop the backdrop at the top of the terminal pane (its measured height is
+   * published as --terminal-pane-height by TerminalPane) so a popup never
+   * overlays the terminal — it stays visible and usable while a modal is open.
+   * Falls back to a full-height overlay when the variable is unset. */
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: var(--terminal-pane-height, 0px);
   background: rgba(0, 0, 0, 0.45);
   display: flex;
   align-items: center;
@@ -23,6 +43,14 @@
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.32);
   display: flex;
   flex-direction: column;
+}
+
+/* Size defaults at zero specificity (`:where`) so each modal's own
+ * `.<name> { width / max-height }` always wins. The per-modal stylesheets are
+ * bundled *before* modal-base.css, so a plain `.modal { width }` at equal
+ * specificity would otherwise clobber every per-modal width — which is exactly
+ * what pinned every popup to 1100px regardless of its intended size. */
+:where(.modal) {
   width: min(1100px, 100%);
   max-height: 100%;
 }
@@ -274,5 +302,5 @@
 }
 
 .help-modal {
-  width: min(800px, 92vw);
+  width: var(--modal-w-md);
 }

--- a/src/renderer/new-project-modal.css
+++ b/src/renderer/new-project-modal.css
@@ -1,7 +1,7 @@
 /* "+ New project" modal — minimal-info form. Title + Kind + Status,
  * with live-derived slug preview and incident-only extras. */
 .new-project-modal {
-  width: min(560px, 100%);
+  width: var(--modal-w-md);
 }
 
 .new-project-body {

--- a/src/renderer/note-modal.css
+++ b/src/renderer/note-modal.css
@@ -5,7 +5,7 @@
  */
 
 .note-modal {
-  width: min(85vw, 1600px);
+  width: var(--modal-w-lg);
   height: auto;
   max-height: calc(100% - 48px);
 }

--- a/src/renderer/panes/tasks-pane.css
+++ b/src/renderer/panes/tasks-pane.css
@@ -192,17 +192,39 @@
  * one the .tasks-editor block is flush — no margin/border/own background. */
 .tasks-editor-modal,
 .tasks-fill-modal {
-  width: min(720px, 100%);
+  width: var(--modal-w-md);
   max-height: 100%;
-  overflow: auto;
 }
 
+/* Header / scrolling-body / pinned-footer column. The middle (fields + a
+ * possibly long prompt preview) scrolls inside the popup so the modal never
+ * grows past the visible area and the Run / Save action row stays on screen. */
 .tasks-editor-modal .tasks-editor,
 .tasks-fill-modal .tasks-editor {
   margin: 0;
   border: none;
   border-radius: 0;
   background: transparent;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  max-height: 100%;
+}
+
+.tasks-editor > header,
+.tasks-editor-actions {
+  flex-shrink: 0;
+}
+
+.tasks-fill-scroll,
+.tasks-editor-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  /* Nudge the scroll edges off the pinned header/footer without clipping
+   * focus rings on the fields inside. */
+  padding: 0.1rem;
+  margin: 0 -0.1rem;
 }
 
 /* Push Delete to the right edge of the editor's action row. */

--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -384,63 +384,65 @@ function TaskFill(props: {
               Close
             </button>
           </header>
-          <p class="tasks-editor-note">
-            Agent: <code>{props.fill().def.agent}</code>
-            {' · runs interactively'}
-          </p>
+          <div class="tasks-fill-scroll">
+            <p class="tasks-editor-note">
+              Agent: <code>{props.fill().def.agent}</code>
+              {' · runs interactively'}
+            </p>
 
-          <Show when={needsApp()}>
-            <label>
-              <span>App {'{APP}'}</span>
-              <select
-                value={props.fill().app?.alias ?? ''}
-                onChange={(e) => {
-                  const alias = e.currentTarget.value;
-                  const app = props.apps().find((a) => a.alias === alias) ?? null;
-                  props.setFill({ ...props.fill(), app });
-                }}
-              >
-                <option value="">(pick an app)</option>
-                <For each={props.apps()}>{(a) => <option value={a.alias}>{a.alias}</option>}</For>
-              </select>
-            </label>
-          </Show>
-
-          <Show when={needsProject()}>
-            <label>
-              <span>Project {'{PROJECT}'}</span>
-              <select
-                value={props.fill().project?.slug ?? ''}
-                onChange={(e) => {
-                  const slug = e.currentTarget.value;
-                  const project = props.projects().find((p) => p.slug === slug) ?? null;
-                  props.setFill({ ...props.fill(), project });
-                }}
-              >
-                <option value="">(pick a project)</option>
-                <For each={props.projects()}>
-                  {(p) => <option value={p.slug}>{p.title || p.slug}</option>}
-                </For>
-              </select>
-            </label>
-          </Show>
-
-          <For each={textMarkers()}>
-            {(marker) => (
+            <Show when={needsApp()}>
               <label>
-                <span>{`{${marker.key}}`}</span>
-                <input
-                  type="text"
-                  value={props.fill().fields[marker.key] ?? ''}
-                  onInput={(e) => setField(marker.key, e.currentTarget.value)}
-                />
+                <span>App {'{APP}'}</span>
+                <select
+                  value={props.fill().app?.alias ?? ''}
+                  onChange={(e) => {
+                    const alias = e.currentTarget.value;
+                    const app = props.apps().find((a) => a.alias === alias) ?? null;
+                    props.setFill({ ...props.fill(), app });
+                  }}
+                >
+                  <option value="">(pick an app)</option>
+                  <For each={props.apps()}>{(a) => <option value={a.alias}>{a.alias}</option>}</For>
+                </select>
               </label>
-            )}
-          </For>
+            </Show>
 
-          <div class="tasks-config-view tasks-preview">
-            <span class="tasks-preview-label">Prompt to run:</span>
-            <pre>{preview()}</pre>
+            <Show when={needsProject()}>
+              <label>
+                <span>Project {'{PROJECT}'}</span>
+                <select
+                  value={props.fill().project?.slug ?? ''}
+                  onChange={(e) => {
+                    const slug = e.currentTarget.value;
+                    const project = props.projects().find((p) => p.slug === slug) ?? null;
+                    props.setFill({ ...props.fill(), project });
+                  }}
+                >
+                  <option value="">(pick a project)</option>
+                  <For each={props.projects()}>
+                    {(p) => <option value={p.slug}>{p.title || p.slug}</option>}
+                  </For>
+                </select>
+              </label>
+            </Show>
+
+            <For each={textMarkers()}>
+              {(marker) => (
+                <label>
+                  <span>{`{${marker.key}}`}</span>
+                  <input
+                    type="text"
+                    value={props.fill().fields[marker.key] ?? ''}
+                    onInput={(e) => setField(marker.key, e.currentTarget.value)}
+                  />
+                </label>
+              )}
+            </For>
+
+            <div class="tasks-config-view tasks-preview">
+              <span class="tasks-preview-label">Prompt to run:</span>
+              <pre>{preview()}</pre>
+            </div>
           </div>
 
           <div class="tasks-editor-actions">
@@ -530,65 +532,67 @@ function TaskEditor(props: {
             <h3>{d().editingSlug ? `Edit ${d().editingSlug}` : 'New task'}</h3>
           </header>
 
-          <label>
-            <span>Name</span>
-            <input type="text" value={d().name} onInput={(e) => onName(e.currentTarget.value)} />
-          </label>
+          <div class="tasks-editor-scroll">
+            <label>
+              <span>Name</span>
+              <input type="text" value={d().name} onInput={(e) => onName(e.currentTarget.value)} />
+            </label>
 
-          <label>
-            <span>Slug (directory under tasks/)</span>
-            <input
-              type="text"
-              value={d().slug}
-              placeholder="refresh-app-docs"
-              onInput={(e) => props.patch({ slug: e.currentTarget.value, slugDirty: true })}
-            />
-          </label>
+            <label>
+              <span>Slug (directory under tasks/)</span>
+              <input
+                type="text"
+                value={d().slug}
+                placeholder="refresh-app-docs"
+                onInput={(e) => props.patch({ slug: e.currentTarget.value, slugDirty: true })}
+              />
+            </label>
 
-          <label>
-            <span>Agent</span>
-            <select
-              value={d().agent}
-              onChange={(e) => props.patch({ agent: e.currentTarget.value })}
-            >
-              <Switch>
-                <Match when={agentOptions().length === 0}>
-                  <option value="">(no agents defined)</option>
-                </Match>
-                <Match when={agentOptions().length > 0}>
-                  <For each={agentOptions()}>
-                    {(o) => (
-                      // Only prompt-seedable agents can carry a task prompt. Show
-                      // the rest disabled (kept visible for context), except the
-                      // current selection, which must stay selectable so the bound
-                      // value never lands on a disabled option.
-                      <option value={o.id} disabled={!o.promptFlags && o.id !== d().agent}>
-                        {o.promptFlags ? o.label : `${o.label} — no prompt seeding`}
-                      </option>
-                    )}
-                  </For>
-                </Match>
-              </Switch>
-            </select>
-          </label>
+            <label>
+              <span>Agent</span>
+              <select
+                value={d().agent}
+                onChange={(e) => props.patch({ agent: e.currentTarget.value })}
+              >
+                <Switch>
+                  <Match when={agentOptions().length === 0}>
+                    <option value="">(no agents defined)</option>
+                  </Match>
+                  <Match when={agentOptions().length > 0}>
+                    <For each={agentOptions()}>
+                      {(o) => (
+                        // Only prompt-seedable agents can carry a task prompt. Show
+                        // the rest disabled (kept visible for context), except the
+                        // current selection, which must stay selectable so the bound
+                        // value never lands on a disabled option.
+                        <option value={o.id} disabled={!o.promptFlags && o.id !== d().agent}>
+                          {o.promptFlags ? o.label : `${o.label} — no prompt seeding`}
+                        </option>
+                      )}
+                    </For>
+                  </Match>
+                </Switch>
+              </select>
+            </label>
 
-          <label>
-            <span>Prompt (markdown with {'{MARKERS}'})</span>
-            <textarea
-              class="tasks-prompt-textarea"
-              spellcheck={false}
-              value={d().prompt}
-              placeholder={'Review {APP} and update its docs. Focus: {AREA:CLAUDE.md and docs/}'}
-              onInput={(e) => props.patch({ prompt: e.currentTarget.value })}
-            />
-          </label>
+            <label>
+              <span>Prompt (markdown with {'{MARKERS}'})</span>
+              <textarea
+                class="tasks-prompt-textarea"
+                spellcheck={false}
+                value={d().prompt}
+                placeholder={'Review {APP} and update its docs. Focus: {AREA:CLAUDE.md and docs/}'}
+                onInput={(e) => props.patch({ prompt: e.currentTarget.value })}
+              />
+            </label>
 
-          <Show when={markers().length > 0}>
-            <div class="tasks-markers tasks-editor-markers">
-              <span class="tasks-preview-label">Markers:</span>
-              <For each={markers()}>{(marker) => <MarkerChip marker={marker} />}</For>
-            </div>
-          </Show>
+            <Show when={markers().length > 0}>
+              <div class="tasks-markers tasks-editor-markers">
+                <span class="tasks-preview-label">Markers:</span>
+                <For each={markers()}>{(marker) => <MarkerChip marker={marker} />}</For>
+              </div>
+            </Show>
+          </div>
 
           <div class="tasks-editor-actions">
             <button type="button" onClick={props.onSave}>

--- a/src/renderer/pdf-modal.css
+++ b/src/renderer/pdf-modal.css
@@ -1,7 +1,7 @@
 /* ---- PDF modal --------------------------------------------------------- */
 
 .pdf-modal {
-  width: min(1100px, 100%);
+  width: var(--modal-w-lg);
   height: 100%;
 }
 

--- a/src/renderer/project-preview.css
+++ b/src/renderer/project-preview.css
@@ -1,5 +1,5 @@
 .project-preview {
-  width: min(85vw, 1600px);
+  width: var(--modal-w-lg);
   max-height: min(85vh, 900px);
 }
 

--- a/src/renderer/prompt-modal.css
+++ b/src/renderer/prompt-modal.css
@@ -1,7 +1,7 @@
 /* ---- Prompt modal ------------------------------------------------------ */
 
 .prompt-modal {
-  width: min(480px, 100%);
+  width: var(--modal-w-sm);
 }
 
 .prompt-body {

--- a/src/renderer/quit-confirm-modal.css
+++ b/src/renderer/quit-confirm-modal.css
@@ -1,7 +1,7 @@
 /* ---- Quit-confirm modal ------------------------------------------------ */
 
 .quit-confirm-modal {
-  width: min(420px, 90vw);
+  width: var(--modal-w-sm);
 }
 
 .quit-confirm-body {

--- a/src/renderer/search-modal.css
+++ b/src/renderer/search-modal.css
@@ -10,7 +10,7 @@
 }
 
 .search-modal {
-  width: min(820px, 92vw);
+  width: var(--modal-w-md);
   max-height: 82vh;
   display: flex;
   flex-direction: column;

--- a/src/renderer/shortcuts-overlay.css
+++ b/src/renderer/shortcuts-overlay.css
@@ -2,7 +2,7 @@
  * each group rendered as a <dl> so screen readers get the keys/labels
  * paired up. <kbd> is styled to look like a soft chip. */
 .shortcuts-overlay {
-  width: min(640px, 92vw);
+  width: var(--modal-w-md);
 }
 
 .shortcuts-grid {

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -522,6 +522,32 @@ export function TerminalPane(props: {
   onMount(() => window.addEventListener('resize', resize.onWindowResize));
   onCleanup(() => window.removeEventListener('resize', resize.onWindowResize));
 
+  // Publish the pane's rendered height as a CSS variable so modal backdrops can
+  // stop just above the terminal (it stays visible + usable while a popup is
+  // open). A ResizeObserver covers every height change uniformly: open / close,
+  // resize-drag, split, and window resize.
+  let paneSection: HTMLElement | undefined;
+  const publishPaneHeight = (height: number): void => {
+    document.documentElement.style.setProperty('--terminal-pane-height', `${Math.round(height)}px`);
+  };
+  onMount(() => {
+    if (!paneSection) return;
+    publishPaneHeight(paneSection.getBoundingClientRect().height);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      const box = entry?.borderBoxSize?.[0];
+      publishPaneHeight(
+        box ? box.blockSize : (entry?.target as HTMLElement).getBoundingClientRect().height,
+      );
+    });
+    observer.observe(paneSection);
+    onCleanup(() => {
+      observer.disconnect();
+      // Drop the gap if the pane ever unmounts so a later layout isn't clipped.
+      document.documentElement.style.setProperty('--terminal-pane-height', '0px');
+    });
+  });
+
   createEffect(() => {
     void activeIds();
     void activeColumn();
@@ -665,6 +691,7 @@ export function TerminalPane(props: {
       class="terminal-pane"
       classList={{ closed: !props.open }}
       style={{ height: `${paneHeight()}px` }}
+      ref={(el) => (paneSection = el)}
     >
       <Show when={props.open}>
         <div


### PR DESCRIPTION
## Summary

- Every popup now maps onto a shared three-tier width scale (sm / md / lg) instead of ad-hoc per-modal widths, and no popup overlays the terminal pane.
- Fixes a latent cascade bug that pinned every modal to 1100px regardless of its own intended width.
- The task Run popup's long prompt preview now scrolls inside the modal with the Run button always reachable.

## Changes

- `modal-base.css`: add `--modal-w-sm/md/lg` width tokens; move the base `width`/`max-height` into `:where(.modal)` (zero specificity) so each per-modal width wins regardless of bundle order; clip `.modal-backdrop` above the terminal via `bottom: var(--terminal-pane-height)`.
- Migrate every modal stylesheet onto the tokens (confirm, about, quit, prompt, new-project, tasks, search, logs, shortcuts, help, html, pdf, note, project-preview).
- `terminal-pane.tsx`: publish the pane's rendered height as `--terminal-pane-height` from a ResizeObserver (covers open/close, resize, split, window-resize).
- `tasks.tsx` + `tasks-pane.css`: header / scrolling-body / pinned-footer layout for the run + editor popups so a long preview scrolls and Run/Save stays on screen.
- `docs/explanation/internals.md`: document the modal sizing tiers + the terminal-aware backdrop.

## Impact

- Each modal changes width to its tier: compact dialogs shrink to ~520px; content viewers (notes, project card, html, pdf) now reach 88vw on wide screens instead of being capped at 1100px.
- The dimmed backdrop no longer covers the terminal pane for any popup, Settings included — the terminal stays visible and usable while a modal is open.