### PR TITLE
Fix task fill param input losing focus after one character

### DIFF
--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -332,7 +332,15 @@ function TaskFill(props: {
   conceptionPath: () => string | null;
   onRun: (agentId: string, text: string, taskName: string) => void;
 }): JSX.Element {
-  const markers = createMemo(() => extractMarkers(props.fill().def.prompt));
+  // Derive markers from the prompt alone, not the whole fill signal. The prompt
+  // is immutable during a fill session, so this `prompt` memo's `===` output is
+  // stable across field edits — `extractMarkers` (which allocates fresh Marker
+  // objects) therefore stops re-running on every keystroke. That keeps the
+  // marker arrays referentially stable so the `<For>` over `textMarkers` does
+  // not recreate the param `<input>`s, which would otherwise drop focus after a
+  // single character.
+  const prompt = createMemo(() => props.fill().def.prompt);
+  const markers = createMemo(() => extractMarkers(prompt()));
   const textMarkers = createMemo(() =>
     markers().filter((m) => !isAppToken(m.key) && !isProjectToken(m.key)),
   );

--- a/tests/tasks.spec.ts
+++ b/tests/tasks.spec.ts
@@ -102,6 +102,47 @@ test('tasks pane lists a task and fills its markers', async () => {
   }
 });
 
+test('typing a multi-char value into a param field keeps focus', async () => {
+  // Regression: the fill view derived its marker list from the whole fill
+  // signal, so every keystroke re-ran extractMarkers (fresh Marker objects) and
+  // the <For> over the param inputs recreated each <input> — dropping focus
+  // after one character. Type char-by-char (pressSequentially dispatches real
+  // keystrokes; fill() sets the value atomically and would not catch this) and
+  // assert the field stays focused and accumulates the full value.
+  const booted = await bootApp({
+    prepare: seedTask,
+    extraConfig: {
+      agents: [TASK_AGENT],
+      repositories: [{ name: 'condash', path: '/home/alice/src/vcoeur/condash' }],
+    },
+  });
+  const { window, cleanup } = booted;
+  try {
+    await window.setViewportSize({ width: 1400, height: 900 });
+    await window.locator('.edge-strip-left').first().waitFor({ state: 'visible', timeout: 10_000 });
+    await window.locator('.edge-strip-left .edge-handle', { hasText: 'Tasks' }).click();
+
+    await window.locator('.tasks-row-actions button', { hasText: 'Run…' }).click();
+    await expect(window.locator('.modal-backdrop .tasks-fill-modal')).toBeVisible();
+
+    // The {AREA} text field (the app picker is a <select>, not this input).
+    const areaField = window
+      .locator('.tasks-fill-scroll label', { hasText: '{AREA}' })
+      .locator('input[type="text"]');
+    await areaField.fill('');
+    await areaField.focus();
+    await areaField.pressSequentially('src and tests', { delay: 20 });
+
+    // Focus survives every keystroke and the full value lands (with the bug,
+    // only the first character would register before the input was recreated).
+    await expect(areaField).toBeFocused();
+    await expect(areaField).toHaveValue('src and tests');
+    await expect(window.locator('.tasks-preview pre')).toContainText('Focus: src and tests');
+  } finally {
+    await cleanup();
+  }
+});
+
 test('new task editor creates a task end-to-end', async () => {
   const booted = await bootApp({ prepare: seedTask, extraConfig: { agents: [TASK_AGENT] } });
   const { window, cleanup } = booted;


### PR DESCRIPTION
## Summary

- Typing into a task Run param field (e.g. `{DAYS}`) lost focus after a single character, so multi-character values could not be entered.
- Root cause is reactive-graph over-coupling in the fill view, not anything in the input itself.

## Changes

- `src/renderer/panes/tasks.tsx`: derive the marker list from a new intermediate `prompt` memo instead of reading the whole `fill` signal. The `markers`/`textMarkers` memos previously re-ran on every keystroke (each keystroke replaces the `FillState` object), and `extractMarkers` allocates fresh `Marker` objects each call. That gave the `<For>` over the param inputs new item references every keystroke, so it recreated each `<input>` and dropped focus. The prompt is immutable during a fill, so the `prompt` memo's identity-stable output keeps the marker arrays referentially stable across field edits, leaving the input DOM in place.
- `tests/tasks.spec.ts`: add a regression E2E that types a multi-character value character-by-character and asserts the field keeps focus and accumulates the full value. Verified it fails against the pre-fix build.

## Impact

- The marker grammar is now parsed once per fill session instead of on every keystroke — a minor incidental win.

## Watchpoints

- The fill view still re-derives `{APP}`/`{PROJECT}` pickers and the live preview from the prompt; those are unaffected, but worth a glance if marker parsing behaviour ever changes.