### PR TITLE
Add task scheduling, {TABS} var, and terminal tab auto-titles

### DIFF
--- a/conception-template/tasks/term-titles/prompt.md
+++ b/conception-template/tasks/term-titles/prompt.md
@@ -1,0 +1,70 @@
+You are condash's **terminal-title** task. Your job: give each open terminal
+tab a short, current title describing what it is doing, plus a one-sentence
+summary, and write them to `.condash/term-titles.json`. condash watches that
+file and applies the titles to the tabs — you never touch the tabs directly.
+
+You own your own memory: you read back the file you wrote last cycle to refine
+titles incrementally instead of re-deriving them from scratch. condash holds no
+title state.
+
+## Inputs
+
+- `{TABS}` — the tabs that exist right now, as JSON:
+  `[{ "sid": "t-…", "cwd": "/abs/path", "repo": "name", "cmd": "agedum claude" }]`
+  Only these sids exist. Do not invent sids.
+- Your own previous output, at `./.condash/term-titles.json` (relative to the
+  current directory, which is the conception root). It may be absent on the
+  first run. Its shape is the same one you write below; read back per-sid
+  `title` → `prevTitle`, `summary` → `prevSummary`, `lineCount` → `prevLineCount`.
+
+## Procedure
+
+For each tab in `{TABS}`:
+
+1. **Staleness check.** Get the current total line count:
+   `condash logs read <sid> --meta --json` → read `lines`. If the tab has no
+   log yet, treat the total as 0. Let `delta = total - prevLineCount` (treat a
+   missing `prevLineCount` as 0). If `delta <= 0`, the tab produced nothing new
+   — **keep** `prevTitle`/`prevSummary` (re-emit them unchanged, or omit the
+   tab entirely) and move on. Never blank a title.
+
+2. **Adaptive read.** Read only the new region with a little overlap for
+   context: `N = min(delta + 20, 200)`, then
+   `condash logs read <sid> --tail N --redact --json` and use the `text`.
+   `--redact` masks obvious secrets — always keep it.
+
+3. **Refine.** From `prevTitle` + `prevSummary` + the new lines, produce:
+   - `title`: ≤ 4 words, lowercase-ish, what the tab is doing *now*
+     (e.g. `fixing logs CLI`, `running tests`, `writing PR body`). When the
+     content is thin, fall back to a cheap heuristic: the `cwd` basename plus a
+     hint from `cmd`.
+   - `summary`: one sentence carrying enough state to refine again next cycle
+     (this is your memory, not just a label).
+   - `lineCount`: the `total` from step 1 (your next-cycle `prevLineCount`).
+
+## Output
+
+Write a **sparse** object — only the tabs you changed (omit unchanged/stale
+tabs) — to `.condash/term-titles.json`, **atomically** (write a temp file, then
+rename over the target so condash never reads a half-file):
+
+```json
+{ "titles": [ { "sid": "t-a1b2c3d4", "title": "fixing logs CLI", "summary": "Debugging the logs CLI byte-cursor and adding the kind field.", "lineCount": 482 } ] }
+```
+
+Concretely, from your shell:
+
+```sh
+cat > .condash/term-titles.json.tmp <<'JSON'
+{ "titles": [ … ] }
+JSON
+mv -f .condash/term-titles.json.tmp .condash/term-titles.json
+```
+
+Rules:
+- Only emit sids that appear in `{TABS}`. condash ignores unknown sids and
+  leaves omitted sids untouched, but a tight file is cheaper to validate.
+- Keep titles short — condash clamps to ~48 chars on apply; the detail lives in
+  `summary`.
+- Do not print the titles to the terminal as your "answer" — the **file** is
+  the deliverable. Write it and stop.

--- a/conception-template/tasks/term-titles/task.json
+++ b/conception-template/tasks/term-titles/task.json
@@ -1,0 +1,4 @@
+{
+  "name": "Term titles",
+  "agent": "opencode-kimi-flash"
+}

--- a/docs/guides/tasks-pane.md
+++ b/docs/guides/tasks-pane.md
@@ -52,6 +52,16 @@ A prompt that uses only a sub-token (say just `{APP_PATH}`) still surfaces the m
 
 The app picker lists your configured [repositories](repositories-and-open-with.md); the project picker lists the projects condash already loaded.
 
+### Provided variable: `{TABS}`
+
+`{TABS}` is a **condash-provided** marker — it is never a fillable field; condash injects it from runtime state. It expands to the JSON list of the open terminal tabs that exist right now:
+
+```json
+[ { "sid": "t-a1b2c3d4", "cwd": "/home/you/src/...", "repo": "condash", "cmd": "agedum claude" } ]
+```
+
+Only the tabs that actually exist are injected — no prior titles, no closed tabs. A task that wants to reason about "what is running where" reads `{TABS}` and looks each session up via [`condash logs read`](../reference/cli.md). The shipped **Term titles** task (below) is built on it.
+
 ## Run a task
 
 A task card carries a single **Run…** button — clicking it opens the **run popup**:
@@ -59,8 +69,9 @@ A task card carries a single **Run…** button — clicking it opens the **run p
 1. Open the **Tasks** handle and click **Run…** on a task card.
 2. At the top, the **Agent** select defaults to the task's stored agent — leave it, or switch it to run this one time with a different agent (only prompt-seedable agents are selectable). The **Run** button sits beside it.
 3. Fill the markers below — pick an app / project where prompted, edit the text fields (prefilled from defaults).
-4. The **Prompt to run** box previews the substituted text live.
-5. Click **Run**. condash spawns the chosen agent in a fresh terminal tab (working directory = the conception root), names the tab **`<agent>•<task name>`** so a running task is identifiable at a glance, and delivers the filled prompt: typed into the tab (then Enter when **submit** is on) for an opaque agent, or passed in argv (`--prompt`) when the agent has **promptFlags** set.
+4. A **Keep out of logs** checkbox sits beside the agent picker, prefilled from the task's default (below). When ticked, this run's console log is routed to `.condash/manual/<slug>/` instead of the normal session logs — the tab is still visible and interactive.
+5. The **Prompt to run** box previews the substituted text live.
+6. Click **Run**. condash spawns the chosen agent in a fresh terminal tab (working directory = the conception root), names the tab **`<agent>•<task name>`** so a running task is identifiable at a glance, and delivers the filled prompt: typed into the tab (then Enter when **submit** is on) for an opaque agent, or passed in argv (`--prompt`) when the agent has **promptFlags** set.
 
 Run is disabled when the selected agent is not defined — pick a current one from the top select (a task whose stored agent went missing opens with that dangling id shown as *(missing)*). The card's **Run…** button itself stays disabled while the task's stored agent is missing (the card shows a *missing* badge).
 
