### PR TITLE
Persist task runMode so the --run/--prompt choice survives reopen

### DIFF
--- a/src/main/ipc/tasks.test.ts
+++ b/src/main/ipc/tasks.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Tasks-IPC tests for the per-task config (`taskConfig`) read/write path.
+ *
+ * Regression cover for the shipped bug where per-task `runMode` was added to
+ * the schema, types, editor UI, and scheduler but the `setTaskConfig` handler
+ * kept a stale three-key projection (`schedule` / `timeout` / `excludeFromLogs`)
+ * — so saving a task as one-shot (`--run`) silently dropped `runMode`, and on
+ * reopen the task reverted to the interactive (`--prompt`) default.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskConfigEntry } from '../../shared/types';
+
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  app: { getPath: () => '/tmp/electron-app' },
+}));
+
+let tmp: string;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
+let settingsPathValue: string;
+
+async function readSettingsFile(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(settingsPathValue, 'utf8');
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+async function getTaskConfig(): Promise<Record<string, TaskConfigEntry>> {
+  return (await handlers.getTaskConfig()) as Record<string, TaskConfigEntry>;
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  tmp = mkdtempSync(join(tmpdir(), 'condash-task-config-'));
+  settingsPathValue = join(tmp, 'settings.json');
+  const isolatedTmp = tmp;
+  vi.doMock('../user-data-dir', () => ({ userDataDir: () => isolatedTmp }));
+
+  handlers = {};
+  const { ipcMain } = await import('electron');
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (ipcMain.handle as any).mockImplementation(
+    (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
+      handlers[channel] = fn;
+    },
+  );
+  // getTaskConfig resolves through the active conception. Point it at the tmp
+  // dir — with no `.condash/` there, the global settings.json `taskConfig`
+  // (where setTaskConfig writes) is the layer surfaced on read.
+  await fs.writeFile(
+    settingsPathValue,
+    JSON.stringify({ lastConceptionPath: tmp, recentConceptionPaths: [] }),
+  );
+  const { registerTasksIpc } = await import('./tasks');
+  registerTasksIpc();
+});
+
+afterEach(async () => {
+  try {
+    const { drainSettingsQueue } = await import('../settings');
+    await drainSettingsQueue();
+  } catch {
+    /* Module not loaded yet — fine. */
+  }
+  rmSync(tmp, { recursive: true, force: true });
+  vi.doUnmock('../user-data-dir');
+});
+
+describe('setTaskConfig / getTaskConfig runMode round-trip', () => {
+  it('persists a one-shot runMode and reads it back', async () => {
+    await handlers.setTaskConfig(null, 'term-titles', { schedule: '1m', runMode: 'oneshot' });
+
+    const onDisk = await readSettingsFile();
+    expect(onDisk.taskConfig).toEqual({ 'term-titles': { schedule: '1m', runMode: 'oneshot' } });
+
+    const effective = await getTaskConfig();
+    expect(effective['term-titles'].runMode).toBe('oneshot');
+  });
+
+  it('does not persist the interactive default (stays absent)', async () => {
+    await handlers.setTaskConfig(null, 'term-titles', { schedule: '1m', runMode: 'interactive' });
+
+    const onDisk = await readSettingsFile();
+    // interactive is the implied default — only schedule survives.
+    expect(onDisk.taskConfig).toEqual({ 'term-titles': { schedule: '1m' } });
+
+    const effective = await getTaskConfig();
+    expect(effective['term-titles'].runMode).toBeUndefined();
+  });
+
+  it('keeps a task whose only setting is a one-shot runMode', async () => {
+    // The delete-guard must treat runMode as a real setting, not prune the
+    // entry as empty when schedule/timeout/excludeFromLogs are all absent.
+    await handlers.setTaskConfig(null, 'solo', { runMode: 'oneshot' });
+
+    const onDisk = await readSettingsFile();
+    expect(onDisk.taskConfig).toEqual({ solo: { runMode: 'oneshot' } });
+  });
+
+  it('persists runMode alongside the other per-task settings', async () => {
+    await handlers.setTaskConfig(null, 'term-titles', {
+      schedule: '1m',
+      timeout: '10m',
+      excludeFromLogs: true,
+      runMode: 'oneshot',
+    });
+
+    const onDisk = await readSettingsFile();
+    expect(onDisk.taskConfig).toEqual({
+      'term-titles': { schedule: '1m', timeout: '10m', excludeFromLogs: true, runMode: 'oneshot' },
+    });
+  });
+});

