### PR TITLE
Recolour terminal tabs as buttons; right-click close/rename

### DIFF
--- a/src/renderer/dropdown-menu.ts
+++ b/src/renderer/dropdown-menu.ts
@@ -21,6 +21,10 @@ interface DropdownMenu {
   /** Open the menu programmatically (e.g. from a keyboard handler that
    *  already swallowed the event). */
   open: () => void;
+  /** Open the menu anchored at a viewport coordinate (a right-click cursor
+   *  point) instead of a trigger element. Reuses the same viewport-flip and
+   *  outside-click / Escape dismissal as the trigger-anchored path. */
+  openAt: (x: number, y: number) => void;
   /** Close programmatically (e.g. after picking a menu item). */
   close: () => void;
 }
@@ -56,14 +60,22 @@ export function createDropdownMenu(options: CreateDropdownMenuOptions = {}): Dro
   const [anchor, setAnchor] = createSignal<MenuAnchor | null>(null);
   let triggerEl: HTMLElement | undefined;
   let menuEl: HTMLElement | undefined;
+  // Set by openAt() for cursor-anchored (right-click) menus; cleared by the
+  // trigger-anchored open paths so the two modes can't bleed into each other.
+  let cursorPoint: { x: number; y: number } | null = null;
 
   const positionMenu = (): void => {
-    if (!triggerEl) return;
-    const rect = triggerEl.getBoundingClientRect();
+    // A cursor menu anchors to a zero-size rect at the click point; otherwise
+    // anchor to the trigger element's box.
+    const rect = cursorPoint
+      ? { top: cursorPoint.y, bottom: cursorPoint.y, left: cursorPoint.x, right: cursorPoint.x }
+      : triggerEl?.getBoundingClientRect();
+    if (!rect) return;
     const margin = 8;
     // 8 px gap (was 4 px) so the menu doesn't visually merge with the
     // trigger button; matches the "+ New project" button's visual rhythm.
-    const gap = 8;
+    // Cursor menus open flush at the pointer (no gap).
+    const gap = cursorPoint ? 0 : 8;
     let top = rect.bottom + gap;
     const menuH = menuEl?.getBoundingClientRect().height ?? 0;
     if (menuH > 0 && top + menuH > window.innerHeight - margin) {
@@ -140,11 +152,18 @@ export function createDropdownMenu(options: CreateDropdownMenuOptions = {}): Dro
         setOpen(false);
         return;
       }
+      cursorPoint = null;
       positionMenu();
       setOpen(true);
     },
     open: () => {
       if (openSig()) return;
+      cursorPoint = null;
+      positionMenu();
+      setOpen(true);
+    },
+    openAt: (x: number, y: number): void => {
+      cursorPoint = { x, y };
       positionMenu();
       setOpen(true);
     },

--- a/src/renderer/terminal-pane.css
+++ b/src/renderer/terminal-pane.css
@@ -190,28 +190,47 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 2px 4px 2px 8px;
-  border: 1px solid var(--border);
-  border-radius: 4px;
+  padding: 3px 10px;
+  border: 1px solid transparent;
+  border-radius: 6px;
   font-size: var(--text-xs);
+  font-weight: 500;
   cursor: pointer;
-  background: var(--bg-elevated);
+  /* Button colour comes from the shared app-pill wheel — the `app-pill-N`
+   * class on the tab sets these vars (same palette as the Code pane + project
+   * cards). Falls back to the neutral surface if no slot resolved. */
+  background: var(--app-pill-bg, var(--bg-elevated));
+  color: var(--app-pill-fg, var(--text));
   max-width: 220px;
   min-width: 80px;
   flex-shrink: 0;
