### PR TITLE
Term tabs: wrap to compact rows, brighter inactive, bolder active

### DIFF
--- a/docs/guides/terminal.md
+++ b/docs/guides/terminal.md
@@ -30,7 +30,7 @@ The pane starts as a single column. The right column materialises only when at l
 Each side header carries:
 
 - **Spawn dropdown** — a single button that opens a menu listing your **agents**. The first option is always `New shell` (spawns the configured shell); below it is one entry per agent, shown by its `label`, from the [`agents` settings list](agent-clis-and-models.md). Selecting an agent spawns a tab running its `command`. The menu is rendered through a Solid `<Portal>` to `document.body` (with `position: fixed` coordinates from `createDropdownMenu({ align: 'left' })`) so it escapes `.terminal-pane`'s `contain: layout paint` and the strip's `overflow: auto` — both of which would otherwise clip the menu down to the strip's 32 px height.
-- **Tab strip** — click to focus the tab; middle-click to close. Clicking inside the xterm itself also promotes the tab to active (the click+focus listener was wired so a stray click never silently sends keys to a different tab than the one you're looking at).
+- **Tab strip** — click to focus the tab; middle-click to close. Clicking inside the xterm itself also promotes the tab to active (the click+focus listener was wired so a stray click never silently sends keys to a different tab than the one you're looking at). Tabs are coloured buttons that **wrap onto multiple compact rows** when the strip gets crowded rather than scrolling sideways, so every tab stays visible; the focused tab is set apart by an accent ring + bold label (not by dimming the rest), and hovering a truncated tab shows its full title.
 
 Tab titles depend on how the tab was spawned:
 

--- a/src/renderer/terminal-pane.css
+++ b/src/renderer/terminal-pane.css
@@ -168,12 +168,19 @@
 
 .terminal-tabs {
   display: flex;
-  gap: 4px;
+  /* Tabs now carry richer auto-titles, so the strip wraps to several
+   * compact rows instead of scrolling sideways — every tab stays visible.
+   * Tight row-gap + thin vertical padding keep the extra rows from eating
+   * the terminal body; past a few rows it scrolls rather than grows. */
+  flex-wrap: wrap;
+  gap: 3px 4px;
   align-items: center;
-  padding: 4px 8px;
+  align-content: flex-start;
+  padding: 3px 8px;
   border-bottom: 1px solid var(--border);
   background: var(--bg);
-  overflow-x: auto;
+  overflow-y: auto;
+  max-height: 96px;
   scrollbar-width: thin;
   flex-shrink: 0;
   min-height: 32px;
@@ -190,7 +197,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 3px 10px;
+  padding: 2px 8px;
   border: 1px solid transparent;
   border-radius: 6px;
   font-size: var(--text-xs);
@@ -201,24 +208,34 @@
    * cards). Falls back to the neutral surface if no slot resolved. */
   background: var(--app-pill-bg, var(--bg-elevated));
   color: var(--app-pill-fg, var(--text));
-  max-width: 220px;
-  min-width: 80px;
+  max-width: 300px;
+  min-width: 72px;
   flex-shrink: 0;
-  /* Inactive tabs sit muted; the active one is full-strength + ringed. */
-  opacity: 0.62;
+  /* Inactive tabs stay nearly full-strength so their titles read clearly;
+   * the active tab is set apart by decoration (ring + glow + bold), not by
+   * dimming everything else. */
+  opacity: 0.9;
   transition:
     opacity 0.1s ease,
     box-shadow 0.1s ease;
 }
 
 .terminal-tab:hover {
-  opacity: 0.82;
+  opacity: 1;
 }
 
 .terminal-tab.active {
   opacity: 1;
   border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
+  /* Crisp 2px accent ring + soft accent glow so the focused tab is
+   * unmistakable even when the inactive tabs are barely dimmed. */
+  box-shadow:
+    0 0 0 2px var(--accent),
+    0 1px 7px -1px color-mix(in srgb, var(--accent) 60%, transparent);
+}
+
+.terminal-tab.active .terminal-tab-label {
+  font-weight: 700;
 }
 
 .terminal-tab.exited {
@@ -226,7 +243,7 @@
 }
 
 .terminal-tab.exited:not(.active) {
-  opacity: 0.42;
+  opacity: 0.55;
 }
 
 .terminal-tab.renaming {

--- a/src/renderer/terminal-pane/column.tsx
+++ b/src/renderer/terminal-pane/column.tsx
@@ -213,13 +213,10 @@ export function TerminalColumn(props: TerminalColumnProps) {
                 ctxMenu.openAt(e.clientX, e.clientY);
               }}
               onDblClick={() => props.onRequestRename(tab.id)}
-              title={
-                tab.cwd
-                  ? `${displayName(tab)} — ${tab.cwd}`
-                  : displayName(tab) === tab.label
-                    ? tab.label
-                    : `${tab.label} (renamed)`
-              }
+              // Always lead with the complete current title so a hover reveals
+              // the full text when the label is truncated; append the cwd as
+              // context when the shell reported one.
+              title={tab.cwd ? `${displayName(tab)} — ${tab.cwd}` : displayName(tab)}
             >
               <Show
                 when={tab.id === props.renamingId}


### PR DESCRIPTION
## Summary

Follow-up to the coloured term-tab buttons (#290) now that term-titles (#291) fills the bottom terminal tabs with richer auto-titles. The tab strip now carries that text without ballooning, and rebalances the active/inactive contrast so non-active tabs stay readable while the focused tab is unmistakable.

## Changes

- **Multi-row wrap** — the strip wraps onto multiple compact rows (`flex-wrap`) instead of scrolling sideways, so every tab stays visible; tight row-gap + thinner vertical padding keep the extra rows cheap, capped at ~3–4 rows then it scrolls.
- **More text per tab** — `max-width` 220→300px and minimal tab padding, so more of the auto-title shows and more tabs fit per row.
- **Less dimming** — inactive opacity 0.62→0.9 (exited-inactive 0.42→0.55); non-active tabs now read clearly.
- **Clearer active tab** — replaced the 1px ring with a 2px accent ring + soft glow and a bold label; decoration carries the contrast, not dimming.
- **Full-title hover** — the `title` tooltip always leads with the complete current title (it previously showed the stale spawn label + `(renamed)` for a renamed/auto-titled tab with no cwd).
- Updated `docs/guides/terminal.md`.

## Impact

Renderer-only — `terminal-pane.css` plus one tooltip string in `column.tsx`. No data/state/IPC changes; client-only, no server-before-client ordering. format + typecheck + 764 vitest tests + build all green; before/after screenshots captured in light + dark.

## Watchpoints

- The strip caps at `max-height: 96px` (~3–4 rows) then scrolls vertically — a very crowded split column scrolls rather than growing without bound.