@@ -72,8 +83,30 @@ Click **+ New task**, or **click a task card** to open the **editor popup** for 
 - **Agent** — pick an agent from the [`agents` settings list](agent-clis-and-models.md#register-it-as-a-condash-agent); the select shows the agent's `label` and stores its stable `id`. Only agents with [`promptFlags`](../reference/config.md#agents) are selectable — a task hands its filled prompt to the agent via `--prompt`/`--run`, which an opaque command can't accept. Agents without the flag are shown disabled (a new task defaults to the first prompt-seedable agent). A task already pointing at an opaque agent keeps that selection and still runs via the type-into-tab fallback.
 - **Submit** — press Enter after typing (on by default).
 - **Prompt** — markdown with `{MARKERS}`. The **Markers** chips below update live as you type so you can see the fields you're creating.
+- **Schedule** — an opt-in cadence (`30s` / `2m` / `1h`; blank = off). See *Schedule a task* below.
+- **Keep manual runs out of the normal logs** — the per-task default for the run-popup toggle.
 
 The editor carries **Save** / **Cancel** and, for an existing task, a **Delete** button that asks for confirmation first. Renaming the slug moves the task directory.
+
+The **Schedule** and **Keep out of logs** fields are *not* stored in `task.json` (which stays `name` + `agent`); they live under a `taskConfig` map keyed by slug in `.condash/settings.json` (a conception may override it in `condash.json`). Clearing both removes the entry.
+
+## Schedule a task
+
+A task with a **Schedule** cadence runs itself on that interval — **headless**, with no visible tab and no `termSessions` broadcast. There is no default schedule and no default agent: a task is inert until you give it a cadence, and it always carries its own (prompt-seedable) agent.
+
+A scheduled run is **never** written to the normal session logs. Its console output is teed to `.condash/scheduled/<slug>/` (last ~5 runs kept), independent of your global terminal-logging toggle — purely for debugging the agent's chatter. The run's actual *product* is whatever the task itself writes (e.g. `.condash/term-titles.json`); condash does not capture it.
+
+The scheduler is cheap on idle workspaces: it **single-flights** (never overlaps a still-running run of the same task) and **growth-gates** (skips a tick when no open tab produced new output since the last run).
+
+## Keep runs out of the logs
+
+The **Keep out of logs** toggle (per-task default in the editor, overridable per run in the popup) routes a *manual* run's `.txt` to `.condash/manual/<slug>/` instead of `.condash/logs/`. The tab stays visible and interactive; only its on-disk log location changes. With the flag off, the run logs normally.
+
+Both stores — `.condash/scheduled/<slug>/` and `.condash/manual/<slug>/` — are browsable from the Logs pane's **Task runs** view, and stay invisible to the normal Logs list, search, and reports.
+
+## The shipped `term-titles` task
+
+A fresh conception ships an adoptable `tasks/term-titles/` task (it is **not** auto-scheduled). It reads `{TABS}`, sizes an adaptive [`condash logs read --tail`](../reference/cli.md) per tab, refines a short title + one-sentence summary, and writes the sparse `.condash/term-titles.json` that condash watches to auto-name the tabs (see [the embedded terminal](terminal.md#auto-titled-tabs)). Give it a cheap, prompt-seedable agent and a `Schedule` of a minute or two to keep your tab titles current.
 
 ## See also
 

--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -40,6 +40,14 @@ Tab titles depend on how the tab was spawned:
 
 A manual double-click rename always wins. The full path shows in the title attribute. Tabs **auto-close on process exit** — the previous "[process exited N]" stale-tab behaviour is gone. If you want the buffer before close lands, use the toolbar's **Save buffer** button (powered by xterm's serialize addon).
 
+The full title precedence is **manual rename → auto-title → cwd basename (unpinned) → spawn-time label**.
+
+### Auto-titled tabs { #auto-titled-tabs }
+
+condash watches `<conception>/.condash/term-titles.json` and, on change, applies a short title to each tab named in it (matched by session id). A user rename still wins; an auto-title otherwise sits just above the cwd basename. condash never invents these titles itself and holds no title state — it only watches the file and applies what it finds. Sids it doesn't recognise are ignored; tabs not named in the file are left untouched (never blanked).
+
+The file is meant to be produced by a [task](tasks-pane.md): the shipped **Term titles** task reads the open tabs (`{TABS}`), skims each tab's recent log, and writes the sparse file. Schedule it (Tasks → editor → Schedule) to keep titles current, or run it by hand. Any process that writes a valid `term-titles.json` works — condash does not care who wrote it.
+
 `TERM=xterm-256color`, and the shell is launched with `-l` so your login rc-files run.
 
 ## Power-user shortcuts
@@ -208,6 +216,8 @@ The whole `.condash/` directory is gitignored by default — the auto-migrator a
 `View → Show Logs` (`Cmd+Shift+L`) opens the Logs working surface — sessions as a **collapsible card grid grouped by date**, newest first. The last 7 days each get their own collapsible group; **today is always expanded** while the other recent days start collapsed. Anything older is folded into collapsible **per-month** groups (with a day sub-header inside each). Each session card shows the spawn time, repo (when launched via Run), short command, size on disk, and exit code (or "running" while alive; the left edge tints red for non-zero exits).
 
 Clicking a card opens the **session viewer modal**: a wide overlay with the full plain-text transcript and a case-insensitive search box. The transcript is virtualised — only the visible window of lines is mounted, so even a 100 MB log scrolls smoothly. Long lines horizontal-scroll rather than wrap (every row stays exactly one line-height tall, which the virtualizer needs). Search precomputes per-line hit indices once per query; the n/N counter plus the ↑/↓ buttons cycle hits, `Enter` jumps forward, `Shift+Enter` backward, `Cmd/Ctrl+F` focuses the search box, `Esc` closes the modal.
+
+A **Sessions | Task runs** switch at the top of the pane flips to the segregated [task-run](tasks-pane.md#keep-runs-out-of-the-logs) store — scheduled runs and manual runs flagged *Keep out of logs*, grouped by task with a `scheduled` / `manual` badge. These never appear in the normal Sessions list, search, or reports; the same viewer modal opens them.
 
 The `⌫` button in the modal head deletes the open session (one `.txt`, no sidecar to clean up).
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -16,7 +16,7 @@ condash reads two JSON files. Both share **the same schema**. The per-machine `s
 | `settings.json`          | `${XDG_CONFIG_HOME:-~/.config}/condash/settings.json` (Linux) · `~/Library/Application Support/condash/settings.json` (macOS) · `%APPDATA%\condash\settings.json` (Windows) | Per-user, per-machine                     | `lastConceptionPath`, `recentConceptionPaths` (cap 5) |
 | `.condash/settings.json` | `<conception_path>/.condash/settings.json` (legacy fallbacks: `condash.json`, `configuration.json`)                                                                         | Per-conception, **per-host** (gitignored) | (none — every key here also accepts a global default) |
 
-Both files share the **same schema** modulo the two path-tracking keys above. Every other top-level key (`workspace_path`, `worktrees_path`, `repositories`, `retired_apps`, `agents`, `open_with`, `pdf_viewer`, `terminal`, `theme`, `layout`, `welcome`, `cardMinWidth`, `treeExpansion`, `selectedBranches`, `branchFilterStickyAll`) may live in either file — see the [full table](#all-config-keys) below. When the same key appears in both, the conception's value **replaces** the global one entirely (top-level replace; arrays replace, objects replace whole, no deep merge — the one exception is `terminal`, below).
+Both files share the **same schema** modulo the two path-tracking keys above. Every other top-level key (`workspace_path`, `worktrees_path`, `repositories`, `retired_apps`, `agents`, `taskConfig`, `open_with`, `pdf_viewer`, `terminal`, `theme`, `layout`, `welcome`, `cardMinWidth`, `treeExpansion`, `selectedBranches`, `branchFilterStickyAll`) may live in either file — see the [full table](#all-config-keys) below. When the same key appears in both, the conception's value **replaces** the global one entirely (top-level replace; arrays replace, objects replace whole, no deep merge — the one exception is `terminal`, below).
 
 **Exception: `terminal` merges one level deep.** Its sub-schema straddles per-machine input / device prefs (`shell`, `shortcut`, `screenshot_dir`, `xterm`, `screenshot_paste_shortcut`, `move_tab_{left,right}_shortcut`) and per-tree retention policy (`logging.{enabled, retentionDays, maxDirMb, scrollback}`). A pure replace meant any conception that customised `terminal.logging` silently lost every per-machine terminal pref — the screenshot-paste shortcut toasted "no screenshot directory". Conception sub-keys win at the first level; sub-keys absent from the conception fall through to the global block. Nested values inside `terminal.xterm` and `terminal.logging` still replace whole — only the immediate sub-keys of `terminal` merge.
 
@@ -42,6 +42,7 @@ Every top-level key, in one place. **Scope** is which file the key is valid in: 
 | `repositories` | both | array | `[]` | Ordered Code-pane repo list; also the app registry (`#handle`, `label`, `aliases`, `run`, `submodules`, `section`). [↓](#repositories) |
 | `retired_apps` | both | array | `[]` | Defunct `#handle`s still referenced by closed projects — resolve, never rendered. [↓](#retired_apps) |
 | `agents` | both | array | `[]` | Flat `{id,label,command}` terminal-launcher list shown in the tab-strip spawn dropdown. [↓](#agents) |
+| `taskConfig` | both | object | — | Per-task `{schedule?, excludeFromLogs?}` keyed by slug — opt-in headless scheduling + run-log routing. [↓](#tasks) |
 | `open_with` | both | object | — | The three IDE/terminal launch slots (`main_ide`, `secondary_ide`, `terminal`). [↓](#open_with) |
 | `pdf_viewer` | both | array | — | Ordered fallback chain of external PDF viewers. |
 | `terminal` | both | object | — | Shell, shortcuts, screenshot dir, `xterm` theming, `logging`. **Merges one level deep** (the sole exception to top-level replace). [↓](#terminal) |
@@ -55,7 +56,7 @@ Every top-level key, in one place. **Scope** is which file the key is valid in: 
 | `lastConceptionPath` | global-only | string\|null | `null` | Currently-open conception path. |
 | `recentConceptionPaths` | global-only | array | `[]` | Most-recently-opened paths, newest first (cap 5). |
 
-Tasks are **not** a config key — they live on disk at `<conception>/tasks/<slug>/` (see [Tasks](#tasks)). condash also persists a few small UI-state fields it manages itself (e.g. `skillsActiveScope`, the last-active Settings tab) in `settings.json`; you don't edit those by hand. Strict-mode validation rejects any unknown top-level key on save.
+Task *definitions* are **not** a config key — they live on disk at `<conception>/tasks/<slug>/` (see [Tasks](#tasks)). Their per-task **scheduling / log-routing** lives in the `taskConfig` key above, keyed by slug. condash also persists a few small UI-state fields it manages itself (e.g. `skillsActiveScope`, the last-active Settings tab) in `settings.json`; you don't edit those by hand. Strict-mode validation rejects any unknown top-level key on save.
 
 ## `.condash/settings.json` (per-conception, per-host)
 
@@ -263,8 +264,13 @@ condash builds **no** provider environment and stores **no** secrets — model/p
 **Tasks** are reusable, parameterized agent prompts — like agents, they live under the conception (not a `condash.json` key), managed by the **Tasks** pane (left-edge strip → **Tasks**). A task is a referenced agent plus a markdown prompt with fillable `{markers}`.
 
 - **Definition** — `<conception>/tasks/<slug>/`, one directory per task. `task.json` carries `name`, `agent` (the `id` of an agent from the `agents` list above), and `submit` (optional bool, default `true`); `prompt.md` is the raw markdown prompt with markers. Config in JSON, prose in markdown — both are safe to commit. The slug is the directory name (`^[a-z0-9-]+$`); the `tasks/` tree is created on first save.
-- **Markers** — `{KEY}` (required field) or `{KEY:default}` (prefilled). Reserved `{APP}` / `{PROJECT}` (and their `{APP_PATH}` / `{PROJECT_BRANCH}` / … sub-tokens) render as searchable pickers; one selection fills the whole family.
+- **Markers** — `{KEY}` (required field) or `{KEY:default}` (prefilled). Reserved `{APP}` / `{PROJECT}` (and their `{APP_PATH}` / `{PROJECT_BRANCH}` / … sub-tokens) render as searchable pickers; one selection fills the whole family. `{TABS}` is **condash-provided** (never a field) — it expands to the open-tab list `[{sid,cwd,repo,cmd}]`.
 - **Run** — spawns the task's agent in a fresh terminal tab (cwd = conception root). For an opaque agent it types the substituted prompt and presses Enter when `submit` is true; for an agent with [`promptFlags`](#agents) it instead passes the prompt in argv (`--run` when `submit`, else `--prompt`) and types nothing.
+- **`taskConfig`** — per-task scheduling + log routing, keyed by slug, in **`.condash/settings.json`** (or overridden in `condash.json`) — *not* in `task.json`. Each entry is `{ schedule?, excludeFromLogs? }`:
+    - `schedule` — opt-in cadence (`30s` / `2m` / `1h`). A scheduled task runs **headless** (no tab) on that interval, single-flighted + growth-gated; its console output is teed to `.condash/scheduled/<slug>/` (last ~5), **never** the normal logs. No default schedule; the task must carry a prompt-seedable agent.
+    - `excludeFromLogs` — per-task default for routing a *manual* run's `.txt` to `.condash/manual/<slug>/` instead of `.condash/logs/` (overridable per run in the run popup). The tab stays visible.
+  
+  Both segregated stores are browsable from the Logs pane's **Task runs** view and stay invisible to the normal Logs list, search, and reports.
 
 See the [Tasks pane guide](../guides/tasks-pane.md). The same `{KEY:default}` fallback applies to the project / new-project action templates below.
 

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -93,6 +93,9 @@ The terminal pane spawns and drives node-pty sessions. Lifecycle: `termSpawn` �
 | `onTermData(cb)` | Subscribe to stdout/stderr bytes — single channel, multiplexed by session id. |
 | `onTermExit(cb)` | Subscribe to session-exit events. |
 | `onTermSessions(cb)` | Sessions changed (spawn / exit / close). Receives the full snapshot. |
+| `onTermAutoTitles(cb)` | Auto-titles changed — the watcher on `.condash/term-titles.json` validated a new sparse `{sid,title}[]` list (capability 3). The renderer sparse-merges them onto its tabs. |
+| `termAutoTitlesList()` | Pull the current validated auto-titles from `.condash/term-titles.json`. Called on renderer mount to paint titles without waiting for the next file write. |
+| `termTabsContext()` | The open, live tabs as `[{sid,cwd,repo,cmd}]` — the `{TABS}` provided-var payload (capability 2), used to seed a manual task run. |
 
 ## Terminal log surfaces
 
@@ -105,6 +108,7 @@ Per-session terminal capture (when `terminal.logging.enabled` is true) lands at 
 | `logsReadSession(filePath)` | Read one session file. Returns `TermLogSessionRead` — `{ text, meta }` with metadata header / footer stripped from the body. |
 | `logsDeleteDay(day)` | Delete an entire day directory. Returns the number of session files removed. |
 | `logsDeleteSession(filePath)` | Delete one session file. Refuses paths outside `.condash/logs/`. |
+| `logsListTaskRuns()` | Enumerate the segregated task-run store under `.condash/{scheduled,manual}/<slug>/` (capabilities 1 + 4). One `TaskRunGroup` per `<trigger>/<slug>`, runs newest-first. Never reads `.condash/logs/`; the Logs pane's **Task runs** view renders it. |
 
 ## Tree mutations (Knowledge / Resources / Skills panes)
 

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -99,6 +99,43 @@ describe('configSchema repoEntry', () => {
   });
 });
 
+describe('configSchema taskConfig (capability 1)', () => {
+  it('accepts a per-task schedule + excludeFromLogs map', () => {
+    const result = configSchema.safeParse({
+      taskConfig: {
+        'term-titles': { schedule: '2m', excludeFromLogs: true },
+        'daily-journal': { schedule: '1h' },
+        adopted: { excludeFromLogs: true },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty entry (task present but inert)', () => {
+    expect(configSchema.safeParse({ taskConfig: { x: {} } }).success).toBe(true);
+  });
+
+  it('rejects unknown keys inside an entry', () => {
+    const result = configSchema.safeParse({
+      taskConfig: { x: { schedule: '2m', bogus: 1 } },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a non-string schedule / non-boolean excludeFromLogs', () => {
+    expect(configSchema.safeParse({ taskConfig: { x: { schedule: 120 } } }).success).toBe(false);
+    expect(configSchema.safeParse({ taskConfig: { x: { excludeFromLogs: 'yes' } } }).success).toBe(
+      false,
+    );
+  });
+
+  it('is accepted by the global settings schema too (shared field)', () => {
+    expect(globalSettingsSchema.safeParse({ taskConfig: { x: { schedule: '30s' } } }).success).toBe(
+      true,
+    );
+  });
+});
+
 describe('configSchema dropped path keys', () => {
   // Both `resources_path` and `skills_path` were dropped in the reframe —
   // the Resources pane is hard-coded to `<root>/resources/` and the Skills

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -363,6 +363,22 @@ const sharedSchemaFields = {
    *  the tab-strip spawn dropdown. Replaces the per-file `<conception>/agents/`
    *  store. */
   agents: z.array(agentSchema).optional(),
+  /** Per-task config keyed by task slug (capability 1). `schedule` is an
+   *  opt-in cadence (`30s`/`2m`/`1h`) that arms the headless scheduler; absent
+   *  = not scheduled. `excludeFromLogs` is the per-task default for routing a
+   *  manual run out of `.condash/logs/` into `.condash/manual/<slug>/`,
+   *  overridable per run. No default entries — a task is inert until added. */
+  taskConfig: z
+    .record(
+      z.string(),
+      z
+        .object({
+          schedule: z.string().optional(),
+          excludeFromLogs: z.boolean().optional(),
+        })
+        .strict(),
+    )
+    .optional(),
   open_with: z
     .object({
       main_ide: openWithSlot.optional(),

--- a/src/main/effective-config.ts
+++ b/src/main/effective-config.ts
@@ -4,6 +4,7 @@ import type {
   Agent,
   CardMinWidthPrefs,
   LayoutState,
+  TaskConfigEntry,
   TerminalPrefs,
   Theme,
   TreeExpansionPrefs,
@@ -61,6 +62,7 @@ export interface EffectiveConfig extends ConfigShape {
   layout?: LayoutState;
   treeExpansion?: TreeExpansionPrefs;
   agents?: Agent[];
+  taskConfig?: Record<string, TaskConfigEntry>;
 }
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,6 +8,9 @@ import { pathToFileURL } from 'node:url';
 import { decideDispatch } from './dispatch';
 import { DEFAULT_LAYOUT, readSettings } from './settings';
 import { setWatchedConception } from './watcher';
+import { setWatchedTermTitles } from './term-titles-watcher';
+import { setScheduledConception } from './task-scheduler';
+import { registerTermTitlesIpc } from './ipc/term-titles';
 import { disposeRepoWatchers } from './repo-watchers';
 import { killAll, migrateTerminalFromConfigIfNeeded } from './terminals';
 import { loginPath } from './shell-env';
@@ -313,6 +316,7 @@ function registerIpc(): void {
   registerReposIpc();
   registerTerminalIpc();
   registerLogsIpc();
+  registerTermTitlesIpc();
   registerSettingsIpc({ onLayoutChange: rebuildMenu });
   registerSystemIpc({
     onConceptionPicked: (picked) => {
@@ -320,6 +324,10 @@ function registerIpc(): void {
       updateWindowTitle(picked);
       void rebuildMenuFromSettings();
       startJanitor(picked);
+      // Re-point the term-titles watcher + the task scheduler at the newly
+      // picked conception (capabilities 1 + 3).
+      void setWatchedTermTitles(picked);
+      void setScheduledConception(picked);
       // Heal any orphan "running" logs in the newly-picked conception so
       // the Logs pane reflects reality on first render.
       void sealOrphanLogs(picked).catch((err) => {
@@ -386,6 +394,10 @@ app.whenReady().then(async () => {
   const conceptionPath = settings.lastConceptionPath;
   cachedConceptionPath = conceptionPath;
   await setWatchedConception(conceptionPath);
+  // Watch `.condash/term-titles.json` (capability 3) and arm the per-task
+  // scheduler (capability 1) for the active conception.
+  await setWatchedTermTitles(conceptionPath);
+  await setScheduledConception(conceptionPath);
   // Sweep `.condash/logs/` for expired day-directories. Runs once at
   // startup and on a 24 h interval. Bounded by the effective
   // `terminal.logging.retentionDays` / `maxDirMb` settings; defaults are

--- a/src/main/ipc/logs.ts
+++ b/src/main/ipc/logs.ts
@@ -3,9 +3,10 @@ import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import type { TermLogSessionMeta, TermLogSessionRead } from '../../shared/types';
 import { parseMetaLine, splitContent, type FooterJson, type HeaderJson } from '../logs-format';
-import { condashLogsRoot } from '../condash-dir';
+import { condashDir, condashLogsRoot } from '../condash-dir';
 import { requirePathUnder } from '../path-bounds';
 import { readSettings } from '../settings';
+import { isTaskRunPath, listTaskRuns } from '../task-runs';
 
 // Re-exported so callers that historically imported `splitContent` from this
 // file keep working. New code should import directly from `../logs-format`.
@@ -29,6 +30,13 @@ export function registerLogsIpc(): void {
   ipcMain.handle('logsReadSession', async (_e, filePath: string) => readSession(filePath));
   ipcMain.handle('logsDeleteDay', async (_e, day: string) => deleteDay(day));
   ipcMain.handle('logsDeleteSession', async (_e, filePath: string) => deleteSession(filePath));
+  ipcMain.handle('logsListTaskRuns', async () => listTaskRunsForActiveConception());
+}
+
+async function listTaskRunsForActiveConception(): ReturnType<typeof listTaskRuns> {
+  const conception = await activeConceptionPath();
+  if (!conception) return [];
+  return listTaskRuns(conception);
 }
 
 interface DayEntry {
@@ -212,7 +220,15 @@ function findLastFooterLine(text: string): FooterJson | null {
 async function readSession(filePath: string): Promise<TermLogSessionRead> {
   const conception = await activeConceptionPath();
   if (!conception) return { text: '', meta: null };
-  await requirePathUnder(filePath, condashLogsRoot(conception));
+  // Task-run files (capabilities 1 + 4) live under `.condash/{scheduled,
+  // manual}/<slug>/`, outside the normal logs root — bound those reads to the
+  // `.condash/` dir (realpath-checked, so `..` traversal is still rejected);
+  // everything else stays bounded to the logs root.
+  if (isTaskRunPath(conception, filePath)) {
+    await requirePathUnder(filePath, condashDir(conception));
+  } else {
+    await requirePathUnder(filePath, condashLogsRoot(conception));
+  }
   if (!filePath.endsWith('.txt')) {
     throw new Error('logsReadSession: only .txt files');
   }

--- a/src/main/ipc/tasks.ts
+++ b/src/main/ipc/tasks.ts
@@ -1,6 +1,9 @@
 import { ipcMain } from 'electron';
 import type { TaskDef } from '../../shared/tasks';
+import type { TaskConfigEntry } from '../../shared/types';
 import { deleteTask, listTasks, readTask, writeTask } from '../tasks';
+import { getEffectiveConceptionConfig } from '../effective-config';
+import { updateSettings } from '../settings';
 import { withConception } from './utils';
 
 /**
@@ -22,4 +25,37 @@ export function registerTasksIpc(): void {
       await deleteTask(c, slug);
     }, undefined),
   );
+
+  // Per-task schedule / excludeFromLogs config (capability 1). Read merges
+  // through the effective config (condash.json over settings.json); writes
+  // always target the per-machine settings.json `taskConfig` map.
+  ipcMain.handle('getTaskConfig', () =>
+    withConception(async (c) => {
+      const config = await getEffectiveConceptionConfig(c);
+      return (config.taskConfig ?? {}) as Record<string, TaskConfigEntry>;
+    }, {}),
+  );
+
+  ipcMain.handle('setTaskConfig', async (_, slug: string, entry: TaskConfigEntry) => {
+    if (typeof slug !== 'string' || slug.length === 0) {
+      throw new Error('setTaskConfig: slug must be a non-empty string');
+    }
+    const schedule =
+      typeof entry?.schedule === 'string' && entry.schedule.trim().length > 0
+        ? entry.schedule.trim()
+        : undefined;
+    const excludeFromLogs = entry?.excludeFromLogs === true ? true : undefined;
+    await updateSettings((cur) => {
+      const map = { ...((cur.taskConfig ?? {}) as Record<string, TaskConfigEntry>) };
+      if (schedule === undefined && excludeFromLogs === undefined) {
+        delete map[slug];
+      } else {
+        map[slug] = {
+          ...(schedule ? { schedule } : {}),
+          ...(excludeFromLogs ? { excludeFromLogs } : {}),
+        };
+      }
+      return { ...cur, taskConfig: Object.keys(map).length > 0 ? map : undefined };
+    });
+  });
 }

--- a/src/main/ipc/term-titles.ts
+++ b/src/main/ipc/term-titles.ts
@@ -1,0 +1,17 @@
+import { ipcMain } from 'electron';
+import { readTermTitles } from '../term-titles';
+import { readSettings } from '../settings';
+
+/**
+ * IPC for capability 3's apply path. The live channel is the push-only
+ * `termAutoTitles` event (broadcast by `term-titles-watcher.ts`); this verb is
+ * the pull complement so a freshly-mounted renderer (or one reloaded after a
+ * crash) can paint the current titles without waiting for the next file write.
+ */
+export function registerTermTitlesIpc(): void {
+  ipcMain.handle('termAutoTitlesList', async () => {
+    const { lastConceptionPath } = await readSettings();
+    if (!lastConceptionPath) return [];
+    return readTermTitles(lastConceptionPath);
+  });
+}

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -8,6 +8,7 @@ import {
   setSessionSide,
   setTerminalPrefs,
   spawnTerminal,
+  tabsContext,
   writeTerminal,
 } from '../terminals';
 import { latestScreenshot } from '../screenshot';
@@ -41,6 +42,8 @@ export function registerTerminalIpc(): void {
   });
 
   ipcMain.handle('termList', () => listTerminalSessions());
+
+  ipcMain.handle('termTabsContext', () => tabsContext());
 
   ipcMain.handle('termAttach', (event, id: string) => attachTerminal(id, event.sender));
 

--- a/src/main/task-runs.test.ts
+++ b/src/main/task-runs.test.ts
@@ -1,0 +1,96 @@
+import { mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  isTaskRunPath,
+  listTaskRuns,
+  rotateTaskRuns,
+  taskRunDir,
+  taskRunLogPath,
+} from './task-runs';
+import { condashLogsRoot } from './condash-dir';
+
+let root: string;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'condash-taskruns-'));
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+function seedRun(trigger: 'scheduled' | 'manual', slug: string, name: string): void {
+  const dir = taskRunDir(root, trigger, slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, name), '# condash: {"sid":"x"}\n\nbody\n');
+}
+
+describe('taskRunLogPath', () => {
+  it('builds .condash/<trigger>/<slug>/YYYYMMDD-HHMMSS-<sid>.txt', () => {
+    const p = taskRunLogPath(
+      root,
+      'scheduled',
+      'term-titles',
+      't-abc',
+      new Date('2026-05-31T09:08:07'),
+    );
+    expect(p).toContain(join('.condash', 'scheduled', 'term-titles'));
+    expect(p.endsWith('20260531-090807-t-abc.txt')).toBe(true);
+  });
+});
+
+describe('rotateTaskRuns', () => {
+  it('keeps the newest N run files, prunes the rest', async () => {
+    const slug = 'term-titles';
+    for (let i = 1; i <= 8; i++) {
+      seedRun('scheduled', slug, `2026053${i}-090807-t-${i}.txt`);
+    }
+    await rotateTaskRuns(taskRunDir(root, 'scheduled', slug), 5);
+    const remaining = readdirSync(taskRunDir(root, 'scheduled', slug)).sort();
+    expect(remaining.length).toBe(5);
+    // Newest five (suffix 4..8) survive; oldest (1..3) pruned.
+    expect(remaining[0]).toContain('-t-4.txt');
+    expect(remaining.at(-1)).toContain('-t-8.txt');
+  });
+
+  it('is a no-op on a missing dir', async () => {
+    await expect(rotateTaskRuns(taskRunDir(root, 'manual', 'nope'))).resolves.toBeUndefined();
+  });
+});
+
+describe('listTaskRuns', () => {
+  it('groups by trigger+slug, runs newest-first', async () => {
+    seedRun('scheduled', 'term-titles', '20260531-090801-t-a.txt');
+    seedRun('scheduled', 'term-titles', '20260531-090802-t-b.txt');
+    seedRun('manual', 'term-titles', '20260531-090803-t-c.txt');
+    const groups = await listTaskRuns(root);
+    const scheduled = groups.find((g) => g.trigger === 'scheduled')!;
+    expect(scheduled.taskSlug).toBe('term-titles');
+    expect(scheduled.runs.map((r) => r.sid)).toEqual(['t-b', 't-a']); // newest first
+    expect(scheduled.runs[0].day).toBe('2026-05-31');
+    expect(scheduled.runs[0].time).toBe('09:08:02');
+    expect(groups.some((g) => g.trigger === 'manual')).toBe(true);
+  });
+
+  it('returns [] when the store is empty', async () => {
+    expect(await listTaskRuns(root)).toEqual([]);
+  });
+
+  it('ignores files that are not run-shaped', async () => {
+    seedRun('scheduled', 'term-titles', 'not-a-run.txt');
+    expect(await listTaskRuns(root)).toEqual([]);
+  });
+});
+
+describe('isTaskRunPath', () => {
+  it('accepts a .txt under a task-run dir', () => {
+    expect(isTaskRunPath(root, taskRunLogPath(root, 'manual', 's', 't-a'))).toBe(true);
+  });
+  it('rejects a normal logs path and non-.txt', () => {
+    expect(
+      isTaskRunPath(root, join(condashLogsRoot(root), '2026', '05', '31', '090807-t-a.txt')),
+    ).toBe(false);
+    expect(isTaskRunPath(root, taskRunDir(root, 'manual', 's') + '/run.log')).toBe(false);
+  });
+});

--- a/src/main/task-runs.ts
+++ b/src/main/task-runs.ts
@@ -1,0 +1,146 @@
+/**
+ * Segregated task-run console logs (capabilities 1 + 4).
+ *
+ * Task runs that opt out of the normal logs — every `scheduled` run, and a
+ * `manual` run of a task flagged `excludeFromLogs` — write their console
+ * output here instead of `.condash/logs/`:
+ *
+ *   <conception>/.condash/<trigger>/<task-slug>/<YYYYMMDD>-<HHMMSS>-<sid>.txt
+ *
+ * `trigger` ∈ {scheduled, manual}. Files reuse the session `.txt` format (a
+ * `# condash:` header line + rendered body) so the existing logs-modal viewer
+ * and `splitContent` readers work unchanged. The dirs are **never** under
+ * `.condash/logs/`, so `logs-reports`, the normal Logs list, and `work-overview`
+ * never see them. The Logs pane's "Task runs" view browses this store.
+ *
+ * Retention: last ~5 runs per `<trigger>/<slug>` dir, oldest pruned.
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { isValidSlugTail } from '../shared/slug';
+import type { TaskRunEntry, TaskRunGroup, TaskTrigger } from '../shared/types';
+import { condashDir } from './condash-dir';
+
+export const TASK_TRIGGERS: readonly TaskTrigger[] = ['scheduled', 'manual'];
+
+/** Keep at most this many run files per `<trigger>/<slug>` dir. */
+export const TASK_RUN_KEEP = 5;
+
+/** Absolute path to `<conception>/.condash/<trigger>/<slug>/`. */
+export function taskRunDir(conception: string, trigger: TaskTrigger, slug: string): string {
+  return join(condashDir(conception), trigger, slug);
+}
+
+/** Build the run-file path for one spawn. Filename `YYYYMMDD-HHMMSS-<sid>.txt`
+ *  carries its own date so a flat per-slug dir stays sortable. */
+export function taskRunLogPath(
+  conception: string,
+  trigger: TaskTrigger,
+  slug: string,
+  sid: string,
+  when: Date = new Date(),
+): string {
+  const yyyy = String(when.getFullYear());
+  const mm = String(when.getMonth() + 1).padStart(2, '0');
+  const dd = String(when.getDate()).padStart(2, '0');
+  const hh = String(when.getHours()).padStart(2, '0');
+  const mi = String(when.getMinutes()).padStart(2, '0');
+  const ss = String(when.getSeconds()).padStart(2, '0');
+  return join(
+    taskRunDir(conception, trigger, slug),
+    `${yyyy}${mm}${dd}-${hh}${mi}${ss}-${sid}.txt`,
+  );
+}
+
+const RUN_FILE_RE = /^(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})-(.+)\.txt$/;
+
+/** Parse a run filename into its entry fields, or null when it doesn't match. */
+function parseRunFile(dir: string, name: string, bytes: number): TaskRunEntry | null {
+  const m = RUN_FILE_RE.exec(name);
+  if (!m) return null;
+  const [, y, mo, d, hh, mi, ss, sid] = m;
+  return {
+    path: join(dir, name),
+    day: `${y}-${mo}-${d}`,
+    time: `${hh}:${mi}:${ss}`,
+    sid,
+    bytes,
+  };
+}
+
+async function readDirSafe(path: string): Promise<string[]> {
+  try {
+    return await fs.readdir(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+/**
+ * Prune a `<trigger>/<slug>` dir down to the newest `keep` run files. Called
+ * after a new run file is created. Best-effort — swallows fs errors so a
+ * rotation failure never blocks a spawn.
+ */
+export async function rotateTaskRuns(dir: string, keep: number = TASK_RUN_KEEP): Promise<void> {
+  try {
+    const names = (await readDirSafe(dir)).filter((n) => RUN_FILE_RE.test(n));
+    // Filenames sort lexicographically === chronologically (zero-padded
+    // YYYYMMDD-HHMMSS prefix). Newest last; drop everything before the tail.
+    names.sort();
+    const excess = names.length - keep;
+    for (let i = 0; i < excess; i++) {
+      await fs.rm(join(dir, names[i]), { force: true }).catch(() => undefined);
+    }
+  } catch {
+    /* rotation is best-effort */
+  }
+}
+
+/**
+ * Enumerate every segregated task run under `.condash/scheduled/*` and
+ * `.condash/manual/*`. Returns one group per `<trigger>/<slug>`, runs
+ * newest-first, groups sorted by slug then trigger. Empty when nothing exists.
+ */
+export async function listTaskRuns(conception: string): Promise<TaskRunGroup[]> {
+  const groups: TaskRunGroup[] = [];
+  for (const trigger of TASK_TRIGGERS) {
+    const triggerRoot = join(condashDir(conception), trigger);
+    const slugs = await readDirSafe(triggerRoot);
+    for (const slug of slugs) {
+      if (!isValidSlugTail(slug)) continue;
+      const dir = join(triggerRoot, slug);
+      const names = await readDirSafe(dir);
+      const runs: TaskRunEntry[] = [];
+      for (const name of names) {
+        if (!RUN_FILE_RE.test(name)) continue;
+        let bytes = 0;
+        try {
+          bytes = (await fs.stat(join(dir, name))).size;
+        } catch {
+          continue;
+        }
+        const entry = parseRunFile(dir, name, bytes);
+        if (entry) runs.push(entry);
+      }
+      if (runs.length === 0) continue;
+      runs.sort((a, b) => (a.path < b.path ? 1 : -1));
+      groups.push({ taskSlug: slug, trigger, runs });
+    }
+  }
+  groups.sort((a, b) => a.taskSlug.localeCompare(b.taskSlug) || a.trigger.localeCompare(b.trigger));
+  return groups;
+}
+
+/** True when `path` is a `.txt` inside one of this conception's task-run
+ *  dirs. Used by the Logs IPC to bound `logsReadSession` reads to the
+ *  segregated store as well as the normal logs root. */
+export function isTaskRunPath(conception: string, path: string): boolean {
+  if (!path.endsWith('.txt')) return false;
+  for (const trigger of TASK_TRIGGERS) {
+    const root = join(condashDir(conception), trigger);
+    if (path === root) continue;
+    if (path.startsWith(root + '/') || path.startsWith(root + '\\')) return true;
+  }
+  return false;
+}

--- a/src/main/task-scheduler.ts
+++ b/src/main/task-scheduler.ts
@@ -1,0 +1,215 @@
+/**
+ * Capability 1 — schedule any task, headless, without polluting the logs.
+ *
+ * A main-side recurring interval (the same pattern that drives the log
+ * janitor, `index.ts`) ticks over the per-task `taskConfig` map in the
+ * effective config. For each task carrying a `schedule` cadence it:
+ *   - single-flights (skips while a prior run of the same task is in flight),
+ *   - growth-gates (skips when no open tab produced new output since the last
+ *     run — an idle workspace costs nothing),
+ *   - and, when due, runs the bound task in a **background pty** with no tab,
+ *     no `TermSession` broadcast, and output teed to
+ *     `.condash/scheduled/<slug>/` (always — independent of the user's global
+ *     logging toggle), keeping the last ~5 runs.
+ *
+ * condash never captures the run's *product*: the task writes
+ * `.condash/term-titles.json` itself and the watcher applies it. There is no
+ * capture-on-exit handshake here.
+ *
+ * No default schedule and no default agent: a task runs only when its
+ * `taskConfig` entry sets a cadence, and it carries its own agent.
+ */
+import { randomBytes } from 'node:crypto';
+import * as pty from 'node-pty';
+import { listAgents } from './agents';
+import { getEffectiveConceptionConfig } from './effective-config';
+import { readSettings } from './settings';
+import { readTask } from './tasks';
+import { spawnEnv } from './shell-env';
+import { substitute } from '../shared/action-template';
+import { parseCadence } from '../shared/cadence';
+import { SessionLogger } from './terminal-logger';
+import { tabsContext, totalBytesSeen } from './terminals';
+import type { Agent, TaskConfigEntry } from '../shared/types';
+
+/** How often the scheduler wakes to check for due tasks. */
+const TICK_MS = 20_000;
+
+/** Hard cap on a single headless run before it is killed — a runaway or hung
+ *  agent must not accumulate background ptys. */
+const RUN_TIMEOUT_MS = 10 * 60_000;
+
+interface TaskState {
+  /** Epoch ms of the last time we launched (or deliberately skipped) this task. */
+  lastCheckedAt: number;
+  /** True while a headless run of this task is still alive (single-flight). */
+  inFlight: boolean;
+  /** `totalBytesSeen()` captured at the last actual launch — the growth gate. */
+  bytesAtLastRun: number;
+}
+
+let current: { path: string; interval: ReturnType<typeof setInterval> } | null = null;
+const states = new Map<string, TaskState>();
+
+/** POSIX single-quote so the substituted prompt survives `-c "<cmd>"`. */
+function shellSingleQuote(text: string): string {
+  return `'${text.replace(/'/g, "'\\''")}'`;
+}
+
+function makeSid(): string {
+  return `t-${randomBytes(4).toString('hex')}`;
+}
+
+function resolveShell(configured?: string): string {
+  if (configured && configured.trim()) return configured;
+  if (process.platform !== 'win32' && process.env.SHELL) return process.env.SHELL;
+  if (process.platform === 'win32') return process.env.ComSpec || 'cmd.exe';
+  return '/bin/bash';
+}
+
+function wrap(command: string): string[] {
+  if (process.platform === 'win32') return ['/d', '/s', '/c', command];
+  return ['-c', command];
+}
+
+/**
+ * Run one task headlessly. Resolves the bound task + agent, substitutes the
+ * prompt (including the `{TABS}` provided var), spawns a background pty seeded
+ * with the agent's `--prompt`, and tees output to `.condash/scheduled/<slug>/`
+ * via a forced-on `SessionLogger`. Resolves when the pty exits (or is killed
+ * on timeout). Throws on any setup error so the caller can clear in-flight.
+ */
+async function runHeadless(conceptionPath: string, slug: string): Promise<void> {
+  const task = await readTask(conceptionPath, slug);
+  if (!task) throw new Error(`task ${slug} not found`);
+  const agents = await listAgents(conceptionPath);
+  const agent: Agent | undefined = agents.find((a) => a.id === task.agent);
+  if (!agent || !agent.command.trim()) {
+    throw new Error(`task ${slug}: agent '${task.agent}' is not defined`);
+  }
+  // Headless runs can only deliver the prompt via argv — there is no live TUI
+  // to keystroke into. Require a prompt-seedable agent.
+  if (!agent.promptFlags) {
+    throw new Error(`task ${slug}: agent '${agent.id}' has no promptFlags (cannot run headless)`);
+  }
+
+  const settings = await readSettings();
+  const config = await getEffectiveConceptionConfig(conceptionPath);
+  const shell = resolveShell(config.terminal?.shell ?? settings.terminal?.shell);
+
+  const prompt = substitute(task.prompt, { TABS: JSON.stringify(tabsContext()) });
+  const command = `${agent.command} --prompt ${shellSingleQuote(prompt)}`;
+  const argv = wrap(command);
+
+  const childEnv: NodeJS.ProcessEnv = { ...(await spawnEnv()), TERM: 'xterm-256color' };
+  delete childEnv.npm_config_prefix;
+  delete childEnv.npm_config_globalconfig;
+  delete childEnv.npm_config_userconfig;
+
+  const sid = makeSid();
+  // Force-enable the logger: a scheduled run is always recorded to its
+  // segregated dir regardless of the user's global terminal-logging toggle.
+  const logger = new SessionLogger(
+    conceptionPath,
+    {
+      sid,
+      side: 'my',
+      cwd: conceptionPath,
+      spawn: { cmd: shell, argv },
+      taskContext: { taskSlug: slug, trigger: 'scheduled' },
+    },
+    { ...(config.terminal?.logging ?? {}), enabled: true },
+  );
+  logger.spawn();
+
+  const child = pty.spawn(shell, argv, {
+    name: 'xterm-256color',
+    cols: 120,
+    rows: 40,
+    cwd: conceptionPath,
+    env: childEnv,
+  });
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      void logger.close().finally(resolve);
+    };
+    const timer = setTimeout(() => {
+      try {
+        if (process.platform === 'win32') child.kill();
+        else process.kill(-child.pid, 'SIGKILL');
+      } catch {
+        /* already gone */
+      }
+      finish();
+    }, RUN_TIMEOUT_MS);
+    child.onData((data) => logger.output(data));
+    child.onExit(({ exitCode }) => {
+      logger.exit(exitCode);
+      finish();
+    });
+  });
+}
+
+/** One scheduler tick: launch every due, non-in-flight, grown task. */
+async function tick(conceptionPath: string): Promise<void> {
+  let config;
+  try {
+    config = await getEffectiveConceptionConfig(conceptionPath);
+  } catch {
+    return;
+  }
+  const taskConfig = (config.taskConfig ?? {}) as Record<string, TaskConfigEntry>;
+  const now = Date.now();
+  for (const [slug, entry] of Object.entries(taskConfig)) {
+    const cadence = parseCadence(entry?.schedule);
+    if (cadence === null) continue;
+    let state = states.get(slug);
+    if (!state) {
+      state = { lastCheckedAt: 0, inFlight: false, bytesAtLastRun: -1 };
+      states.set(slug, state);
+    }
+    if (state.inFlight) continue;
+    if (now - state.lastCheckedAt < cadence) continue;
+
+    // Growth gate: after the first run, skip when no tab produced new output.
+    const bytes = totalBytesSeen();
+    if (state.bytesAtLastRun >= 0 && bytes === state.bytesAtLastRun) {
+      state.lastCheckedAt = now;
+      continue;
+    }
+
+    state.inFlight = true;
+    state.lastCheckedAt = now;
+    state.bytesAtLastRun = bytes;
+    void runHeadless(conceptionPath, slug)
+      .catch((err) => {
+        process.stderr.write(`condash task-scheduler: ${slug}: ${(err as Error).message}\n`);
+      })
+      .finally(() => {
+        const s = states.get(slug);
+        if (s) s.inFlight = false;
+      });
+  }
+}
+
+/**
+ * Arm (or re-point) the per-task scheduler for `conceptionPath`, or tear it
+ * down with `null`. Clears prior per-task state on a conception switch so a
+ * stale cadence from the old tree doesn't carry over.
+ */
+export async function setScheduledConception(conceptionPath: string | null): Promise<void> {
+  if (current?.path === conceptionPath) return;
+  if (current) {
+    clearInterval(current.interval);
+    current = null;
+  }
+  states.clear();
+  if (!conceptionPath) return;
+  const interval = setInterval(() => void tick(conceptionPath), TICK_MS);
+  current = { path: conceptionPath, interval };
+}

--- a/src/main/term-titles-watcher.ts
+++ b/src/main/term-titles-watcher.ts
@@ -1,0 +1,80 @@
+/**
+ * Standalone watcher for `<conception>/.condash/term-titles.json` (capability
+ * 3 — watch + apply). Deliberately *not* folded into the conception-tree
+ * watcher (`watcher.ts`): that watcher ignores dotfile segments (`.condash/`),
+ * fires `tree-events` (which trigger full tree rebuilds), and classifying a
+ * `.condash/` file there would couple title-apply to project/knowledge
+ * reconciliation. This one watches a single file and broadcasts a dedicated
+ * `termAutoTitles` event carrying the validated `{sid, title}` list. The
+ * renderer sparse-merges them onto its tabs (unknown sids ignored, omitted
+ * sids left untouched) — see `terminal-pane.tsx`.
+ *
+ * Atomic writes (tmp + rename) by the producing task pair with chokidar's
+ * `awaitWriteFinish` so a watcher never reads a half-file.
+ */
+import chokidar, { type FSWatcher } from 'chokidar';
+import { BrowserWindow } from 'electron';
+import type { TermAutoTitle } from '../shared/types';
+import { readTermTitles, termTitlesPath } from './term-titles';
+
+const DEBOUNCE_MS = 150;
+
+let current: { path: string; watcher: FSWatcher } | null = null;
+let timer: NodeJS.Timeout | null = null;
+
+function broadcast(titles: TermAutoTitle[]): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) continue;
+    win.webContents.send('termAutoTitles', titles);
+  }
+}
+
+/** Read the current file and push its validated titles to every window. */
+async function applyNow(conceptionPath: string): Promise<void> {
+  broadcast(await readTermTitles(conceptionPath));
+}
+
+function schedule(conceptionPath: string): void {
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    timer = null;
+    void applyNow(conceptionPath);
+  }, DEBOUNCE_MS);
+}
+
+/**
+ * Point the term-titles watcher at `conceptionPath` (or tear it down with
+ * `null`). Idempotent for the same path. Does an immediate apply on setup so a
+ * conception opened with a pre-existing file paints its titles without waiting
+ * for the next write.
+ */
+export async function setWatchedTermTitles(conceptionPath: string | null): Promise<void> {
+  if (current?.path === conceptionPath) return;
+  if (current) {
+    await current.watcher.close().catch(() => undefined);
+    current = null;
+  }
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+  if (!conceptionPath) return;
+
+  const file = termTitlesPath(conceptionPath);
+  const watcher = chokidar.watch(file, {
+    ignoreInitial: true,
+    persistent: true,
+    awaitWriteFinish: { stabilityThreshold: 100, pollInterval: 50 },
+  });
+  watcher.on('add', () => schedule(conceptionPath));
+  watcher.on('change', () => schedule(conceptionPath));
+  // unlink → broadcast empty so nothing new is applied; existing titles are
+  // left in place on the renderer (we never wipe), matching the sparse-merge
+  // contract. No-op broadcast is harmless.
+  watcher.on('error', (err) => console.error('[term-titles-watcher]', err));
+
+  current = { path: conceptionPath, watcher };
+  // Best-effort initial apply (the renderer also pulls via termAutoTitlesList
+  // on mount, covering the case where no window exists yet at boot).
+  void applyNow(conceptionPath);
+}

--- a/src/main/term-titles.test.ts
+++ b/src/main/term-titles.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { TITLE_MAX_LEN, validateTermTitles } from './term-titles';
+
+describe('validateTermTitles', () => {
+  it('parses a good sparse file into {sid,title}', () => {
+    const raw = JSON.stringify({
+      titles: [
+        { sid: 't-a1', title: 'fixing logs CLI', summary: 'long sentence', lineCount: 482 },
+        { sid: 't-b2', title: 'running tests' },
+      ],
+    });
+    expect(validateTermTitles(raw)).toEqual([
+      { sid: 't-a1', title: 'fixing logs CLI' },
+      { sid: 't-b2', title: 'running tests' },
+    ]);
+  });
+
+  it('returns [] for malformed JSON', () => {
+    expect(validateTermTitles('{ not json')).toEqual([]);
+  });
+
+  it('returns [] for the wrong shape (no titles array)', () => {
+    expect(validateTermTitles(JSON.stringify({ foo: 1 }))).toEqual([]);
+    expect(validateTermTitles(JSON.stringify({ titles: 'nope' }))).toEqual([]);
+  });
+
+  it('returns [] for an entry missing sid or with a non-string title', () => {
+    expect(validateTermTitles(JSON.stringify({ titles: [{ title: 'x' }] }))).toEqual([]);
+    expect(validateTermTitles(JSON.stringify({ titles: [{ sid: 't-a', title: 5 }] }))).toEqual([]);
+  });
+
+  it('clamps an over-long title and collapses whitespace', () => {
+    const long = 'a'.repeat(100);
+    const [entry] = validateTermTitles(JSON.stringify({ titles: [{ sid: 't-a', title: long }] }));
+    expect(entry.title.length).toBe(TITLE_MAX_LEN);
+    expect(entry.title.endsWith('…')).toBe(true);
+
+    const [ws] = validateTermTitles(
+      JSON.stringify({ titles: [{ sid: 't-a', title: '  fixing   logs\n CLI ' }] }),
+    );
+    expect(ws.title).toBe('fixing logs CLI');
+  });
+
+  it('drops entries that clamp to an empty title (never blanks a tab)', () => {
+    expect(validateTermTitles(JSON.stringify({ titles: [{ sid: 't-a', title: '   ' }] }))).toEqual(
+      [],
+    );
+  });
+
+  it('keeps the first of duplicate sids', () => {
+    const raw = JSON.stringify({
+      titles: [
+        { sid: 't-a', title: 'first' },
+        { sid: 't-a', title: 'second' },
+      ],
+    });
+    expect(validateTermTitles(raw)).toEqual([{ sid: 't-a', title: 'first' }]);
+  });
+});

--- a/src/main/term-titles.ts
+++ b/src/main/term-titles.ts
@@ -1,0 +1,95 @@
+/**
+ * `.condash/term-titles.json` — the watched product of capability 3.
+ *
+ * condash does **not** know how the file is produced: a scheduled or adopted
+ * task writes it (sparse, atomic tmp+rename); condash watches it and, on
+ * change, validates + clamps it into a list of `{sid, title}` auto-titles that
+ * the renderer sparse-merges onto its tabs. The task owns all title *state*
+ * (it reads back its own prior file); condash holds none.
+ *
+ * This module is the single parser/validator. It is pure + `fs`-free below
+ * `readTermTitles` (split out so the watcher and the unit tests can share the
+ * validation without a real file). Malformed / partial input yields `[]` — the
+ * caller does nothing and current titles are left untouched.
+ */
+import { promises as fs } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import type { TermAutoTitle } from '../shared/types';
+import { condashDir } from './condash-dir';
+
+/** Watched filename inside `.condash/`. */
+export const TERM_TITLES_FILENAME = 'term-titles.json';
+
+/** Absolute path to `<conception>/.condash/term-titles.json`. */
+export function termTitlesPath(conception: string): string {
+  return join(condashDir(conception), TERM_TITLES_FILENAME);
+}
+
+/** Max rendered length of an applied title. Longer titles are truncated with
+ *  an ellipsis — the one-sentence summary (the task's own memory) carries the
+ *  detail; the tab strip only has room for a few words. */
+export const TITLE_MAX_LEN = 48;
+
+/** The on-disk shape. `summary` / `lineCount` are the *task's* memory — read
+ *  back by the task on its next cycle — and are accepted here (so the file
+ *  validates) but ignored by condash's apply path, which only needs `title`. */
+const titleEntrySchema = z
+  .object({
+    sid: z.string().min(1),
+    title: z.string(),
+    summary: z.string().optional(),
+    lineCount: z.number().optional(),
+  })
+  .passthrough();
+
+const termTitlesSchema = z.object({
+  titles: z.array(titleEntrySchema),
+});
+
+/** Collapse internal whitespace and clamp to `TITLE_MAX_LEN`. */
+function clampTitle(title: string): string {
+  const collapsed = title.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= TITLE_MAX_LEN) return collapsed;
+  return collapsed.slice(0, TITLE_MAX_LEN - 1).trimEnd() + '…';
+}
+
+/**
+ * Validate a raw JSON string into the list of `{sid, title}` auto-titles.
+ * Returns `[]` on any parse / shape error (malformed, partial, wrong type) so
+ * a half-written or corrupt file is a no-op rather than a crash. Entries with
+ * an empty title after clamping are dropped (an empty auto-title would just
+ * fall through to the cwd basename anyway, and we never want to *blank* a tab).
+ */
+export function validateTermTitles(raw: string): TermAutoTitle[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  const result = termTitlesSchema.safeParse(parsed);
+  if (!result.success) return [];
+  const out: TermAutoTitle[] = [];
+  const seen = new Set<string>();
+  for (const entry of result.data.titles) {
+    if (seen.has(entry.sid)) continue;
+    const title = clampTitle(entry.title);
+    if (title.length === 0) continue;
+    seen.add(entry.sid);
+    out.push({ sid: entry.sid, title });
+  }
+  return out;
+}
+
+/** Read + validate the active conception's `term-titles.json`. Missing /
+ *  unreadable file → `[]`. */
+export async function readTermTitles(conception: string): Promise<TermAutoTitle[]> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(termTitlesPath(conception), 'utf8');
+  } catch {
+    return [];
+  }
+  return validateTermTitles(raw);
+}

--- a/src/main/terminal-logger.test.ts
+++ b/src/main/terminal-logger.test.ts
@@ -84,6 +84,25 @@ describe('sessionLogPath', () => {
     expect(path.startsWith(condashLogsRoot('/x/conception'))).toBe(true);
     expect(path).toMatch(/[/]\d{4}[/]\d{2}[/]\d{2}[/]\d{6}-t-abc\.txt$/);
   });
+
+  it('routes a manual task run out of logs/ into .condash/manual/<slug>/', () => {
+    const path = sessionLogPath('/x/conception', 't-abc', new Date('2026-05-13T14:22:07Z'), {
+      taskSlug: 'term-titles',
+      trigger: 'manual',
+    });
+    expect(path.startsWith(condashLogsRoot('/x/conception'))).toBe(false);
+    expect(path).toContain('/.condash/manual/term-titles/');
+    expect(path).toMatch(/[/]\d{8}-\d{6}-t-abc\.txt$/);
+  });
+
+  it('routes a scheduled task run into .condash/scheduled/<slug>/ — never logs/', () => {
+    const path = sessionLogPath('/x/conception', 't-xyz', new Date('2026-05-13T14:22:07Z'), {
+      taskSlug: 'term-titles',
+      trigger: 'scheduled',
+    });
+    expect(path.startsWith(condashLogsRoot('/x/conception'))).toBe(false);
+    expect(path).toContain('/.condash/scheduled/term-titles/');
+  });
 });
 
 describe('resolveLoggingPrefs', () => {

--- a/src/main/terminal-logger.ts
+++ b/src/main/terminal-logger.ts
@@ -1,10 +1,11 @@
 import { mkdir, rename, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { Terminal } from '@xterm/headless';
-import type { TermSide, TerminalLoggingPrefs } from '../shared/types';
+import type { TaskRunContext, TermSide, TerminalLoggingPrefs } from '../shared/types';
 import { condashLogsRoot } from './condash-dir';
 import { META_LINE_PREFIX, type LogKind } from './logs-format';
 import { OscTranscriptExtractor } from './osc-transcript';
+import { rotateTaskRuns, taskRunDir, taskRunLogPath } from './task-runs';
 
 /**
  * Single-session writer. One instance per pty spawn; lives from `open()`
@@ -58,6 +59,10 @@ export interface SessionContext {
   repo?: string;
   cwd: string;
   spawn: { cmd: string; argv: string[] };
+  /** When set, the session is a task run whose output is segregated out of
+   *  `.condash/logs/` into `.condash/<trigger>/<taskSlug>/` — see
+   *  `sessionLogPath`. Used for `excludeFromLogs` manual runs. */
+  taskContext?: TaskRunContext;
 }
 
 /** Header-line JSON shape, written on every flush. */
@@ -109,12 +114,19 @@ const ROWS = 50;
 export { META_LINE_PREFIX };
 
 /** Resolve the per-session log file path inside `conceptionPath`. Returns
- * the canonical `.txt` path, no side effects. */
+ * the canonical `.txt` path, no side effects. When `taskContext` is supplied
+ * the path is routed to the segregated `.condash/<trigger>/<taskSlug>/` store
+ * (capability 4) instead of the normal `.condash/logs/YYYY/MM/DD/` tree, so a
+ * flagged run never lands among the regular session logs. */
 export function sessionLogPath(
   conceptionPath: string,
   sid: string,
   when: Date = new Date(),
+  taskContext?: TaskRunContext,
 ): string {
+  if (taskContext) {
+    return taskRunLogPath(conceptionPath, taskContext.trigger, taskContext.taskSlug, sid, when);
+  }
   const yyyy = String(when.getFullYear());
   const mm = String(when.getMonth() + 1).padStart(2, '0');
   const dd = String(when.getDate()).padStart(2, '0');
@@ -147,6 +159,9 @@ export class SessionLogger {
   private exitCode: number | undefined;
   private finishedTs: string | undefined;
   private readonly txtPath: string;
+  /** When the session is a segregated task run, the `<trigger>/<slug>` dir to
+   * prune to the last ~5 runs once this run's file exists. Null otherwise. */
+  private readonly rotateDir: string | null;
   private closed = false;
   private paused = false;
   private dirty = false;
@@ -167,7 +182,10 @@ export class SessionLogger {
     this.prefs = resolveLoggingPrefs(prefs);
     this.flushMs = flushMs;
     this.startedTs = new Date().toISOString();
-    this.txtPath = sessionLogPath(conceptionPath, ctx.sid, new Date());
+    this.txtPath = sessionLogPath(conceptionPath, ctx.sid, new Date(), ctx.taskContext);
+    this.rotateDir = ctx.taskContext
+      ? taskRunDir(conceptionPath, ctx.taskContext.trigger, ctx.taskContext.taskSlug)
+      : null;
     this.term = new Terminal({
       cols: COLS,
       rows: ROWS,
@@ -199,6 +217,9 @@ export class SessionLogger {
     // header line, even if no output ever follows.
     this.dirty = true;
     this.flushNowFireAndForget();
+    // For a segregated task run, prune the dir to the last ~5 runs once this
+    // run's file lands. Best-effort + fire-and-forget — never blocks the pty.
+    if (this.rotateDir) void rotateTaskRuns(this.rotateDir);
   }
 
   /** No-op. Pty echoes typed bytes back through stdout. */

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -5,7 +5,13 @@ import { homedir } from 'node:os';
 import { basename, join } from 'node:path';
 import { BrowserWindow, type WebContents } from 'electron';
 import * as pty from 'node-pty';
-import type { TermSession, TermSide, TermSpawnRequest, TerminalPrefs } from '../shared/types';
+import type {
+  TabInfo,
+  TermSession,
+  TermSide,
+  TermSpawnRequest,
+  TerminalPrefs,
+} from '../shared/types';
 import { atomicWrite } from './atomic-write';
 import { findRepoEntry, type ConfigShape } from './config-walk';
 import { getEffectiveConceptionConfig } from './effective-config';
@@ -23,6 +29,14 @@ interface Session {
   webContents: WebContents;
   /** Optional repo this session was spawned for (Run button). */
   repo?: string;
+  /** Human command label for this session (repo `run:`, the free-form
+   * command, or the shell). Surfaced in the `{TABS}` provided var so a task
+   * can see what each tab is running. */
+  cmd?: string;
+  /** Cumulative bytes the pty has emitted. Monotonic (unlike `buffer`, which
+   * is a capped rolling tail) so the scheduler can growth-gate: skip a run
+   * when no tab has produced new output since the last run. */
+  bytesSeen: number;
   /** Resolved cwd of the spawned pty. Surfaced in the broadcast snapshot
    * so the Code pane can match a session to the worktree it was started in. */
   cwd: string;
@@ -71,6 +85,34 @@ function broadcastSessions(): void {
 
 export function listTerminalSessions(): TermSession[] {
   return snapshot();
+}
+
+/**
+ * Build the `{TABS}` provided-var payload (capability 2): the open, still-live
+ * tabs as `[{sid, cwd, repo, cmd}]`. Exited sessions are excluded — a task
+ * titles only tabs that actually exist. No prior titles (the task owns that
+ * memory via its own `.condash/term-titles.json`).
+ */
+export function tabsContext(): TabInfo[] {
+  return [...sessions.values()]
+    .filter((s) => s.exited === undefined)
+    .map((s) => ({
+      sid: s.id,
+      cwd: s.cwd,
+      ...(s.repo ? { repo: s.repo } : {}),
+      ...(s.cmd ? { cmd: s.cmd } : {}),
+    }));
+}
+
+/** Sum of cumulative bytes emitted across all live sessions. The scheduler
+ *  growth-gates on this: an unchanged total since the last run means no tab
+ *  produced new output, so there is nothing to re-title. */
+export function totalBytesSeen(): number {
+  let total = 0;
+  for (const s of sessions.values()) {
+    if (s.exited === undefined) total += s.bytesSeen;
+  }
+  return total;
 }
 
 export function attachTerminal(
@@ -175,6 +217,7 @@ export async function spawnTerminal(
   let argv: string[] = [];
   let program = shell;
   let forceStop: string | undefined;
+  let commandLabel: string | undefined;
 
   if (request.repo && conceptionPath) {
     const entry = findRepoEntry(config, request.repo);
@@ -190,11 +233,13 @@ export async function spawnTerminal(
     if (entry.run) {
       program = shell;
       argv = wrapForShell(shell, entry.run);
+      commandLabel = entry.run;
     }
     forceStop = entry.forceStop;
   } else if (request.command) {
     program = shell;
     argv = wrapForShell(shell, request.command);
+    commandLabel = request.command;
   }
 
   // One run per repo: kill any prior code-side session for the same repo
@@ -244,6 +289,7 @@ export async function spawnTerminal(
           repo: request.repo,
           cwd,
           spawn: { cmd: program, argv },
+          taskContext: request.taskContext,
         },
         config.terminal?.logging,
       )
@@ -254,6 +300,8 @@ export async function spawnTerminal(
     pty: ptyProcess,
     webContents,
     repo: request.repo,
+    cmd: commandLabel,
+    bytesSeen: 0,
     cwd,
     forceStop,
     buffer: '',
@@ -263,6 +311,7 @@ export async function spawnTerminal(
   logger?.spawn();
 
   ptyProcess.onData((data) => {
+    session.bytesSeen += data.length;
     appendBuffer(session, data);
     session.logger?.output(data);
     if (webContents.isDestroyed()) return;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import type { CondashApi, MenuCommand } from '../shared/api';
 import type {
   RepoEvent,
+  TermAutoTitle,
   TermDataMessage,
   TermExitMessage,
   TermSession,
@@ -110,11 +111,21 @@ const api: CondashApi = {
     ipcRenderer.on('termSessions', handler);
     return () => ipcRenderer.removeListener('termSessions', handler);
   },
+  onTermAutoTitles: (callback) => {
+    const handler = (_: unknown, titles: TermAutoTitle[]): void => callback(titles);
+    ipcRenderer.on('termAutoTitles', handler);
+    return () => ipcRenderer.removeListener('termAutoTitles', handler);
+  },
+  termAutoTitlesList: () => ipcRenderer.invoke('termAutoTitlesList'),
+  termTabsContext: () => ipcRenderer.invoke('termTabsContext'),
   logsListDays: () => ipcRenderer.invoke('logsListDays'),
   logsListSessions: (day) => ipcRenderer.invoke('logsListSessions', day),
   logsReadSession: (filePath) => ipcRenderer.invoke('logsReadSession', filePath),
   logsDeleteDay: (day) => ipcRenderer.invoke('logsDeleteDay', day),
   logsDeleteSession: (filePath) => ipcRenderer.invoke('logsDeleteSession', filePath),
+  logsListTaskRuns: () => ipcRenderer.invoke('logsListTaskRuns'),
+  getTaskConfig: () => ipcRenderer.invoke('getTaskConfig'),
+  setTaskConfig: (slug, entry) => ipcRenderer.invoke('setTaskConfig', slug, entry),
   openConceptionDirectory: () => ipcRenderer.invoke('openConceptionDirectory'),
   openExternal: (target: string) => ipcRenderer.invoke('openExternal', target),
   openPath: (target: string) => ipcRenderer.invoke('openPath', target),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -525,8 +525,8 @@ function App() {
                           projects={() => projects() ?? []}
                           apps={appOptions}
                           flashToast={flashToast}
-                          onRun={(agentId, text, taskName) =>
-                            void bridge.runTask(agentId, text, taskName)
+                          onRun={(agentId, text, taskName, opts) =>
+                            void bridge.runTask(agentId, text, taskName, opts)
                           }
                         />
                       </Match>

--- a/src/renderer/panes/logs-pane.css
+++ b/src/renderer/panes/logs-pane.css
@@ -58,6 +58,52 @@
   background: var(--bg-hover);
 }
 
+/* Sessions | Task runs view switcher. */
+.logs-view-switch {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.logs-view-switch button {
+  font-size: 0.8rem;
+  padding: 0.2rem 0.6rem;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.logs-view-switch button.active {
+  background: var(--bg-hover);
+  color: inherit;
+  font-weight: 600;
+}
+
+/* scheduled / manual trigger badge in the Task runs view. */
+.logs-taskrun-trigger {
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 0.05rem 0.4rem;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+}
+
+.logs-taskrun-trigger[data-trigger='scheduled'] {
+  background: #e6f0ff;
+  color: #00357a;
+  border-color: #b9d2ff;
+}
+
+.logs-taskrun-trigger[data-trigger='manual'] {
+  background: #fdecd9;
+  color: #6b3b00;
+  border-color: #f0cba0;
+}
+
 .logs-list {
   flex: 1 1 auto;
   min-height: 0;

--- a/src/renderer/panes/logs.tsx
+++ b/src/renderer/panes/logs.tsx
@@ -9,10 +9,14 @@ import {
   type Accessor,
   type JSX,
 } from 'solid-js';
-import type { LogsOpenRequest, TermLogSessionMeta } from '@shared/types';
+import type { LogsOpenRequest, TaskRunGroup, TermLogSessionMeta } from '@shared/types';
 import { ConfirmModal } from '../confirm-modal';
 import { LogsViewerModal } from '../logs-modal';
 import './logs-pane.css';
+
+/** Which list the Logs pane shows: the normal day-grouped sessions, or the
+ *  segregated task-run store under `.condash/{scheduled,manual}/` (caps 1+4). */
+type LogsViewMode = 'sessions' | 'taskruns';
 
 /**
  * Logs pane — browse `<conception>/.condash/logs/`.
@@ -58,6 +62,12 @@ export function LogsView(props: {
   const [activePath, setActivePath] = createSignal<string | null>(null);
   const [pendingDelete, setPendingDelete] = createSignal<TermLogSessionMeta | null>(null);
 
+  // "Task runs" view — the segregated `.condash/{scheduled,manual}/` store.
+  const [view, setView] = createSignal<LogsViewMode>('sessions');
+  const [taskRuns, { refetch: refetchTaskRuns }] = createResource(() =>
+    window.condash.logsListTaskRuns(),
+  );
+
   // External "open this log" requests from the global-search modal.
   createEffect(() => {
     const req = props.openRequest?.();
@@ -68,6 +78,7 @@ export function LogsView(props: {
   const refreshAll = (): void => {
     void refetchDays();
     void refetchSessions();
+    void refetchTaskRuns();
   };
 
   // External refresh from View → Refresh. `defer: true` skips the run on mount
@@ -95,6 +106,10 @@ export function LogsView(props: {
     for (const arr of map.values()) n += arr.length;
     return n;
   });
+
+  const taskRunCount = createMemo<number>(() =>
+    (taskRuns() ?? []).reduce((n, g) => n + g.runs.length, 0),
+  );
 
   // Today + the start of the 7-day "recent" window (today and the 6 prior
   // days). Day strings sort lexicographically === chronologically, so a plain
@@ -130,8 +145,33 @@ export function LogsView(props: {
       <div class="logs-toolbar">
         <div class="logs-toolbar-row">
           <span class="logs-toolbar-title">Logs</span>
+          <div class="logs-view-switch" role="tablist" aria-label="Logs view">
+            <button
+              type="button"
+              role="tab"
+              classList={{ active: view() === 'sessions' }}
+              aria-selected={view() === 'sessions'}
+              onClick={() => setView('sessions')}
+            >
+              Sessions
+            </button>
+            <button
+              type="button"
+              role="tab"
+              classList={{ active: view() === 'taskruns' }}
+              aria-selected={view() === 'taskruns'}
+              onClick={() => setView('taskruns')}
+            >
+              Task runs
+            </button>
+          </div>
           <span class="logs-toolbar-count">
-            {totalSessionCount()} session{totalSessionCount() === 1 ? '' : 's'}
+            <Show
+              when={view() === 'sessions'}
+              fallback={`${taskRunCount()} run${taskRunCount() === 1 ? '' : 's'}`}
+            >
+              {totalSessionCount()} session{totalSessionCount() === 1 ? '' : 's'}
+            </Show>
           </span>
           <span class="logs-toolbar-spacer" />
           <button type="button" class="logs-refresh" onClick={refreshAll}>
@@ -166,71 +206,132 @@ export function LogsView(props: {
         )}
       </Show>
 
-      <section class="logs-list">
-        <Show
-          when={!days.loading && !sessionsByDay.loading}
-          fallback={<div class="empty">Loading…</div>}
-        >
+      <Show when={view() === 'taskruns'}>
+        <section class="logs-list logs-taskruns">
+          <Show when={!taskRuns.loading} fallback={<div class="empty">Loading…</div>}>
+            <Show
+              when={(taskRuns() ?? []).length > 0}
+              fallback={
+                <div class="empty">
+                  No task runs yet. Scheduled runs and manual runs flagged “Keep out of logs” land
+                  here, kept separate from the normal session logs.
+                </div>
+              }
+            >
+              <For each={taskRuns()}>
+                {(group) => <TaskRunGroupView group={group} onOpen={setActivePath} />}
+              </For>
+            </Show>
+          </Show>
+        </section>
+      </Show>
+
+      <Show when={view() === 'sessions'}>
+        <section class="logs-list">
           <Show
-            when={(days() ?? []).length > 0}
-            fallback={<div class="empty">No sessions captured yet.</div>}
+            when={!days.loading && !sessionsByDay.loading}
+            fallback={<div class="empty">Loading…</div>}
           >
-            {/* Recent band: one group per day for the last 7 days. Today is
+            <Show
+              when={(days() ?? []).length > 0}
+              fallback={<div class="empty">No sessions captured yet.</div>}
+            >
+              {/* Recent band: one group per day for the last 7 days. Today is
                 always expanded and non-collapsible; the other days are
                 collapsible and default to collapsed. */}
-            <For each={recentDays()}>
-              {(d) => (
-                <Show
-                  when={d.day !== today}
-                  fallback={
-                    <div class="logs-day-group logs-day-today">
-                      <div class="logs-day-header logs-day-header-static">
-                        <span class="logs-day-label">Today · {dayLabel(d.day)}</span>
-                        <span class="logs-group-count">{sessionsFor(d.day).length}</span>
-                      </div>
-                      <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
-                    </div>
-                  }
-                >
-                  <details class="logs-day-group">
-                    <summary class="logs-day-header">
-                      <span class="logs-caret" aria-hidden="true" />
-                      <span class="logs-day-label">{dayLabel(d.day)}</span>
-                      <span class="logs-group-count">{sessionsFor(d.day).length}</span>
-                    </summary>
-                    <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
-                  </details>
-                </Show>
-              )}
-            </For>
-
-            {/* Older band: collapsible per-month groups, default collapsed,
-                with a light day sub-header inside each month. */}
-            <For each={monthGroups()}>
-              {(month) => (
-                <details class="logs-month-group">
-                  <summary class="logs-month-header">
-                    <span class="logs-caret" aria-hidden="true" />
-                    <span class="logs-month-label">{monthLabel(month.key)}</span>
-                    <span class="logs-group-count">
-                      {month.days.reduce((n, d) => n + sessionsFor(d.day).length, 0)}
-                    </span>
-                  </summary>
-                  <For each={month.days}>
-                    {(d) => (
-                      <div class="logs-day-subgroup">
-                        <div class="logs-day-subheader">{dayLabel(d.day)}</div>
+              <For each={recentDays()}>
+                {(d) => (
+                  <Show
+                    when={d.day !== today}
+                    fallback={
+                      <div class="logs-day-group logs-day-today">
+                        <div class="logs-day-header logs-day-header-static">
+                          <span class="logs-day-label">Today · {dayLabel(d.day)}</span>
+                          <span class="logs-group-count">{sessionsFor(d.day).length}</span>
+                        </div>
                         <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
                       </div>
-                    )}
-                  </For>
-                </details>
-              )}
-            </For>
+                    }
+                  >
+                    <details class="logs-day-group">
+                      <summary class="logs-day-header">
+                        <span class="logs-caret" aria-hidden="true" />
+                        <span class="logs-day-label">{dayLabel(d.day)}</span>
+                        <span class="logs-group-count">{sessionsFor(d.day).length}</span>
+                      </summary>
+                      <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
+                    </details>
+                  </Show>
+                )}
+              </For>
+
+              {/* Older band: collapsible per-month groups, default collapsed,
+                with a light day sub-header inside each month. */}
+              <For each={monthGroups()}>
+                {(month) => (
+                  <details class="logs-month-group">
+                    <summary class="logs-month-header">
+                      <span class="logs-caret" aria-hidden="true" />
+                      <span class="logs-month-label">{monthLabel(month.key)}</span>
+                      <span class="logs-group-count">
+                        {month.days.reduce((n, d) => n + sessionsFor(d.day).length, 0)}
+                      </span>
+                    </summary>
+                    <For each={month.days}>
+                      {(d) => (
+                        <div class="logs-day-subgroup">
+                          <div class="logs-day-subheader">{dayLabel(d.day)}</div>
+                          <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
+                        </div>
+                      )}
+                    </For>
+                  </details>
+                )}
+              </For>
+            </Show>
           </Show>
-        </Show>
-      </section>
+        </section>
+      </Show>
     </div>
+  );
+}
+
+/** One task's run group in the "Task runs" view — a collapsible header with a
+ *  trigger badge and a row per run, opening the same viewer as a session. */
+function TaskRunGroupView(props: {
+  group: TaskRunGroup;
+  onOpen: (path: string) => void;
+}): JSX.Element {
+  return (
+    <details class="logs-day-group" open>
+      <summary class="logs-day-header">
+        <span class="logs-caret" aria-hidden="true" />
+        <span class="logs-day-label">{props.group.taskSlug}</span>
+        <span class="logs-taskrun-trigger" data-trigger={props.group.trigger}>
+          {props.group.trigger}
+        </span>
+        <span class="logs-group-count">{props.group.runs.length}</span>
+      </summary>
+      <ul class="logs-day-sessions">
+        <For each={props.group.runs}>
+          {(run) => (
+            <li>
+              <button
+                type="button"
+                class="logs-session-card"
+                onClick={() => props.onOpen(run.path)}
+              >
+                <span class="logs-session-time">
+                  {run.day} {run.time}
+                </span>
+                <span class="logs-session-cmd">{run.sid}</span>
+                <span class="logs-session-size">{formatBytes(run.bytes)}</span>
+              </button>
+            </li>
+          )}
+        </For>
+      </ul>
+    </details>
   );
 }
 

--- a/src/renderer/panes/tasks-pane.css
+++ b/src/renderer/panes/tasks-pane.css
@@ -236,6 +236,27 @@
   padding: 0.3rem 1.1rem;
 }
 
+/* "Keep out of logs" toggle in the run popup + the editor's per-task default.
+ * Inline checkbox + label that does not grow like the marker text fields. */
+.tasks-fill-exclude,
+.tasks-editor-checkbox {
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: row;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-bottom: 0;
+  white-space: nowrap;
+}
+
+.tasks-fill-exclude input,
+.tasks-editor-checkbox input {
+  width: auto;
+  margin: 0;
+}
+
 .tasks-fill-scroll,
 .tasks-editor-scroll {
   flex: 1 1 auto;

--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -6,6 +6,7 @@ import {
   extractMarkers,
   isAppToken,
   isProjectToken,
+  isProvidedToken,
   projectTokenContext,
   type Marker,
   type TaskDef,
@@ -35,6 +36,12 @@ interface Draft {
   agent: string;
   prompt: string;
   editingSlug: string | null;
+  /** Schedule cadence (`30s`/`2m`/`1h`); empty = not scheduled (capability 1).
+   *  Persisted to `taskConfig[slug]` in settings.json, not task.json. */
+  schedule: string;
+  /** Per-task default for routing manual runs out of `.condash/logs/`
+   *  (capability 4). Persisted alongside `schedule`. */
+  excludeFromLogs: boolean;
 }
 
 /** Fill state: the read task plus the picker selections and per-marker field
@@ -49,6 +56,18 @@ interface FillState {
   app: AppOption | null;
   project: Project | null;
   fields: Record<string, string>;
+  /** condash-provided substitutions (e.g. `{TABS}`), fetched once when the
+   *  fill opens — never user-editable. */
+  provided: Record<string, string>;
+  /** Effective per-run "route this run out of the logs" flag (capability 4),
+   *  seeded from the task's `excludeFromLogs` default and toggleable here. */
+  excludeFromLogs: boolean;
+}
+
+/** Options carried alongside a task run launch. */
+export interface RunOptions {
+  taskSlug: string;
+  excludeFromLogs: boolean;
 }
 
 function blankDraft(agents: readonly Agent[]): Draft {
@@ -63,6 +82,8 @@ function blankDraft(agents: readonly Agent[]): Draft {
     agent: seedable?.id ?? '',
     prompt: '',
     editingSlug: null,
+    schedule: '',
+    excludeFromLogs: false,
   };
 }
 
@@ -90,8 +111,10 @@ export function TasksView(props: {
   apps: () => readonly AppOption[];
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
   /** Run a filled task: spawn the agent (by id) and deliver the substituted
-   *  prompt. `taskName` titles the spawned tab. Always launches interactively. */
-  onRun: (agentId: string, text: string, taskName: string) => void;
+   *  prompt. `taskName` titles the spawned tab. `opts` carries the task slug +
+   *  effective excludeFromLogs so a flagged manual run routes its log to
+   *  `.condash/manual/<slug>/`. Always launches interactively. */
+  onRun: (agentId: string, text: string, taskName: string, opts: RunOptions) => void;
 }): JSX.Element {
   const [draft, setDraft] = createSignal<Draft | null>(null);
   const [fill, setFill] = createSignal<FillState | null>(null);
@@ -112,6 +135,7 @@ export function TasksView(props: {
       props.flashToast(`Task ${slug} not found`, 'error');
       return;
     }
+    const cfg = (await window.condash.getTaskConfig())[slug] ?? {};
     setDraft({
       slug,
       slugDirty: true,
@@ -119,6 +143,8 @@ export function TasksView(props: {
       agent: def.agent,
       prompt: def.prompt,
       editingSlug: slug,
+      schedule: cfg.schedule ?? '',
+      excludeFromLogs: cfg.excludeFromLogs === true,
     });
   };
 
@@ -131,10 +157,30 @@ export function TasksView(props: {
     }
     const fields: Record<string, string> = {};
     for (const marker of extractMarkers(def.prompt)) {
-      if (isAppToken(marker.key) || isProjectToken(marker.key)) continue;
+      if (isAppToken(marker.key) || isProjectToken(marker.key) || isProvidedToken(marker.key)) {
+        continue;
+      }
       fields[marker.key] = marker.default;
     }
-    setFill({ slug, def, agent: def.agent, app: null, project: null, fields });
+    // Seed `{TABS}` and the excludeFromLogs default. Both come from runtime
+    // state, fetched once when the popup opens (the open-tab set is stable
+    // enough for the duration of a fill).
+    const [tabs, cfgMap] = await Promise.all([
+      window.condash.termTabsContext(),
+      window.condash.getTaskConfig(),
+    ]);
+    const provided: Record<string, string> = { TABS: JSON.stringify(tabs) };
+    const excludeFromLogs = cfgMap[slug]?.excludeFromLogs === true;
+    setFill({
+      slug,
+      def,
+      agent: def.agent,
+      app: null,
+      project: null,
+      fields,
+      provided,
+      excludeFromLogs,
+    });
   };
 
   const save = async (): Promise<void> => {
@@ -159,6 +205,16 @@ export function TasksView(props: {
     };
     try {
       const slug = await window.condash.writeTask(d.slug, def, d.editingSlug ?? undefined);
+      // Persist schedule / excludeFromLogs to settings.json's taskConfig under
+      // the *resolved* slug (a rename moves the config with the task). When the
+      // slug changed, clear the old entry.
+      if (d.editingSlug && d.editingSlug !== slug) {
+        await window.condash.setTaskConfig(d.editingSlug, {});
+      }
+      await window.condash.setTaskConfig(slug, {
+        schedule: d.schedule.trim() || undefined,
+        excludeFromLogs: d.excludeFromLogs || undefined,
+      });
       props.flashToast(`Saved ${slug}`, 'success');
       setDraft(null);
       props.reload();
@@ -174,6 +230,8 @@ export function TasksView(props: {
     if (!d?.editingSlug) return;
     try {
       await window.condash.deleteTask(d.editingSlug);
+      // Drop any schedule / excludeFromLogs config for the deleted task.
+      await window.condash.setTaskConfig(d.editingSlug, {});
       props.flashToast(`Deleted ${d.name || d.editingSlug}`, 'success');
       if (fill()?.slug === d.editingSlug) setFill(null);
       setDraft(null);
@@ -330,7 +388,7 @@ function TaskFill(props: {
   apps: () => readonly AppOption[];
   projects: () => readonly Project[];
   conceptionPath: () => string | null;
-  onRun: (agentId: string, text: string, taskName: string) => void;
+  onRun: (agentId: string, text: string, taskName: string, opts: RunOptions) => void;
 }): JSX.Element {
   // Derive markers from the prompt alone, not the whole fill signal. The prompt
   // is immutable during a fill session, so this `prompt` memo's `===` output is
@@ -342,7 +400,9 @@ function TaskFill(props: {
   const prompt = createMemo(() => props.fill().def.prompt);
   const markers = createMemo(() => extractMarkers(prompt()));
   const textMarkers = createMemo(() =>
-    markers().filter((m) => !isAppToken(m.key) && !isProjectToken(m.key)),
+    markers().filter(
+      (m) => !isAppToken(m.key) && !isProjectToken(m.key) && !isProvidedToken(m.key),
+    ),
   );
   const needsApp = createMemo(() => markers().some((m) => isAppToken(m.key)));
   const needsProject = createMemo(() => markers().some((m) => isProjectToken(m.key)));
@@ -380,6 +440,7 @@ function TaskFill(props: {
   };
 
   const ctx = createMemo<Record<string, string>>(() => ({
+    ...props.fill().provided,
     ...appContext(props.fill().app),
     ...projectTokenContext(props.fill().project, props.conceptionPath() ?? undefined),
     ...props.fill().fields,
@@ -391,7 +452,10 @@ function TaskFill(props: {
 
   const run = (): void => {
     const f = props.fill();
-    props.onRun(f.agent, substitute(f.def.prompt, ctx()), f.def.name);
+    props.onRun(f.agent, substitute(f.def.prompt, ctx()), f.def.name, {
+      taskSlug: f.slug,
+      excludeFromLogs: f.excludeFromLogs,
+    });
     close();
   };
 
@@ -439,6 +503,19 @@ function TaskFill(props: {
                   </Match>
                 </Switch>
               </select>
+            </label>
+            <label
+              class="tasks-fill-exclude"
+              title="Route this run's log to .condash/manual/<slug>/ instead of the normal logs"
+            >
+              <input
+                type="checkbox"
+                checked={props.fill().excludeFromLogs}
+                onChange={(e) =>
+                  props.setFill({ ...props.fill(), excludeFromLogs: e.currentTarget.checked })
+                }
+              />
+              <span>Keep out of logs</span>
             </label>
             <button
               type="button"
@@ -632,6 +709,25 @@ function TaskEditor(props: {
                 placeholder={'Review {APP} and update its docs. Focus: {AREA:CLAUDE.md and docs/}'}
                 onInput={(e) => props.patch({ prompt: e.currentTarget.value })}
               />
+            </label>
+
+            <label>
+              <span>Schedule (e.g. 2m / 30s / 1h — blank = off)</span>
+              <input
+                type="text"
+                value={d().schedule}
+                placeholder="off"
+                onInput={(e) => props.patch({ schedule: e.currentTarget.value })}
+              />
+            </label>
+
+            <label class="tasks-editor-checkbox">
+              <input
+                type="checkbox"
+                checked={d().excludeFromLogs}
+                onChange={(e) => props.patch({ excludeFromLogs: e.currentTarget.checked })}
+              />
+              <span>Keep manual runs out of the normal logs (default — overridable per run)</span>
             </label>
 
             <Show when={markers().length > 0}>

--- a/src/renderer/terminal-bridge.ts
+++ b/src/renderer/terminal-bridge.ts
@@ -3,6 +3,7 @@ import type {
   ActionTemplate,
   Project,
   RepoEntry,
+  TaskRunContext,
   TerminalPrefs,
   Worktree,
 } from '@shared/types';
@@ -53,8 +54,15 @@ export interface TerminalBridge {
    *  `<agent label>•<taskName>`. Tasks always launch interactively — a
    *  `promptFlags` agent is seeded with `--prompt` (the session stays open after
    *  the prompt runs); an opaque agent is spawned bare, then the prompt is
-   *  keystroke-injected and submitted once the TUI settles. */
-  runTask: (agentId: string, text: string, taskName: string) => Promise<void>;
+   *  keystroke-injected and submitted once the TUI settles. When `opts`
+   *  requests it, the run's log is routed to `.condash/manual/<slug>/` instead
+   *  of the normal logs (capability 4). */
+  runTask: (
+    agentId: string,
+    text: string,
+    taskName: string,
+    opts?: { taskSlug: string; excludeFromLogs: boolean },
+  ) => Promise<void>;
 }
 
 /** Upper bound on animation frames waited for the pane to mount after
@@ -134,6 +142,7 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
   const spawnAgentTab = async (
     agent: Agent,
     title?: string,
+    taskContext?: TaskRunContext,
   ): Promise<TerminalPaneHandle | null> => {
     if (!deps.terminalHandle()) {
       deps.ensureTerminalOpen();
@@ -143,9 +152,13 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     if (!handle) return null;
     deps.ensureTerminalOpen();
     try {
-      // Pass the title only when set so the non-task spawn keeps the agent's
-      // own label (and the 2-arg call shape its callers assert on).
-      if (title === undefined) {
+      // Keep the call shape minimal: bare 2-arg for an untitled spawn, 3-arg
+      // when a title is set, and only widen to 4-arg when a task context must
+      // ride along (capability 4). Preserves the shapes existing callers
+      // assert on.
+      if (taskContext !== undefined) {
+        await handle.spawnUserShell(agent, 'my', title, taskContext);
+      } else if (title === undefined) {
         await handle.spawnUserShell(agent, 'my');
       } else {
         await handle.spawnUserShell(agent, 'my', title);
@@ -171,13 +184,14 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     text: string,
     submit: boolean,
     title?: string,
+    taskContext?: TaskRunContext,
   ): Promise<void> => {
     if (agent.promptFlags) {
       const command = `${agent.command} --prompt ${shellSingleQuote(text)}`;
-      await spawnAgentTab({ ...agent, command }, title);
+      await spawnAgentTab({ ...agent, command }, title, taskContext);
       return;
     }
-    const handle = await spawnAgentTab(agent, title);
+    const handle = await spawnAgentTab(agent, title, taskContext);
     if (!handle) return;
     handle.typeIntoActive(text);
     if (submit) {
@@ -306,17 +320,30 @@ export function createTerminalBridge(deps: TerminalBridgeDeps): TerminalBridge {
     handle.typeIntoActive(text);
   };
 
-  const runTask = async (agentId: string, text: string, taskName: string): Promise<void> => {
+  const runTask = async (
+    agentId: string,
+    text: string,
+    taskName: string,
+    opts?: { taskSlug: string; excludeFromLogs: boolean },
+  ): Promise<void> => {
     const agent = findAgentById(deps.agents(), agentId);
     if (!agent) {
       deps.flashToast(`Task agent not found: ${agentId}`, 'error');
       return;
     }
+    // A manual task run that opts out of the normal logs carries a task
+    // context so the SessionLogger routes its `.txt` to
+    // `.condash/manual/<slug>/` (capability 4). Without the flag the run logs
+    // normally, as today.
+    const taskContext: TaskRunContext | undefined =
+      opts?.excludeFromLogs && opts.taskSlug
+        ? { taskSlug: opts.taskSlug, trigger: 'manual' }
+        : undefined;
     // Same interactive spawn-and-deliver path as an agent-bound project action.
     // `submit: true` presses Enter on the opaque keystroke path; a promptFlags
     // agent is seeded with `--prompt` (interactive) regardless. The tab is named
     // `<agent label>•<task title>` so a running task is identifiable at a glance.
-    await runAgentTask(agent, text, true, `${agent.label}•${taskName}`);
+    await runAgentTask(agent, text, true, `${agent.label}•${taskName}`, taskContext);
   };
 
   return {

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -19,6 +19,7 @@
 import { createEffect, createMemo, createSignal, onCleanup, onMount, Show } from 'solid-js';
 import type {
   Agent,
+  TaskRunContext,
   TermSide,
   TermSpawnRequest,
   TerminalPrefs,
@@ -63,8 +64,14 @@ export interface TerminalPaneHandle {
   /** Add a fresh user shell tab to "My terms". `agent` may be an `Agent` to pin
    *  and run that agent's command, or `null` for a plain shell. `titleOverride`
    *  pins a custom tab label (e.g. a task's `<agent>•<title>`) instead of the
-   *  agent's own label. */
-  spawnUserShell(agent?: AgentChoice, side?: TermSide, titleOverride?: string): Promise<string>;
+   *  agent's own label. `taskContext` routes the session's log to the
+   *  segregated `.condash/<trigger>/<slug>/` store (capability 4). */
+  spawnUserShell(
+    agent?: AgentChoice,
+    side?: TermSide,
+    titleOverride?: string,
+    taskContext?: TaskRunContext,
+  ): Promise<string>;
   /** Move the active tab within its column strip. */
   moveActiveTab(direction: -1 | 1): void;
   /** Type a literal string into the active terminal (no shell parsing). */
@@ -118,6 +125,22 @@ export function TerminalPane(props: {
   // sole writer of the tabs signal; `spawn` records intent here so the
   // following onTermSessions broadcast inserts the tab with the right label.
   const pendingSpawnIntent = new Map<string, { label: string; pinned?: boolean }>();
+
+  // Latest auto-titles by sid (capability 3 — `.condash/term-titles.json`).
+  // The `termAutoTitles` event sparse-merges into this map; `reconcile` reads
+  // it so a tab that (re)appears after a title arrived still picks it up.
+  const autoTitleBySid = new Map<string, string>();
+  const applyAutoTitles = (titles: readonly { sid: string; title: string }[]): void => {
+    for (const t of titles) autoTitleBySid.set(t.sid, t.title);
+    // Sparse merge: only touch tabs named in this batch (unknown sids have no
+    // matching tab; omitted sids are left untouched — never wiped).
+    const present = new Set(titles.map((t) => t.sid));
+    setTabs((prev) =>
+      prev.map((tab) =>
+        present.has(tab.id) ? { ...tab, autoTitle: autoTitleBySid.get(tab.id) } : tab,
+      ),
+    );
+  };
 
   // Tracks tabs that are already in the process of closing so that
   // user-initiated close (× button) and process-exit close don't race.
@@ -343,6 +366,7 @@ export function TerminalPane(props: {
         column,
         label,
         customName: meta?.customName,
+        autoTitle: autoTitleBySid.get(s.id),
         pinned,
         exited: s.exited,
       };
@@ -398,8 +422,15 @@ export function TerminalPane(props: {
   const offTermSessions = window.condash.onTermSessions((snap) => void reconcile(snap));
   onCleanup(offTermSessions);
 
+  // Auto-titles applied from `.condash/term-titles.json` (capability 3).
+  const offAutoTitles = window.condash.onTermAutoTitles((titles) => applyAutoTitles(titles));
+  onCleanup(offAutoTitles);
+
   onMount(() => {
     void window.condash.termList().then((snap) => void reconcile(snap));
+    // Pull current titles so a fresh / reloaded window paints them without
+    // waiting for the next file write.
+    void window.condash.termAutoTitlesList().then((titles) => applyAutoTitles(titles));
   });
 
   // ---- spawn helpers ----
@@ -432,6 +463,7 @@ export function TerminalPane(props: {
     agent: AgentChoice = null,
     sd: TermSide = 'my',
     titleOverride?: string,
+    taskContext?: TermSpawnRequest['taskContext'],
   ): Promise<string> => {
     const label = uniqueLabel(titleOverride ?? agent?.label ?? 'shell');
     // Pin the label when the caller picked an agent or supplied an explicit
@@ -442,6 +474,7 @@ export function TerminalPane(props: {
         side: sd,
         command: agent?.command,
         cwd: props.cwd ?? undefined,
+        taskContext,
       },
       label,
       { pinned: agent !== null || titleOverride !== undefined },

--- a/src/renderer/terminal-pane/types.test.ts
+++ b/src/renderer/terminal-pane/types.test.ts
@@ -28,6 +28,32 @@ describe('displayName', () => {
     );
   });
 
+  describe('autoTitle (capability 3)', () => {
+    it('uses autoTitle over the cwd basename and label', () => {
+      expect(
+        displayName(
+          tab({
+            label: 'shell',
+            cwd: '/home/alice/src/vcoeur/condash',
+            autoTitle: 'fixing logs CLI',
+          }),
+        ),
+      ).toBe('fixing logs CLI');
+    });
+
+    it('customName still wins over autoTitle', () => {
+      expect(
+        displayName(tab({ label: 'shell', customName: 'my-term', autoTitle: 'fixing logs CLI' })),
+      ).toBe('my-term');
+    });
+
+    it('autoTitle wins even when the tab is pinned (it is a deliberate title)', () => {
+      expect(displayName(tab({ label: 'lambda', pinned: true, autoTitle: 'running tests' }))).toBe(
+        'running tests',
+      );
+    });
+  });
+
   describe('pinned', () => {
     it('keeps the spawn-time label when the shell emits OSC 7', () => {
       expect(

--- a/src/renderer/terminal-pane/types.ts
+++ b/src/renderer/terminal-pane/types.ts
@@ -27,15 +27,22 @@ export interface Tab {
    *  until the user manually renames. Set at spawn time for sources that
    *  carry a deliberate title (lambda launcher, code-card "open in term"). */
   pinned?: boolean;
+  /** Auto-derived title applied from `.condash/term-titles.json` by a
+   *  scheduled/adopted task (capability 3). Sparse-merged in by the
+   *  `termAutoTitles` event — sits just below `customName` in `displayName`
+   *  so a user rename always wins. condash holds no title state; this is
+   *  ephemeral renderer state re-applied on each file change. */
+  autoTitle?: string;
   /** Process exit code; the tab can still be cleared via close. */
   exited?: number;
 }
 
-/** Display name for a tab. Custom rename wins; otherwise the cwd basename if
- *  the shell emitted OSC 7 (and the tab isn't pinned); otherwise the
- *  spawn-time label. */
+/** Display name for a tab. Custom rename wins; then an auto-title applied from
+ *  `.condash/term-titles.json`; then the cwd basename if the shell emitted
+ *  OSC 7 (and the tab isn't pinned); otherwise the spawn-time label. */
 export function displayName(tab: Tab): string {
   if (tab.customName) return tab.customName;
+  if (tab.autoTitle) return tab.autoTitle;
   if (!tab.pinned && tab.cwd) {
     const basename = tab.cwd.split('/').filter(Boolean).pop();
     if (basename) return basename;

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -21,6 +21,10 @@ import type {
   SkillNode,
   SkillScope,
   StepMarker,
+  TabInfo,
+  TaskConfigEntry,
+  TaskRunGroup,
+  TermAutoTitle,
   TermDataMessage,
   TermExitMessage,
   TermLogSessionMeta,
@@ -269,6 +273,19 @@ export interface CondashApi {
   onTermExit(callback: (msg: TermExitMessage) => void): () => void;
   /** Sessions changed (spawn / exit / close). Receives the full snapshot. */
   onTermSessions(callback: (sessions: TermSession[]) => void): () => void;
+  /** Auto-titles changed — the watcher on `.condash/term-titles.json`
+   *  validated a new sparse `{sid,title}` list (capability 3). The renderer
+   *  sparse-merges them onto its tabs: sets the sids present, ignores unknown
+   *  sids, leaves omitted sids untouched. Returns an unsubscribe function. */
+  onTermAutoTitles(callback: (titles: TermAutoTitle[]) => void): () => void;
+  /** Pull the current validated auto-titles from `.condash/term-titles.json`.
+   *  Called on renderer mount so a fresh / reloaded window paints existing
+   *  titles without waiting for the next file write. */
+  termAutoTitlesList(): Promise<TermAutoTitle[]>;
+  /** The open, still-live tabs as `[{sid,cwd,repo,cmd}]` — the `{TABS}`
+   *  provided-var payload (capability 2). Used to seed `{TABS}` for a manual
+   *  task run from the Tasks pane. */
+  termTabsContext(): Promise<TabInfo[]>;
 
   /** List the day-directories present under
    * `<conception>/.condash/logs/` — newest first. Empty when no
@@ -286,6 +303,18 @@ export interface CondashApi {
    *  `<conception>/.condash/logs/`; rejects paths outside the logs root
    *  or files that don't end in `.txt`. */
   logsDeleteSession(filePath: string): Promise<{ deleted: boolean }>;
+  /** Enumerate the segregated task-run store under
+   *  `.condash/{scheduled,manual}/<slug>/` (capabilities 1 + 4). One group per
+   *  `<trigger>/<slug>`, runs newest-first. Powers the Logs pane's "Task runs"
+   *  view; never reads `.condash/logs/`. */
+  logsListTaskRuns(): Promise<TaskRunGroup[]>;
+
+  /** Per-task config map keyed by slug (`{schedule?, excludeFromLogs?}`), from
+   *  the effective config (capability 1). Empty when no conception. */
+  getTaskConfig(): Promise<Record<string, TaskConfigEntry>>;
+  /** Persist one task's config entry into `settings.json`'s `taskConfig`. An
+   *  entry with neither a schedule nor `excludeFromLogs` is removed. */
+  setTaskConfig(slug: string, entry: TaskConfigEntry): Promise<void>;
 
   /** Open the configured conception directory in the OS file manager. */
   openConceptionDirectory(): Promise<void>;

--- a/src/shared/cadence.test.ts
+++ b/src/shared/cadence.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { parseCadence } from './cadence';
+
+describe('parseCadence', () => {
+  it('parses seconds / minutes / hours to ms', () => {
+    expect(parseCadence('30s')).toBe(30_000);
+    expect(parseCadence('2m')).toBe(120_000);
+    expect(parseCadence('1h')).toBe(3_600_000);
+  });
+
+  it('tolerates surrounding + inner whitespace', () => {
+    expect(parseCadence('  5 m ')).toBe(300_000);
+  });
+
+  it('returns null for absent / empty / malformed input', () => {
+    expect(parseCadence(undefined)).toBeNull();
+    expect(parseCadence('')).toBeNull();
+    expect(parseCadence('2d')).toBeNull();
+    expect(parseCadence('m')).toBeNull();
+    expect(parseCadence('0s')).toBeNull();
+    expect(parseCadence('-3m')).toBeNull();
+    expect(parseCadence('abc')).toBeNull();
+  });
+});

--- a/src/shared/cadence.ts
+++ b/src/shared/cadence.ts
@@ -1,0 +1,17 @@
+/** Schedule-cadence parsing for the task scheduler (capability 1). Pure +
+ *  dependency-free so it can be unit-tested without the Electron main graph. */
+
+/** Parse a cadence string (`30s`, `2m`, `1h`) to milliseconds. Returns null
+ *  when the string is absent or malformed — the task is then treated as not
+ *  scheduled. Whitespace around the unit is tolerated; the count must be a
+ *  positive integer. */
+export function parseCadence(spec: string | undefined): number | null {
+  if (!spec) return null;
+  const m = /^(\d+)\s*(s|m|h)$/.exec(spec.trim());
+  if (!m) return null;
+  const n = Number.parseInt(m[1], 10);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  const unit = m[2];
+  const factor = unit === 's' ? 1_000 : unit === 'm' ? 60_000 : 3_600_000;
+  return n * factor;
+}

--- a/src/shared/tasks.test.ts
+++ b/src/shared/tasks.test.ts
@@ -6,6 +6,7 @@ import {
   extractMarkers,
   isAppToken,
   isProjectToken,
+  isProvidedToken,
   projectTokenContext,
 } from './tasks';
 
@@ -47,6 +48,19 @@ describe('reserved token predicates', () => {
     expect(isProjectToken('PROJECT_BRANCH')).toBe(true);
     expect(isProjectToken('PROJECT_TITLE')).toBe(true);
     expect(isProjectToken('PROMPT')).toBe(false);
+  });
+
+  it('recognises the provided {TABS} token (capability 2)', () => {
+    expect(isProvidedToken('TABS')).toBe(true);
+    expect(isProvidedToken('APP')).toBe(false);
+    expect(isProvidedToken('AREA')).toBe(false);
+  });
+});
+
+describe('substitute with a provided {TABS} var', () => {
+  it('injects the open-tab JSON for a {TABS} marker', () => {
+    const tabs = JSON.stringify([{ sid: 't-a', cwd: '/x', repo: 'condash', cmd: 'agedum claude' }]);
+    expect(substitute('Tabs: {TABS}', { TABS: tabs })).toBe(`Tabs: ${tabs}`);
   });
 });
 

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -55,8 +55,15 @@ export const PROJECT_TOKENS = [
   'PROJECT_TITLE',
 ] as const;
 
+/** Reserved provided tokens — injected by condash from runtime state, never
+ *  prompted in the fill form. `{TABS}` carries the open-tab list (capability
+ *  2). Unlike `{APP}` / `{PROJECT}`, there is no picker: the value is supplied
+ *  wholesale. */
+export const PROVIDED_TOKENS = ['TABS'] as const;
+
 const APP_TOKEN_SET: ReadonlySet<string> = new Set(APP_TOKENS);
 const PROJECT_TOKEN_SET: ReadonlySet<string> = new Set(PROJECT_TOKENS);
+const PROVIDED_TOKEN_SET: ReadonlySet<string> = new Set(PROVIDED_TOKENS);
 
 /** True when `key` is one of the reserved `{APP_*}` tokens. */
 export function isAppToken(key: string): boolean {
@@ -66,6 +73,12 @@ export function isAppToken(key: string): boolean {
 /** True when `key` is one of the reserved `{PROJECT_*}` tokens. */
 export function isProjectToken(key: string): boolean {
   return PROJECT_TOKEN_SET.has(key);
+}
+
+/** True when `key` is a condash-provided token (e.g. `{TABS}`) — injected
+ *  from runtime state, never rendered as a fillable field. */
+export function isProvidedToken(key: string): boolean {
+  return PROVIDED_TOKEN_SET.has(key);
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -265,6 +265,11 @@ export interface Settings {
    *  scope reads `<conception>/.agents/`. Persisted per-machine; defaults
    *  to `conception`. */
   skillsActiveScope?: SkillScope;
+  /** Per-task schedule / log-routing config keyed by task slug (capability
+   *  1). Shared with `condash.json` via the config schema's
+   *  `sharedSchemaFields`; the effective-config merge lets a conception
+   *  override the per-machine value. */
+  taskConfig?: Record<string, TaskConfigEntry>;
 }
 
 /** Sets of expanded directory `relPath`s for the three tree panes. The
@@ -578,6 +583,20 @@ export interface TermSession {
   exited?: number;
 }
 
+/** Which trigger produced a task run. Routes its console log out of the
+ *  normal `.condash/logs/` tree and into `.condash/<trigger>/<task-slug>/`. */
+export type TaskTrigger = 'scheduled' | 'manual';
+
+/** Task-run context carried on a spawn so the SessionLogger can route the
+ *  run's console output to the segregated `.condash/<trigger>/<slug>/` store
+ *  instead of `.condash/logs/`. Present only for task runs that opt out of the
+ *  normal logs (a `manual` run of an `excludeFromLogs` task, or any
+ *  `scheduled` run — those are always segregated). Absent → normal logging. */
+export interface TaskRunContext {
+  taskSlug: string;
+  trigger: TaskTrigger;
+}
+
 export interface TermSpawnRequest {
   side: TermSide;
   /** When set, looks up the repo's `run:` and uses its cwd. */
@@ -589,6 +608,59 @@ export interface TermSpawnRequest {
   cwd?: string;
   cols?: number;
   rows?: number;
+  /** When set, the session is a task run whose console output is routed to
+   *  `.condash/<trigger>/<taskSlug>/` instead of `.condash/logs/`. */
+  taskContext?: TaskRunContext;
+}
+
+/** One auto-title applied to a tab from `.condash/term-titles.json`
+ *  (capability 3). Broadcast on the `termAutoTitles` channel. `title` is
+ *  already length-clamped by the main-side validator. */
+export interface TermAutoTitle {
+  sid: string;
+  title: string;
+}
+
+/** One open terminal tab, as injected into a task's `{TABS}` provided var
+ *  (capability 2). Built from the main session map. No prior titles — the
+ *  task owns its own memory via its `.condash/term-titles.json`. */
+export interface TabInfo {
+  sid: string;
+  cwd: string;
+  repo?: string;
+  cmd?: string;
+}
+
+/** Per-task config persisted under `taskConfig` in `.condash/settings.json`
+ *  (capability 1). Absent entry → not scheduled, normal logging. */
+export interface TaskConfigEntry {
+  /** Cadence string (e.g. `2m`, `30s`, `1h`). Absent = not scheduled. */
+  schedule?: string;
+  /** Per-task default for routing manual runs out of `.condash/logs/`;
+   *  overridable per run in the run popup. */
+  excludeFromLogs?: boolean;
+}
+
+/** One segregated task-run file under `.condash/<trigger>/<slug>/`,
+ *  surfaced by the Logs pane's "Task runs" view. */
+export interface TaskRunEntry {
+  /** Absolute path to the `.txt`. */
+  path: string;
+  /** Spawn-time `HH:MM:SS` parsed from the filename prefix. */
+  time: string;
+  /** `YYYY-MM-DD` parsed from the filename prefix. */
+  day: string;
+  /** Session id (the `<sid>` suffix). */
+  sid: string;
+  /** File size in bytes. */
+  bytes: number;
+}
+
+/** All runs of one task under one trigger, newest-first. */
+export interface TaskRunGroup {
+  taskSlug: string;
+  trigger: TaskTrigger;
+  runs: TaskRunEntry[];
 }
 
 export interface TermDataMessage {

--- a/tests/terminal-tab-titles.spec.ts
+++ b/tests/terminal-tab-titles.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from '@playwright/test';
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { bootApp } from './fixtures/electron-app';
 
 test('terminal pane: New shell spawns an unpinned shell; agents populate the spawn dropdown', async ({}, testInfo) => {
@@ -36,6 +38,50 @@ test('terminal pane: New shell spawns an unpinned shell; agents populate the spa
     await win.evaluate(async () => {
       const list = await window.condash.termList();
       await Promise.all(list.map((s) => window.condash.termClose(s.id)));
+    });
+  } finally {
+    await booted.cleanup();
+  }
+});
+
+test('auto-title from .condash/term-titles.json applies to the tab; malformed leaves it', async ({}, testInfo) => {
+  testInfo.setTimeout(60_000);
+  const booted = await bootApp({});
+  try {
+    const win = booted.window;
+
+    // Spawn one plain shell tab (a real shell exists on CI, so it stays open).
+    const dropdown = win.locator('.terminal-tab-dropdown').first();
+    await dropdown.click();
+    const menu = win.locator('.terminal-tab-dropdown-menu');
+    await expect(menu).toBeVisible();
+    await menu.locator('li', { hasText: 'New shell' }).click();
+    await expect(win.locator('.terminal-tab-label')).toHaveCount(1);
+
+    // Discover its session id so we can target it by sid in the watched file.
+    const list = await win.evaluate(() => window.condash.termList());
+    expect(list.length).toBe(1);
+    const sid = list[0].id;
+
+    const titlesPath = join(booted.conceptionDir, '.condash', 'term-titles.json');
+
+    // Write a valid sparse file → the watcher validates + broadcasts; the
+    // renderer sparse-merges the title onto the matching tab (autoTitle beats
+    // the cwd basename in displayName).
+    await writeFile(titlesPath, JSON.stringify({ titles: [{ sid, title: 'auto named tab' }] }), 'utf8');
+    await expect(win.locator('.terminal-tab-label', { hasText: 'auto named tab' })).toHaveCount(1, {
+      timeout: 15_000,
+    });
+
+    // A malformed file must be a no-op — current titles are never wiped.
+    await writeFile(titlesPath, '{ not valid json', 'utf8');
+    // Give the watcher time to process the change, then assert the title held.
+    await win.waitForTimeout(800);
+    await expect(win.locator('.terminal-tab-label', { hasText: 'auto named tab' })).toHaveCount(1);
+
+    await win.evaluate(async () => {
+      const sessions = await window.condash.termList();
+      await Promise.all(sessions.map((s) => window.condash.termClose(s.id)));
     });
   } finally {
     await booted.cleanup();


### PR DESCRIPTION
## Summary

Auto-name open terminal tabs from what they're doing, composed from **three independent, reusable condash capabilities** rather than a bespoke feature. condash never invents titles or captures task output — a task writes a file, condash watches it and applies.

1. **Schedule any task** — an opt-in cadence (`30s`/`2m`/`1h`) in the Tasks editor, persisted to `taskConfig` in `.condash/settings.json`. A scheduled task runs **headless** via a main-side executor (background pty, no tab, no `termSessions` broadcast), single-flighted + growth-gated. Its console output is teed to `.condash/scheduled/<slug>/` (last ~5), **never** `.condash/logs/`. No default schedule, no default agent.
2. **`{TABS}` provided var** — injects the open-tab list `[{sid,cwd,repo,cmd}]` into a task prompt, built from the main session map. Reserved (never a fillable field); seeded for both scheduled and manual runs.
3. **Watch + apply** — a standalone watcher on `.condash/term-titles.json` validates + clamps a sparse `{sid,title}` list and broadcasts `termAutoTitles`; the renderer sparse-merges into `Tab.autoTitle`. Precedence: `customName → autoTitle → cwd basename → label`. Unknown sids ignored, omitted sids never wiped. condash holds no title state.

Plus: per-task `excludeFromLogs` (a default in the editor + a per-run toggle in the run popup) routes a manual run to `.condash/manual/<slug>/`; a **Sessions | Task runs** switch in the Logs pane browses the segregated store; and an adoptable `term-titles` example task ships in `conception-template/tasks/`.

## Changes

- **Cap 3** — `Tab.autoTitle` + `displayName()` rung (`terminal-pane/types.ts`); `term-titles.ts` (zod validator + length clamp), `term-titles-watcher.ts` (chokidar + `termAutoTitles` broadcast), `termAutoTitlesList` IPC; renderer listener + reconcile seeding (`terminal-pane.tsx`).
- **Cap 2** — `isProvidedToken` + `{TABS}`; `tabsContext()` / `totalBytesSeen()` in `terminals.ts`; `termTabsContext` IPC; injected in `task-scheduler` and the Tasks fill popup.
- **Cap 1** — `taskConfig` added to `sharedSchemaFields`; `task-scheduler.ts` (interval + headless executor reusing `SessionLogger` forced-on); schedule field in the Tasks editor.
- **Run-log segregation** — `TaskRunContext` threaded `runTask → spawnUserShell → TermSpawnRequest → SessionLogger`; `sessionLogPath` + `task-runs.ts` (path layout, rotation, enumeration); `getTaskConfig`/`setTaskConfig` IPC.
- **Logs pane** — `logsListTaskRuns()` IPC + view switcher reusing `logs-modal.tsx`; `logsReadSession` bound to read the task-run store too (realpath-checked).
- **Docs** — `tasks-pane.md`, `terminal.md`, `reference/config.md`, `reference/ipc-api.md`.
- **Tests** — +30 vitest (validator, run-log routing, rotation, listing, cadence, schema, `{TABS}`, `displayName` precedence) and a new auto-title playwright e2e. Full suite green (764 unit, 42 e2e), typecheck + build clean.

## Watchpoints

- **Two design deviations from the original spec** (both deliberate, lower-risk): the apply path uses a *dedicated* watcher + `termAutoTitles` event instead of folding into the conception-tree watcher; and the schedule/`excludeFromLogs` controls live in the **Tasks editor**, not a new Settings-modal section (the schedule UI was an open sub-decision; the modal is a whole-file JSON-draft editor and the most fragile surface).
- Headless scheduled runs require a `promptFlags` agent (no live TUI to keystroke into) — a non-promptFlags agent is skipped with a logged warning.
- Auto-titles are ephemeral renderer state; on reload the renderer re-pulls via `termAutoTitlesList`, so they survive a reload but a tab opened *after* a title was written only picks it up on the next file write.
- Deleting a task-run from the viewer modal would hit `logsDeleteSession` (bounded to `.condash/logs/`) and fail — task-run files are meant to auto-rotate, not be hand-deleted.