### PR TITLE
Fix Settings card-density rejecting Log/Task/Deliverable widths

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -442,7 +442,7 @@ The IPC verbs `getLayout` / `setLayout` read and write this block atomically —
 
 ### CardMinWidth
 
-`cardMinWidth` controls the n→n+1 reflow threshold for the nine card grids (Projects, Code, Knowledge, Resources, Skills, Agents, Logs, Tasks, Deliverables). Each grid uses `minmax(min(<min>, 100%), 1fr)`, so a row of _n_ cards reflows to _n+1_ once the pane is wide enough to fit _n+1_ cards each at this width.
+`cardMinWidth` controls the n→n+1 reflow threshold for the eight card grids (Projects, Code, Knowledge, Resources, Skills, Logs, Tasks, Deliverables). Each grid uses `minmax(min(<min>, 100%), 1fr)`, so a row of _n_ cards reflows to _n+1_ once the pane is wide enough to fit _n+1_ cards each at this width.
 
 | Field          | Type                | Default | Meaning                                                      |
 | -------------- | ------------------- | ------- | ------------------------------------------------------------ |

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -139,7 +139,7 @@ The three tree panes (Knowledge / Resources / Skills) expose create-file / creat
 | `getTheme()` / `setTheme(theme)` | Persist `'light' \| 'dark' \| 'system'` in `settings.json`. |
 | `getLayout()` / `setLayout(layout)` | Read or write the composite-layout snapshot (`projects: bool`, `working: 'code' \| 'knowledge' \| 'resources' \| 'skills' \| 'logs' \| null`, `terminal: bool`, `projectsWidth: int`). See [Config — LayoutState](config.md#layoutstate). |
 | `getWelcomeDismissed()` / `setWelcomeDismissed(value)` | Persistent first-launch welcome-screen flag (`welcome.dismissed` in `settings.json`). |
-| `getCardMinWidth()` / `setCardMinWidth(prefs)` | Read or write the per-pane card-grid min-width block (`projects`, `code`, `knowledge`, `resources`, `skills`). See [Config — CardMinWidth](config.md#cardminwidth). |
+| `getCardMinWidth()` / `setCardMinWidth(prefs)` | Read or write the per-pane card-grid min-width block (`projects`, `code`, `knowledge`, `resources`, `skills`, `logs`, `tasks`, `deliverables`). See [Config — CardMinWidth](config.md#cardminwidth). |
 | `getTreeExpansion()` / `setTreeExpansion(prefs)` | Read or write the per-pane set of expanded directory `relPath`s (Knowledge / Resources / Skills tabs). Empty values mean every directory is collapsed — the on-purpose first-load state. |
 | `getSelectedBranches()` / `setSelectedBranches(list)` | Read or write the Code-pane top-of-pane branch filter selection. Honoured only when `branchFilterStickyAll` is false. |
 | `getBranchFilterStickyAll()` / `setBranchFilterStickyAll(value)` | Read or write the "All (sticky)" mode flag for the Code-pane branch filter — when true, every branch is shown and new branches auto-pin. |

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -6,6 +6,7 @@ import {
   validateAndCanonicaliseConceptionConfig,
   validateAndCanonicaliseGlobalSettings,
 } from './config-schema';
+import { CARD_MIN_WIDTH_KEYS, DEFAULT_CARD_MIN_WIDTH } from '../shared/types';
 
 describe('configSchema repoEntry', () => {
   it('accepts the new env / install / pinned_branch fields', () => {
@@ -245,5 +246,51 @@ describe('migrateRawSettings — launchers replaced by agents', () => {
     const parsed = JSON.parse(canon);
     expect(parsed.terminal.launchers).toBeUndefined();
     expect(parsed.terminal.shell).toBe('/bin/zsh');
+  });
+});
+
+describe('configSchema cardMinWidth — every card grid is accepted', () => {
+  // The reported bug: the Card-density UI grew from five panes to eight
+  // (logs / tasks / deliverables added), but the schema's key list stayed at
+  // five. Saving a Log/Task/Deliverable width on the conception tab threw
+  // `condash.json: cardMinWidth — Unrecognized key: "logs"`. Drive every
+  // canonical key through the schema so a future pane can't drift again.
+  it('accepts every key in DEFAULT_CARD_MIN_WIDTH', () => {
+    for (const key of CARD_MIN_WIDTH_KEYS) {
+      const result = configSchema.safeParse({ cardMinWidth: { [key]: 500 } });
+      expect(result.success, `cardMinWidth.${key} should be accepted`).toBe(true);
+    }
+  });
+
+  it('accepts a full eight-key cardMinWidth object', () => {
+    const result = configSchema.safeParse({ cardMinWidth: { ...DEFAULT_CARD_MIN_WIDTH } });
+    expect(result.success).toBe(true);
+  });
+
+  it('still rejects an unknown cardMinWidth key (typo guard intact)', () => {
+    const result = configSchema.safeParse({ cardMinWidth: { logz: 500 } });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-positive cardMinWidth value', () => {
+    expect(configSchema.safeParse({ cardMinWidth: { logs: 0 } }).success).toBe(false);
+    expect(configSchema.safeParse({ cardMinWidth: { logs: -10 } }).success).toBe(false);
+  });
+
+  it('lets a conception save round-trip a `logs` card width (the reported failure)', () => {
+    // Reproduces the screenshot: editing the Log-cards min-width on the
+    // conception tab canonicalises condash.json. Before the fix this threw
+    // `condash.json: cardMinWidth — Unrecognized key: "logs"`.
+    const json = JSON.stringify({ cardMinWidth: { logs: 500, tasks: 360, deliverables: 380 } });
+    const canon = validateAndCanonicaliseConceptionConfig(json);
+    const parsed = JSON.parse(canon);
+    expect(parsed.cardMinWidth).toEqual({ logs: 500, tasks: 360, deliverables: 380 });
+  });
+
+  it('lets a global save round-trip the new card widths too', () => {
+    const json = JSON.stringify({ cardMinWidth: { logs: 500, tasks: 360, deliverables: 380 } });
+    const canon = validateAndCanonicaliseGlobalSettings(json);
+    const parsed = JSON.parse(canon);
+    expect(parsed.cardMinWidth).toEqual({ logs: 500, tasks: 360, deliverables: 380 });
   });
 });

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { CardMinWidthPrefs } from '../shared/types';
 
 /**
  * Schemas for the two condash settings files. The unified shape lives here
@@ -319,6 +320,10 @@ const layoutSchema = z
   })
   .strict();
 
+// One entry per card grid. The `satisfies Record<keyof CardMinWidthPrefs, …>`
+// makes this list exhaustive at compile time: adding a pane to CardMinWidthPrefs
+// without adding it here is a tsc error, not a silent `Unrecognized key` at save
+// time. This is the guard that was missing when logs/tasks/deliverables shipped.
 const cardMinWidthSchema = z
   .object({
     projects: z.number().int().positive().optional(),
@@ -326,7 +331,10 @@ const cardMinWidthSchema = z
     knowledge: z.number().int().positive().optional(),
     resources: z.number().int().positive().optional(),
     skills: z.number().int().positive().optional(),
-  })
+    logs: z.number().int().positive().optional(),
+    tasks: z.number().int().positive().optional(),
+    deliverables: z.number().int().positive().optional(),
+  } satisfies Record<keyof CardMinWidthPrefs, z.ZodTypeAny>)
   .strict();
 
 const treeExpansionSchema = z

--- a/src/main/ipc/settings-card-min-width.test.ts
+++ b/src/main/ipc/settings-card-min-width.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Settings-IPC tests for the card-density (`cardMinWidth`) read/write path.
+ *
+ * Regression cover for the shipped bug where the Logs / Tasks / Deliverables
+ * panes were added to the type + UI but the IPC handler kept a stale five-key
+ * allow-list — so `setCardMinWidth({ logs })` threw `unknown key "logs"` on the
+ * Global tab and `getCardMinWidth` silently dropped those keys on read. The
+ * handler now derives its key list from the canonical `CARD_MIN_WIDTH_KEYS`.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEFAULT_CARD_MIN_WIDTH } from '../../shared/types';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: () => '/tmp/electron-app' },
+}));
+
+let tmp: string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
+let settingsPathValue: string;
+
+async function writeSettings(content: object): Promise<void> {
+  await fs.writeFile(settingsPathValue, JSON.stringify(content));
+}
+
+async function readSettingsFile(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(settingsPathValue, 'utf8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  tmp = mkdtempSync(join(tmpdir(), 'condash-card-min-width-'));
+  settingsPathValue = join(tmp, 'settings.json');
+  const isolatedTmp = tmp;
+  vi.doMock('../user-data-dir', () => ({ userDataDir: () => isolatedTmp }));
+
+  handlers = {};
+  const { ipcMain } = await import('electron');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ipcMain.handle as any).mockImplementation(
+    (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
+      handlers[channel] = fn;
+    },
+  );
+  const { registerSettingsIpc } = await import('./settings');
+  registerSettingsIpc({ onLayoutChange: () => undefined });
+  // No conception open — getCardMinWidth then reads the global cardMinWidth.
+  await writeSettings({ lastConceptionPath: null, recentConceptionPaths: [], terminal: {} });
+});
+
+afterEach(async () => {
+  try {
+    const { drainSettingsQueue } = await import('../settings');
+    await drainSettingsQueue();
+  } catch {
+    /* Module not loaded yet — fine. */
+  }
+  rmSync(tmp, { recursive: true, force: true });
+  vi.doUnmock('../user-data-dir');
+});
+
+describe('setCardMinWidth / getCardMinWidth round-trip', () => {
+  it('persists and reads back the new logs / tasks / deliverables keys', async () => {
+    await handlers.setCardMinWidth(null, {
+      projects: 700,
+      logs: 500,
+      tasks: 360,
+      deliverables: 380,
+    });
+
+    // Read path returns the set values, with built-in defaults for the rest.
+    const effective = (await handlers.getCardMinWidth()) as Record<string, number>;
+    expect(effective.projects).toBe(700);
+    expect(effective.logs).toBe(500);
+    expect(effective.tasks).toBe(360);
+    expect(effective.deliverables).toBe(380);
+    expect(effective.code).toBe(DEFAULT_CARD_MIN_WIDTH.code);
+
+    // On disk only the non-default keys are kept (pruneDefaults).
+    const onDisk = await readSettingsFile();
+    expect(onDisk.cardMinWidth).toEqual({
+      projects: 700,
+      logs: 500,
+      tasks: 360,
+      deliverables: 380,
+    });
+  });
+
+  it('round-trips every canonical card key', async () => {
+    const widths = Object.fromEntries(Object.keys(DEFAULT_CARD_MIN_WIDTH).map((key) => [key, 700]));
+    await handlers.setCardMinWidth(null, widths);
+    const effective = (await handlers.getCardMinWidth()) as Record<string, number>;
+    for (const key of Object.keys(DEFAULT_CARD_MIN_WIDTH)) {
+      expect(effective[key], `getCardMinWidth should return ${key}`).toBe(700);
+    }
+  });
+
+  it('rejects an unknown key (typo guard intact)', async () => {
+    await expect(handlers.setCardMinWidth(null, { logz: 500 })).rejects.toThrow(/unknown key/);
+  });
+
+  it('drops a key whose value equals the built-in default', async () => {
+    await handlers.setCardMinWidth(null, { logs: DEFAULT_CARD_MIN_WIDTH.logs, tasks: 360 });
+    const onDisk = await readSettingsFile();
+    // logs == default → pruned; tasks != default → kept.
+    expect(onDisk.cardMinWidth).toEqual({ tasks: 360 });
+    const effective = (await handlers.getCardMinWidth()) as Record<string, number>;
+    expect(effective.logs).toBe(DEFAULT_CARD_MIN_WIDTH.logs);
+  });
+
+  it('clamps an out-of-range value to the inherited default', async () => {
+    await handlers.setCardMinWidth(null, { logs: 5 });
+    const effective = (await handlers.getCardMinWidth()) as Record<string, number>;
+    // 5 < 120 floor → rejected by clampMinWidth → inherits the default.
+    expect(effective.logs).toBe(DEFAULT_CARD_MIN_WIDTH.logs);
+  });
+});

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -9,7 +9,7 @@ import type {
   Theme,
   TreeExpansionPrefs,
 } from '../../shared/types';
-import { DEFAULT_CARD_MIN_WIDTH, SKILL_SCOPES } from '../../shared/types';
+import { CARD_MIN_WIDTH_KEYS, DEFAULT_CARD_MIN_WIDTH, SKILL_SCOPES } from '../../shared/types';
 
 // Tree-expansion keys after the reframe: knowledge, resources, plus one
 // skills set per scope (conception / user). The pre-reframe per-harness
@@ -23,7 +23,9 @@ const SKILL_SCOPE_SET: ReadonlySet<SkillScope> = new Set(SKILL_SCOPES);
 
 const THEMES: ReadonlySet<Theme> = new Set(['light', 'dark', 'system']);
 
-const CARD_MIN_KEYS = ['projects', 'code', 'knowledge', 'resources', 'skills'] as const;
+// Canonical card-grid key list (shared/types.ts), not a local copy — so the
+// read/write/prune paths below always cover every pane the type knows about.
+const CARD_MIN_KEYS = CARD_MIN_WIDTH_KEYS;
 type CardKey = (typeof CARD_MIN_KEYS)[number];
 
 /**

--- a/src/renderer/settings-modal-parts/fields.tsx
+++ b/src/renderer/settings-modal-parts/fields.tsx
@@ -211,6 +211,18 @@ const CARD_DENSITY_FIELDS = [
   { key: 'deliverables', label: 'Deliverable cards (Deliverables pane)', short: 'Deliverable' },
 ] as const;
 
+// Compile-time guard: every CardMinWidthPrefs key must have a density field
+// here. Add a pane to the type without a field and `_MissingDensityField`
+// becomes that key (not `never`), so this assignment fails tsc — the Settings
+// UI can no longer silently fall behind the schema (the logs/tasks/deliverables
+// regression).
+type _MissingDensityField = Exclude<
+  keyof CardMinWidthPrefs,
+  (typeof CARD_DENSITY_FIELDS)[number]['key']
+>;
+const _assertAllDensityFieldsPresent: _MissingDensityField extends never ? true : false = true;
+void _assertAllDensityFieldsPresent;
+
 export function CardDensityFields(props: {
   resolve: (key: keyof CardMinWidthPrefs) => number;
   onChange: (patch: CardMinWidthPrefs) => void;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -316,6 +316,15 @@ export const DEFAULT_CARD_MIN_WIDTH = {
   deliverables: 340,
 } as const satisfies Required<CardMinWidthPrefs>;
 
+/** Canonical list of card-grid keys, derived from the one place the panes are
+ * enumerated (`DEFAULT_CARD_MIN_WIDTH`). The config schema and the settings IPC
+ * import this rather than hand-maintaining their own copies — a stale copy is
+ * exactly how `logs` / `tasks` / `deliverables` shipped unsavable. Adding a pane
+ * to `DEFAULT_CARD_MIN_WIDTH` extends every consumer automatically. */
+export const CARD_MIN_WIDTH_KEYS = Object.keys(
+  DEFAULT_CARD_MIN_WIDTH,
+) as (keyof CardMinWidthPrefs)[];
+
 /** One row of `git status --porcelain=v1` output, joined with the
  *  matching `git diff --numstat HEAD` row when present. */
 export interface DirtyFile {

--- a/tests/settings-modal-audit.spec.ts
+++ b/tests/settings-modal-audit.spec.ts
@@ -362,15 +362,20 @@ test('settings modal: audit every field round-trips edit → on-disk', async () 
       }
     }
 
-    // Card density (5 panes)
-    const densityKeys: ('projects' | 'code' | 'knowledge' | 'resources' | 'skills')[] = [
+    // Card density (8 panes — must stay in lock-step with CARD_DENSITY_FIELDS /
+    // DEFAULT_CARD_MIN_WIDTH; logs/tasks/deliverables were the panes that shipped
+    // unsavable because this list lagged the UI at five).
+    const densityKeys: DensityKey[] = [
       'projects',
       'code',
       'knowledge',
       'resources',
       'skills',
+      'logs',
+      'tasks',
+      'deliverables',
     ];
-    const densityValues = [222, 333, 444, 555, 666];
+    const densityValues = [222, 333, 444, 555, 666, 777, 888, 999];
     for (let i = 0; i < densityKeys.length; i++) {
       const label = densityKeys[i];
       const value = densityValues[i];
@@ -694,22 +699,39 @@ test('settings modal: audit every field round-trips edit → on-disk', async () 
       }
     }
 
-    // Conception · Card density override (one pane is enough).
+    // Conception · Card density override. Cover both an original pane
+    // (projects) and a late-added one (logs): the conception tab → writeNote →
+    // condash.json path is exactly where the reported failure surfaced
+    // (`condash.json: cardMinWidth — Unrecognized key: "logs"`).
     {
-      const labelRow = conceptionPanel
+      const projectsRow = conceptionPanel
         .locator('section#settings-section-appearance\\:conception label', {
           hasText: 'Project cards',
         })
         .first();
-      const input = labelRow.locator('input[type="number"]').first();
       await auditNumber({
         scope: 'conception',
         section: 'Appearance',
         field: 'Card density override · projects',
         expectedKey: 'cardMinWidth.projects',
         filePath: conceptionPath,
-        input,
+        input: projectsRow.locator('input[type="number"]').first(),
         value: 999,
+      });
+
+      const logsRow = conceptionPanel
+        .locator('section#settings-section-appearance\\:conception label', {
+          hasText: 'Log cards',
+        })
+        .first();
+      await auditNumber({
+        scope: 'conception',
+        section: 'Appearance',
+        field: 'Card density override · logs',
+        expectedKey: 'cardMinWidth.logs',
+        filePath: conceptionPath,
+        input: logsRow.locator('input[type="number"]').first(),
+        value: 480,
       });
     }
 
@@ -911,7 +933,20 @@ test('settings modal: audit every field round-trips edit → on-disk', async () 
   }
 });
 
-function labelText(key: 'projects' | 'code' | 'knowledge' | 'resources' | 'skills'): string {
+/** Card-density pane keys. Mirror `CardMinWidthPrefs` / `DEFAULT_CARD_MIN_WIDTH`
+ *  in src/shared/types.ts — extend both this union and `labelText` when a pane
+ *  is added, or the audit silently stops covering it. */
+type DensityKey =
+  | 'projects'
+  | 'code'
+  | 'knowledge'
+  | 'resources'
+  | 'skills'
+  | 'logs'
+  | 'tasks'
+  | 'deliverables';
+
+function labelText(key: DensityKey): string {
   switch (key) {
     case 'projects':
       return 'Project cards';
@@ -923,5 +958,11 @@ function labelText(key: 'projects' | 'code' | 'knowledge' | 'resources' | 'skill
       return 'Resource cards';
     case 'skills':
       return 'Skill cards';
+    case 'logs':
+      return 'Log cards';
+    case 'tasks':
+      return 'Task cards';
+    case 'deliverables':
+      return 'Deliverable cards';
   }
 }


### PR DESCRIPTION
## Summary

The card-density settings grew from five panes to eight (`logs`, `tasks`,
`deliverables` added), and the type, hook, UI fields and pane CSS were all
updated to eight. Two consumers that hand-maintain their own key list were
not: the `cardMinWidth` zod schema and the settings IPC. Saving a Log / Task /
Deliverable min-width therefore failed:

- Conception tab: `condash.json: cardMinWidth — Unrecognized key: "logs"` (the validator).
- Global tab: `setCardMinWidth: unknown key "logs"` (the IPC allow-list).
- `getCardMinWidth` also dropped those three keys on read.

Root cause is duplicated key lists drifting from the one canonical source
(`DEFAULT_CARD_MIN_WIDTH`). The fix removes the duplication so a future pane
can't repeat it.

## Changes

- `shared/types.ts`: export `CARD_MIN_WIDTH_KEYS`, derived from `DEFAULT_CARD_MIN_WIDTH` — the single canonical key list.
- `main/config-schema.ts`: `cardMinWidthSchema` now lists all eight keys, behind a `satisfies Record<keyof CardMinWidthPrefs, …>` exhaustiveness guard — a missing key is a `tsc` error, not a runtime `Unrecognized key`.
- `main/ipc/settings.ts`: `CARD_MIN_KEYS` is now the canonical list, not a local five-key copy — read / write / prune all cover every pane.
- `renderer/settings-modal-parts/fields.tsx`: compile-time guard so the UI field list can't fall behind the type either.
- Tests: schema round-trip reproducing the reported `writeNote` failure; new IPC round-trip for `setCardMinWidth`/`getCardMinWidth`; the Playwright settings audit now drives all eight keys on both tabs (it only covered five — which is why this shipped uncaught).
- Docs: `config.md` + `ipc-api.md` updated to the eight-key block.

## Impact

Fixes saving Log / Task / Deliverable card widths on both the Global and
conception tabs. No data migration — existing files are unaffected; the keys
were simply unsavable before.

## Watchpoints

- Verified locally: `typecheck`, full `vitest` (734 passing), production `build`, prettier (`src/`).
- The extended Playwright audit typechecks but was not executed here (needs `xvfb` + an Electron build); the regression is locked by the two vitest suites, which reproduce the exact failure.