### PR TITLE
Force X11 backend for xvfb test run so no window pops up on Wayland

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,15 @@ PREVIEW_PORT ?= 5601
 # a visible run where xvfb-run is absent (macOS/Windows). `make test-visible`
 # always shows the window; `make test-headless` always wraps and errors out if
 # xvfb-run is missing.
+#
+# On a Wayland session the dev shell exports ELECTRON_OZONE_PLATFORM_HINT=wayland
+# and WAYLAND_DISPLAY; Electron honours those over xvfb's virtual X DISPLAY and
+# opens the window on the real compositor — stealing focus despite the wrap. For
+# the wrapped run, drop the Wayland socket and pin the X11 Ozone backend so
+# Electron renders into Xvfb only. (test-visible deliberately keeps Wayland.)
 XVFB_RUN  := $(shell command -v xvfb-run 2>/dev/null)
-TEST_WRAP := $(if $(XVFB_RUN),xvfb-run -a,)
+XVFB_X11  := env -u WAYLAND_DISPLAY ELECTRON_OZONE_PLATFORM_HINT=x11
+TEST_WRAP := $(if $(XVFB_RUN),xvfb-run -a $(XVFB_X11),)
 
 help:
 	@echo "Targets:"
@@ -59,7 +66,7 @@ test:
 
 test-headless:
 	npm run build
-	xvfb-run -a npm run test
+	xvfb-run -a $(XVFB_X11) npm run test
 
 test-visible:
 	npm run build

--- a/docs/explanation/contributing.md
+++ b/docs/explanation/contributing.md
@@ -92,6 +92,8 @@ For a feature that touches the dashboard's behaviour, prefer Playwright. The e2e
 
 Driving the real Electron app means the suite opens an on-screen window unless it runs against a virtual display. On Linux, `make test` wraps the suite in `xvfb-run` when it's installed, so the window never appears or steals focus — the same thing CI does. `make test-headless` forces that wrap (and errors if `xvfb-run` is missing); `make test-visible` runs with the window visible when you want to watch a run. On macOS/Windows (no `xvfb`), `make test` runs visibly.
 
+On a Wayland session there's a catch: the shell exports `ELECTRON_OZONE_PLATFORM_HINT=wayland` and `WAYLAND_DISPLAY`, and Electron honours those over the virtual X `DISPLAY` that `xvfb-run` provides — so the window would still open on the real compositor and steal focus despite the wrap. The wrapped targets therefore drop `WAYLAND_DISPLAY` and pin `ELECTRON_OZONE_PLATFORM_HINT=x11` for the run, forcing Electron to render into Xvfb. `make test-visible` keeps Wayland on purpose.
+
 ## Style and conventions
 
 - **`make format`** runs Prettier across `src/`. Run it before every commit. CI fails on unformatted code.


### PR DESCRIPTION
## Summary

- `make test` already wraps the Playwright suite in `xvfb-run`, but on a Wayland desktop the Electron window still pops up and steals focus mid-run.
- Cause: the dev shell exports `ELECTRON_OZONE_PLATFORM_HINT=wayland` and `WAYLAND_DISPLAY`, which Electron honours over the virtual X `DISPLAY` that `xvfb-run` provides, so it renders on the real compositor instead of Xvfb.

## Changes

- `Makefile`: the wrapped test targets (`make test`, `make test-headless`) now run under `xvfb-run -a env -u WAYLAND_DISPLAY ELECTRON_OZONE_PLATFORM_HINT=x11`, dropping the Wayland socket and pinning the X11 Ozone backend so Electron renders into Xvfb. Factored into an `XVFB_X11` variable shared by both targets.
- `docs/explanation/contributing.md`: document the Wayland caveat and the x11 pin.

## Impact

- `make test-visible` is unchanged — it still shows the window on Wayland on purpose.
- No effect on CI (already headless on X11 runners) or macOS/Windows (no `xvfb`).