### PR TITLE
Add stale-index audit check for projects and knowledge trees

### DIFF
--- a/docs/help/cli.md
+++ b/docs/help/cli.md
@@ -27,7 +27,7 @@ condash <noun> <verb> [args] [--flags]
 | `search` | `condash search "<query>" [--scope all\|projects\|knowledge]` |
 | `repos` | `list [--include-worktrees]` |
 | `worktrees` | `list`, `setup <branch>`, `remove <branch>`, `check <branch>` |
-| `audit` | `--include lfs,binaries,cross-repo,worktrees,index` |
+| `audit` | `--include lfs,binaries,cross-repo,worktrees,index,stale-index` |
 | `dirty` | `list`, `touch <tree>`, `clear <tree\|all>` |
 | `skills` | `list`, `install`, `status` |
 | `config` | `conception-path [<path>]`, `path`, `list`, `get <key>`, `set <key> <value>` (`--global` / `--effective` on read verbs) |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -188,7 +188,8 @@ condash audit --include lfs,binaries
 | `binaries` | Binary files (PDF, .docx, images > size threshold) that may need migrating |
 | `cross-repo` | Cross-repo wikilinks or relative paths that escape the conception |
 | `worktrees` | Same shape as `worktrees mismatch` — items declaring a `branch` with no on-disk worktree, or vice versa |
-| `index` | `index.md` files out of sync with the on-disk tree |
+| `index` | Structural `index.md` problems under `knowledge/` — missing index, dangling links, orphan body files |
+| `stale-index` | `index.md` files under `projects/` or `knowledge/` whose content has drifted from the tree (a regen would rewrite them); autofix re-runs `condash <tree> index` |
 | `knowledge-recheck` | Projects with a deferred knowledge promotion (a `[knowledge-recheck:pending]` timeline marker) never resolved by a later `[knowledge-recheck:done]`. Checked across all statuses, `done` included |
 | `knowledge-check` | `done` projects whose last timeline entry isn't `Checked knowledge promotion` — the promotion review is missing or stale. Resolve by doing the real `/knowledge` review, then `projects check-knowledge <slug> --record`. Legacy done projects stay flagged until actually reviewed (no backfill shortcut) |
 

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -9,6 +9,7 @@ const ALL_AUDIT_CHECKS: AuditCheckName[] = [
   'cross-repo',
   'worktrees',
   'index',
+  'stale-index',
   'knowledge-recheck',
   'knowledge-check',
 ];

--- a/src/main/audit.ts
+++ b/src/main/audit.ts
@@ -14,6 +14,10 @@
  *                   whose Status is not `done` are checked.)
  *  - `index`      — every directory under `knowledge/` carries an `index.md`
  *                   listing its children; flag dangling and orphan entries.
+ *  - `stale-index`— `index.md` files under `projects/` or `knowledge/` whose
+ *                   content has drifted from the tree (regen dry-run would
+ *                   rewrite them). Covers freshness where `index` covers
+ *                   structure, and covers `projects/` too.
  *  - `knowledge-recheck` — projects with a deferred knowledge promotion
  *                   (a `[knowledge-recheck:pending]` timeline marker) that
  *                   was never resolved by a later `[knowledge-recheck:done]`.
@@ -37,6 +41,7 @@ import { checkIndex } from './audit/index-check';
 import { checkKnowledgeCheck } from './audit/knowledge-check';
 import { checkKnowledgeRecheck } from './audit/knowledge-recheck';
 import { checkLfs } from './audit/lfs';
+import { checkStaleIndex } from './audit/stale-index';
 import { checkWorktrees } from './audit/worktrees';
 import type { AuditCheckName, AuditIssue, AuditReport } from './audit/shared';
 
