### PR TITLE
Tasks: pick agent at run time, top run controls, resize-safe popups

### DIFF
--- a/docs/guides/tasks-pane.md
+++ b/docs/guides/tasks-pane.md
@@ -57,11 +57,12 @@ The app picker lists your configured [repositories](repositories-and-open-with.m
 A task card carries a single **Run…** button — clicking it opens the **run popup**:
 
 1. Open the **Tasks** handle and click **Run…** on a task card.
-2. Fill the markers — pick an app / project where prompted, edit the text fields (prefilled from defaults).
-3. The **Prompt to run** box previews the substituted text live.
-4. Click **Run**. condash spawns the task's agent in a fresh terminal tab (working directory = the conception root) and delivers the filled prompt: typed into the tab (then Enter when **submit** is on) for an opaque agent, or passed in argv (`--run` when **submit** is on, else `--prompt`) when the agent has **promptFlags** set.
+2. At the top, the **Agent** select defaults to the task's stored agent — leave it, or switch it to run this one time with a different agent (only prompt-seedable agents are selectable). The **Run** button sits beside it.
+3. Fill the markers below — pick an app / project where prompted, edit the text fields (prefilled from defaults).
+4. The **Prompt to run** box previews the substituted text live.
+5. Click **Run**. condash spawns the chosen agent in a fresh terminal tab (working directory = the conception root), names the tab **`<agent>•<task name>`** so a running task is identifiable at a glance, and delivers the filled prompt: typed into the tab (then Enter when **submit** is on) for an opaque agent, or passed in argv (`--prompt`) when the agent has **promptFlags** set.
 
-Run is disabled when the task's referenced agent is no longer defined (the card shows a *missing* badge) — click the card to open the editor and pick a current agent.
+Run is disabled when the selected agent is not defined — pick a current one from the top select (a task whose stored agent went missing opens with that dangling id shown as *(missing)*). The card's **Run…** button itself stays disabled while the task's stored agent is missing (the card shows a *missing* badge).
 
 ## Create or edit a task
 

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -525,7 +525,9 @@ function App() {
                           projects={() => projects() ?? []}
                           apps={appOptions}
                           flashToast={flashToast}
-                          onRun={(agentId, text) => void bridge.runTask(agentId, text)}
+                          onRun={(agentId, text, taskName) =>
+                            void bridge.runTask(agentId, text, taskName)
+                          }
                         />
                       </Match>
                       <Match when={layout().leftView === 'projects'}>

--- a/src/renderer/modal-helpers.ts
+++ b/src/renderer/modal-helpers.ts
@@ -26,3 +26,29 @@ export function useModalEscHandler(onClose: () => void): void {
   onMount(() => document.addEventListener('keydown', handleKey, true));
   onCleanup(() => document.removeEventListener('keydown', handleKey, true));
 }
+
+/**
+ * Backdrop click-to-close handlers that ignore clicks synthesised from a drag
+ * that *began* inside the modal. Dragging a textarea's resize grip past the
+ * modal edge releases the pointer over the backdrop; the browser then fires a
+ * `click` on the nearest common ancestor of the press and release targets — the
+ * backdrop — which a naive `onClick={onClose}` reads as a dismiss. Recording
+ * whether the press landed on the backdrop and only closing when both the press
+ * and the click target are the backdrop itself rejects those drag-out clicks.
+ *
+ * Spread the returned handlers onto the `.modal-backdrop` element.
+ */
+export function createBackdropClose(onClose: () => void): {
+  onMouseDown: (e: MouseEvent) => void;
+  onClick: (e: MouseEvent) => void;
+} {
+  let pressedOnBackdrop = false;
+  return {
+    onMouseDown: (e) => {
+      pressedOnBackdrop = e.target === e.currentTarget;
+    },
+    onClick: (e) => {
+      if (pressedOnBackdrop && e.target === e.currentTarget) onClose();
+    },
+  };
+}

--- a/src/renderer/panes/tasks-pane.css
+++ b/src/renderer/panes/tasks-pane.css
@@ -212,8 +212,28 @@
 }
 
 .tasks-editor > header,
+.tasks-fill-top,
 .tasks-editor-actions {
   flex-shrink: 0;
+}
+
+/* Run popup top control row: agent picker (grows) + Run button (pinned right),
+ * sitting above the variable settings and the prompt preview. */
+.tasks-fill-top {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+
+.tasks-fill-top label {
+  flex: 1 1 auto;
+  margin-bottom: 0;
+}
+
+.tasks-fill-top .tasks-fill-run {
+  flex: 0 0 auto;
+  padding: 0.3rem 1.1rem;
 }
 
 .tasks-fill-scroll,
@@ -286,7 +306,9 @@
 .tasks-prompt-textarea {
   font-family: var(--font-mono);
   font-size: 0.8rem;
-  min-height: 7rem;
+  /* Taller default so a multi-paragraph prompt is comfortable to edit; the
+   * modal caps at the viewport and the body scrolls, so it still fits. */
+  min-height: 12rem;
   resize: vertical;
   width: 100%;
   box-sizing: border-box;

--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -14,6 +14,7 @@ import {
 import { substitute } from '@shared/action-template';
 import { isValidSlugTail, slugify } from '@shared/slug';
 import { ConfirmModal } from '../confirm-modal';
+import { createBackdropClose } from '../modal-helpers';
 import './tasks-pane.css';
 
 /** One app the `{APP}` picker can select. `alias` is the `#<name>` form. */
@@ -38,10 +39,13 @@ interface Draft {
 
 /** Fill state: the read task plus the picker selections and per-marker field
  *  values that feed substitution. `fields` holds only the plain (non-reserved)
- *  markers — the `{APP_*}` / `{PROJECT_*}` families come from the pickers. */
+ *  markers — the `{APP_*}` / `{PROJECT_*}` families come from the pickers.
+ *  `agent` is the run-time agent id, seeded from the task's stored `def.agent`
+ *  but overridable in the run popup. */
 interface FillState {
   slug: string;
   def: TaskDef;
+  agent: string;
   app: AppOption | null;
   project: Project | null;
   fields: Record<string, string>;
@@ -86,13 +90,11 @@ export function TasksView(props: {
   apps: () => readonly AppOption[];
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
   /** Run a filled task: spawn the agent (by id) and deliver the substituted
-   *  prompt. Always launches interactively. */
-  onRun: (agentId: string, text: string) => void;
+   *  prompt. `taskName` titles the spawned tab. Always launches interactively. */
+  onRun: (agentId: string, text: string, taskName: string) => void;
 }): JSX.Element {
   const [draft, setDraft] = createSignal<Draft | null>(null);
   const [fill, setFill] = createSignal<FillState | null>(null);
-
-  const agentExists = (id: string): boolean => props.agents().some((a) => a.id === id);
 
   const patch = (p: Partial<Draft>): void => {
     setDraft((d) => (d ? { ...d, ...p } : d));
@@ -132,7 +134,7 @@ export function TasksView(props: {
       if (isAppToken(marker.key) || isProjectToken(marker.key)) continue;
       fields[marker.key] = marker.default;
     }
-    setFill({ slug, def, app: null, project: null, fields });
+    setFill({ slug, def, agent: def.agent, app: null, project: null, fields });
   };
 
   const save = async (): Promise<void> => {
@@ -264,10 +266,10 @@ export function TasksView(props: {
           <TaskFill
             fill={f}
             setFill={setFill}
+            agents={props.agents}
             apps={props.apps}
             projects={props.projects}
             conceptionPath={props.conceptionPath}
-            agentExists={agentExists}
             onRun={props.onRun}
           />
         )}
@@ -317,16 +319,18 @@ function MarkerChip(props: { marker: Marker }): JSX.Element {
   );
 }
 
-/** Fill view — one input per plain marker plus app / project pickers for the
- *  reserved families, a live preview of the substituted prompt, and Run. */
+/** Fill view — a top control row (agent picker + Run) above the variable
+ *  settings (app / project pickers + one input per plain marker), with a live
+ *  preview of the substituted prompt at the bottom. The agent defaults to the
+ *  task's stored agent but can be overridden here at run time. */
 function TaskFill(props: {
   fill: () => FillState;
   setFill: (next: FillState | null) => void;
+  agents: () => readonly Agent[];
   apps: () => readonly AppOption[];
   projects: () => readonly Project[];
   conceptionPath: () => string | null;
-  agentExists: (name: string) => boolean;
-  onRun: (agentName: string, text: string) => void;
+  onRun: (agentId: string, text: string, taskName: string) => void;
 }): JSX.Element {
   const markers = createMemo(() => extractMarkers(props.fill().def.prompt));
   const textMarkers = createMemo(() =>
@@ -336,6 +340,7 @@ function TaskFill(props: {
   const needsProject = createMemo(() => markers().some((m) => isProjectToken(m.key)));
 
   const close = (): void => props.setFill(null);
+  const backdrop = createBackdropClose(close);
 
   // Esc closes the run popup.
   const handleKey = (event: KeyboardEvent): void => {
@@ -346,6 +351,20 @@ function TaskFill(props: {
   };
   onMount(() => document.addEventListener('keydown', handleKey, true));
   onCleanup(() => document.removeEventListener('keydown', handleKey, true));
+
+  // Run-time agent choices, keyed by id like the editor: only prompt-seedable
+  // agents are selectable (a task hands its prompt via `--prompt`), with the
+  // current selection kept selectable even if it dangles.
+  const agentOptions = createMemo(() => {
+    const opts = props
+      .agents()
+      .map((a) => ({ id: a.id, label: a.label, promptFlags: a.promptFlags === true }));
+    const current = props.fill().agent;
+    if (current && !opts.some((o) => o.id === current)) {
+      return [{ id: current, label: `${current} (missing)`, promptFlags: false }, ...opts];
+    }
+    return opts;
+  });
 
   const setField = (key: string, value: string): void => {
     const f = props.fill();
@@ -360,16 +379,16 @@ function TaskFill(props: {
 
   const preview = createMemo(() => substitute(props.fill().def.prompt, ctx()));
 
-  const agentOk = createMemo(() => props.agentExists(props.fill().def.agent));
+  const agentOk = createMemo(() => props.agents().some((a) => a.id === props.fill().agent));
 
   const run = (): void => {
     const f = props.fill();
-    props.onRun(f.def.agent, substitute(f.def.prompt, ctx()));
+    props.onRun(f.agent, substitute(f.def.prompt, ctx()), f.def.name);
     close();
   };
 
   return (
-    <div class="modal-backdrop" onClick={close}>
+    <div class="modal-backdrop" onMouseDown={backdrop.onMouseDown} onClick={backdrop.onClick}>
       <div
         class="modal tasks-fill-modal"
         role="dialog"
@@ -384,12 +403,51 @@ function TaskFill(props: {
               Close
             </button>
           </header>
-          <div class="tasks-fill-scroll">
-            <p class="tasks-editor-note">
-              Agent: <code>{props.fill().def.agent}</code>
-              {' · runs interactively'}
-            </p>
 
+          {/* Top control row: pick the agent and run, above the variable
+              settings. The prompt preview stays at the bottom. */}
+          <div class="tasks-fill-top">
+            <label>
+              <span>Agent</span>
+              <select
+                value={props.fill().agent}
+                onChange={(e) => props.setFill({ ...props.fill(), agent: e.currentTarget.value })}
+              >
+                <Switch>
+                  <Match when={agentOptions().length === 0}>
+                    <option value="">(no agents defined)</option>
+                  </Match>
+                  <Match when={agentOptions().length > 0}>
+                    <For each={agentOptions()}>
+                      {(o) => (
+                        <option
+                          value={o.id}
+                          disabled={!o.promptFlags && o.id !== props.fill().agent}
+                        >
+                          {o.promptFlags ? o.label : `${o.label} — no prompt seeding`}
+                        </option>
+                      )}
+                    </For>
+                  </Match>
+                </Switch>
+              </select>
+            </label>
+            <button
+              type="button"
+              class="tasks-run tasks-fill-run"
+              disabled={!agentOk()}
+              title={
+                agentOk()
+                  ? 'Spawn the agent and run interactively'
+                  : `Agent ${props.fill().agent} is not defined`
+              }
+              onClick={run}
+            >
+              Run
+            </button>
+          </div>
+
+          <div class="tasks-fill-scroll">
             <Show when={needsApp()}>
               <label>
                 <span>App {'{APP}'}</span>
@@ -444,25 +502,6 @@ function TaskFill(props: {
               <pre>{preview()}</pre>
             </div>
           </div>
-
-          <div class="tasks-editor-actions">
-            <button
-              type="button"
-              class="tasks-run"
-              disabled={!agentOk()}
-              title={
-                agentOk()
-                  ? 'Spawn the agent and run'
-                  : `Agent ${props.fill().def.agent} is not defined`
-              }
-              onClick={run}
-            >
-              Run
-            </button>
-            <button type="button" onClick={close}>
-              Cancel
-            </button>
-          </div>
         </section>
       </div>
     </div>
@@ -482,6 +521,7 @@ function TaskEditor(props: {
   const d = props.draft;
   const markers = createMemo(() => extractMarkers(d().prompt));
   const [confirmDelete, setConfirmDelete] = createSignal(false);
+  const backdrop = createBackdropClose(props.onCancel);
 
   // Esc closes the editor — but defer to the delete-confirm dialog when it is
   // open (its own handler closes it first).
@@ -519,7 +559,7 @@ function TaskEditor(props: {
   };
 
   return (
-    <div class="modal-backdrop" onClick={props.onCancel}>
+    <div class="modal-backdrop" onMouseDown={backdrop.onMouseDown} onClick={backdrop.onClick}>
       <div
         class="modal tasks-editor-modal"
         role="dialog"

--- a/src/renderer/terminal-bridge.test.ts
+++ b/src/renderer/terminal-bridge.test.ts
@@ -250,10 +250,10 @@ describe('runTask', () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
     const bridge = createTerminalBridge(makeDeps(handle, [kimiAgent]));
-    const promise = bridge.runTask('kimi-cli-native', 'review the docs');
+    const promise = bridge.runTask('kimi-cli-native', 'review the docs', 'Review docs');
     await vi.advanceTimersByTimeAsync(600);
     await promise;
-    expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my');
+    expect(handle.spawnUserShell).toHaveBeenCalledWith(kimiAgent, 'my', 'Kimi native•Review docs');
     expect(handle.typeIntoActive).toHaveBeenCalledWith('review the docs');
     expect(handle.typeIntoActive).toHaveBeenLastCalledWith('\r');
     vi.useRealTimers();
@@ -263,7 +263,7 @@ describe('runTask', () => {
     const handle = makeFakeHandle();
     const deps = makeDeps(handle, [claudeAgent]);
     const bridge = createTerminalBridge(deps);
-    await bridge.runTask('does-not-exist', 'text');
+    await bridge.runTask('does-not-exist', 'text', 'Some task');
     expect(deps.flashToast).toHaveBeenCalledWith(
       expect.stringContaining('Task agent not found'),
       'error',
@@ -278,12 +278,13 @@ describe('runTask with promptFlags agent', () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
     const bridge = createTerminalBridge(makeDeps(handle, [agedumAgent]));
-    const promise = bridge.runTask('agedum-claude', 'review the docs');
+    const promise = bridge.runTask('agedum-claude', 'review the docs', 'Review docs');
     await vi.advanceTimersByTimeAsync(400);
     await promise;
     expect(handle.spawnUserShell).toHaveBeenCalledWith(
       { ...agedumAgent, command: "agedum claude --prompt 'review the docs'" },
       'my',
+      'agedum · claude•Review docs',
     );
     expect(handle.typeIntoActive).not.toHaveBeenCalled();
     vi.useRealTimers();
@@ -293,12 +294,13 @@ describe('runTask with promptFlags agent', () => {
     vi.useFakeTimers();
     const handle = makeFakeHandle();
     const bridge = createTerminalBridge(makeDeps(handle, [agedumAgent]));
-    const promise = bridge.runTask('agedum-claude', "it's a $PATH; rm -rf");
+    const promise = bridge.runTask('agedum-claude', "it's a $PATH; rm -rf", 'Risky run');
     await vi.advanceTimersByTimeAsync(400);
     await promise;
     expect(handle.spawnUserShell).toHaveBeenCalledWith(
       { ...agedumAgent, command: "agedum claude --prompt 'it'\\''s a $PATH; rm -rf'" },
       'my',
+      'agedum · claude•Risky run',
     );
     vi.useRealTimers();
   });

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -49,11 +49,12 @@ export interface TerminalBridge {
    *  shell if needed" dance as `handleWorkOn`. Does not press Enter. */
   handlePasteToTerm: (text: string) => Promise<void>;
   /** Run a Tasks-pane task: spawn a fresh tab running the agent with `agentId`
-   *  and deliver the already-substituted `text`. Tasks always launch
-   *  interactively — a `promptFlags` agent is seeded with `--prompt` (the
-   *  session stays open after the prompt runs); an opaque agent is spawned bare,
-   *  then the prompt is keystroke-injected and submitted once the TUI settles. */
-  runTask: (agentId: string, text: string) => Promise<void>;
+   *  and deliver the already-substituted `text`. The tab title is pinned to
+   *  `<agent label>•<taskName>`. Tasks always launch interactively — a
+   *  `promptFlags` agent is seeded with `--prompt` (the session stays open after
+   *  the prompt runs); an opaque agent is spawned bare, then the prompt is
+   *  keystroke-injected and submitted once the TUI settles. */
+  runTask: (agentId: string, text: string, taskName: string) => Promise<void>;
 }
 
 /** Upper bound on animation frames waited for the pane to mount after
@@ -130,7 +131,10 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
    *  characters or lands in a not-yet-ready REPL. AGENT_SPAWN_SETTLE_MS covers
    *  both. setTimeout (not requestAnimationFrame) so this stays callable in
    *  unit tests (jsdom env has no rAF). */
-  const spawnAgentTab = async (agent: Agent): Promise<TerminalPaneHandle | null> => {
+  const spawnAgentTab = async (
+    agent: Agent,
+    title?: string,
+  ): Promise<TerminalPaneHandle | null> => {
     if (!deps.terminalHandle()) {
       deps.ensureTerminalOpen();
       await waitForTerminalHandle(deps);
@@ -139,7 +143,13 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     if (!handle) return null;
     deps.ensureTerminalOpen();
     try {
-      await handle.spawnUserShell(agent, 'my');
+      // Pass the title only when set so the non-task spawn keeps the agent's
+      // own label (and the 2-arg call shape its callers assert on).
+      if (title === undefined) {
+        await handle.spawnUserShell(agent, 'my');
+      } else {
+        await handle.spawnUserShell(agent, 'my', title);
+      }
     } catch (err) {
       deps.flashToast(`Could not spawn ${agent.label}: ${(err as Error).message}`, 'error');
       return null;
@@ -156,13 +166,18 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
    *  command, let the TUI settle, and keystroke-inject `text` (plus Enter when
    *  `submit`) — the generic path for an opaque agent. `submit` only governs that
    *  keystroke Enter; a `promptFlags` agent is always seeded interactively. */
-  const runAgentTask = async (agent: Agent, text: string, submit: boolean): Promise<void> => {
+  const runAgentTask = async (
+    agent: Agent,
+    text: string,
+    submit: boolean,
+    title?: string,
+  ): Promise<void> => {
     if (agent.promptFlags) {
       const command = `${agent.command} --prompt ${shellSingleQuote(text)}`;
-      await spawnAgentTab({ ...agent, command });
+      await spawnAgentTab({ ...agent, command }, title);
       return;
     }
-    const handle = await spawnAgentTab(agent);
+    const handle = await spawnAgentTab(agent, title);
     if (!handle) return;
     handle.typeIntoActive(text);
     if (submit) {
@@ -291,7 +306,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     handle.typeIntoActive(text);
   };
 
-  const runTask = async (agentId: string, text: string): Promise<void> => {
+  const runTask = async (agentId: string, text: string, taskName: string): Promise<void> => {
     const agent = findAgentById(deps.agents(), agentId);
     if (!agent) {
       deps.flashToast(`Task agent not found: ${agentId}`, 'error');
@@ -299,8 +314,9 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     }
     // Same interactive spawn-and-deliver path as an agent-bound project action.
     // `submit: true` presses Enter on the opaque keystroke path; a promptFlags
-    // agent is seeded with `--prompt` (interactive) regardless.
-    await runAgentTask(agent, text, true);
+    // agent is seeded with `--prompt` (interactive) regardless. The tab is named
+    // `<agent label>•<task title>` so a running task is identifiable at a glance.
+    await runAgentTask(agent, text, true, `${agent.label}•${taskName}`);
   };
 
   return {

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -61,8 +61,10 @@ export interface TerminalPaneHandle {
   spawn(request: TermSpawnRequest, label: string, opts?: SpawnOptions): Promise<string>;
   switchTo(side: TermSide, id?: string): void;
   /** Add a fresh user shell tab to "My terms". `agent` may be an `Agent` to pin
-   *  and run that agent's command, or `null` for a plain shell. */
-  spawnUserShell(agent?: AgentChoice, side?: TermSide): Promise<string>;
+   *  and run that agent's command, or `null` for a plain shell. `titleOverride`
+   *  pins a custom tab label (e.g. a task's `<agent>•<title>`) instead of the
+   *  agent's own label. */
+  spawnUserShell(agent?: AgentChoice, side?: TermSide, titleOverride?: string): Promise<string>;
   /** Move the active tab within its column strip. */
   moveActiveTab(direction: -1 | 1): void;
   /** Type a literal string into the active terminal (no shell parsing). */
@@ -429,11 +431,12 @@ export function TerminalPane(props: {
   const spawnUserShell = async (
     agent: AgentChoice = null,
     sd: TermSide = 'my',
+    titleOverride?: string,
   ): Promise<string> => {
-    const label = uniqueLabel(agent?.label || 'shell');
-    // Pin the label only when the caller picked an agent. The bare "New shell"
-    // path leaves the tab unpinned so the shell's OSC 7 cwd basename drives the
-    // displayed title.
+    const label = uniqueLabel(titleOverride ?? agent?.label ?? 'shell');
+    // Pin the label when the caller picked an agent or supplied an explicit
+    // title. The bare "New shell" path leaves the tab unpinned so the shell's
+    // OSC 7 cwd basename drives the displayed title.
     return spawn(
       {
         side: sd,
@@ -441,7 +444,7 @@ export function TerminalPane(props: {
         cwd: props.cwd ?? undefined,
       },
       label,
-      { pinned: agent !== null },
+      { pinned: agent !== null || titleOverride !== undefined },
     );
   };
 

--- a/tests/tasks.spec.ts
+++ b/tests/tasks.spec.ts
@@ -80,6 +80,10 @@ test('tasks pane lists a task and fills its markers', async () => {
     await expect(window.locator('.modal-backdrop .tasks-fill-modal')).toBeVisible();
     await expect(window.locator('.tasks-fill')).toBeVisible();
 
+    // The run-time Agent picker sits in the top control row and defaults to the
+    // task's stored agent id (overridable per run).
+    await expect(window.locator('.tasks-fill-top select')).toHaveValue('claude-deepseek-v4-pro');
+
     // The {AREA} field is prefilled from its default; the preview echoes it.
     const preview = window.locator('.tasks-preview pre');
     await expect(preview).toContainText('Focus: CLAUDE.md and docs/');
@@ -87,7 +91,9 @@ test('tasks pane lists a task and fills its markers', async () => {
     await expect(preview).toContainText('{APP}');
 
     // Pick the seeded app → bare {APP} resolves to its #alias in the preview.
-    await window.locator('.tasks-fill select').first().selectOption('#condash');
+    // The app picker is the first select in the scroll body (the agent picker
+    // lives in the top control row, not here).
+    await window.locator('.tasks-fill-scroll select').first().selectOption('#condash');
     await expect(preview).toContainText('Review #condash');
 
     await window.screenshot({ path: join(outDir, 'tasks-fill.png') });
@@ -113,6 +119,9 @@ test('new task editor creates a task end-to-end', async () => {
     await editor.locator('input[type="text"]').first().fill('Triage incident');
     await editor.locator('textarea').fill('Triage {PROJECT} on {SEVERITY:high}');
     await expect(editor.locator('.tasks-marker[data-kind="project"]')).toHaveText('{PROJECT}');
+
+    await mkdir(outDir, { recursive: true });
+    await window.screenshot({ path: join(outDir, 'tasks-editor.png') });
 
     await editor.locator('button', { hasText: 'Save' }).click();
 


### PR DESCRIPTION
## Summary

Makes the Tasks-pane run flow more robust and flexible: the run/editor popups survive dragging the prompt textarea's resize grip, the agent that runs a task is pickable at run time, the run popup's controls sit at the top, and a launched task tab is named after its agent and title.

## Changes

- **Resize-safe popups** — backdrop click-to-close now only fires when the pointer press *started* on the backdrop. Dragging the prompt textarea's resize grip past the modal edge released the pointer over the backdrop, whose synthesised `click` dismissed the popup mid-resize. Added a reusable `createBackdropClose` helper in `modal-helpers.ts`, applied to both task popups.
- **Run-time agent picker** — the run popup gains an `Agent` select defaulting to the task's stored agent (only prompt-seedable agents selectable, like the editor). The run uses the selected agent.
- **Top run controls** — the `Run` button moves to a top control row beside the agent select; the variable settings (app/project pickers + marker fields) and the live preview follow below. The bottom action row is gone.
- **Taller editor textarea** — the editor's prompt textarea default height goes 7rem → 12rem; the modal still caps at the viewport and the body scrolls.
- **Named task tabs** — a launched task pins its terminal tab title to `<agent label>•<task title>`. Threaded through `onRun` → `runTask` → `spawnUserShell(agent, side, titleOverride?)`.

## Impact

`spawnUserShell` gains an optional third arg (`titleOverride`); non-task spawns are unchanged. `runTask` gains a required `taskName`. Docs (`docs/guides/tasks-pane.md`) updated. Unit + tasks e2e green; e2e doubles as the screenshot source.