+  /* Inactive tabs sit muted; the active one is full-strength + ringed. */
+  opacity: 0.62;
+  transition:
+    opacity 0.1s ease,
+    box-shadow 0.1s ease;
+}
+
+.terminal-tab:hover {
+  opacity: 0.82;
 }
 
 .terminal-tab.active {
-  background: var(--bg-hover);
+  opacity: 1;
   border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
 }
 
 .terminal-tab.exited {
-  opacity: 0.65;
+  font-style: italic;
+}
+
+.terminal-tab.exited:not(.active) {
+  opacity: 0.42;
 }
 
 .terminal-tab.renaming {
-  background: var(--bg-hover);
+  opacity: 1;
   border-color: var(--accent);
 }
 
@@ -246,16 +265,18 @@
 .terminal-tab-rename {
   font-family: var(--font-mono);
   font-size: 11px;
+  /* The rename input overlays a coloured tab — give it a solid neutral
+   * surface so the text stays legible against any palette slot. */
   color: var(--text);
-  background: transparent;
+  background: var(--bg);
   border: none;
   outline: none;
-  padding: 0;
+  border-radius: 3px;
+  padding: 0 3px;
   width: 140px;
   min-width: 60px;
 }
 
-.terminal-tab-close,
 .terminal-tab-add {
   background: transparent;
   border: none;
@@ -265,32 +286,20 @@
   height: 20px;
   border-radius: 3px;
   font-size: 16px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 1;
+  margin-left: 2px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  /* Symbol glyphs (×, +, λ, ⤓, ⌕) sit a hair above the optical baseline in
+  /* Symbol glyphs (+, λ, ⤓, ⌕) sit a hair above the optical baseline in
    * most fonts; nudge them down so they read centered inside the box. */
   padding: 0;
 }
 
