### PR TITLE
Drop flaky setup-node npm cache from release-chain workflows

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -27,11 +27,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # No `cache: 'npm'` here. Its cache *save* runs as a post-step, and a
+      # transient GHA cache-service timeout there exits the build job non-zero —
+      # which on a release tag skips `publish` and ships nothing (hit v4.19.0 on
+      # the windows-latest leg). This matrix runs only on tags, so a cold
+      # `npm ci` download costs little; a reliable publish matters far more.
       - name: Set up Node
         uses: actions/setup-node@v5
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/_fast.yml
+++ b/.github/workflows/_fast.yml
@@ -16,11 +16,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # No `cache: 'npm'`: the node_modules cache below already restores the full
+      # install on a hit (npm ci is then skipped), so setup-node's npm cache only
+      # helped rare lockfile-change runs — while its save post-step's transient
+      # cache-service timeouts can fail a release-tag run and skip publish.
       - name: Set up Node
         uses: actions/setup-node@v5
         with:
           node-version: '20'
-          cache: 'npm'
 
       # Cache node_modules + the electron/electron-builder caches. On a
       # hit we skip npm ci entirely — the `electron-rebuild` postinstall

--- a/.github/workflows/_playwright.yml
+++ b/.github/workflows/_playwright.yml
@@ -21,11 +21,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
+      # No `cache: 'npm'`: the node_modules cache below already restores the full
+      # install on a hit (npm ci is then skipped), so setup-node's npm cache only
+      # helped rare lockfile-change runs — while its save post-step's transient
+      # cache-service timeouts can fail a release-tag run and skip publish.
       - name: Set up Node
         uses: actions/setup-node@v5
         with:
           node-version: '20'
-          cache: 'npm'
 
       - name: Cache node_modules + electron caches
         id: deps-cache


### PR DESCRIPTION
## Summary

The `v4.19.0` release built installers on all three OSes but published nothing: the `build (windows-latest)` leg failed in its `Post Set up Node` step when the GitHub Actions cache service timed out saving the npm cache. That non-zero exit failed the `build` job, and because `publish` declares `needs: [validate-tag, build]`, the GitHub Release was never created — v4.19.0 is an orphan tag (v4.19.1/.2 published fine minutes later).

The failing step is pure cache bookkeeping: it runs *after* the installers are built and uploaded, so it has no bearing on their validity. This removes `cache: 'npm'` from the `Set up Node` step in all three release-chain reusable workflows so the publish path no longer depends on it.

## Changes

- `_build.yml` — remove `cache: 'npm'` (the leg that failed). No `node_modules` cache here, so the npm cache only sped the `npm ci` download on this tag-only matrix.
- `_fast.yml`, `_playwright.yml` — remove `cache: 'npm'`. A separate `actions/cache@v5` already caches `node_modules` wholesale (npm ci skipped on a hit), so the setup-node npm cache was near-redundant and only added the flaky post-step.

## Impact

- A transient cache-service timeout in cache bookkeeping can no longer fail a build leg and skip the release publish.
- Negligible CI cost: `_fast`/`_playwright` keep their `node_modules` cache; only rare lockfile-change runs do a cold npm download. `_build` runs only on tags.
- CI/release config only — no app or runtime behavior change.