### PR TITLE
Bound the project detail popup so the Timeline can't overflow the window

### DIFF
--- a/src/renderer/project-preview.css
+++ b/src/renderer/project-preview.css
@@ -658,6 +658,10 @@
 .preview-timeline {
   border-top: 1px solid var(--border);
   background: var(--bg-subtle);
+  /* Pinned band: never shrink, so the toggle stays anchored at the popup's
+   * bottom edge while the body above it scrolls. Paired with the capped list
+   * below, this keeps the whole popup bounded to its max-height (#301). */
+  flex-shrink: 0;
 }
 
 .preview-timeline-toggle {
@@ -704,6 +708,13 @@
   margin: 0;
   padding: 4px 14px 12px 36px;
   border-top: 1px solid var(--border);
+  /* Cap the expanded list and scroll it internally so a long timeline can't
+   * grow the popup past the window's bottom edge — without this the list has
+   * no min-height floor, can't be shrunk by the flex column, and overflows
+   * the modal's max-height (the modal itself does not clip). Every entry
+   * stays reachable via this scroll (#301). */
+  max-height: clamp(140px, 30vh, 360px);
+  overflow-y: auto;
 }
 
 .preview-timeline-entry {


### PR DESCRIPTION
## Summary

Fixes #301. In condash 4.27.0 the project detail popup renders taller than the window for projects with a long `## Timeline`: the Timeline section overflows past the bottom edge and is clipped, with no overall scroll to reach it.

The popup is a flex column where the body (`overflow-y:auto`) scrolls, but the Timeline pane is a sibling outside that scroll. `.preview-timeline-list` had no height cap and no overflow, and a flex item's default `min-height:auto` meant the flex column could not shrink it — so a long expanded timeline painted past the modal's `max-height` (the modal does not clip itself) and ran off the window.

## Changes

- `.preview-timeline { flex-shrink: 0 }` — pin the band so its toggle stays anchored at the popup's bottom edge while the body scrolls.
- `.preview-timeline-list { max-height: clamp(140px, 30vh, 360px); overflow-y: auto }` — cap the expanded list and scroll it internally, so a long timeline can't grow the popup past the viewport. Every entry stays reachable.

CSS-only; no DOM or component-logic change.

## Impact / Watchpoints

- The popup now stays bounded to its `max-height`; the body scrolls for steps/files and the timeline list scrolls for its entries.
- `overflow:hidden` on the modal was deliberately avoided — it would clip the head's status dropdown menu.
- Verified with a faithful before/after render at 1280×900 (linking the real `project-preview.css` + `modal-base.css`); `make format`/`typecheck`/`build` clean. Playwright runs at tag time.