### PR TITLE
Fix tasks e2e locator broken by the run-mode select (v4.24.0)

### DIFF
--- a/src/renderer/panes/tasks.tsx
+++ b/src/renderer/panes/tasks.tsx
@@ -705,7 +705,7 @@ function TaskFill(props: {
           {/* Top control row: pick the agent and run, above the variable
               settings. The prompt preview stays at the bottom. */}
           <div class="tasks-fill-top">
-            <label>
+            <label class="tasks-fill-agent">
               <span>Agent</span>
               <select
                 value={props.fill().agent}

--- a/tests/tasks.spec.ts
+++ b/tests/tasks.spec.ts
@@ -81,8 +81,9 @@ test('tasks pane lists a task and fills its markers', async () => {
     await expect(window.locator('.tasks-fill')).toBeVisible();
 
     // The run-time Agent picker sits in the top control row and defaults to the
-    // task's stored agent id (overridable per run).
-    await expect(window.locator('.tasks-fill-top select')).toHaveValue('claude-deepseek-v4-pro');
+    // task's stored agent id (overridable per run). Scoped to the agent label so
+    // the sibling Run-mode select in the same row is not matched.
+    await expect(window.locator('.tasks-fill-agent select')).toHaveValue('claude-deepseek-v4-pro');
 
     // The {AREA} field is prefilled from its default; the preview echoes it.
     const preview = window.locator('.tasks-preview pre');


### PR DESCRIPTION
## Summary

The v4.24.0 release of #295 **failed at the release-time Playwright gate**: the new Run-mode `<select>` is a second `<select>` inside `.tasks-fill-top`, so `tasks.spec.ts`'s `locator('.tasks-fill-top select')` hit a strict-mode violation (2 elements) and the build + publish jobs were skipped. PR CI only runs the light gate (format/typecheck/build/vitest) — Playwright runs only in `release.yml` — so it slipped through.

## Changes

- `src/renderer/panes/tasks.tsx` — tag the run-popup Agent `<label>` with `.tasks-fill-agent`.
- `tests/tasks.spec.ts` — scope the agent-value assertion to `.tasks-fill-agent select` (order-independent).

## Impact

No behavior change. Verified locally under the CI config (`xvfb` + `ELECTRON_OZONE_PLATFORM_HINT=x11`): the full `tasks.spec.ts` (4 tests) passes; full suite re-run before tagging v4.24.1.