-.terminal-tab-close:hover,
 .terminal-tab-add:hover {
   background: var(--bg-hover);
   color: var(--text);
-}
-
-.terminal-tab-close {
-  /* The U+00D7 multiplication sign renders smaller than the box; bump it
-   * so it matches the visual weight of the +/λ glyphs. */
-  font-size: 18px;
-  font-weight: 400;
-}
-
-.terminal-tab-add {
-  margin-left: 2px;
-  font-weight: 600;
 }
 
 .terminal-tab-add[data-label] {
@@ -362,6 +371,49 @@
 .terminal-tab-dropdown-menu li.highlighted,
 .terminal-tab-dropdown-menu li:hover {
   background: var(--bg-hover);
+}
+
+/* ── Tab right-click context menu ─────────────────────────────────── */
+
+/* Same `position: fixed` portal treatment as the spawn dropdown so it
+ * escapes the strip's `overflow: auto`. Coords come from
+ * createDropdownMenu().anchor() seeded at the cursor via openAt(). */
+.terminal-tab-context-menu.portal {
+  position: fixed;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 6px;
+  min-width: 132px;
+  z-index: 1000;
+  padding: 4px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  box-shadow: var(--shadow-lift);
+}
+
+.terminal-tab-context-menu-item {
+  display: flex;
+  align-items: center;
+  padding: 6px 10px;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--text-sm);
+  text-align: left;
+}
+
+.terminal-tab-context-menu-item:hover {
+  background: var(--bg-hover);
+}
+
+.terminal-tab-context-menu-item.danger:hover {
+  background: color-mix(in srgb, var(--col-now) 16%, var(--bg-hover));
+  color: var(--col-now);
 }
 
 .terminal-tab[draggable='true']:active {

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -32,6 +32,7 @@ import { mountXterm, type MountedTerm } from './xterm-mount';
 import { TerminalColumn } from './terminal-pane/column';
 import { createDragDropController, DRAG_MIME } from './terminal-pane/drag-drop';
 import {
+  allocateColorSlot,
   DEFAULT_PANE_HEIGHT,
   DEFAULT_SPLIT_RATIO,
   deleteMeta,
@@ -42,6 +43,7 @@ import {
 import { createResizeHandlers } from './terminal-pane/resize';
 import { createSearchController } from './terminal-pane/search';
 import { type Column, displayName, type Tab } from './terminal-pane/types';
+import './panes/app-pill.css';
 import './terminal-pane.css';
 
 export type { Column, Tab } from './terminal-pane/types';
@@ -120,7 +122,8 @@ export function TerminalPane(props: {
   const pendingSpawnIntent = new Map<string, { label: string; pinned?: boolean }>();
 
   // Tracks tabs that are already in the process of closing so that
-  // user-initiated close (× button) and process-exit close don't race.
+  // user-initiated close (right-click → Close) and process-exit close
+  // don't race.
   const closingTabs = new Set<string>();
 
   // Accumulated raw pty output per session (ANSI codes included). Used by
@@ -337,17 +340,21 @@ export function TerminalPane(props: {
       const column: Column = meta?.column ?? nextSpawnColumn;
       nextSpawnColumn = 'left';
       const pinned = intent?.pinned ?? meta?.pinned;
+      // Reuse the persisted slot on restore; allocate the next zebra slot for
+      // a genuinely new tab. Frozen here for the tab's lifetime.
+      const colorSlot = meta?.colorSlot ?? allocateColorSlot();
       const tab: Tab = {
         id: s.id,
         side: 'my',
         column,
         label,
         customName: meta?.customName,
+        colorSlot,
         pinned,
         exited: s.exited,
       };
       setTabs((prev) => [...prev, tab]);
-      setMeta(s.id, { label, customName: meta?.customName, column, pinned });
+      setMeta(s.id, { label, customName: meta?.customName, column, colorSlot, pinned });
       mountForSession(s.id, column, attach?.output);
       setActiveIn(column, s.id);
       setActiveColumn(column);
@@ -508,6 +515,7 @@ export function TerminalPane(props: {
         label: tab.label,
         customName: trimmed || undefined,
         column: tab.column,
+        colorSlot: tab.colorSlot,
         pinned: tab.pinned,
       });
     }

--- a/src/renderer/terminal-pane/column.tsx
+++ b/src/renderer/terminal-pane/column.tsx
@@ -146,6 +146,11 @@ function SpawnDropdown(props: {
  *  imperatively by the parent (so they can be re-parented across columns
  *  on drag-drop without losing their buffer). */
 export function TerminalColumn(props: TerminalColumnProps) {
+  // Right-click context menu (Close / Rename), anchored at the cursor. Tracks
+  // which tab it was opened on so the action targets the right session.
+  const ctxMenu = createDropdownMenu({ align: 'left' });
+  const [ctxTabId, setCtxTabId] = createSignal<string | null>(null);
+
   return (
     <div class="terminal-column" classList={{ active: props.isActiveColumn }}>
       <div
@@ -181,7 +186,7 @@ export function TerminalColumn(props: TerminalColumnProps) {
         <For each={props.tabs}>
           {(tab) => (
             <div
-              class="terminal-tab"
+              class={`terminal-tab app-pill-${tab.colorSlot ?? 0}`}
               classList={{
                 active: tab.id === props.activeId,
                 exited: tab.exited !== undefined,
@@ -201,10 +206,13 @@ export function TerminalColumn(props: TerminalColumnProps) {
                 e.stopPropagation();
                 props.onActivateTab(props.col, tab.id);
               }}
-              onDblClick={(e) => {
-                if ((e.target as HTMLElement).closest('.terminal-tab-close')) return;
-                props.onRequestRename(tab.id);
+              onContextMenu={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setCtxTabId(tab.id);
+                ctxMenu.openAt(e.clientX, e.clientY);
               }}
+              onDblClick={() => props.onRequestRename(tab.id)}
               title={
                 tab.cwd
                   ? `${displayName(tab)} — ${tab.cwd}`
@@ -236,16 +244,6 @@ export function TerminalColumn(props: TerminalColumnProps) {
                   }}
                 />
               </Show>
-              <button
-                class="terminal-tab-close"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  props.onCloseTab(tab.id);
-                }}
-                title="Close tab"
-              >
-                ×
-              </button>
             </div>
           )}
         </For>
@@ -277,6 +275,44 @@ export function TerminalColumn(props: TerminalColumnProps) {
         </button>
       </div>
       <div class="terminal-host" ref={(el) => props.registerHost(props.col, el)} />
+      {/* Right-click tab menu. Portal'd to the body so it escapes the strip's
+       *  `overflow: auto` (same reason as the spawn dropdown). */}
+      <Show when={ctxMenu.isOpen() && ctxMenu.anchor()}>
+        <Portal>
+          <div
+            ref={ctxMenu.setMenu}
+            class="terminal-tab-context-menu portal"
+            role="menu"
+            style={{
+              top: `${ctxMenu.anchor()!.top}px`,
+              left: `${ctxMenu.anchor()!.left}px`,
+            }}
+          >
+            <button
+              class="terminal-tab-context-menu-item"
+              role="menuitem"
+              onClick={() => {
+                const id = ctxTabId();
+                ctxMenu.close();
+                if (id) props.onRequestRename(id);
+              }}
+            >
+              Rename
+            </button>
+            <button
+              class="terminal-tab-context-menu-item danger"
+              role="menuitem"
+              onClick={() => {
+                const id = ctxTabId();
+                ctxMenu.close();
+                if (id) props.onCloseTab(id);
+              }}
+            >
+              Close
+            </button>
+          </div>
+        </Portal>
+      </Show>
     </div>
   );
 }

--- a/src/renderer/terminal-pane/drag-drop.ts
+++ b/src/renderer/terminal-pane/drag-drop.ts
@@ -82,7 +82,13 @@ export function createDragDropController(deps: DragDropDeps): DragDropController
       deps.moveMount(srcId, target.column);
       const tab = deps.tabs().find((t) => t.id === srcId);
       if (tab) {
-        setMeta(srcId, { label: tab.label, customName: tab.customName, column: target.column });
+        setMeta(srcId, {
+          label: tab.label,
+          customName: tab.customName,
+          column: target.column,
+          colorSlot: tab.colorSlot,
+          pinned: tab.pinned,
+        });
       }
       deps.setActiveIn(target.column, srcId);
       deps.setActiveColumn(target.column);

--- a/src/renderer/terminal-pane/persistence.ts
+++ b/src/renderer/terminal-pane/persistence.ts
@@ -9,6 +9,10 @@ export interface PersistedTabMeta {
   label: string;
   customName?: string;
   column: Column;
+  /** Palette slot (0..TAB_COLOR_SLOT_COUNT-1) frozen onto the tab at
+   *  creation. Persisted so the colour survives restarts and never shifts
+   *  when other tabs are closed or reordered. */
+  colorSlot?: number;
   /** When true, `displayName` ignores OSC 7 cwd updates and keeps `label`
    *  (unless `customName` is set). Pinned at spawn time by launchers that
    *  supply a deliberate title — lambda button, code-card "open in term".
@@ -27,6 +31,16 @@ export interface PersistedLayout {
 // is the migration trigger — old keys are left in place to be GC'd.
 export const META_KEY = 'condash:term:meta:v1';
 export const LAYOUT_KEY = 'condash:term:layout:v1';
+// Monotonic colour-sequence counter. Each new tab consumes one tick; the
+// slot is derived from it, then frozen onto the tab. Persisted so the zebra
+// keeps advancing across restarts instead of resetting to red every launch.
+export const COLORSEQ_KEY = 'condash:term:colorseq:v1';
+// Mirrors the app-pill palette length in `panes/app-pill.css` (slots 0..19).
+export const TAB_COLOR_SLOT_COUNT = 20;
+// Stride between consecutive tabs' slots. Coprime with the slot count, so the
+// sequence visits every hue once before repeating and adjacent tabs land far
+// apart on the wheel (red → chartreuse → indigo → …) for clear alternation.
+const COLOR_SLOT_STRIDE = 7;
 export const DEFAULT_PANE_HEIGHT = 280;
 export const DEFAULT_SPLIT_RATIO = 0.5;
 export const MIN_PANE_HEIGHT = 120;
@@ -104,6 +118,27 @@ export function deleteMeta(id: string): void {
   const map = readMeta();
   delete map[id];
   writeMeta(map);
+}
+
+/** Allocate the next creation-time colour slot. Reads + bumps the persisted
+ *  monotonic counter (written synchronously so back-to-back spawns don't all
+ *  collide on the same slot) and maps it onto the palette via the coprime
+ *  stride. Falls back to slot 0 if storage is unavailable. */
+export function allocateColorSlot(): number {
+  let seq = 0;
+  try {
+    const raw = localStorage.getItem(COLORSEQ_KEY);
+    seq = raw ? Number.parseInt(raw, 10) || 0 : 0;
+  } catch {
+    /* sandboxed env — start the sequence from 0 */
+  }
+  const slot = (seq * COLOR_SLOT_STRIDE) % TAB_COLOR_SLOT_COUNT;
+  try {
+    localStorage.setItem(COLORSEQ_KEY, String(seq + 1));
+  } catch {
+    /* ignore quota / sandboxed env */
+  }
+  return slot;
 }
 
 export function readLayout(): PersistedLayout {

--- a/src/renderer/terminal-pane/types.ts
+++ b/src/renderer/terminal-pane/types.ts
@@ -27,6 +27,10 @@ export interface Tab {
    *  until the user manually renames. Set at spawn time for sources that
    *  carry a deliberate title (lambda launcher, code-card "open in term"). */
   pinned?: boolean;
+  /** Palette slot (0..19) assigned at creation and frozen for the tab's
+   *  lifetime — the button colour, drawn from the shared app-pill wheel.
+   *  Stable across closes / reorders / restarts. */
+  colorSlot?: number;
   /** Process exit code; the tab can still be cleared via close. */
   exited?: number;
 }


### PR DESCRIPTION
## Summary

condash's bottom terminal tabs now read as coloured buttons that reuse the shared app-pill palette — the same 20-colour wheel used by the Code pane and project cards. The per-tab close cross (×), easy to hit by accident, is replaced by a right-click context menu with **Close** and **Rename**.

Tab colour is assigned **creation-time zebra**: each new tab takes the next palette slot via a persisted monotonic counter (stride 7 over 20 slots), and the slot is **frozen per tab** (`Tab.colorSlot`, persisted by id). Closing or reordering tabs never recolours the survivors, and colours persist across restarts.

## Changes

- `terminal-pane/types.ts`, `persistence.ts` — add `Tab.colorSlot`, persist it in tab meta, and add `allocateColorSlot()` (monotonic counter in localStorage, mapped onto the palette via a coprime stride).
- `terminal-pane.tsx` — allocate a slot for new tabs / restore it for known tabs in `reconcile`; carry it through rename; import `app-pill.css`.
- `terminal-pane/column.tsx` — apply the `app-pill-N` class to each tab; `onContextMenu` opens a cursor-anchored Close/Rename menu; remove the `×` button; double-click still renames.
- `terminal-pane/drag-drop.ts` — preserve `colorSlot` (and `pinned`) when re-persisting a moved tab.
- `dropdown-menu.ts` — add `openAt(x, y)` so the hook can anchor a menu at a right-click cursor, reusing the existing viewport-flip + dismissal logic.
- `terminal-pane.css` — coloured-button styling (muted inactive, full-strength + accent ring active), context-menu styling; drop the close-cross rules.
- `docs/terminal-pane.md` — update the Tabs (colours) and Close/rename sections.

## Impact / Watchpoints

- localStorage gains a `condash:term:colorseq:v1` counter and a `colorSlot` per tab. Existing tabs with no stored slot get one allocated on the next reconcile (graceful; falls back to slot 0 if storage is unavailable).
- Colour permanence on close/reorder is verified by the data flow and before/after screenshots, not yet by an automated test.

Verified: `make format`, `make typecheck`, `npx vitest run` (734 tests green), `make build` — all pass; before/after screenshots captured headlessly (light + dark) plus the context menu.