@@ -64,6 +69,9 @@ export async function runAudit(
           break;
         case 'index':
           issues.push(...(await checkIndex(conceptionPath)));
+          break;
+        case 'stale-index':
+          issues.push(...(await checkStaleIndex(conceptionPath)));
           break;
         case 'knowledge-recheck':
           issues.push(...(await checkKnowledgeRecheck(conceptionPath)));

--- a/src/main/audit/shared.ts
+++ b/src/main/audit/shared.ts
@@ -18,6 +18,7 @@ export type AuditCheckName =
   | 'cross-repo'
   | 'worktrees'
   | 'index'
+  | 'stale-index'
   | 'knowledge-recheck'
   | 'knowledge-check';
 

--- a/src/main/audit/stale-index.test.ts
+++ b/src/main/audit/stale-index.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for the `stale-index` audit check — that a freshly regenerated tree is
+ * clean, and that drift (a new unindexed body file, or a status-tag change)
+ * surfaces an issue carrying the right tree's regen autofix action.
+ */
+import { promises as fs } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { knowledgeStrategy } from '../index-knowledge';
+import { projectsStrategy } from '../index-projects';
+import { regenerateIndex } from '../index-tree';
+import { checkStaleIndex } from './stale-index';
+
+let conceptionDir: string;
+
+beforeEach(async () => {
+  conceptionDir = await mkdtemp(join(tmpdir(), 'condash-stale-index-test-'));
+});
+
+afterEach(async () => {
+  await rm(conceptionDir, { recursive: true, force: true });
+});
+
+async function writeFile(relPath: string, content: string): Promise<void> {
+  const abs = join(conceptionDir, relPath);
+  await fs.mkdir(join(abs, '..'), { recursive: true });
+  await fs.writeFile(abs, content, 'utf8');
+}
+
+async function buildKnowledge(): Promise<void> {
+  await writeFile(
+    'knowledge/topics/index.md',
+    '# Topics\n\nCross-cutting subjects.\n\n## Current files\n',
+  );
+  await writeFile(
+    'knowledge/topics/sandbox-testing.md',
+    '# Sandbox testing\n\nHow to drive vcoeur apps.\n\n## Recipe\n\nCall the binary.\n',
+  );
+}
+
+async function buildProjectReadme(status: string): Promise<void> {
+  await writeFile(
+    'projects/2026-05/2026-05-09-feature/README.md',
+    [
+      '---',
+      'date: 2026-05-09',
+      'kind: project',
+      `status: ${status}`,
+      'apps:',
+      '  - condash',
+      '---',
+      '',
+      '# Feature',
+      '',
+      '## Goal',
+      '',
+      'Ship a thing.',
+      '',
+    ].join('\n'),
+  );
+}
+
+describe('checkStaleIndex', () => {
+  it('returns no issues for a freshly regenerated tree', async () => {
+    await buildKnowledge();
+    await buildProjectReadme('now');
+    await regenerateIndex(conceptionDir, knowledgeStrategy);
+    await regenerateIndex(conceptionDir, projectsStrategy);
+
+    expect(await checkStaleIndex(conceptionDir)).toEqual([]);
+  });
+
+  it('flags a knowledge index left stale by a new unindexed body file', async () => {
+    await buildKnowledge();
+    await regenerateIndex(conceptionDir, knowledgeStrategy);
+    await writeFile('knowledge/topics/fresh-topic.md', '# Fresh topic\n\nBrand new material.\n');
+
+    const issues = await checkStaleIndex(conceptionDir);
+    const knowledge = issues.filter((i) => i.fix.action === 'run_knowledge_index');
+    expect(knowledge.length).toBeGreaterThan(0);
+    expect(knowledge[0].check).toBe('stale-index');
+    expect(knowledge[0].severity).toBe('warn');
+    expect(knowledge[0].fix.autoFix).toBe(true);
+    expect(knowledge.some((i) => (i.file ?? '').includes('knowledge/topics/index.md'))).toBe(true);
+  });
+
+  it('flags a projects index left stale by a status-tag change', async () => {
+    await buildProjectReadme('now');
+    await regenerateIndex(conceptionDir, projectsStrategy);
+    await buildProjectReadme('review');
+
+    const issues = await checkStaleIndex(conceptionDir);
+    const projects = issues.filter((i) => i.fix.action === 'run_projects_index');
+    expect(projects.length).toBeGreaterThan(0);
+    expect(projects[0].check).toBe('stale-index');
+    expect(projects[0].fix.autoFix).toBe(true);
+  });
+});

--- a/src/main/audit/stale-index.ts
+++ b/src/main/audit/stale-index.ts
@@ -1,0 +1,49 @@
+/**
+ * `stale-index` audit check — flags `index.md` files under `projects/` and
+ * `knowledge/` whose content has drifted from the tree (a status tag changed, a
+ * bullet needs adding or dropping). The sibling `index` check covers structure —
+ * missing files, dangling links, orphan bodies; this one covers *freshness*, and
+ * it covers `projects/` too (the `index` check is knowledge-only).
+ *
+ * It reuses the regen engine in dry-run mode, which writes nothing and leaves the
+ * `.index-dirty` marker untouched: any index the regen reports under `created` or
+ * `updated` is stale. The autofix runs the matching `condash <tree> index` — the
+ * very write the dry-run previewed. Surfaced in the default audit set so `/tidy`
+ * and routine sweeps catch drift before a manual regen bundles it with unrelated
+ * work.
+ */
+
+import { knowledgeStrategy } from '../index-knowledge';
+import { projectsStrategy } from '../index-projects';
+import { regenerateIndex, type IndexStrategy } from '../index-tree';
+import type { AuditIssue } from './shared';
+
+/** Trees to probe, paired with the `/tidy` autofix action that regenerates each. */
+const TREES: { strategy: IndexStrategy; fixAction: string }[] = [
+  { strategy: projectsStrategy, fixAction: 'run_projects_index' },
+  { strategy: knowledgeStrategy, fixAction: 'run_knowledge_index' },
+];
+
+/**
+ * Flag every `index.md` the regen engine would rewrite. Pure read-only: each
+ * tree is regenerated in dry-run mode and only the reported `created`/`updated`
+ * paths are turned into issues.
+ */
+export async function checkStaleIndex(conceptionPath: string): Promise<AuditIssue[]> {
+  const issues: AuditIssue[] = [];
+  for (const { strategy, fixAction } of TREES) {
+    const report = await regenerateIndex(conceptionPath, strategy, { dryRun: true });
+    const stalePaths = [...report.created, ...report.updated.map((row) => row.indexPath)];
+    for (const indexPath of stalePaths) {
+      issues.push({
+        check: 'stale-index',
+        severity: 'warn',
+        file: indexPath,
+        line: null,
+        message: `index.md is stale (regen would rewrite it) — run condash ${strategy.treeName} index`,
+        fix: { action: fixAction, autoFix: true },
+      });
+    }
+  }
+  return issues;
+}


### PR DESCRIPTION
## Summary

`condash audit` gains a `stale-index` check that flags `index.md` files under `projects/` and `knowledge/` whose content has drifted from the tree. It surfaces in the default check set, so routine sweeps catch drift before a manual regen bundles it with unrelated in-flight work. The existing `index` check is knowledge-only and structural (missing index, dangling links, orphans) and never detected staleness.

## Changes

- `src/main/audit/stale-index.ts` — new check; reuses the regen engine in dry-run mode (read-only; leaves `.index-dirty` untouched) for both trees. Indexes the regen reports under `created`/`updated` become `warn` issues with an autofix action (`run_projects_index` / `run_knowledge_index`).
- Wired into the audit dispatcher, the `AuditCheckName` union, and the default `--include` set; doc comment updated.
- `src/main/audit/stale-index.test.ts` — fresh tree → clean; a new unindexed body file → flagged; a status-tag change → flagged.
- Docs: `reference/cli.md` (split structural `index` from freshness `stale-index`), `help/cli.md`.

## Impact

- `condash audit` (and any wrapping triage skill) now reports stale indexes by default; the autofix re-runs the matching `condash <tree> index` — the exact write the dry-run previewed.
- Pure read-only check; no change to the regen engine itself.

## Watchpoints

- The consuming triage skill's apply-table mapping for the new `run_projects_index` action lives outside this repo and is shipped separately.