### PR TITLE
Fix logs viewer overflowing terminal and clipping its header

### DIFF
--- a/src/renderer/logs-modal.css
+++ b/src/renderer/logs-modal.css
@@ -4,8 +4,13 @@
 
 .logs-modal {
   width: var(--modal-w-lg);
-  height: 90vh;
-  max-height: 90vh;
+  /* Size to the backdrop, not the viewport. The backdrop already stops above
+   * the terminal (bottom: var(--terminal-pane-height)), so 100% fills the space
+   * over the terminal exactly. A viewport-relative 90vh overflowed the shrunken
+   * backdrop when the terminal was open — spilling over the terminal and pushing
+   * the modal head off the top of the screen. */
+  height: 100%;
+  max-height: 100%;
   display: flex;
   flex-direction: column;
 }


### PR DESCRIPTION
## Summary

The session logs viewer rendered over the terminal pane, and its header/title bar was cut off the top of the screen — but only when the terminal was open.

## Cause

`.logs-modal` was sized in viewport units (`height: 90vh`), while the shared `.modal-backdrop` is deliberately shrunk to stop just above the terminal pane (`bottom: var(--terminal-pane-height)`) so popups never cover the terminal. With the terminal open the backdrop is shorter than 90vh, so the modal overflowed it: the bottom spilled onto the terminal, and — being centered in a too-short backdrop — the top spilled off-screen, clipping the modal head.

## Changes

- `src/renderer/logs-modal.css`: size `.logs-modal` to `height: 100%` / `max-height: 100%` of the backdrop content box instead of viewport-relative `90vh`, matching the base `.modal { max-height: 100% }` pattern. The backdrop already excludes the terminal, so 100% fills exactly the space above it.

## Watchpoints

- Reasoned from the CSS rather than captured in a running Electron session.
- `search-modal.css` uses the same viewport-relative pattern (`max-height: 82vh`, `padding-top: 6vh`) and could spill over the terminal in the same way; left out of scope for this targeted fix.