### PR TITLE
Preview images/HTML/text in-app; reveal files in OS file manager

### DIFF
--- a/docs/guides/deliverables-pane.md
+++ b/docs/guides/deliverables-pane.md
@@ -24,7 +24,9 @@ A trailing comment (after ` — `) is shown next to the label for any item type.
 
 ## Opening a deliverable
 
-Click a row to open it. The viewer is chosen by type — wikilinks navigate to the linked item within condash; PDF and HTML preview in-app; URLs open in your browser; Markdown opens read-only; everything else hands off to your OS default app. See **[Deliverables](deliverables.md#how-each-item-opens)** for the full table and the HTML-preview relative-asset notes.
+Click a row to open it. The viewer is chosen by type — wikilinks navigate to the linked item within condash; PDF, HTML, images, and text/source files preview in-app; URLs open in your browser; Markdown opens read-only; everything else hands off to your OS default app. See **[Deliverables](deliverables.md#how-each-item-opens)** for the full table and the HTML-preview relative-asset notes.
+
+Local-file rows (anything that isn't a wikilink or URL) also carry a **reveal** button (`⤷`) that opens the file in your OS file manager, selected in its parent folder.
 
 ## Empty state
 

--- a/docs/guides/deliverables.md
+++ b/docs/guides/deliverables.md
@@ -48,9 +48,13 @@ The viewer is chosen by the item's type:
 | `[[slug]]` wikilink | the linked conception item, navigated to within condash |
 | `http(s)://…` | your external browser (`shell.openExternal`) |
 | `.pdf` | the in-app PDF viewer modal |
-| `.html` / `.htm` | the in-app HTML preview (sandboxed `condash-file://` webview, with an **↗ Open externally** button) |
+| `.html` / `.htm` | the in-app HTML preview (sandboxed `condash-file://` webview), with a **Rendered / Source** header toggle |
 | `.md` / `.markdown` | the in-app note modal, read-only |
-| anything else | your OS default application (`shell.openPath`) |
+| images (`.png` / `.jpg` / `.svg` / …) | the in-app image viewer, fit-to-window |
+| text / source code (`.txt` / `.json` / `.css` / `.js` / …) | the in-app note modal, read-only, syntax-highlighted |
+| anything else (audio, video, archives, binaries) | your OS default application (`shell.openPath`) |
+
+Every in-app viewer's header carries a **⤷ Reveal in file manager** button alongside the **↗ Open in OS default** escape hatch.
 
 The HTML preview loads the file over the `condash-file://` scheme, so **relative** references inside it (`<img src="sibling.png">`, relative CSS/JS) resolve against the deliverable's own directory. Root-absolute paths (`/assets/…`) and remote assets may not load under the renderer's CSP — use **↗ Open externally** for those.
 

--- a/docs/guides/resources-pane.md
+++ b/docs/guides/resources-pane.md
@@ -17,8 +17,9 @@ Each card carries a coloured glyph for its file type:
 |-------|---------------------------------------|
 | `MD`  | `.md`, `.markdown`                    |
 | `PDF` | `.pdf`                                |
+| `WEB` | `.html`, `.htm`                       |
 | `TXT` | Source code, JSON, YAML, plain text   |
-| `IMG` | Images                                |
+| `IMG` | Images (raster + SVG)                 |
 | `AUD` | Audio                                 |
 | `VID` | Video                                 |
 | `ZIP` | Archives                              |
@@ -29,12 +30,21 @@ Each card carries a coloured glyph for its file type:
 
 A button row at the bottom of each card exposes:
 
-- **view** — `.md` and `.txt` open in the in-app note modal in **read-only** mode; `.pdf` opens in the existing PDF viewer modal. Any other extension hides this button.
+- **view** — opens the file in-app, picking the viewer by type:
+    - Markdown → the note modal, rendered, **read-only**.
+    - Text / source code (JSON, YAML, CSS, JS, …) → the note modal, **read-only**, syntax-highlighted by extension.
+    - PDF → the PDF viewer modal.
+    - HTML → the HTML viewer modal, rendered, with a **Rendered / Source** toggle in the header.
+    - Image (raster or SVG) → the image viewer modal, fit-to-window.
+    - Audio, video, archives and binaries have no in-app viewer — the button is hidden and the card opens them in the OS default app instead.
 - **open** — opens the file via the user's `open_with.main_ide` slot (configured in `.condash/settings.json`, or the legacy `condash.json`).
+- **reveal** — reveals the file in your OS file manager (selected in its parent folder).
 - **copy** — copies the absolute path to the system clipboard.
 - **→ term** — pastes the absolute path into the focused terminal session (no `↵`). If no session is live, the button still pastes once you spawn one.
 
 Clicking the card body itself runs the most-likely action for the file type — view for inline-viewable types, open-in-IDE otherwise.
+
+Each in-app viewer (PDF, HTML, image) carries the same reveal + open-in-OS escape hatches in its header, so a file that can't render in-app (e.g. an HTML page pulling root-absolute or remote assets, or an image outside the conception tree) is always one click from the real application.
 
 ## Configuration
 

--- a/src/main/ipc/system.ts
+++ b/src/main/ipc/system.ts
@@ -193,6 +193,17 @@ export function registerSystemIpc(opts: {
     if (error) throw new Error(error);
   });
 
+  // Reveal a file/dir in the OS file manager, selected in its parent folder.
+  // Same trust boundary as openInEditor / openPath: the renderer hands it a
+  // path it already displays, and this only delegates to Electron's shell
+  // (no shell expansion, no command-injection vector).
+  ipcMain.handle('showInFolder', (_, target: string) => {
+    if (typeof target !== 'string' || target.length === 0) {
+      throw new Error('showInFolder: target must be a non-empty string');
+    }
+    shell.showItemInFolder(target);
+  });
+
   ipcMain.handle('quitApp', () => {
     app.quit();
   });

--- a/src/main/resources.ts
+++ b/src/main/resources.ts
@@ -1,10 +1,16 @@
 import { promises as fs } from 'node:fs';
-import { basename, extname, join } from 'node:path';
-import type { ResourceCategory, ResourceNode } from '../shared/types';
+import { basename, join } from 'node:path';
+import type { ResourceNode } from '../shared/types';
 import { toPosix } from '../shared/path';
+import { categorise, mimeFor } from '../shared/file-category';
 import { DEFAULT_RESOURCES_PATH } from './config-schema';
 import { parseHead } from './knowledge';
 import { readFileHead } from './read-file-head';
+
+// Re-exported so existing importers (and `resources.test.ts`) keep reaching
+// the classifier through this module; the implementation now lives in the
+// node-free shared module shared with the renderer's file-open router.
+export { categorise, mimeFor };
 
 const HIDDEN_PREFIX = /^\./;
 
@@ -110,137 +116,3 @@ async function readMarkdownMeta(
   const meta = parseHead(head, fallback);
   return { title: meta.title, summary: meta.summary };
 }
-
-/**
- * Coarse category from the filename extension. Drives the icon picker and
- * which "View" action shows on the card. Every entry maps to one bucket;
- * unknown extensions fall through to `other`.
- */
-export function categorise(name: string): ResourceCategory {
-  const ext = extname(name).toLowerCase();
-  if (ext === '.md' || ext === '.markdown') return 'markdown';
-  if (ext === '.pdf') return 'pdf';
-  if (TEXT_EXTS.has(ext)) return 'text';
-  if (IMAGE_EXTS.has(ext)) return 'image';
-  if (AUDIO_EXTS.has(ext)) return 'audio';
-  if (VIDEO_EXTS.has(ext)) return 'video';
-  if (ARCHIVE_EXTS.has(ext)) return 'archive';
-  if (BINARY_EXTS.has(ext)) return 'binary';
-  return 'other';
-}
-
-/**
- * Best-effort mime hint. Kept compact rather than pulling in `mime-types`;
- * the renderer only uses this for tooltips, the category drives behaviour.
- */
-export function mimeFor(name: string): string | undefined {
-  const ext = extname(name).toLowerCase();
-  return MIME_TABLE[ext];
-}
-
-const TEXT_EXTS = new Set([
-  '.txt',
-  '.log',
-  '.csv',
-  '.tsv',
-  '.json',
-  '.yaml',
-  '.yml',
-  '.toml',
-  '.ini',
-  '.env',
-  '.xml',
-  '.html',
-  '.htm',
-  '.css',
-  '.scss',
-  '.sass',
-  '.less',
-  '.js',
-  '.cjs',
-  '.mjs',
-  '.ts',
-  '.tsx',
-  '.jsx',
-  '.py',
-  '.rb',
-  '.go',
-  '.rs',
-  '.java',
-  '.kt',
-  '.kts',
-  '.c',
-  '.h',
-  '.cpp',
-  '.hpp',
-  '.cc',
-  '.hh',
-  '.sh',
-  '.bash',
-  '.zsh',
-  '.fish',
-  '.lua',
-  '.sql',
-  '.r',
-  '.swift',
-  '.scala',
-  '.tex',
-]);
-
-const IMAGE_EXTS = new Set([
-  '.png',
-  '.jpg',
-  '.jpeg',
-  '.gif',
-  '.webp',
-  '.svg',
-  '.bmp',
-  '.tiff',
-  '.ico',
-  '.avif',
-  '.heic',
-]);
-
-const AUDIO_EXTS = new Set(['.mp3', '.wav', '.ogg', '.flac', '.m4a', '.aac', '.opus']);
-
-const VIDEO_EXTS = new Set(['.mp4', '.mov', '.mkv', '.webm', '.avi', '.m4v']);
-
-const ARCHIVE_EXTS = new Set(['.zip', '.tar', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.rar']);
-
-const BINARY_EXTS = new Set(['.exe', '.dll', '.so', '.dylib', '.bin', '.dat', '.iso', '.dmg']);
-
-const MIME_TABLE: Record<string, string> = {
-  '.md': 'text/markdown',
-  '.markdown': 'text/markdown',
-  '.pdf': 'application/pdf',
-  '.txt': 'text/plain',
-  '.log': 'text/plain',
-  '.csv': 'text/csv',
-  '.tsv': 'text/tab-separated-values',
-  '.json': 'application/json',
-  '.yaml': 'application/yaml',
-  '.yml': 'application/yaml',
-  '.toml': 'application/toml',
-  '.html': 'text/html',
-  '.htm': 'text/html',
-  '.css': 'text/css',
-  '.js': 'text/javascript',
-  '.mjs': 'text/javascript',
-  '.cjs': 'text/javascript',
-  '.ts': 'text/typescript',
-  '.tsx': 'text/typescript',
-  '.png': 'image/png',
-  '.jpg': 'image/jpeg',
-  '.jpeg': 'image/jpeg',
-  '.gif': 'image/gif',
-  '.webp': 'image/webp',
-  '.svg': 'image/svg+xml',
-  '.mp3': 'audio/mpeg',
-  '.wav': 'audio/wav',
-  '.ogg': 'audio/ogg',
-  '.mp4': 'video/mp4',
-  '.mov': 'video/quicktime',
-  '.zip': 'application/zip',
-  '.tar': 'application/x-tar',
-  '.gz': 'application/gzip',
-};

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -129,6 +129,7 @@ const api: CondashApi = {
   openConceptionDirectory: () => ipcRenderer.invoke('openConceptionDirectory'),
   openExternal: (target: string) => ipcRenderer.invoke('openExternal', target),
   openPath: (target: string) => ipcRenderer.invoke('openPath', target),
+  showInFolder: (target: string) => ipcRenderer.invoke('showInFolder', target),
   createProjectNote: (projectPath: string, slug: string) =>
     ipcRenderer.invoke('createProjectNote', projectPath, slug),
   treeCreateMd: (root, dirRelPath, filename) =>

--- a/src/renderer/deliverable-open.ts
+++ b/src/renderer/deliverable-open.ts
@@ -1,42 +1,54 @@
 import type { Setter } from 'solid-js';
 import type { ModalState } from './note-modal';
+import { categorise } from '@shared/file-category';
 
 export interface DeliverableOpenSetters {
   setPdfPath: Setter<string | null>;
   setHtmlPath: Setter<string | null>;
+  setImagePath: Setter<string | null>;
   setModal: Setter<ModalState>;
 }
 
 /**
- * Open a deliverable target by type. `target` is either a resolved local path
- * or a verbatim http(s) URL (`Deliverable.path`):
+ * Open a file/URL target in the right surface. `target` is either a resolved
+ * local path or a verbatim http(s) URL (`Deliverable.path`). Local files are
+ * classified by `categorise` (the same classifier the Resources pane uses), so
+ * every pane opens a given file type the same way:
  *
  *   - http(s) URL → external browser
- *   - .pdf        → in-app PDF modal
- *   - .html/.htm  → in-app HTML preview
- *   - .md         → in-app read-only markdown viewer
+ *   - pdf         → in-app PDF modal
+ *   - html        → in-app HTML preview (rendered, with a source toggle)
+ *   - image       → in-app image viewer
+ *   - markdown    → in-app read-only markdown viewer
+ *   - text/code   → in-app read-only, syntax-highlighted viewer
  *   - everything else → OS default application
  *
- * Shared by the project-preview deliverables list and the Outputs pane so both
- * route every artifact the same way.
+ * Shared by the project-preview deliverables list, the knowledge/resources
+ * tree, and the Deliverables pane so every artifact routes identically.
  */
 export function openDeliverableTarget(target: string, setters: DeliverableOpenSetters): void {
-  const lower = target.toLowerCase();
   if (/^https?:\/\//i.test(target)) {
     void window.condash.openExternal(target);
     return;
   }
-  if (lower.endsWith('.pdf')) {
-    setters.setPdfPath(target);
-    return;
+  // Classify on the basename so a dotted parent directory can't be mistaken
+  // for an extension.
+  const base = target.split(/[/\\]/).pop() ?? target;
+  switch (categorise(base)) {
+    case 'pdf':
+      setters.setPdfPath(target);
+      return;
+    case 'html':
+      setters.setHtmlPath(target);
+      return;
+    case 'image':
+      setters.setImagePath(target);
+      return;
+    case 'markdown':
+    case 'text':
+      setters.setModal({ path: target, readOnly: true });
+      return;
+    default:
+      void window.condash.openPath(target);
   }
-  if (lower.endsWith('.html') || lower.endsWith('.htm')) {
-    setters.setHtmlPath(target);
-    return;
-  }
-  if (lower.endsWith('.md') || lower.endsWith('.markdown')) {
-    setters.setModal({ path: target, readOnly: true });
-    return;
-  }
-  void window.condash.openPath(target);
 }

--- a/src/renderer/hooks/use-modals.ts
+++ b/src/renderer/hooks/use-modals.ts
@@ -12,6 +12,8 @@ export interface UseModals {
   setPdfPath: Setter<string | null>;
   htmlPath: () => string | null;
   setHtmlPath: Setter<string | null>;
+  imagePath: () => string | null;
+  setImagePath: Setter<string | null>;
   helpDoc: () => HelpDoc | null;
   setHelpDoc: Setter<HelpDoc | null>;
   searchModalOpen: () => boolean;
@@ -48,6 +50,7 @@ export function useModals(): UseModals {
   const [previewPath, setPreviewPath] = createSignal<string | null>(null);
   const [pdfPath, setPdfPath] = createSignal<string | null>(null);
   const [htmlPath, setHtmlPath] = createSignal<string | null>(null);
+  const [imagePath, setImagePath] = createSignal<string | null>(null);
   const [helpDoc, setHelpDoc] = createSignal<HelpDoc | null>(null);
   const [searchModalOpen, setSearchModalOpen] = createSignal(false);
   const [settingsOpen, setSettingsOpen] = createSignal(false);
@@ -74,6 +77,8 @@ export function useModals(): UseModals {
     setPdfPath,
     htmlPath,
     setHtmlPath,
+    imagePath,
+    setImagePath,
     helpDoc,
     setHelpDoc,
     searchModalOpen,

--- a/src/renderer/hooks/use-project-actions.ts
+++ b/src/renderer/hooks/use-project-actions.ts
@@ -2,6 +2,7 @@ import { createMemo, type Setter } from 'solid-js';
 import type { Deliverable, KnowledgeNode, Project, Step } from '@shared/types';
 import { applyStatus, applyStepMarker, groupByStatus, nextMarker } from '../panes/projects';
 import { buildSlugIndex } from '../wikilinks';
+import { categorise } from '@shared/file-category';
 import { openDeliverableTarget } from '../deliverable-open';
 import type { ModalState } from '../note-modal';
 import type { ModalRouter } from '../modal-router';
@@ -16,6 +17,7 @@ export interface UseProjectActionsDeps {
   setPreviewPath: Setter<string | null>;
   setPdfPath: Setter<string | null>;
   setHtmlPath: Setter<string | null>;
+  setImagePath: Setter<string | null>;
   openPrompt: (init: Omit<PromptModalState, 'resolve'>) => Promise<string | null>;
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
 }
@@ -94,31 +96,41 @@ export function useProjectActions(deps: UseProjectActionsDeps): UseProjectAction
     });
   };
 
+  const openTarget = (path: string): void =>
+    openDeliverableTarget(path, {
+      setPdfPath: deps.setPdfPath,
+      setHtmlPath: deps.setHtmlPath,
+      setImagePath: deps.setImagePath,
+      setModal: deps.setModal,
+    });
+
   const handleOpenDeliverableFromPreview = (deliverable: Deliverable): void => {
     if (deliverable.kind === 'wikilink') {
       handleWikilink(deliverable.path);
       return;
     }
-    openDeliverableTarget(deliverable.path, {
-      setPdfPath: deps.setPdfPath,
-      setHtmlPath: deps.setHtmlPath,
-      setModal: deps.setModal,
-    });
+    openTarget(deliverable.path);
   };
 
   const handleOpenFileFromPreview = (path: string, previewPath: () => string | null): void => {
     const back = previewProject(previewPath)?.title;
-    if (path.toLowerCase().endsWith('.md')) {
+    // Markdown opens editable in the note modal (it's usually a project note),
+    // closing the preview and remembering it for the back button.
+    if (path.toLowerCase().endsWith('.md') || path.toLowerCase().endsWith('.markdown')) {
       deps.router.setPreviewBackPath(previewPath());
       deps.setPreviewPath(null);
       deps.setModal({ path, backLabel: back });
-    } else if (path.toLowerCase().endsWith('.pdf')) {
-      deps.router.setPreviewBackPath(previewPath());
-      deps.setPdfPath(path);
-    } else {
-      // Non-md, non-pdf — opens externally, preview stays in place.
-      void window.condash.openInEditor(path);
+      return;
     }
+    // Other in-app viewers (pdf / html / image / text-code) overlay the preview
+    // and restore it on close via the back-path; non-viewable kinds open in the
+    // OS app and leave the preview in place.
+    const base = path.split(/[/\\]/).pop() ?? path;
+    const cat = categorise(base);
+    if (cat === 'pdf' || cat === 'html' || cat === 'image' || cat === 'text') {
+      deps.router.setPreviewBackPath(previewPath());
+    }
+    openTarget(path);
   };
 
   const handleDropOnColumn = async (path: string, newStatus: string): Promise<void> => {

--- a/src/renderer/hooks/use-tree-actions.ts
+++ b/src/renderer/hooks/use-tree-actions.ts
@@ -17,6 +17,7 @@ export interface UseTreeActionsDeps {
   setModal: Setter<ModalState>;
   setPdfPath: Setter<string | null>;
   setHtmlPath: Setter<string | null>;
+  setImagePath: Setter<string | null>;
   setSettingsOpen: Setter<boolean>;
   bridge: TerminalBridge;
   flashToast: (msg: string, kind?: 'success' | 'error' | 'info') => void;
@@ -81,13 +82,15 @@ export function useTreeActions(deps: UseTreeActionsDeps): UseTreeActions {
     void window.condash.openInEditor(path);
   };
 
-  const handleOpenDeliverable = (path: string): void => {
+  const openTarget = (path: string): void =>
     openDeliverableTarget(path, {
       setPdfPath: deps.setPdfPath,
       setHtmlPath: deps.setHtmlPath,
+      setImagePath: deps.setImagePath,
       setModal: deps.setModal,
     });
-  };
+
+  const handleOpenDeliverable = (path: string): void => openTarget(path);
 
   const handleOpenKnowledgeFile = (path: string, title?: string): void => {
     deps.setModal({ path, title });
@@ -135,16 +138,10 @@ export function useTreeActions(deps: UseTreeActionsDeps): UseTreeActions {
       handleOpenSkillFile(newPath, title, null);
       return;
     }
-    // Resources: open via the user's main editor for non-viewable kinds,
-    // or the inline viewer for markdown / pdf / text.
-    const lower = newPath.toLowerCase();
-    if (lower.endsWith('.md')) {
-      handleViewResource(newPath, newPath.split('/').pop() ?? newPath);
-    } else if (lower.endsWith('.pdf')) {
-      deps.setPdfPath(newPath);
-    } else {
-      void window.condash.openInEditor(newPath);
-    }
+    // Resources: open the new file the same way a click would — the shared
+    // router picks the in-app viewer for markdown / pdf / html / image /
+    // text-code and falls back to the OS app for everything else.
+    openTarget(newPath);
   };
 
   const resourcesActions: ResourcesViewActions = {
@@ -152,6 +149,9 @@ export function useTreeActions(deps: UseTreeActionsDeps): UseTreeActions {
     viewMarkdown: handleViewResource,
     viewText: handleViewResource,
     viewPdf: (path) => deps.setPdfPath(path),
+    viewHtml: (path) => deps.setHtmlPath(path),
+    viewImage: (path) => deps.setImagePath(path),
+    reveal: (path) => void window.condash.showInFolder(path),
     copyPath: (path) => {
       void navigator.clipboard
         .writeText(path)

--- a/src/renderer/html-modal.css
+++ b/src/renderer/html-modal.css
@@ -18,3 +18,19 @@
   border: none;
   background: #fff;
 }
+
+/* Source tab — scrollable highlighted markup filling the body. */
+.html-source {
+  flex: 1;
+  overflow: auto;
+  padding: 16px;
+  background: var(--bg-elevated);
+}
+
+/* Rendered / Source segmented toggle in the modal head. Tightens the gap so
+ * the two buttons read as one control rather than two stray head buttons. */
+.modal-seg {
+  display: inline-flex;
+  gap: 4px;
+  flex-shrink: 0;
+}

--- a/src/renderer/html-modal.tsx
+++ b/src/renderer/html-modal.tsx
@@ -1,27 +1,45 @@
+import { createMemo, createResource, createSignal, Show } from 'solid-js';
 import { useModalEscHandler } from './modal-helpers';
-import { pathToCondashFileUrl } from './markdown';
+import { highlightCode, pathToCondashFileUrl } from './markdown';
 import './html-modal.css';
 
+type HtmlMode = 'rendered' | 'source';
+
 /**
- * In-app preview for a local HTML deliverable. Mirrors `PdfModal`: a sandboxed
- * `<webview>` with an "open externally" escape hatch in the header.
+ * In-app preview for a local HTML file. Two modes via the header toggle:
+ *   - Rendered — a sandboxed `<webview>` loading the page over the
+ *     conception-sandboxed `condash-file://` protocol, so relative references
+ *     (`<img src="sibling.jpg">`, relative CSS/JS) resolve against the file's
+ *     own directory. Root-absolute (`/assets/…`) and remote assets may not load
+ *     under the renderer CSP — the open-in-OS button is the fallback for those.
+ *   - Source — the raw markup, syntax-highlighted (read via `readNote`, which
+ *     is conception-bounded like every file the tree surfaces).
  *
- * Loaded over `condash-file:///<abs>` rather than `file://` so relative
- * references inside the document (e.g. `<img src="sibling.jpg">`, relative CSS
- * / JS) resolve against the deliverable's own directory and are served by the
- * conception-sandboxed protocol handler in main/index.ts. Root-absolute paths
- * (`/assets/...`) and remote assets may not load under the renderer CSP — the
- * "open externally" button is the fallback for those documents.
+ * The header also reveals the file in the OS file manager and opens it in the
+ * OS default browser.
  */
 export function HtmlModal(props: {
   path: string;
   onClose: () => void;
-  onOpenExternally: (path: string) => void;
+  onOpenInOs: (path: string) => void;
+  onReveal: (path: string) => void;
 }) {
   useModalEscHandler(props.onClose);
 
+  const [mode, setMode] = createSignal<HtmlMode>('rendered');
+
   const filename = (): string => props.path.split('/').pop() ?? props.path;
   const url = (): string => pathToCondashFileUrl(props.path);
+
+  // Only read the source when the Source tab is active.
+  const [source] = createResource(
+    () => (mode() === 'source' ? props.path : null),
+    (path) => window.condash.readNote(path),
+  );
+  const sourceHtml = createMemo(() => {
+    const text = source();
+    return text == null ? '' : highlightCode(text, props.path);
+  });
 
   return (
     <div class="modal-backdrop" onClick={props.onClose}>
@@ -35,33 +53,67 @@ export function HtmlModal(props: {
         <header class="modal-head">
           <span class="modal-title">{filename()}</span>
           <span class="modal-path">{props.path}</span>
+          <div class="modal-seg" role="tablist" aria-label="HTML view mode">
+            <button
+              type="button"
+              role="tab"
+              class="modal-button modal-button--text"
+              classList={{ active: mode() === 'rendered' }}
+              aria-selected={mode() === 'rendered'}
+              onClick={() => setMode('rendered')}
+            >
+              Rendered
+            </button>
+            <button
+              type="button"
+              role="tab"
+              class="modal-button modal-button--text"
+              classList={{ active: mode() === 'source' }}
+              aria-selected={mode() === 'source'}
+              onClick={() => setMode('source')}
+            >
+              Source
+            </button>
+          </div>
           <button
             class="modal-button"
-            onClick={() => props.onOpenExternally(props.path)}
-            title="Open in external browser"
+            onClick={() => props.onReveal(props.path)}
+            title="Reveal in file manager"
+          >
+            ⤷
+          </button>
+          <button
+            class="modal-button"
+            onClick={() => props.onOpenInOs(props.path)}
+            title="Open in OS default browser"
           >
             ↗
           </button>
-          <button class="modal-button" onClick={props.onClose} title="Close (Esc)">
+          <button class="modal-button modal-close" onClick={props.onClose} title="Close (Esc)">
             ×
           </button>
         </header>
         <div class="html-body">
-          {/* Hardened webview: Node off, context isolated, OS-sandboxed. The
-              defence-in-depth `web-contents-created` handler in main/index.ts
-              re-applies these if the attribute is ever dropped.
+          <Show
+            when={mode() === 'rendered'}
+            fallback={<div class="html-source md-rendered raw-code" innerHTML={sourceHtml()} />}
+          >
+            {/* Hardened webview: Node off, context isolated, OS-sandboxed. The
+                defence-in-depth `web-contents-created` handler in main/index.ts
+                re-applies these if the attribute is ever dropped.
 
-              Deliberately NO `partition` — same lesson as the PDF viewer
-              (3.19.4): a custom partition runs in a non-default session.
-              Worse here, the `condash-file://` protocol handler is registered
-              on the *default* session, so a partitioned webview can't resolve
-              the document or its relative assets at all (blank). The webview
-              only loads a local, conception-sandboxed file. */}
-          <webview
-            src={url()}
-            class="html-webview"
-            webpreferences="contextIsolation=true,nodeIntegration=false,sandbox=true"
-          />
+                Deliberately NO `partition` — same lesson as the PDF viewer
+                (3.19.4): a custom partition runs in a non-default session.
+                Worse here, the `condash-file://` protocol handler is registered
+                on the *default* session, so a partitioned webview can't resolve
+                the document or its relative assets at all (blank). The webview
+                only loads a local, conception-sandboxed file. */}
+            <webview
+              src={url()}
+              class="html-webview"
+              webpreferences="contextIsolation=true,nodeIntegration=false,sandbox=true"
+            />
+          </Show>
         </div>
       </div>
     </div>

--- a/src/renderer/image-modal.css
+++ b/src/renderer/image-modal.css
@@ -1,0 +1,46 @@
+/* ---- Image preview modal ----------------------------------------------- */
+
+.image-modal {
+  width: var(--modal-w-lg);
+  height: 100%;
+}
+
+.image-body {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: auto;
+  padding: 16px;
+  /* Light checkerboard so transparent regions of a PNG/SVG read clearly
+   * against the modal background regardless of theme. */
+  background-color: var(--bg);
+  background-image:
+    linear-gradient(45deg, var(--bg-subtle) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--bg-subtle) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--bg-subtle) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--bg-subtle) 75%);
+  background-size: 20px 20px;
+  background-position:
+    0 0,
+    0 10px,
+    10px -10px,
+    -10px 0;
+}
+
+.image-view {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+  /* Crisp scaling for pixel art / icons; smooth for photos is the browser
+   * default, so leave the rest alone. */
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.28);
+}
+
+.image-error {
+  color: var(--text-muted);
+  font-size: 13px;
+  line-height: 1.5;
+  text-align: center;
+  max-width: 42ch;
+}

--- a/src/renderer/image-modal.tsx
+++ b/src/renderer/image-modal.tsx
@@ -1,0 +1,74 @@
+import { createSignal, Show } from 'solid-js';
+import { useModalEscHandler } from './modal-helpers';
+import { pathToCondashFileUrl } from './markdown';
+import './image-modal.css';
+
+/**
+ * In-app preview for a local image (raster or SVG). Mirrors `PdfModal` /
+ * `HtmlModal`: the image is served over the conception-sandboxed
+ * `condash-file://` protocol and shown fit-to-window. The header carries
+ * reveal-in-file-manager + open-in-OS escape hatches.
+ *
+ * An image that resolves outside the conception tree is rejected by the
+ * protocol handler (the same constraint as the HTML / PDF viewers); the
+ * `onError` fallback points the user at the open-externally button.
+ */
+export function ImageModal(props: {
+  path: string;
+  onClose: () => void;
+  onOpenInOs: (path: string) => void;
+  onReveal: (path: string) => void;
+}) {
+  useModalEscHandler(props.onClose);
+
+  const filename = (): string => props.path.split('/').pop() ?? props.path;
+  const url = (): string => pathToCondashFileUrl(props.path);
+  const [errored, setErrored] = createSignal(false);
+
+  return (
+    <div class="modal-backdrop" onClick={props.onClose}>
+      <div
+        class="modal image-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Image: ${filename()}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header class="modal-head">
+          <span class="modal-title">{filename()}</span>
+          <span class="modal-path">{props.path}</span>
+          <button
+            class="modal-button"
+            onClick={() => props.onReveal(props.path)}
+            title="Reveal in file manager"
+          >
+            ⤷
+          </button>
+          <button
+            class="modal-button"
+            onClick={() => props.onOpenInOs(props.path)}
+            title="Open in OS default viewer"
+          >
+            ↗
+          </button>
+          <button class="modal-button modal-close" onClick={props.onClose} title="Close (Esc)">
+            ×
+          </button>
+        </header>
+        <div class="image-body">
+          <Show
+            when={!errored()}
+            fallback={
+              <div class="image-error">
+                Could not load this image in-app. It may live outside the conception tree — use
+                “open in OS default viewer” above.
+              </div>
+            }
+          >
+            <img class="image-view" src={url()} alt={filename()} onError={() => setErrored(true)} />
+          </Show>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -6,6 +6,7 @@ import { ProjectPreview } from './project-preview';
 import { TerminalPane, type TerminalPaneHandle } from './terminal-pane';
 import { PdfModal } from './pdf-modal';
 import { HtmlModal } from './html-modal';
+import { ImageModal } from './image-modal';
 import { HelpModal } from './help-modal';
 import { WelcomeScreen } from './welcome-screen';
 import { PromptModal } from './prompt-modal';
@@ -101,6 +102,8 @@ function App() {
     setPdfPath,
     htmlPath,
     setHtmlPath,
+    imagePath,
+    setImagePath,
     helpDoc,
     setHelpDoc,
     searchModalOpen,
@@ -286,6 +289,7 @@ function App() {
     setModal,
     setPdfPath,
     setHtmlPath,
+    setImagePath,
     setSettingsOpen,
     bridge,
     flashToast,
@@ -312,6 +316,7 @@ function App() {
     setPreviewPath,
     setPdfPath,
     setHtmlPath,
+    setImagePath,
     openPrompt,
     flashToast,
   });
@@ -513,6 +518,7 @@ function App() {
                         <DeliverablesView
                           projects={projects() ?? []}
                           onOpenDeliverable={openDeliverable}
+                          onReveal={(p) => void window.condash.showInFolder(p)}
                         />
                       </Match>
                       <Match when={layout().leftView === 'tasks'}>
@@ -791,6 +797,7 @@ function App() {
           path={pdfPath()!}
           onClose={() => router.closeChildModal(() => setPdfPath(null))}
           onOpenInOs={handleOpenInEditor}
+          onReveal={(p) => void window.condash.showInFolder(p)}
         />
       </Show>
 
@@ -798,7 +805,17 @@ function App() {
         <HtmlModal
           path={htmlPath()!}
           onClose={() => router.closeChildModal(() => setHtmlPath(null))}
-          onOpenExternally={(p) => void window.condash.openExternal(p)}
+          onOpenInOs={handleOpenInEditor}
+          onReveal={(p) => void window.condash.showInFolder(p)}
+        />
+      </Show>
+
+      <Show when={imagePath()}>
+        <ImageModal
+          path={imagePath()!}
+          onClose={() => router.closeChildModal(() => setImagePath(null))}
+          onOpenInOs={handleOpenInEditor}
+          onReveal={(p) => void window.condash.showInFolder(p)}
         />
       </Show>
 

--- a/src/renderer/markdown.test.ts
+++ b/src/renderer/markdown.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { highlightCode } from './markdown';
+
+describe('highlightCode', () => {
+  it('wraps output in a hljs pre/code block', () => {
+    const html = highlightCode('body { color: red; }', 'styles.css');
+    expect(html.startsWith('<pre class="hljs"><code>')).toBe(true);
+    expect(html.endsWith('</code></pre>')).toBe(true);
+  });
+
+  it('emits highlight token classes for a known language', () => {
+    const html = highlightCode('const x = 1;', 'a.ts');
+    expect(html).toContain('hljs-');
+  });
+
+  it('escapes HTML so source content cannot inject markup', () => {
+    const html = highlightCode('<script>alert(1)</script>', 'note.txt');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('falls back to escaped plain text for an unknown extension', () => {
+    const html = highlightCode('a < b && c > d', 'data.unknownext');
+    expect(html).toContain('&lt;');
+    expect(html).toContain('&amp;&amp;');
+    expect(html).toContain('&gt;');
+  });
+
+  it('degrades to plain text past the size cap without throwing', () => {
+    const big = 'x'.repeat(200_001);
+    const html = highlightCode(big, 'huge.js');
+    expect(html.startsWith('<pre class="hljs"><code>')).toBe(true);
+    expect(html).not.toContain('hljs-');
+  });
+});

--- a/src/renderer/markdown.ts
+++ b/src/renderer/markdown.ts
@@ -106,6 +106,85 @@ export function renderMarkdown(input: string, options: RenderMarkdownOptions = {
   return md.render(input, { baseDir: options.baseDir });
 }
 
+// Above this size highlighting a single file is dropped to escaped plain text:
+// hljs runs synchronously, and tokenising a multi-hundred-KB file blows the
+// 16 ms interaction-to-paint budget. The text stays readable, just uncoloured.
+const MAX_HIGHLIGHT_BYTES = 200_000;
+
+/** Map a file path's extension to a highlight.js language id. Anything not
+ *  listed (or not bundled in `highlight.js/lib/common`) falls back to escaped
+ *  plain text in `highlightCode`. */
+function hljsLangForPath(path: string): string | undefined {
+  const lower = path.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  if (dot < 0) return undefined;
+  return HLJS_LANG_BY_EXT[lower.slice(dot)];
+}
+
+/**
+ * Render a non-markdown text/code file as a syntax-highlighted `<pre><code>`
+ * block. Language is inferred from the extension; unknown or unbundled
+ * languages (and over-large files) degrade to escaped plain text. The `.hljs`
+ * classes are themed by `code-theme.css`, the same palette the markdown fenced
+ * code blocks use. Used by the note modal's read-only view and the HTML modal's
+ * "Source" tab.
+ */
+export function highlightCode(text: string, path: string): string {
+  if (text.length > MAX_HIGHLIGHT_BYTES) {
+    return `<pre class="hljs"><code>${md.utils.escapeHtml(text)}</code></pre>`;
+  }
+  const lang = hljsLangForPath(path);
+  if (lang && hljs.getLanguage(lang)) {
+    try {
+      const { value } = hljs.highlight(text, { language: lang, ignoreIllegals: true });
+      return `<pre class="hljs"><code>${value}</code></pre>`;
+    } catch {
+      /* fall through to plain text */
+    }
+  }
+  return `<pre class="hljs"><code>${md.utils.escapeHtml(text)}</code></pre>`;
+}
+
+const HLJS_LANG_BY_EXT: Record<string, string> = {
+  '.js': 'javascript',
+  '.cjs': 'javascript',
+  '.mjs': 'javascript',
+  '.jsx': 'javascript',
+  '.ts': 'typescript',
+  '.tsx': 'typescript',
+  '.json': 'json',
+  '.css': 'css',
+  '.scss': 'scss',
+  '.sass': 'scss',
+  '.less': 'less',
+  '.html': 'xml',
+  '.htm': 'xml',
+  '.xml': 'xml',
+  '.svg': 'xml',
+  '.yaml': 'yaml',
+  '.yml': 'yaml',
+  '.toml': 'ini',
+  '.ini': 'ini',
+  '.env': 'ini',
+  '.py': 'python',
+  '.rb': 'ruby',
+  '.go': 'go',
+  '.rs': 'rust',
+  '.java': 'java',
+  '.c': 'c',
+  '.h': 'c',
+  '.cpp': 'cpp',
+  '.hpp': 'cpp',
+  '.cc': 'cpp',
+  '.hh': 'cpp',
+  '.sh': 'bash',
+  '.bash': 'bash',
+  '.zsh': 'bash',
+  '.sql': 'sql',
+  '.md': 'markdown',
+  '.markdown': 'markdown',
+};
+
 let mermaidPromise: Promise<typeof import('mermaid').default> | null = null;
 
 function activeMermaidTheme(): 'default' | 'dark' {

--- a/src/renderer/note-modal.css
+++ b/src/renderer/note-modal.css
@@ -309,15 +309,12 @@
   font-size: 12px;
 }
 
-.md-rendered.raw-text {
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  white-space: pre-wrap;
-  background: var(--bg-hover);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 12px;
-  max-width: none;
+/* Read view of a non-markdown file: one full-width highlighted code block.
+ * The inner `<pre class="hljs">` inherits `.md-rendered pre` chrome (border,
+ * background, horizontal scroll); drop its block margin so it fills the body
+ * flush instead of floating like an inline fenced block. */
+.md-rendered.raw-code pre {
+  margin: 0;
 }
 
 .config-summary-panel {

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -9,7 +9,7 @@ import {
   onMount,
   Show,
 } from 'solid-js';
-import { renderMarkdown, runMermaidIn } from './markdown';
+import { highlightCode, renderMarkdown, runMermaidIn } from './markdown';
 import { routeMarkdownClick, scrollToAnchor } from './md-link-router';
 import type { MountedEditor } from './editor';
 import type { Deliverable } from '@shared/types';
@@ -209,6 +209,13 @@ export function NoteModal(props: {
     const path = props.state?.path ?? null;
     const baseDir = path ? path.replace(/\/[^/]*$/, '') : undefined;
     return renderMarkdown(text, { baseDir });
+  });
+
+  // Read view for a non-markdown file: syntax-highlight the source by extension.
+  const codeHtml = createMemo(() => {
+    const text = content();
+    if (text == null) return '';
+    return highlightCode(text, props.state?.path ?? '');
   });
 
   let bodyRef: HTMLDivElement | undefined;
@@ -708,7 +715,7 @@ export function NoteModal(props: {
               !isMarkdown(props.state.path)
             }
           >
-            <pre class="md-rendered raw-text">{content() ?? ''}</pre>
+            <div class="md-rendered raw-code" innerHTML={codeHtml()} />
           </Show>
           <Show when={!content.loading && !content.error && mode() === 'edit'}>
             <div class="cm-host" ref={(el) => (editorParent = el)} />

--- a/src/renderer/panes/deliverables-pane.css
+++ b/src/renderer/panes/deliverables-pane.css
@@ -112,6 +112,38 @@
   gap: 4px;
 }
 
+/* Each grid cell is a flex row: the open button flexes to fill, the reveal
+ * button sits beside it. Scoped to the pane (`.deliverables-rows`) so the
+ * project-preview's deliverable rows keep their own layout. */
+.deliverables-rows .deliverable-row {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
+}
+
+.deliverables-rows .deliverable-button {
+  flex: 1;
+  min-width: 0;
+}
+
+.deliverable-reveal {
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0 10px;
+  font-size: 14px;
+  line-height: 1;
+}
+
+.deliverable-reveal:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
 /* Coarse type tag in front of each deliverable label. */
 .deliverables-kind {
   flex: none;

--- a/src/renderer/panes/deliverables.tsx
+++ b/src/renderer/panes/deliverables.tsx
@@ -26,6 +26,8 @@ function deliverableKind(deliverable: Deliverable): string {
 export function DeliverablesView(props: {
   projects: Project[];
   onOpenDeliverable: (deliverable: Deliverable) => void;
+  /** Reveal a local-file deliverable in the OS file manager. */
+  onReveal: (path: string) => void;
 }) {
   const scrollRef = usePaneScrollMemory('deliverables');
 
@@ -90,6 +92,17 @@ export function DeliverablesView(props: {
                             : deliverable.path}
                         </span>
                       </button>
+                      <Show when={deliverable.kind === 'file'}>
+                        <button
+                          type="button"
+                          class="deliverable-reveal"
+                          title="Reveal in file manager"
+                          aria-label="Reveal in file manager"
+                          onClick={() => props.onReveal(deliverable.path)}
+                        >
+                          ⤷
+                        </button>
+                      </Show>
                     </li>
                   )}
                 </For>

--- a/src/renderer/panes/logs-pane.css
+++ b/src/renderer/panes/logs-pane.css
@@ -215,11 +215,40 @@
   gap: 0.4rem;
 }
 
+/* Each grid cell is a flex row: the clickable card plus a reveal button. The
+ * reveal can't nest inside the card button (button-in-button is invalid), so
+ * it sits as a sibling and the card flexes to fill the rest of the cell. */
+.logs-session-li {
+  display: flex;
+  align-items: stretch;
+  gap: 0.3rem;
+  min-width: 0;
+}
+
+.logs-session-reveal {
+  flex-shrink: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-subtle);
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0 0.6rem;
+  font-size: 0.95rem;
+  line-height: 1;
+}
+
+.logs-session-reveal:hover {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+
 .logs-session-card {
   display: grid;
   grid-template-columns: auto auto 1fr auto auto;
   gap: 0.7rem;
   align-items: center;
+  flex: 1;
+  min-width: 0;
   width: 100%;
   padding: 0.5rem 0.75rem;
   font-size: 0.85rem;

--- a/src/renderer/panes/logs.tsx
+++ b/src/renderer/panes/logs.tsx
@@ -140,6 +140,8 @@ export function LogsView(props: {
 
   const sessionsFor = (day: string): TermLogSessionMeta[] => sessionsByDay()?.get(day) ?? [];
 
+  const reveal = (path: string): void => void window.condash.showInFolder(path);
+
   return (
     <div class="logs-pane">
       <div class="logs-toolbar">
@@ -219,7 +221,9 @@ export function LogsView(props: {
               }
             >
               <For each={taskRuns()}>
-                {(group) => <TaskRunGroupView group={group} onOpen={setActivePath} />}
+                {(group) => (
+                  <TaskRunGroupView group={group} onOpen={setActivePath} onReveal={reveal} />
+                )}
               </For>
             </Show>
           </Show>
@@ -249,7 +253,11 @@ export function LogsView(props: {
                           <span class="logs-day-label">Today · {dayLabel(d.day)}</span>
                           <span class="logs-group-count">{sessionsFor(d.day).length}</span>
                         </div>
-                        <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
+                        <DaySessionGrid
+                          sessions={sessionsFor(d.day)}
+                          onOpen={setActivePath}
+                          onReveal={reveal}
+                        />
                       </div>
                     }
                   >
@@ -259,7 +267,11 @@ export function LogsView(props: {
                         <span class="logs-day-label">{dayLabel(d.day)}</span>
                         <span class="logs-group-count">{sessionsFor(d.day).length}</span>
                       </summary>
-                      <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
+                      <DaySessionGrid
+                        sessions={sessionsFor(d.day)}
+                        onOpen={setActivePath}
+                        onReveal={reveal}
+                      />
                     </details>
                   </Show>
                 )}
@@ -281,7 +293,11 @@ export function LogsView(props: {
                       {(d) => (
                         <div class="logs-day-subgroup">
                           <div class="logs-day-subheader">{dayLabel(d.day)}</div>
-                          <DaySessionGrid sessions={sessionsFor(d.day)} onOpen={setActivePath} />
+                          <DaySessionGrid
+                            sessions={sessionsFor(d.day)}
+                            onOpen={setActivePath}
+                            onReveal={reveal}
+                          />
                         </div>
                       )}
                     </For>
@@ -301,6 +317,7 @@ export function LogsView(props: {
 function TaskRunGroupView(props: {
   group: TaskRunGroup;
   onOpen: (path: string) => void;
+  onReveal: (path: string) => void;
 }): JSX.Element {
   return (
     <details class="logs-day-group" open>
@@ -315,7 +332,7 @@ function TaskRunGroupView(props: {
       <ul class="logs-day-sessions">
         <For each={props.group.runs}>
           {(run) => (
-            <li>
+            <li class="logs-session-li">
               <button
                 type="button"
                 class="logs-session-card"
@@ -326,6 +343,15 @@ function TaskRunGroupView(props: {
                 </span>
                 <span class="logs-session-cmd">{run.sid}</span>
                 <span class="logs-session-size">{formatBytes(run.bytes)}</span>
+              </button>
+              <button
+                type="button"
+                class="logs-session-reveal"
+                title="Reveal in file manager"
+                aria-label="Reveal in file manager"
+                onClick={() => props.onReveal(run.path)}
+              >
+                ⤷
               </button>
             </li>
           )}
@@ -373,6 +399,7 @@ function monthLabel(key: string): string {
 function DaySessionGrid(props: {
   sessions: TermLogSessionMeta[];
   onOpen: (path: string) => void;
+  onReveal: (path: string) => void;
 }): JSX.Element {
   return (
     <Show
@@ -381,14 +408,24 @@ function DaySessionGrid(props: {
     >
       <ul class="logs-day-sessions">
         <For each={props.sessions}>
-          {(sess) => <SessionCard sess={sess} onOpen={() => props.onOpen(sess.path)} />}
+          {(sess) => (
+            <SessionCard
+              sess={sess}
+              onOpen={() => props.onOpen(sess.path)}
+              onReveal={props.onReveal}
+            />
+          )}
         </For>
       </ul>
     </Show>
   );
 }
 
-function SessionCard(props: { sess: TermLogSessionMeta; onOpen: () => void }): JSX.Element {
+function SessionCard(props: {
+  sess: TermLogSessionMeta;
+  onOpen: () => void;
+  onReveal: (path: string) => void;
+}): JSX.Element {
   const isFailure = (): boolean =>
     typeof props.sess.exitCode === 'number' && props.sess.exitCode !== 0;
   // `exitCode === undefined` → no footer on disk → session genuinely alive.
@@ -407,7 +444,7 @@ function SessionCard(props: { sess: TermLogSessionMeta; onOpen: () => void }): J
     return 'Session ended without a recorded exit code (condash exited or crashed before the footer could flush).';
   };
   return (
-    <li>
+    <li class="logs-session-li">
       <button
         type="button"
         class="logs-session-card"
@@ -423,6 +460,15 @@ function SessionCard(props: { sess: TermLogSessionMeta; onOpen: () => void }): J
         <span class="logs-session-exit" title={statusTitle()}>
           {statusLabel()}
         </span>
+      </button>
+      <button
+        type="button"
+        class="logs-session-reveal"
+        title="Reveal in file manager"
+        aria-label="Reveal in file manager"
+        onClick={() => props.onReveal(props.sess.path)}
+      >
+        ⤷
       </button>
     </li>
   );

--- a/src/renderer/panes/resources-pane.css
+++ b/src/renderer/panes/resources-pane.css
@@ -105,6 +105,11 @@
   color: var(--col-soon, var(--accent));
 }
 
+.resources-card[data-category='html'] .resources-card-glyph {
+  background: color-mix(in srgb, var(--col-later, var(--accent)) 16%, transparent);
+  color: var(--col-later, var(--accent));
+}
+
 .resources-card[data-category='binary'] .resources-card-glyph,
 .resources-card[data-category='archive'] .resources-card-glyph,
 .resources-card[data-category='other'] .resources-card-glyph {

--- a/src/renderer/panes/resources.tsx
+++ b/src/renderer/panes/resources.tsx
@@ -20,6 +20,12 @@ export interface ResourcesViewActions {
   viewText: (path: string, title: string) => void;
   /** View a PDF in the existing pdf-modal. */
   viewPdf: (path: string) => void;
+  /** View an HTML file in the html-modal (rendered, with a source toggle). */
+  viewHtml: (path: string) => void;
+  /** View an image (raster or SVG) in the image-modal. */
+  viewImage: (path: string) => void;
+  /** Reveal the file in the OS file manager. */
+  reveal: (path: string) => void;
   /** Copy a path to the system clipboard. */
   copyPath: (path: string) => void;
   /** Paste a path into the active terminal session. */
@@ -106,12 +112,17 @@ function ResourceCard(props: { node: ResourceNode; actions: ResourcesViewActions
     }
   };
 
-  const canViewInline = (): boolean => cat() === 'markdown' || cat() === 'pdf' || cat() === 'text';
+  const canViewInline = (): boolean => {
+    const c = cat();
+    return c === 'markdown' || c === 'pdf' || c === 'text' || c === 'html' || c === 'image';
+  };
 
   const handleView = (): void => {
     const c = cat();
     if (c === 'markdown') props.actions.viewMarkdown(props.node.path, props.node.title);
     else if (c === 'pdf') props.actions.viewPdf(props.node.path);
+    else if (c === 'html') props.actions.viewHtml(props.node.path);
+    else if (c === 'image') props.actions.viewImage(props.node.path);
     else if (c === 'text') props.actions.viewText(props.node.path, props.node.title);
   };
 
@@ -173,6 +184,18 @@ function ResourceCard(props: { node: ResourceNode; actions: ResourcesViewActions
           class="resources-card-action"
           onClick={(e) => {
             e.stopPropagation();
+            props.actions.reveal(props.node.path);
+          }}
+          title="Reveal in file manager"
+          aria-label="Reveal in file manager"
+        >
+          reveal
+        </button>
+        <button
+          type="button"
+          class="resources-card-action"
+          onClick={(e) => {
+            e.stopPropagation();
             props.actions.copyPath(props.node.path);
           }}
           title="Copy absolute path"
@@ -205,6 +228,8 @@ function CategoryGlyph(props: { category: ResourceCategory }) {
         return 'MD';
       case 'pdf':
         return 'PDF';
+      case 'html':
+        return 'WEB';
       case 'text':
         return 'TXT';
       case 'image':

--- a/src/renderer/pdf-modal.tsx
+++ b/src/renderer/pdf-modal.tsx
@@ -6,6 +6,7 @@ export function PdfModal(props: {
   path: string;
   onClose: () => void;
   onOpenInOs: (path: string) => void;
+  onReveal: (path: string) => void;
 }) {
   useModalEscHandler(props.onClose);
 
@@ -33,12 +34,19 @@ export function PdfModal(props: {
           <span class="modal-path">{props.path}</span>
           <button
             class="modal-button"
+            onClick={() => props.onReveal(props.path)}
+            title="Reveal in file manager"
+          >
+            ⤷
+          </button>
+          <button
+            class="modal-button"
             onClick={() => props.onOpenInOs(props.path)}
             title="Open in OS default viewer"
           >
             ↗
           </button>
-          <button class="modal-button" onClick={props.onClose} title="Close (Esc)">
+          <button class="modal-button modal-close" onClick={props.onClose} title="Close (Esc)">
             ×
           </button>
         </header>

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -326,6 +326,10 @@ export interface CondashApi {
    *  the Settings modal's "Open externally" buttons for condash.json
    *  and settings.json. Caller must pass an absolute path. */
   openPath(target: string): Promise<void>;
+  /** Reveal a file or directory in the OS file manager (selects it in its
+   *  parent folder). Used by the "reveal in file manager" affordance on the
+   *  Resources / Logs / Deliverables / Code card panes. Absolute path. */
+  showInFolder(target: string): Promise<void>;
   /** Create a new note file under <projectPath>/notes/. The slug is sanitised
    *  and prefixed with the next zero-padded NN- counter. Returns the absolute
    *  path of the new file (always created — caller can then open it). */

--- a/src/shared/file-category.test.ts
+++ b/src/shared/file-category.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { categorise, mimeFor } from './file-category';
+
+describe('categorise', () => {
+  it('buckets common extensions', () => {
+    expect(categorise('readme.md')).toBe('markdown');
+    expect(categorise('readme.markdown')).toBe('markdown');
+    expect(categorise('doc.pdf')).toBe('pdf');
+    expect(categorise('a.json')).toBe('text');
+    expect(categorise('styles.css')).toBe('text');
+    expect(categorise('img.PNG')).toBe('image');
+    expect(categorise('vector.svg')).toBe('image');
+    expect(categorise('clip.mp4')).toBe('video');
+    expect(categorise('track.mp3')).toBe('audio');
+    expect(categorise('archive.zip')).toBe('archive');
+    expect(categorise('thing.bin')).toBe('binary');
+    expect(categorise('mystery.xyzzy')).toBe('other');
+  });
+
+  it('classifies html/htm as their own category, not text', () => {
+    expect(categorise('page.html')).toBe('html');
+    expect(categorise('page.HTM')).toBe('html');
+  });
+
+  it('is case-insensitive on the extension', () => {
+    expect(categorise('REPORT.PDF')).toBe('pdf');
+    expect(categorise('Page.Html')).toBe('html');
+  });
+
+  it('treats a leading-dot name as having no extension (matches node extname)', () => {
+    // `.env` is a dotfile, not a `*.env` file — no extension, so `other`.
+    expect(categorise('.env')).toBe('other');
+    expect(categorise('config.env')).toBe('text');
+  });
+
+  it('classifies on the final extension only', () => {
+    expect(categorise('archive.tar.gz')).toBe('archive');
+    expect(categorise('noext')).toBe('other');
+  });
+});
+
+describe('mimeFor', () => {
+  it('returns a hint for known extensions', () => {
+    expect(mimeFor('a.md')).toBe('text/markdown');
+    expect(mimeFor('a.png')).toBe('image/png');
+    expect(mimeFor('a.html')).toBe('text/html');
+    expect(mimeFor('a.css')).toBe('text/css');
+  });
+
+  it('returns undefined for unknown extensions', () => {
+    expect(mimeFor('a.xyzzy')).toBeUndefined();
+  });
+});

--- a/src/shared/file-category.ts
+++ b/src/shared/file-category.ts
@@ -1,0 +1,154 @@
+import type { ResourceCategory } from './types';
+
+/**
+ * Coarse file classification shared between the main-process resources walk
+ * (`main/resources.ts`) and the renderer's file-open router
+ * (`renderer/deliverable-open.ts`). Kept node-free (a local `extLower` instead
+ * of `node:path`) so the renderer bundle can import it.
+ *
+ * One source of truth means a `.css` resolves to `text` — and opens the same
+ * way — whether the Resources pane or a deliverable link asked for it.
+ */
+
+/** Lowercased extension including the dot (e.g. `.css`), or `''` when there is
+ *  none. Matches `node:path.extname` semantics: a leading-dot name like `.env`
+ *  has no extension. */
+function extLower(name: string): string {
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0) return '';
+  return name.slice(dot).toLowerCase();
+}
+
+/**
+ * Coarse category from the filename extension. Drives the icon picker and which
+ * in-app viewer (or external fallback) a file opens in. Every entry maps to one
+ * bucket; unknown extensions fall through to `other`.
+ */
+export function categorise(name: string): ResourceCategory {
+  const ext = extLower(name);
+  if (ext === '.md' || ext === '.markdown') return 'markdown';
+  if (ext === '.pdf') return 'pdf';
+  if (HTML_EXTS.has(ext)) return 'html';
+  if (TEXT_EXTS.has(ext)) return 'text';
+  if (IMAGE_EXTS.has(ext)) return 'image';
+  if (AUDIO_EXTS.has(ext)) return 'audio';
+  if (VIDEO_EXTS.has(ext)) return 'video';
+  if (ARCHIVE_EXTS.has(ext)) return 'archive';
+  if (BINARY_EXTS.has(ext)) return 'binary';
+  return 'other';
+}
+
+/**
+ * Best-effort mime hint. Kept compact rather than pulling in `mime-types`; the
+ * renderer only uses this for tooltips, the category drives behaviour.
+ */
+export function mimeFor(name: string): string | undefined {
+  return MIME_TABLE[extLower(name)];
+}
+
+const HTML_EXTS = new Set(['.html', '.htm']);
+
+const TEXT_EXTS = new Set([
+  '.txt',
+  '.log',
+  '.csv',
+  '.tsv',
+  '.json',
+  '.yaml',
+  '.yml',
+  '.toml',
+  '.ini',
+  '.env',
+  '.xml',
+  '.css',
+  '.scss',
+  '.sass',
+  '.less',
+  '.js',
+  '.cjs',
+  '.mjs',
+  '.ts',
+  '.tsx',
+  '.jsx',
+  '.py',
+  '.rb',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.kts',
+  '.c',
+  '.h',
+  '.cpp',
+  '.hpp',
+  '.cc',
+  '.hh',
+  '.sh',
+  '.bash',
+  '.zsh',
+  '.fish',
+  '.lua',
+  '.sql',
+  '.r',
+  '.swift',
+  '.scala',
+  '.tex',
+]);
+
+const IMAGE_EXTS = new Set([
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.svg',
+  '.bmp',
+  '.tiff',
+  '.ico',
+  '.avif',
+  '.heic',
+]);
+
+const AUDIO_EXTS = new Set(['.mp3', '.wav', '.ogg', '.flac', '.m4a', '.aac', '.opus']);
+
+const VIDEO_EXTS = new Set(['.mp4', '.mov', '.mkv', '.webm', '.avi', '.m4v']);
+
+const ARCHIVE_EXTS = new Set(['.zip', '.tar', '.gz', '.tgz', '.bz2', '.xz', '.7z', '.rar']);
+
+const BINARY_EXTS = new Set(['.exe', '.dll', '.so', '.dylib', '.bin', '.dat', '.iso', '.dmg']);
+
+const MIME_TABLE: Record<string, string> = {
+  '.md': 'text/markdown',
+  '.markdown': 'text/markdown',
+  '.pdf': 'application/pdf',
+  '.txt': 'text/plain',
+  '.log': 'text/plain',
+  '.csv': 'text/csv',
+  '.tsv': 'text/tab-separated-values',
+  '.json': 'application/json',
+  '.yaml': 'application/yaml',
+  '.yml': 'application/yaml',
+  '.toml': 'application/toml',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.css': 'text/css',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.cjs': 'text/javascript',
+  '.ts': 'text/typescript',
+  '.tsx': 'text/typescript',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.mp3': 'audio/mpeg',
+  '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg',
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.zip': 'application/zip',
+  '.tar': 'application/x-tar',
+  '.gz': 'application/gzip',
+};

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -808,6 +808,7 @@ export interface KnowledgeNode {
 export type ResourceCategory =
   | 'markdown'
   | 'pdf'
+  | 'html'
   | 'text'
   | 'image'
   | 'audio'

--- a/tests/file-preview.spec.ts
+++ b/tests/file-preview.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect } from '@playwright/test';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import { bootApp } from './fixtures/electron-app';
+
+/**
+ * End-to-end for the in-app file viewers + reveal affordance added by
+ * 2026-05-31-condash-file-preview-and-reveal. Boots a fixture conception whose
+ * `resources/` holds an image, a CSS file, and an HTML file, then drives the
+ * Resources pane to confirm each opens in the right in-app viewer (and that the
+ * reveal button is wired). Screenshots of each viewer are captured for the PR.
+ */
+
+// 1×1 transparent PNG — the smallest valid raster the image viewer can load.
+const PNG_1x1 = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+const SHOTS = resolve(__dirname, 'screenshots-out', 'file-preview');
+
+test('Resources viewers: image, highlighted code, HTML rendered/source, reveal', async () => {
+  const booted = await bootApp({
+    prepare: async (conceptionDir) => {
+      const res = join(conceptionDir, 'resources');
+      await mkdir(res, { recursive: true });
+      await writeFile(join(res, 'pixel.png'), PNG_1x1);
+      await writeFile(
+        join(res, 'styles.css'),
+        '.card {\n  color: #1a1a1a;\n  margin: 0 auto;\n  padding: 12px;\n}\n',
+        'utf8',
+      );
+      await writeFile(
+        join(res, 'page.html'),
+        '<!doctype html>\n<html>\n<body>\n<h1>Hello</h1>\n<p>Rendered by condash.</p>\n</body>\n</html>\n',
+        'utf8',
+      );
+    },
+  });
+  const { window, cleanup } = booted;
+  try {
+    await window.setViewportSize({ width: 1280, height: 900 });
+    const resourcesHandle = window
+      .locator('.edge-strip-right .edge-handle')
+      .filter({ hasText: 'Resources' });
+    await resourcesHandle.click();
+    await expect(window.locator('.resources-pane')).toBeVisible();
+
+    // Every card carries the reveal affordance.
+    const cssCard = window.locator('.resources-card', { hasText: 'styles.css' });
+    await expect(cssCard.locator('.resources-card-action', { hasText: 'reveal' })).toBeVisible();
+
+    // CSS → note modal, read-only, syntax-highlighted.
+    await cssCard.locator('.resources-card-body').click();
+    await expect(window.locator('.note-modal')).toBeVisible();
+    await expect(window.locator('.note-modal .raw-code .hljs')).toBeVisible();
+    await mkdir(SHOTS, { recursive: true }).catch(() => undefined);
+    await window.screenshot({ path: join(SHOTS, 'code-highlight.png') }).catch(() => undefined);
+    await window.keyboard.press('Escape');
+    await expect(window.locator('.note-modal')).toHaveCount(0);
+
+    // Image → image modal with a live <img>.
+    await window
+      .locator('.resources-card', { hasText: 'pixel.png' })
+      .locator('.resources-card-body')
+      .click();
+    await expect(window.locator('.image-modal')).toBeVisible();
+    await expect(window.locator('.image-modal .image-view')).toBeVisible();
+    await window.screenshot({ path: join(SHOTS, 'image-modal.png') }).catch(() => undefined);
+    await window.keyboard.press('Escape');
+    await expect(window.locator('.image-modal')).toHaveCount(0);
+
+    // HTML → rendered webview by default, with a Rendered/Source toggle.
+    await window
+      .locator('.resources-card', { hasText: 'page.html' })
+      .locator('.resources-card-body')
+      .click();
+    await expect(window.locator('.html-modal')).toBeVisible();
+    await expect(window.locator('.html-modal .html-webview')).toBeVisible();
+    // Flip to Source → highlighted markup.
+    await window.locator('.html-modal .modal-button--text', { hasText: 'Source' }).click();
+    await expect(window.locator('.html-modal .html-source .hljs')).toBeVisible();
+    await window.screenshot({ path: join(SHOTS, 'html-source.png') }).catch(() => undefined);
+    await window.keyboard.press('Escape');
+    await expect(window.locator('.html-modal')).toHaveCount(0);
+  } finally {
+    await cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

Widens in-app file preview beyond `md`/`pdf` and adds a "reveal in file manager" affordance to the panes that show on-disk things. Previously only md/pdf/html previewed in-app (text as raw monospace); images and code shelled out to the OS, and there was no quick path to a file in the OS file manager.

## Changes

**One file-open router.** New node-free `src/shared/file-category.ts` (extension → category, adds an `html` category) is now the single classifier shared by the resources walk (`main/resources.ts` re-exports it) and the renderer's `openDeliverableTarget`. The two previously-divergent open paths now agree.

**Viewers**
- New **image viewer modal** (raster + SVG), served over the conception-sandboxed `condash-file://` protocol, fit-to-window on a checkerboard backdrop.
- Non-markdown **text/code** opens read-only **syntax-highlighted** (new `highlightCode` in `markdown.ts`, language-by-extension, size-capped at 200 KB) instead of raw `<pre>`.
- **HTML modal** gains a **Rendered / Source** header toggle (source = highlighted markup).

**Reveal in file manager**
- New `showInFolder` IPC (`shell.showItemInFolder`) on `api`/`preload`/`system.ts`.
- Reveal button on **Resources** cards, **Logs** (sessions + task runs), and local-file **Deliverables** rows, plus the pdf/html/image viewer headers. The **Code** pane already exposes "Open in file manager" per worktree.

**Fix:** the HTML modal's "open externally" called `openExternal` (http/mailto-only), so it silently no-opped on a local `.html`; local files now route through `openPath`.

## Impact

- New `html` value in `ResourceCategory` (enum widening — `CategoryGlyph`, `resources.test.ts` updated). No new settings keys, so no `migrateRawSettings` churn.
- Audio, video, archives and binaries intentionally still open in the OS default app.

## Watchpoints

- `condash-file://` is conception-bounded: a deliverable image resolving outside the tree 404s in the image modal (same constraint as the HTML/PDF viewers) — the open-externally button is the fallback.
- The doc screenshot sweep (`screenshots.spec.ts`) wasn't re-run; the `resources-pane` PNG now omits the new `reveal` button / `WEB` glyph until the next manual refresh.

## Test plan

- `make typecheck` clean; `make test-unit` 776 passing (new `file-category` + `highlightCode` suites); `make build` green.
- New `tests/file-preview.spec.ts` e2e (passing under xvfb): CSS read-only+highlighted, image modal, HTML rendered + Source toggle, reveal button present.