--- a/src/main/ipc/tasks.ts
+++ b/src/main/ipc/tasks.ts
@@ -33,9 +33,10 @@ export function registerTasksIpc(): void {
   ipcMain.handle('listRunningTaskRuns', () => listRunningTaskRuns());
   ipcMain.handle('killTaskRun', (_, sid: string) => killTaskRun(sid));
 
-  // Per-task schedule / excludeFromLogs config (capability 1). Read merges
-  // through the effective config (condash.json over settings.json); writes
-  // always target the per-machine settings.json `taskConfig` map.
+  // Per-task schedule / timeout / excludeFromLogs / runMode config
+  // (capability 1). Read merges through the effective config (condash.json over
+  // settings.json); writes always target the per-machine settings.json
+  // `taskConfig` map.
   ipcMain.handle('getTaskConfig', () =>
     withConception(async (c) => {
       const config = await getEffectiveConceptionConfig(c);
@@ -56,15 +57,24 @@ export function registerTasksIpc(): void {
         ? entry.timeout.trim()
         : undefined;
     const excludeFromLogs = entry?.excludeFromLogs === true ? true : undefined;
+    // Only the non-default `oneshot` mode is persisted; `interactive` is the
+    // implied default and stays absent (matches the renderer's contract).
+    const runMode = entry?.runMode === 'oneshot' ? 'oneshot' : undefined;
     await updateSettings((cur) => {
       const map = { ...((cur.taskConfig ?? {}) as Record<string, TaskConfigEntry>) };
-      if (schedule === undefined && timeout === undefined && excludeFromLogs === undefined) {
+      if (
+        schedule === undefined &&
+        timeout === undefined &&
+        excludeFromLogs === undefined &&
+        runMode === undefined
+      ) {
         delete map[slug];
       } else {
         map[slug] = {
           ...(schedule ? { schedule } : {}),
           ...(timeout ? { timeout } : {}),
           ...(excludeFromLogs ? { excludeFromLogs } : {}),
+          ...(runMode ? { runMode } : {}),
         };
       }
       return { ...cur, taskConfig: Object.keys(map).length > 0 ? map : undefined };


### PR DESCRIPTION
## Summary

- Per-task run mode (`--prompt` / `--run`) was added in 4.24.1 but was never persisted: saving a task as one-shot reverted to interactive (`--prompt`) on the next open.
- Scheduled one-shot tasks were hit by the same gap — they launched headless with `--prompt`, kept the session open, and were SIGKILL'd at their timeout instead of exiting cleanly.

## Changes

- `setTaskConfig` (`src/main/ipc/tasks.ts`): read `runMode` from the entry, write it into the persisted `taskConfig` map, and add it to the empty-entry delete-guard so a task whose only setting is a one-shot `runMode` is not pruned. Only the non-default `oneshot` is stored; `interactive` stays absent, matching the renderer's contract.
- Add `src/main/ipc/tasks.test.ts`: round-trips `runMode` through `setTaskConfig` / `getTaskConfig` — persists one-shot, omits the interactive default, keeps a `runMode`-only task, and persists alongside `schedule` / `timeout` / `excludeFromLogs`. No `ipc/tasks.test.ts` existed before, which is why the gap shipped.

## Impact

- Tasks saved as one-shot before this fix carry no persisted `runMode`; they need to be re-saved once for the choice to stick.