### PR TITLE
Tier-2 perf: in-memory search index + boot bundle diet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,9 +8,10 @@ Electron build of condash. As of 2026-04-27 this **is** the canonical condash �
 - **Preload**: same bundler, output at `dist-electron/preload/index.js`. Stays CJS because `webPreferences.sandbox: true` + ESM preload don't mix on Electron.
 - **Typecheck**: `tsc -p tsconfig.main.json --noEmit` (and the renderer twin). `tsc` no longer emits — esbuild owns emission, tsc owns type-checking.
 - **Renderer**: Solid + Solid signals, Vite (with `vite-plugin-solid`), plain CSS files + CSS variables, `src/renderer/main.tsx`.
+- **Renderer boot chunk is on a diet** — heavy deps are **lazy-split** out of the eager entry chunk and loaded on first use, not at first paint: **xterm + its 9 addons** (`src/renderer/xterm-mount.ts`, dynamic-imported on first terminal open; the `liveTerms` registry + `refreshAllXtermThemes` live in the leaf `xterm-registry.ts` so `use-theme` can repaint terminals without pulling xterm); **markdown-it + highlight.js** (`src/renderer/markdown.ts` builds the engine lazily — `renderMarkdown`/`highlightCode` are async; the note/help/html modals `await` them via `createResource`); mermaid + CodeMirror were already split. Keep new heavy deps off the eager path the same way. (Eager chunk: 1.5 MB → ~0.4 MB at v4.32.0.)
 - **Shared types**: `src/shared/types.ts` — plain serialisable objects, ISO strings, no methods.
 - **Packaging**: electron-builder, single `BrowserWindow`, all modals/panes are in-renderer overlays.
-- **Watcher**: single global chokidar rooted at `<conception>/`, debounced 250 ms.
+- **Watcher**: single global chokidar rooted at `<conception>/`, debounced 250 ms. Also keeps the in-memory **search index** fresh (`src/main/search/index-cache.ts`): the four Markdown sources (projects incl. notes, knowledge, resources, skills) are precomputed in RAM at conception-open and queried without re-reading the tree; `applyIndexFsEvent` updates one file per FS event. **Logs are not indexed** — too large, rarely searched — so they're disk-scanned, and only when in scope. `search()` falls back to the on-disk scan only while the index is still building. See `docs/explanation/internals.md#search-index`.
 
 ### Adding a new main-process dep
 

--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -145,9 +145,11 @@ This is defence in depth. The AppImage build also patches `AppRun` itself (see [
 
 The inverse problem — a GUI launch *missing* entries the user put in their login dotfiles — is handled by `src/main/shell-env.ts`. A Wayland session, the macOS Dock, or a `.desktop` entry never sources `~/.profile` / `~/.zprofile`, so `process.env.PATH` lacks user-installed CLIs (`opencode`, `~/bin` wrappers). `spawnEnv()` resolves the login-shell PATH once at boot (`$SHELL -lic`, cached, 5 s timeout) the way VS Code's integrated terminal does, and replaces PATH on every spawned env. It rewrites **PATH only**, so the scrub above is untouched; on Windows and on any probe failure it falls back to the inherited PATH.
 
-## Why no search index { #why-no-search-index }
+## The search index { #search-index }
 
-`search.ts` re-walks the tree on every query. At conception scale (a few hundred files), full-text search takes a handful of milliseconds — well under the 16 ms interaction-to-paint budget — and an index would be more state to keep coherent under concurrent edits. Revisit if it ever bites.
+The four Markdown sources (projects incl. notes, knowledge, resources, skills) are held in an **in-memory index** in the main process (`src/main/search/index-cache.ts`): each file's content, lowercased content, region map, and title are precomputed once at conception-open, so a query runs only the per-term `indexOf` + scoring over RAM strings — no per-keystroke re-walk / re-read / re-lowercase. The index is built fire-and-forget (never blocks boot; queries fall back to an on-disk scan until it resolves) and kept incrementally fresh by the chokidar watcher (`src/main/watcher.ts` → `applyIndexFsEvent`): an add/change re-prepares one file, an unlink drops it. ~16 MB resident at conception scale.
+
+**Logs are deliberately *not* indexed.** They're ~9/10 of the corpus bytes (tens of MB) and rarely searched, so caching them would cost ~100 MB+ for little gain. They stay on-disk-scanned, and only when `logs` is in scope — so a scoped (Projects/Knowledge/…) query is served entirely from RAM in single-digit-to-tens of milliseconds, while an all-sources query still pays the log disk-scan. (History: search re-walked the *whole* tree on every query through v4.31.0; at a few hundred Markdown files that was a handful of ms, but a conception with thousands of files + large logs pushed per-query cost past 1 s — the index landed in response.)
 
 ## Why Electron, not Tauri
 
@@ -182,7 +184,7 @@ The renderer bundle ships in the asar at `dist/`. The dev server (`vite`) listen
 
 ## What's deliberately *not* an invariant
 
-- **Search index.** Re-walks the tree per query — see above.
+- **Log search index.** The Markdown sources are indexed in RAM ([above](#search-index)), but logs stay scanned on disk per query — they're the bulk of the bytes and rarely searched.
 - **Worker isolation.** Mutations and parses run on the main-process event loop. The largest file is a project README (kilobytes); the parse is microseconds.
 - **Authentication / authorisation.** condash is single-user, local-only. There is no user model.
 - **Cross-process logging.** Main and renderer write to their own console streams. There is no aggregator and no log file.

--- a/docs/explanation/non-goals.md
+++ b/docs/explanation/non-goals.md
@@ -45,11 +45,11 @@ No language server integration, no go-to-definition, no diagnostics. Even for Ma
 
 **Why**: same reason as "no code editing." The IDE owns this surface.
 
-## No notes search index
+## No log search index
 
-Search re-walks the conception tree on every query (`src/main/search.ts`). At conception scale (a few hundred Markdown files of a few KB each) this is comfortably under 50 ms; an index would be a maintenance burden for no observable user gain. See [Internals — Why no search index](internals.md#why-no-search-index).
+The Markdown sources *are* indexed in RAM (`src/main/search/index-cache.ts`), so a Markdown query is served without touching disk. **Logs**, though, are still scanned on disk every query — they're the bulk of the corpus bytes and rarely searched, so caching them would cost a lot of resident memory for little gain. See [Internals — The search index](internals.md#search-index).
 
-**Why**: simplicity wins until it bites. If a future user has a 10 000-file conception tree, this becomes a real problem and a real index can be added. Today it isn't.
+**Why**: index where it pays. Markdown is small and frequently searched; logs are large and rarely. If log search ever feels slow, a deferred / lazy log index (built on first Logs-scope use) is the next step.
 
 ## No multi-window UI
 

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -121,7 +121,7 @@ Same root cause as above. The renderer flips the marker optimistically, the IPC 
 
 ### Refresh button takes longer than a second
 
-The conception tree is too big or sits on a slow filesystem (network mount). condash re-walks the tree on each refresh — there is no index on purpose (see [Why no search index](../explanation/internals.md#why-no-search-index)). At a few hundred items this should be well under 50 ms; if you hit a noticeably slower wall, file an issue with the tree size and FS type.
+The conception tree is too big or sits on a slow filesystem (network mount). condash re-walks the tree on each refresh to re-read project READMEs and repo git state (the project list isn't indexed; [search](../explanation/internals.md#search-index) is). At a few hundred items this should be well under 50 ms; if you hit a noticeably slower wall, file an issue with the tree size and FS type.
 
 ### Embedded terminal is laggy under load
 

--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -35,7 +35,7 @@ Verb names are **camelCase** (e.g. `toggleStep`, `termSpawn`) on both sides of t
 | `readResourcesTree()` | `ResourceNode \| null` | Walk `<conception>/resources/` (hard-coded, not configurable), return the file tree with per-file MIME / category metadata. `null` if the directory doesn't exist. |
 | `readSkillsTree(scope, tab)` | `SkillNode \| null` | Walk the `(scope, tab)` skills directory — `local` reads the conception, `global` reads the per-machine user scope (`~/.config/agents/`, `~/.claude/`, `~/.kimi/`, `~/.config/opencode/`). Markdown only, with title / summary parsed from the head and optional `shipped` / `diverged` chips (condash ships only the Generic `.agents/skills/` tree). `null` when the directory is absent. |
 | `readSkillFile(path)` | `string` | Read-only content fetch for a Skills-pane file. Like `readNote` but also permits the user-scope skill locations (the global scope lives outside the conception); rejects anything else. |
-| `search(query)` | `SearchResults` | Full-text search across every project + knowledge file. Re-walks the tree each call (no index — see [Internals](../explanation/internals.md#why-no-search-index)). |
+| `search(query, scopes?)` | `SearchResults` | Full-text search across projects, knowledge, resources, skills, and logs. Markdown sources are served from an in-memory index; logs are scanned on disk, and only when in scope (see [Internals — The search index](../explanation/internals.md#search-index)). |
 
 ## Mutations
 

--- a/src/main/search/concurrency.ts
+++ b/src/main/search/concurrency.ts
@@ -1,0 +1,25 @@
+/**
+ * Run async task factories with a bounded number in flight. A conception tree
+ * can carry several thousand markdown files; a naive `Promise.all` over the lot
+ * opens file descriptors as fast as the OS allows, occasionally tripping EMFILE
+ * on dense trees. Shared by the per-query disk scan and the index build.
+ */
+export async function runWithConcurrency<T>(
+  factories: ReadonlyArray<() => Promise<T>>,
+  limit: number,
+): Promise<T[]> {
+  const results: T[] = new Array(factories.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    while (true) {
+      const i = next++;
+      if (i >= factories.length) return;
+      results[i] = await factories[i]();
+    }
+  }
+  const workers: Promise<void>[] = [];
+  const n = Math.min(limit, factories.length);
+  for (let i = 0; i < n; i++) workers.push(worker());
+  await Promise.all(workers);
+  return results;
+}

--- a/src/main/search/index-cache.test.ts
+++ b/src/main/search/index-cache.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { toPosix } from '../../shared/path';
+import { parseQuery } from './query';
+import {
+  applyIndexFsEvent,
+  clearSearchIndex,
+  rebuildSearchIndex,
+  searchIndex,
+} from './index-cache';
+
+const ALL = () => true;
+/** Match the renderer's scope-pill semantics. */
+const only =
+  (...scopes: string[]) =>
+  (s: string) =>
+    scopes.includes(s);
+
+function hitPaths(conception: string, query: string, wants: (s: string) => boolean): string[] {
+  const out = searchIndex(conception, parseQuery(query), wants);
+  return (out ?? []).map((m) => m.hit.path);
+}
+
+describe('search index-cache', () => {
+  let dir: string;
+  let readme: string;
+  let note: string;
+  let knowledge: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'condash-idx-'));
+    const item = join(dir, 'projects', '2026-06', '2026-06-03-foo');
+    await mkdir(join(item, 'notes'), { recursive: true });
+    await mkdir(join(dir, 'knowledge'), { recursive: true });
+    readme = join(item, 'README.md');
+    note = join(item, 'notes', '01-design.md');
+    knowledge = join(dir, 'knowledge', 'topic.md');
+    await writeFile(readme, '# Foo\n\nalphaword body\n');
+    await writeFile(note, '# Design\n\ngammaword detail\n');
+    await writeFile(knowledge, '# Topic\n\ndeltaword reference\n');
+    await rebuildSearchIndex(dir);
+  });
+
+  afterEach(async () => {
+    clearSearchIndex();
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('indexes READMEs, project notes, and knowledge', () => {
+    expect(hitPaths(dir, 'alphaword', ALL)).toEqual([toPosix(readme)]);
+    // Project notes are indexed even though the renderer watcher classifies
+    // them as `unknown`.
+    expect(hitPaths(dir, 'gammaword', ALL)).toEqual([toPosix(note)]);
+    expect(hitPaths(dir, 'deltaword', ALL)).toEqual([toPosix(knowledge)]);
+  });
+
+  it('honours the scope filter', () => {
+    expect(hitPaths(dir, 'deltaword', only('projects'))).toEqual([]);
+    expect(hitPaths(dir, 'deltaword', only('knowledge'))).toEqual([toPosix(knowledge)]);
+    expect(hitPaths(dir, 'alphaword', only('projects'))).toEqual([toPosix(readme)]);
+  });
+
+  it('returns null when no index is built for the conception', () => {
+    expect(searchIndex('/some/other/conception', parseQuery('alphaword'), ALL)).toBeNull();
+    clearSearchIndex();
+    expect(searchIndex(dir, parseQuery('alphaword'), ALL)).toBeNull();
+  });
+
+  it('incrementally adds a new note', async () => {
+    const added = join(dir, 'projects', '2026-06', '2026-06-03-foo', 'notes', '02-more.md');
+    await writeFile(added, 'epsilonword\n');
+    await applyIndexFsEvent(dir, 'add', added);
+    expect(hitPaths(dir, 'epsilonword', ALL)).toEqual([toPosix(added)]);
+  });
+
+  it('incrementally reflects a change', async () => {
+    await writeFile(readme, '# Foo\n\nzetaword body\n');
+    await applyIndexFsEvent(dir, 'change', readme);
+    expect(hitPaths(dir, 'zetaword', ALL)).toEqual([toPosix(readme)]);
+    expect(hitPaths(dir, 'alphaword', ALL)).toEqual([]);
+  });
+
+  it('incrementally drops an unlinked file', async () => {
+    await applyIndexFsEvent(dir, 'unlink', note);
+    expect(hitPaths(dir, 'gammaword', ALL)).toEqual([]);
+  });
+
+  it('ignores non-indexed paths (local/, dotfiles)', async () => {
+    const item = join(dir, 'projects', '2026-06', '2026-06-03-foo');
+    const inLocal = join(item, 'local', 'scratch.md');
+    await mkdir(join(item, 'local'), { recursive: true });
+    await writeFile(inLocal, 'etaword\n');
+    await applyIndexFsEvent(dir, 'add', inLocal);
+    expect(hitPaths(dir, 'etaword', ALL)).toEqual([]);
+  });
+});

--- a/src/main/search/index-cache.ts
+++ b/src/main/search/index-cache.ts
@@ -1,0 +1,230 @@
+// In-memory search index for the four markdown sources (projects, knowledge,
+// resources, skills). Built at conception-open, queried in RAM, and kept fresh
+// incrementally by the chokidar watcher — so a keystroke search never re-walks
+// + re-reads + re-lowercases the tree (the dominant per-query cost; see the
+// perf research project's measurement note).
+//
+// Logs are deliberately NOT indexed: they're ~9/10 of the corpus bytes and
+// rarely searched, so caching them would cost ~100 MB+ resident for little gain.
+// They stay on-disk-scanned, and only when 'logs' is in scope (search/index.ts).
+import { join, relative } from 'node:path';
+import { toPosix } from '../../shared/path';
+import type { SearchTerm } from '../../shared/types';
+import { resolveConceptionPaths } from '../conception-paths';
+import { runWithConcurrency } from './concurrency';
+import {
+  matchPrepared,
+  prepareFile,
+  type FileRef,
+  type MatchOutput,
+  type PreparedFile,
+} from './match';
+import {
+  collectKnowledgeFiles,
+  collectProjectFiles,
+  collectResourceFiles,
+  collectSkillFiles,
+} from './walk';
+
+const PREPARE_CONCURRENCY = 32;
+const RESOURCE_EXTS = new Set(['.md', '.markdown', '.txt']);
+// Directory names the markdown walkers skip (walk.ts SKIP_DIR_NAMES, minus the
+// dotfile rule which `segmentsClean` covers separately).
+const SKIP_SEGMENTS = new Set(['node_modules', 'local']);
+
+export type IndexedSource = 'project' | 'knowledge' | 'resources' | 'skills';
+
+/** Scope-pill name (what the renderer forwards) for each indexed source. */
+const SOURCE_TO_SCOPE: Record<IndexedSource, string> = {
+  project: 'projects',
+  knowledge: 'knowledge',
+  resources: 'resources',
+  skills: 'skills',
+};
+
+interface ConceptionIndex {
+  conceptionPath: string;
+  /** Keyed by posix absolute path. */
+  byPath: Map<string, PreparedFile>;
+}
+
+let current: ConceptionIndex | null = null;
+// Bumped on every (re)build / clear so a slow build that's been superseded by a
+// conception switch discards its result instead of clobbering the new index.
+let buildToken = 0;
+
+/** Drop the index (conception teardown / switch). */
+export function clearSearchIndex(): void {
+  current = null;
+  buildToken++;
+}
+
+function getIndex(conceptionPath: string): ConceptionIndex | null {
+  return current && current.conceptionPath === conceptionPath ? current : null;
+}
+
+/**
+ * Run a parsed query over the in-memory index, honouring the scope filter.
+ * Returns `null` when no index is built for this conception yet — the caller
+ * (search/index.ts) then falls back to the on-disk scan.
+ */
+export function searchIndex(
+  conceptionPath: string,
+  terms: readonly SearchTerm[],
+  wants: (scope: string) => boolean,
+): MatchOutput[] | null {
+  const index = getIndex(conceptionPath);
+  if (!index) return null;
+  const out: MatchOutput[] = [];
+  for (const file of index.byPath.values()) {
+    if (!wants(SOURCE_TO_SCOPE[file.source as IndexedSource])) continue;
+    const m = matchPrepared(file, terms);
+    if (m) out.push(m);
+  }
+  return out;
+}
+
+/**
+ * Build (or rebuild) the index for the four markdown sources. Fire-and-forget
+ * from the watcher so it never blocks boot; queries fall back to the disk scan
+ * until it resolves. Passing `null` just clears.
+ */
+export async function rebuildSearchIndex(conceptionPath: string | null): Promise<void> {
+  clearSearchIndex();
+  if (!conceptionPath) return;
+  const token = buildToken;
+  const { resources, skills } = resolveConceptionPaths();
+
+  const [projectFiles, knowledgeFiles, resourceFiles, skillFiles] = await Promise.all([
+    collectProjectFiles(join(conceptionPath, 'projects')),
+    collectKnowledgeFiles(join(conceptionPath, 'knowledge')),
+    collectResourceFiles(join(conceptionPath, resources)),
+    collectSkillFiles(join(conceptionPath, skills)),
+  ]);
+
+  const refs: FileRef[] = [
+    ...projectFiles.map((f) => toRef(conceptionPath, f.path, 'project', f.projectPath)),
+    ...knowledgeFiles.map((p) => toRef(conceptionPath, p, 'knowledge')),
+    ...resourceFiles.map((p) => toRef(conceptionPath, p, 'resources')),
+    ...skillFiles.map((p) => toRef(conceptionPath, p, 'skills')),
+  ];
+
+  const byPath = new Map<string, PreparedFile>();
+  await runWithConcurrency(
+    refs.map((ref) => async () => {
+      const prepared = await prepareFile(ref);
+      if (prepared) byPath.set(ref.path, prepared);
+    }),
+    PREPARE_CONCURRENCY,
+  );
+
+  // A newer rebuild/clear (conception switch) superseded us — drop the result.
+  if (token !== buildToken) return;
+  current = { conceptionPath, byPath };
+}
+
+/**
+ * Apply one chokidar FS event to the index (called from the watcher). Keeps the
+ * index incrementally fresh without a full rebuild: re-prepare a changed/added
+ * markdown file, drop a removed one. No-op when the path isn't an indexed
+ * markdown file (logs, dotfiles, `local/`, non-markdown) or when no index is
+ * built for this conception.
+ */
+export async function applyIndexFsEvent(
+  conceptionPath: string,
+  eventName: string,
+  absPath: string,
+): Promise<void> {
+  if (!getIndex(conceptionPath)) return;
+  const key = toPosix(absPath);
+
+  if (eventName === 'unlink') {
+    getIndex(conceptionPath)?.byPath.delete(key);
+    return;
+  }
+  if (eventName === 'unlinkDir') {
+    const index = getIndex(conceptionPath);
+    if (!index) return;
+    const prefix = `${key}/`;
+    for (const k of index.byPath.keys()) {
+      if (k.startsWith(prefix)) index.byPath.delete(k);
+    }
+    return;
+  }
+  if (eventName !== 'add' && eventName !== 'change') return;
+
+  const classified = classifyIndexedPath(conceptionPath, key);
+  if (!classified) return;
+  const prepared = await prepareFile({
+    path: key,
+    relPath: toPosix(relative(conceptionPath, absPath)),
+    source: classified.source,
+    projectPath: classified.projectPath,
+  });
+  // Re-fetch: a conception switch could have landed while we read the file.
+  const live = getIndex(conceptionPath);
+  if (!live) return;
+  if (prepared) live.byPath.set(key, prepared);
+  else live.byPath.delete(key); // vanished between the event and the read
+}
+
+function toRef(
+  conceptionPath: string,
+  absPath: string,
+  source: IndexedSource,
+  projectPath?: string,
+): FileRef {
+  return {
+    path: toPosix(absPath),
+    relPath: toPosix(relative(conceptionPath, absPath)),
+    source,
+    projectPath: projectPath ? toPosix(projectPath) : undefined,
+  };
+}
+
+/**
+ * Map a posix absolute path to its indexed source (or null), mirroring the
+ * walk.ts collectors' membership: correct extension, and no dot-prefixed /
+ * `node_modules` / `local` segment below the source root.
+ */
+function classifyIndexedPath(
+  conceptionPath: string,
+  posixPath: string,
+): { source: IndexedSource; projectPath?: string } | null {
+  const cp = toPosix(conceptionPath);
+  const lower = posixPath.toLowerCase();
+  const dot = lower.lastIndexOf('.');
+  const ext = dot >= 0 ? lower.slice(dot) : '';
+  const { resources, skills } = resolveConceptionPaths();
+
+  const projRoot = `${cp}/projects`;
+  if (posixPath.startsWith(`${projRoot}/`) && ext === '.md') {
+    const rel = posixPath.slice(projRoot.length + 1).split('/');
+    if (rel.length < 2 || !segmentsClean(rel)) return null;
+    return { source: 'project', projectPath: `${projRoot}/${rel[0]}/${rel[1]}` };
+  }
+
+  const knowRoot = `${cp}/knowledge`;
+  if (posixPath.startsWith(`${knowRoot}/`) && ext === '.md') {
+    if (!segmentsClean(posixPath.slice(knowRoot.length + 1).split('/'))) return null;
+    return { source: 'knowledge' };
+  }
+
+  const resRoot = toPosix(join(cp, resources));
+  if (posixPath.startsWith(`${resRoot}/`) && RESOURCE_EXTS.has(ext)) {
+    if (!segmentsClean(posixPath.slice(resRoot.length + 1).split('/'))) return null;
+    return { source: 'resources' };
+  }
+
+  const skillRoot = toPosix(join(cp, skills));
+  if (posixPath.startsWith(`${skillRoot}/`) && ext === '.md') {
+    if (!segmentsClean(posixPath.slice(skillRoot.length + 1).split('/'))) return null;
+    return { source: 'skills' };
+  }
+
+  return null;
+}
+
+function segmentsClean(segments: string[]): boolean {
+  return segments.every((s) => s.length > 0 && !s.startsWith('.') && !SKIP_SEGMENTS.has(s));
+}

--- a/src/main/search/index.ts
+++ b/src/main/search/index.ts
@@ -1,5 +1,5 @@
 import { join, relative } from 'node:path';
-import type { SearchResults } from '../../shared/types';
+import type { SearchResults, SearchTerm } from '../../shared/types';
 import { toPosix } from '../../shared/path';
 import {
   collectKnowledgeFiles,
@@ -10,6 +10,8 @@ import {
 } from './walk';
 import { matchFile, type MatchOutput } from './match';
 import { parseQuery } from './query';
+import { runWithConcurrency } from './concurrency';
+import { searchIndex } from './index-cache';
 import { resolveConceptionPaths } from '../conception-paths';
 import { condashLogsRoot } from '../condash-dir';
 
@@ -19,43 +21,21 @@ import { condashLogsRoot } from '../condash-dir';
  * on" query and well under the point where the modal starts feeling slow. */
 const RAW_HIT_CAP = 100;
 
-/** Cap on concurrent `fs.readFile` calls in matchFile. A conception tree can
- * carry several thousand markdown files (projects + knowledge + logs); a
- * naive `Promise.all` over the lot was opening file descriptors as fast as
- * the OS would allow, occasionally tripping EMFILE on dense trees. 32 is
- * comfortably above what node's default uv thread pool can chew through and
- * well below the typical ulimit -n. */
+/** Cap on concurrent `fs.readFile` calls in the on-disk scan (logs + the
+ * pre-index fallback). 32 is comfortably above what node's default uv thread
+ * pool can chew through and well below the typical ulimit -n. */
 const READ_CONCURRENCY = 32;
-
-async function runWithConcurrency<T>(
-  factories: ReadonlyArray<() => Promise<T>>,
-  limit: number,
-): Promise<T[]> {
-  const results: T[] = new Array(factories.length);
-  let next = 0;
-  async function worker(): Promise<void> {
-    while (true) {
-      const i = next++;
-      if (i >= factories.length) return;
-      results[i] = await factories[i]();
-    }
-  }
-  const workers: Promise<void>[] = [];
-  const n = Math.min(limit, factories.length);
-  for (let i = 0; i < n; i++) workers.push(worker());
-  await Promise.all(workers);
-  return results;
-}
 
 /**
  * Run a query against the conception tree. Returns ordered hits + the parsed
  * terms (used by the renderer for multi-token highlighting) + truncation
  * metadata for the "Showing 100 of N" footer.
  *
- * Pipeline: parse → walk → match-per-file (scored) → sort → cap. Each step
- * lives in its own module for easy unit-testing and future replacement —
- * for example, swapping the brute-force `walk + match` for a pre-built index
- * would only touch one boundary.
+ * Pipeline: parse → match → sort → cap. The four markdown sources are matched
+ * against the **in-memory index** (`index-cache.ts`) — no per-query walk / read
+ * / lowercase — falling back to an on-disk scan only while the index is still
+ * building (boot window). Logs are never indexed (too large, rarely searched),
+ * so they're disk-scanned, and only when in scope.
  */
 export async function search(
   conceptionPath: string,
@@ -70,83 +50,29 @@ export async function search(
   const wants = (source: string): boolean =>
     !scopes || scopes.length === 0 || scopes.includes(source);
 
-  const { resources, skills } = resolveConceptionPaths();
-
-  // Skills search covers the single agedum source tree at
-  // `<conception>/.agents/skills/`; per-harness compiled outputs are no
-  // longer searched (they're not authored content).
-  const [projectFiles, knowledgeFiles, resourceFiles, skillFiles, logFiles] = await Promise.all([
-    wants('projects') ? collectProjectFiles(join(conceptionPath, 'projects')) : Promise.resolve([]),
-    wants('knowledge')
-      ? collectKnowledgeFiles(join(conceptionPath, 'knowledge'))
-      : Promise.resolve([]),
-    wants('resources')
-      ? collectResourceFiles(join(conceptionPath, resources))
-      : Promise.resolve([]),
-    wants('skills') ? collectSkillFiles(join(conceptionPath, skills)) : Promise.resolve([]),
-    wants('logs') ? collectLogFiles(condashLogsRoot(conceptionPath)) : Promise.resolve([]),
-  ]);
-
-  const matchFactories: Array<() => Promise<MatchOutput | null>> = [];
-
-  for (const file of projectFiles) {
-    matchFactories.push(() =>
-      matchFile({
-        path: toPosix(file.path),
-        relPath: toPosix(relative(conceptionPath, file.path)),
-        source: 'project',
-        projectPath: toPosix(file.projectPath),
-        terms,
-      }),
-    );
+  // Markdown sources from the in-memory index; on-disk fallback until it's built.
+  let matched = searchIndex(conceptionPath, terms, wants);
+  if (matched === null) {
+    matched = await scanMarkdownFromDisk(conceptionPath, terms, wants);
   }
 
-  for (const path of knowledgeFiles) {
-    matchFactories.push(() =>
-      matchFile({
-        path: toPosix(path),
-        relPath: toPosix(relative(conceptionPath, path)),
-        source: 'knowledge',
-        terms,
-      }),
+  // Logs: disk-scanned, never indexed, and only when 'logs' is in scope.
+  if (wants('logs')) {
+    const logFiles = await collectLogFiles(condashLogsRoot(conceptionPath));
+    const settled = await runWithConcurrency(
+      logFiles.map(
+        (path) => () =>
+          matchFile({
+            path: toPosix(path),
+            relPath: toPosix(relative(conceptionPath, path)),
+            source: 'logs',
+            terms,
+          }),
+      ),
+      READ_CONCURRENCY,
     );
+    for (const m of settled) if (m !== null) matched.push(m);
   }
-
-  for (const path of resourceFiles) {
-    matchFactories.push(() =>
-      matchFile({
-        path: toPosix(path),
-        relPath: toPosix(relative(conceptionPath, path)),
-        source: 'resources',
-        terms,
-      }),
-    );
-  }
-
-  for (const path of skillFiles) {
-    matchFactories.push(() =>
-      matchFile({
-        path: toPosix(path),
-        relPath: toPosix(relative(conceptionPath, path)),
-        source: 'skills',
-        terms,
-      }),
-    );
-  }
-
-  for (const path of logFiles) {
-    matchFactories.push(() =>
-      matchFile({
-        path: toPosix(path),
-        relPath: toPosix(relative(conceptionPath, path)),
-        source: 'logs',
-        terms,
-      }),
-    );
-  }
-
-  const settled = await runWithConcurrency(matchFactories, READ_CONCURRENCY);
-  const matched = settled.filter((m): m is MatchOutput => m !== null);
 
   matched.sort((a, b) => {
     if (b.hit.score !== a.hit.score) return b.hit.score - a.hit.score;
@@ -159,4 +85,73 @@ export async function search(
   const hits = matched.slice(0, RAW_HIT_CAP).map((m) => m.hit);
 
   return { hits, terms, totalBeforeCap, truncated };
+}
+
+/**
+ * On-disk scan of the four markdown sources — the original brute-force path,
+ * used only as a fallback while the in-memory index is still building. Honours
+ * the scope filter so unselected sources aren't walked.
+ */
+async function scanMarkdownFromDisk(
+  conceptionPath: string,
+  terms: readonly SearchTerm[],
+  wants: (source: string) => boolean,
+): Promise<MatchOutput[]> {
+  const { resources, skills } = resolveConceptionPaths();
+  const [projectFiles, knowledgeFiles, resourceFiles, skillFiles] = await Promise.all([
+    wants('projects') ? collectProjectFiles(join(conceptionPath, 'projects')) : Promise.resolve([]),
+    wants('knowledge')
+      ? collectKnowledgeFiles(join(conceptionPath, 'knowledge'))
+      : Promise.resolve([]),
+    wants('resources')
+      ? collectResourceFiles(join(conceptionPath, resources))
+      : Promise.resolve([]),
+    wants('skills') ? collectSkillFiles(join(conceptionPath, skills)) : Promise.resolve([]),
+  ]);
+
+  const factories: Array<() => Promise<MatchOutput | null>> = [];
+  for (const file of projectFiles) {
+    factories.push(() =>
+      matchFile({
+        path: toPosix(file.path),
+        relPath: toPosix(relative(conceptionPath, file.path)),
+        source: 'project',
+        projectPath: toPosix(file.projectPath),
+        terms,
+      }),
+    );
+  }
+  for (const path of knowledgeFiles) {
+    factories.push(() =>
+      matchFile({
+        path: toPosix(path),
+        relPath: toPosix(relative(conceptionPath, path)),
+        source: 'knowledge',
+        terms,
+      }),
+    );
+  }
+  for (const path of resourceFiles) {
+    factories.push(() =>
+      matchFile({
+        path: toPosix(path),
+        relPath: toPosix(relative(conceptionPath, path)),
+        source: 'resources',
+        terms,
+      }),
+    );
+  }
+  for (const path of skillFiles) {
+    factories.push(() =>
+      matchFile({
+        path: toPosix(path),
+        relPath: toPosix(relative(conceptionPath, path)),
+        source: 'skills',
+        terms,
+      }),
+    );
+  }
+
+  const settled = await runWithConcurrency(factories, READ_CONCURRENCY);
+  return settled.filter((m): m is MatchOutput => m !== null);
 }

--- a/src/main/search/match.ts
+++ b/src/main/search/match.ts
@@ -20,11 +20,17 @@ import { buildRegions } from './regions';
 import { scoreOccurrences, type ScorerOccurrence } from './scorer';
 import { buildSnippets } from './snippets';
 
-export interface MatchInput {
+/** Static identity of a searchable file — everything the matcher needs that
+ *  isn't the parsed query. Shared by the disk path (`matchFile`) and the
+ *  in-memory index (`prepareFile` → `matchPrepared`). */
+export interface FileRef {
   path: string;
   relPath: string;
   source: 'project' | 'knowledge' | 'resources' | 'skills' | 'logs';
   projectPath?: string;
+}
+
+export interface MatchInput extends FileRef {
   terms: readonly SearchTerm[];
 }
 
@@ -34,40 +40,72 @@ export interface MatchOutput {
   mtimeMs: number;
 }
 
+/** A file read + precomputed for matching: the content the matcher scans plus
+ *  the derivations that don't depend on the query (lowercased content/path, the
+ *  region map, the title, mtime). The in-memory index (`search/index-cache.ts`)
+ *  stores these so a query never re-reads or re-lowercases the markdown tree. */
+export interface PreparedFile extends FileRef {
+  mtimeMs: number;
+  /** Post-log-strip content — what snippets quote and titles derive from. */
+  raw: string;
+  lowerContent: string;
+  lowerPath: string;
+  regions: ReturnType<typeof buildRegions>;
+  title: string;
+}
+
 /**
- * Match a single file against the parsed query. Returns `null` when the file
- * fails the AND filter (some term has no occurrence in either content or
- * path), or on read failure.
- *
- * AND semantics: every term must match somewhere — the body, the path, or
- * any combination. Path-matches alone are enough to surface a file (slug-
- * only hits, e.g. `2026-04-29` matching by date prefix).
+ * Read a file and precompute everything the matcher needs that doesn't depend
+ * on the query. Returns `null` on read failure. The query-independent work
+ * (read + `toLowerCase` + region map + title) is exactly what the in-memory
+ * index caches, so an indexed query skips straight to `matchPrepared`.
  */
-export async function matchFile(input: MatchInput): Promise<MatchOutput | null> {
+export async function prepareFile(ref: FileRef): Promise<PreparedFile | null> {
   let raw: string;
   let mtimeMs: number;
   try {
-    const stat = await fs.stat(input.path);
+    const stat = await fs.stat(ref.path);
     mtimeMs = stat.mtimeMs;
-    raw = await fs.readFile(input.path, 'utf8');
+    raw = await fs.readFile(ref.path, 'utf8');
     // Logs carry a `# condash: {...}` header / footer line for the
     // session's spawn / exit metadata. Strip those before matching so a
     // search for "exit" doesn't snippet-quote the JSON.
-    if (input.source === 'logs') {
+    if (ref.source === 'logs') {
       raw = splitContent(raw).text;
     }
   } catch {
     return null;
   }
 
-  const lowerContent = raw.toLowerCase();
-  const lowerPath = input.relPath.toLowerCase();
-  const regions = buildRegions(raw, input.source);
+  return {
+    ...ref,
+    mtimeMs,
+    raw,
+    lowerContent: raw.toLowerCase(),
+    lowerPath: ref.relPath.toLowerCase(),
+    regions: buildRegions(raw, ref.source),
+    title: extractFirstHeadingOrLine(raw) ?? ref.relPath,
+  };
+}
 
+/**
+ * Match a prepared file against the parsed query — pure, no I/O. Returns `null`
+ * when the file fails the AND filter (some term has no occurrence in either
+ * content or path).
+ *
+ * AND semantics: every term must match somewhere — the body, the path, or
+ * any combination. Path-matches alone are enough to surface a file (slug-
+ * only hits, e.g. `2026-04-29` matching by date prefix).
+ */
+export function matchPrepared(
+  file: PreparedFile,
+  terms: readonly SearchTerm[],
+): MatchOutput | null {
+  const { lowerContent, lowerPath, regions, raw } = file;
   const occurrences: ScorerOccurrence[] = [];
   const pathMatches: SearchHighlight[] = [];
 
-  for (const term of input.terms) {
+  for (const term of terms) {
     let cursor = 0;
     while (cursor < lowerContent.length) {
       const idx = lowerContent.indexOf(term.value, cursor);
@@ -99,29 +137,40 @@ export async function matchFile(input: MatchInput): Promise<MatchOutput | null> 
   }
 
   const matchedTokens = new Set(occurrences.map((o) => o.tokenIndex));
-  for (const term of input.terms) {
+  for (const term of terms) {
     if (!matchedTokens.has(term.index)) return null;
   }
 
-  const score = scoreOccurrences(occurrences, input.terms);
+  const score = scoreOccurrences(occurrences, terms);
   const matchCount = occurrences.length;
-  const title = extractFirstHeadingOrLine(raw) ?? input.relPath;
-  const snippets = buildSnippets(raw, input.terms, regions);
+  const snippets = buildSnippets(raw, terms, regions);
 
   return {
     hit: {
-      path: input.path,
-      relPath: input.relPath,
-      title,
-      source: input.source,
+      path: file.path,
+      relPath: file.relPath,
+      title: file.title,
+      source: file.source,
       score,
       matchCount,
       snippets,
       pathMatches: pathMatches.length > 0 ? pathMatches : undefined,
-      projectPath: input.projectPath,
+      projectPath: file.projectPath,
     },
-    mtimeMs,
+    mtimeMs: file.mtimeMs,
   };
+}
+
+/**
+ * Match a single file against the parsed query, reading it from disk. Returns
+ * `null` on read failure or when the file fails the AND filter. Equivalent to
+ * `prepareFile` + `matchPrepared`; used for the on-disk path (logs, and the
+ * pre-index fallback).
+ */
+export async function matchFile(input: MatchInput): Promise<MatchOutput | null> {
+  const prepared = await prepareFile(input);
+  if (!prepared) return null;
+  return matchPrepared(prepared, input.terms);
 }
 
 /** Best-effort title: returns the first non-empty line with leading

--- a/src/main/watcher.ts
+++ b/src/main/watcher.ts
@@ -5,6 +5,7 @@ import { toPosix } from '../shared/path';
 import type { TreeEvent } from '../shared/types';
 import { migrateLegacyConfig } from './condash-dir-migrate';
 import { resolveConceptionPaths } from './conception-paths';
+import { applyIndexFsEvent, clearSearchIndex, rebuildSearchIndex } from './search/index-cache';
 
 const DEBOUNCE_MS = 250;
 
@@ -59,6 +60,10 @@ let pendingUnknown = false;
 
 export async function setWatchedConception(conceptionPath: string | null): Promise<void> {
   if (current?.path === conceptionPath) return;
+
+  // Conception is changing — drop the in-memory search index; it's rebuilt
+  // below for the new conception (or left empty when clearing).
+  clearSearchIndex();
 
   if (current) {
     await current.watcher.close().catch(() => undefined);
@@ -147,6 +152,13 @@ export async function setWatchedConception(conceptionPath: string | null): Promi
   });
 
   current = { path: conceptionPath, watcher, roots, paths };
+
+  // Build the in-memory search index for the markdown sources. Fire-and-forget
+  // so it never blocks boot; queries fall back to the on-disk scan until it
+  // resolves, and the watcher keeps it fresh thereafter.
+  void rebuildSearchIndex(conceptionPath).catch((err) => {
+    console.error('[watcher] rebuildSearchIndex failed', err);
+  });
 }
 
 /**
@@ -173,6 +185,15 @@ type ChokidarEvent = 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir';
 let refreshChain: Promise<void> = Promise.resolve();
 
 function onWatchEvent(eventName: string, path: string, roots: RootSet, paths: WatchPaths): void {
+  // Keep the in-memory search index incrementally fresh. Independent of the
+  // renderer `classify` below: it covers project notes too (which classify maps
+  // to `unknown`), and only touches indexed markdown files.
+  if (current) {
+    void applyIndexFsEvent(current.path, eventName, path).catch((err) => {
+      console.error('[watcher] applyIndexFsEvent failed', err);
+    });
+  }
+
   const event = classify(eventName as ChokidarEvent, path, roots, paths);
   if (event.kind === 'unknown') pendingUnknown = true;
   else pending.push(event);

--- a/src/renderer/code-runs.tsx
+++ b/src/renderer/code-runs.tsx
@@ -5,7 +5,7 @@
 
 import { createEffect, createSignal, createMemo, For, onCleanup, Show } from 'solid-js';
 import type { TermSession, RepoEntry, TerminalXtermPrefs, Worktree } from '@shared/types';
-import { mountXterm } from './xterm-mount';
+import type { MountedTerm } from './xterm-mount';
 import { StopIcon } from './icons';
 
 interface CodeRunRowsProps {
@@ -112,14 +112,19 @@ function CodeRunRow(props: {
   const xtermElement = document.createElement('div');
   xtermElement.className = 'xterm-host';
   let host: HTMLDivElement | undefined;
-  let mounted: ReturnType<typeof mountXterm> | null = null;
+  let mounted: MountedTerm | null = null;
   let mountPromise: Promise<void> | null = null;
 
   const ensureMounted = (): Promise<void> => {
     if (mounted) return Promise.resolve();
     if (mountPromise) return mountPromise;
     mountPromise = (async () => {
-      const attach = await window.condash.termAttach(props.session.id);
+      // xterm + its addons are dynamic-imported on first terminal open so they
+      // stay out of the boot chunk (the module is cached after the first load).
+      const [{ mountXterm }, attach] = await Promise.all([
+        import('./xterm-mount'),
+        window.condash.termAttach(props.session.id),
+      ]);
       mounted = mountXterm(xtermElement, props.session.id, {
         replay: attach?.output,
         prefs: props.xtermPrefs,

--- a/src/renderer/help-modal.tsx
+++ b/src/renderer/help-modal.tsx
@@ -41,11 +41,9 @@ export function HelpModal(props: { doc: HelpDoc; onClose: () => void }) {
     },
   );
 
-  const html = (): string => {
-    const raw = content();
-    if (raw === undefined) return '';
-    return renderMarkdown(raw);
-  };
+  // markdown-it is lazy-loaded (out of the boot chunk), so the rendered HTML is
+  // a resource keyed on the loaded doc rather than a synchronous derivation.
+  const [html] = createResource(content, (raw) => renderMarkdown(raw));
 
   createEffect(() => {
     if (content() && bodyRef) {
@@ -84,7 +82,7 @@ export function HelpModal(props: { doc: HelpDoc; onClose: () => void }) {
           <div
             class="modal-body markdown-body"
             ref={(el) => (bodyRef = el)}
-            innerHTML={html()}
+            innerHTML={html() ?? ''}
             onClick={handleBodyClick}
           />
         </Show>

--- a/src/renderer/hooks/use-theme.ts
+++ b/src/renderer/hooks/use-theme.ts
@@ -1,7 +1,7 @@
 import { createEffect, createMemo, createSignal, onCleanup } from 'solid-js';
 import type { Theme } from '@shared/types';
 import { resetMermaidTheme } from '../markdown';
-import { refreshAllXtermThemes } from '../xterm-mount';
+import { refreshAllXtermThemes } from '../xterm-registry';
 
 function applyTheme(theme: Theme): void {
   const root = document.documentElement;

--- a/src/renderer/html-modal.tsx
+++ b/src/renderer/html-modal.tsx
@@ -1,4 +1,4 @@
-import { createMemo, createResource, createSignal, Show } from 'solid-js';
+import { createResource, createSignal, Show } from 'solid-js';
 import { useModalEscHandler } from './modal-helpers';
 import { highlightCode, pathToCondashFileUrl } from './markdown';
 import './html-modal.css';
@@ -36,10 +36,10 @@ export function HtmlModal(props: {
     () => (mode() === 'source' ? props.path : null),
     (path) => window.condash.readNote(path),
   );
-  const sourceHtml = createMemo(() => {
-    const text = source();
-    return text == null ? '' : highlightCode(text, props.path);
-  });
+  // highlight.js is lazy-loaded (out of the boot chunk); resource, not memo.
+  const [sourceHtml] = createResource(source, async (text) =>
+    text == null ? '' : highlightCode(text, props.path),
+  );
 
   return (
     <div class="modal-backdrop" onClick={props.onClose}>
@@ -96,7 +96,9 @@ export function HtmlModal(props: {
         <div class="html-body">
           <Show
             when={mode() === 'rendered'}
-            fallback={<div class="html-source md-rendered raw-code" innerHTML={sourceHtml()} />}
+            fallback={
+              <div class="html-source md-rendered raw-code" innerHTML={sourceHtml() ?? ''} />
+            }
           >
             {/* Hardened webview: Node off, context isolated, OS-sandboxed. The
                 defence-in-depth `web-contents-created` handler in main/index.ts

--- a/src/renderer/markdown.test.ts
+++ b/src/renderer/markdown.test.ts
@@ -2,33 +2,33 @@ import { describe, expect, it } from 'vitest';
 import { highlightCode } from './markdown';
 
 describe('highlightCode', () => {
-  it('wraps output in a hljs pre/code block', () => {
-    const html = highlightCode('body { color: red; }', 'styles.css');
+  it('wraps output in a hljs pre/code block', async () => {
+    const html = await highlightCode('body { color: red; }', 'styles.css');
     expect(html.startsWith('<pre class="hljs"><code>')).toBe(true);
     expect(html.endsWith('</code></pre>')).toBe(true);
   });
 
-  it('emits highlight token classes for a known language', () => {
-    const html = highlightCode('const x = 1;', 'a.ts');
+  it('emits highlight token classes for a known language', async () => {
+    const html = await highlightCode('const x = 1;', 'a.ts');
     expect(html).toContain('hljs-');
   });
 
-  it('escapes HTML so source content cannot inject markup', () => {
-    const html = highlightCode('<script>alert(1)</script>', 'note.txt');
+  it('escapes HTML so source content cannot inject markup', async () => {
+    const html = await highlightCode('<script>alert(1)</script>', 'note.txt');
     expect(html).not.toContain('<script>');
     expect(html).toContain('&lt;script&gt;');
   });
 
-  it('falls back to escaped plain text for an unknown extension', () => {
-    const html = highlightCode('a < b && c > d', 'data.unknownext');
+  it('falls back to escaped plain text for an unknown extension', async () => {
+    const html = await highlightCode('a < b && c > d', 'data.unknownext');
     expect(html).toContain('&lt;');
     expect(html).toContain('&amp;&amp;');
     expect(html).toContain('&gt;');
   });
 
-  it('degrades to plain text past the size cap without throwing', () => {
+  it('degrades to plain text past the size cap without throwing', async () => {
     const big = 'x'.repeat(200_001);
-    const html = highlightCode(big, 'huge.js');
+    const html = await highlightCode(big, 'huge.js');
     expect(html.startsWith('<pre class="hljs"><code>')).toBe(true);
     expect(html).not.toContain('hljs-');
   });

--- a/src/renderer/markdown.ts
+++ b/src/renderer/markdown.ts
@@ -1,57 +1,90 @@
-import MarkdownIt from 'markdown-it';
-import anchor from 'markdown-it-anchor';
-import taskLists from 'markdown-it-task-lists';
-import hljs from 'highlight.js/lib/common';
+import type MarkdownIt from 'markdown-it';
 import { wikilinks } from './wikilinks';
 
-const md = new MarkdownIt({
-  html: false,
-  linkify: true,
-  breaks: false,
-  highlight: (str, lang) => {
-    if (lang && hljs.getLanguage(lang)) {
-      try {
-        return hljs.highlight(str, { language: lang, ignoreIllegals: true }).value;
-      } catch {
-        /* fall through */
-      }
-    }
-    return '';
-  },
-})
-  .use(anchor, { permalink: false })
-  .use(taskLists, { enabled: false })
-  .use(wikilinks);
-
-const defaultFence = md.renderer.rules.fence!;
-md.renderer.rules.fence = (tokens, idx, options, env, slf) => {
-  const token = tokens[idx];
-  if (token.info.trim().toLowerCase() === 'mermaid') {
-    const content = md.utils.escapeHtml(token.content);
-    return `<pre class="mermaid">${content}</pre>\n`;
-  }
-  return defaultFence(tokens, idx, options, env, slf);
+// markdown-it + highlight.js are the single biggest non-terminal weight in the
+// eager renderer bundle (~237 KB / 16 % of the boot chunk). They're only needed
+// once the user opens a note / help / html modal, so the engine — the configured
+// MarkdownIt instance plus highlight.js/lib/common — is built lazily on first
+// render and cached. `renderMarkdown` / `highlightCode` are therefore async; the
+// modals already read their content asynchronously, so they await the engine the
+// same way. mermaid is loaded lazily too (see `getMermaid`).
+type MarkdownEngine = {
+  md: MarkdownIt;
+  highlight: typeof import('highlight.js/lib/common').default;
 };
 
-// Rewrite relative `<img src>` to a `condash-file:///abs-path` URL so the
-// custom protocol handler in main/index.ts can serve it. Without this, the
-// renderer's CSP + Chromium's cross-origin file:// policy silently drops the
-// image and falls back to alt text — see issue #85.
-const defaultImage = md.renderer.rules.image!;
-md.renderer.rules.image = (tokens, idx, options, env, slf) => {
-  const token = tokens[idx];
-  const baseDir = (env as { baseDir?: string }).baseDir;
-  if (baseDir) {
-    const srcIdx = token.attrIndex('src');
-    if (srcIdx >= 0 && token.attrs) {
-      const src = token.attrs[srcIdx][1];
-      if (isRelativeAssetPath(src)) {
-        token.attrs[srcIdx][1] = relativeToCondashFile(baseDir, src);
+let enginePromise: Promise<MarkdownEngine> | null = null;
+
+async function getEngine(): Promise<MarkdownEngine> {
+  if (!enginePromise) {
+    enginePromise = buildEngine();
+  }
+  return enginePromise;
+}
+
+async function buildEngine(): Promise<MarkdownEngine> {
+  const [{ default: MarkdownItCtor }, { default: anchor }, taskListsMod, hljsMod] =
+    await Promise.all([
+      import('markdown-it'),
+      import('markdown-it-anchor'),
+      import('markdown-it-task-lists'),
+      import('highlight.js/lib/common'),
+    ]);
+  // markdown-it-task-lists is shimmed as an untyped module (any).
+  const taskLists = taskListsMod.default;
+  const highlight = hljsMod.default;
+
+  const md = new MarkdownItCtor({
+    html: false,
+    linkify: true,
+    breaks: false,
+    highlight: (str, lang) => {
+      if (lang && highlight.getLanguage(lang)) {
+        try {
+          return highlight.highlight(str, { language: lang, ignoreIllegals: true }).value;
+        } catch {
+          /* fall through */
+        }
+      }
+      return '';
+    },
+  })
+    .use(anchor, { permalink: false })
+    .use(taskLists, { enabled: false })
+    .use(wikilinks);
+
+  const defaultFence = md.renderer.rules.fence!;
+  md.renderer.rules.fence = (tokens, idx, options, env, slf) => {
+    const token = tokens[idx];
+    if (token.info.trim().toLowerCase() === 'mermaid') {
+      const content = md.utils.escapeHtml(token.content);
+      return `<pre class="mermaid">${content}</pre>\n`;
+    }
+    return defaultFence(tokens, idx, options, env, slf);
+  };
+
+  // Rewrite relative `<img src>` to a `condash-file:///abs-path` URL so the
+  // custom protocol handler in main/index.ts can serve it. Without this, the
+  // renderer's CSP + Chromium's cross-origin file:// policy silently drops the
+  // image and falls back to alt text — see issue #85.
+  const defaultImage = md.renderer.rules.image!;
+  md.renderer.rules.image = (tokens, idx, options, env, slf) => {
+    const token = tokens[idx];
+    const baseDir = (env as { baseDir?: string }).baseDir;
+    if (baseDir) {
+      const srcIdx = token.attrIndex('src');
+      if (srcIdx >= 0 && token.attrs) {
+        const src = token.attrs[srcIdx][1];
+        if (isRelativeAssetPath(src)) {
+          token.attrs[srcIdx][1] = relativeToCondashFile(baseDir, src);
+        }
       }
     }
-  }
-  return defaultImage(tokens, idx, options, env, slf);
-};
+    return defaultImage(tokens, idx, options, env, slf);
+  };
+
+  return { md, highlight };
+}
 
 function isRelativeAssetPath(src: string): boolean {
   if (!src) return false;
@@ -84,7 +117,9 @@ function relativeToCondashFile(baseDir: string, src: string): string {
  *  Each path segment is URI-encoded; the triple slash means "no host" so the
  *  pathname carries the full absolute path. The custom protocol handler in
  *  main/index.ts serves it from inside the conception tree. Shared by the
- *  relative-image rewriter above and the HTML preview modal. */
+ *  relative-image rewriter above and the HTML preview modal. Pure — kept out of
+ *  the lazy engine so the image/html modals can import it without pulling
+ *  markdown-it. */
 export function pathToCondashFileUrl(absPath: string): string {
   const encoded = absPath
     .replace(/\\/g, '/')
@@ -102,7 +137,13 @@ export interface RenderMarkdownOptions {
   baseDir?: string;
 }
 
-export function renderMarkdown(input: string, options: RenderMarkdownOptions = {}): string {
+/** Render markdown to HTML. Async: the markdown-it + highlight.js engine is
+ *  lazy-loaded and cached on first call (kept out of the boot chunk). */
+export async function renderMarkdown(
+  input: string,
+  options: RenderMarkdownOptions = {},
+): Promise<string> {
+  const { md } = await getEngine();
   return md.render(input, { baseDir: options.baseDir });
 }
 
@@ -127,16 +168,17 @@ function hljsLangForPath(path: string): string | undefined {
  * languages (and over-large files) degrade to escaped plain text. The `.hljs`
  * classes are themed by `code-theme.css`, the same palette the markdown fenced
  * code blocks use. Used by the note modal's read-only view and the HTML modal's
- * "Source" tab.
+ * "Source" tab. Async for the same lazy-engine reason as `renderMarkdown`.
  */
-export function highlightCode(text: string, path: string): string {
+export async function highlightCode(text: string, path: string): Promise<string> {
+  const { md, highlight } = await getEngine();
   if (text.length > MAX_HIGHLIGHT_BYTES) {
     return `<pre class="hljs"><code>${md.utils.escapeHtml(text)}</code></pre>`;
   }
   const lang = hljsLangForPath(path);
-  if (lang && hljs.getLanguage(lang)) {
+  if (lang && highlight.getLanguage(lang)) {
     try {
-      const { value } = hljs.highlight(text, { language: lang, ignoreIllegals: true });
+      const { value } = highlight.highlight(text, { language: lang, ignoreIllegals: true });
       return `<pre class="hljs"><code>${value}</code></pre>`;
     } catch {
       /* fall through to plain text */
@@ -211,7 +253,8 @@ async function getMermaid(): Promise<typeof import('mermaid').default> {
 /**
  * Drop the cached Mermaid instance so the next runMermaidIn re-initialises with
  * the current theme. Newly rendered diagrams pick up the theme; existing rendered
- * SVGs keep their colours until the next render.
+ * SVGs keep their colours until the next render. Pure (no markdown-it / hljs
+ * dependency) so `use-theme` can import it without pulling the markdown engine.
  */
 export function resetMermaidTheme(): void {
   mermaidPromise = null;

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -1,6 +1,5 @@
 import {
   createEffect,
-  createMemo,
   createResource,
   createSignal,
   For,
@@ -203,8 +202,9 @@ export function NoteModal(props: {
     },
   );
 
-  const html = createMemo(() => {
-    const text = content();
+  // markdown-it + highlight.js are lazy-loaded (out of the boot chunk), so the
+  // rendered HTML is a resource keyed on the loaded text rather than a memo.
+  const [html] = createResource(content, async (text) => {
     if (text == null) return '';
     const path = props.state?.path ?? null;
     const baseDir = path ? path.replace(/\/[^/]*$/, '') : undefined;
@@ -212,11 +212,9 @@ export function NoteModal(props: {
   });
 
   // Read view for a non-markdown file: syntax-highlight the source by extension.
-  const codeHtml = createMemo(() => {
-    const text = content();
-    if (text == null) return '';
-    return highlightCode(text, props.state?.path ?? '');
-  });
+  const [codeHtml] = createResource(content, async (text) =>
+    text == null ? '' : highlightCode(text, props.state?.path ?? ''),
+  );
 
   let bodyRef: HTMLDivElement | undefined;
   let editorParent: HTMLDivElement | undefined;
@@ -704,7 +702,7 @@ export function NoteModal(props: {
                 </ul>
               </section>
             </Show>
-            <article class="md-rendered" innerHTML={html()} />
+            <article class="md-rendered" innerHTML={html() ?? ''} />
           </Show>
           <Show
             when={
@@ -715,7 +713,7 @@ export function NoteModal(props: {
               !isMarkdown(props.state.path)
             }
           >
-            <div class="md-rendered raw-code" innerHTML={codeHtml()} />
+            <div class="md-rendered raw-code" innerHTML={codeHtml() ?? ''} />
           </Show>
           <Show when={!content.loading && !content.error && mode() === 'edit'}>
             <div class="cm-host" ref={(el) => (editorParent = el)} />

--- a/src/renderer/terminal-pane.tsx
+++ b/src/renderer/terminal-pane.tsx
@@ -29,7 +29,7 @@ import type { Terminal } from '@xterm/xterm';
 import type { FitAddon } from '@xterm/addon-fit';
 import type { SearchAddon } from '@xterm/addon-search';
 import type { SerializeAddon } from '@xterm/addon-serialize';
-import { mountXterm, type MountedTerm } from './xterm-mount';
+import type { MountedTerm } from './xterm-mount';
 import { TerminalColumn } from './terminal-pane/column';
 import { createDragDropController, DRAG_MIME } from './terminal-pane/drag-drop';
 import {
@@ -211,9 +211,18 @@ export function TerminalPane(props: {
   const hostFor = (col: Column): HTMLDivElement | undefined =>
     col === 'left' ? leftHost : rightHost;
 
-  /** Mount an xterm element into the host of its column. */
-  const mountForSession = (id: string, column: Column, replay?: string): void => {
-    if (xterms.has(id)) return;
+  // Guards re-entrancy while the xterm chunk loads on the very first mount:
+  // without it, a second reconcile pass for the same id could slip past the
+  // `xterms.has(id)` check (which only becomes true once the async mount
+  // completes) and double-mount.
+  const pendingMounts = new Set<string>();
+
+  /** Mount an xterm element into the host of its column. xterm + its addons are
+   * dynamic-imported on first call so they stay out of the boot chunk; the
+   * module is cached after the first load. */
+  const mountForSession = async (id: string, column: Column, replay?: string): Promise<void> => {
+    if (xterms.has(id) || pendingMounts.has(id)) return;
+    pendingMounts.add(id);
     const element = document.createElement('div');
     element.className = 'xterm-host';
     element.style.display = 'none';
@@ -221,6 +230,13 @@ export function TerminalPane(props: {
     if (host) host.appendChild(element);
     if (replay) {
       appendSessionData(id, replay);
+    }
+    const { mountXterm } = await import('./xterm-mount');
+    // Bail if a dispose/race removed the need while the chunk was loading.
+    if (xterms.has(id)) {
+      pendingMounts.delete(id);
+      element.remove();
+      return;
     }
     const mounted = mountXterm(element, id, {
       replay,
@@ -279,6 +295,7 @@ export function TerminalPane(props: {
     mounted.onProgressChange((busy) => {
       setTabs((prev) => prev.map((t) => (t.id === id ? { ...t, busy } : t)));
     });
+    pendingMounts.delete(id);
   };
 
   /** Move an existing xterm element to a new column's host (used when the
@@ -381,7 +398,7 @@ export function TerminalPane(props: {
       };
       setTabs((prev) => [...prev, tab]);
       setMeta(s.id, { label, customName: meta?.customName, column, colorSlot, pinned });
-      mountForSession(s.id, column, attach?.output);
+      await mountForSession(s.id, column, attach?.output);
       setActiveIn(column, s.id);
       setActiveColumn(column);
       queueMicrotask(focusActive);

--- a/src/renderer/xterm-mount.ts
+++ b/src/renderer/xterm-mount.ts
@@ -16,6 +16,7 @@ import { LigaturesAddon } from '@xterm/addon-ligatures';
 import '@xterm/xterm/css/xterm.css';
 
 import type { TerminalXtermPrefs } from '@shared/types';
+import { liveTerms } from './xterm-registry';
 
 export type XtermPrefs = TerminalXtermPrefs;
 
@@ -73,24 +74,10 @@ interface MountOptions {
   onCustomKey?: (ev: KeyboardEvent) => boolean;
 }
 
-// Renderer-global registry of every live MountedTerm. Populated by mountXterm
-// and pruned on dispose so a light/dark flip from main.tsx can repaint every
-// open terminal — both bottom-pane sessions and inline Code-pane runner rows
-// — without each call site wiring its own subscription.
-const liveTerms = new Set<MountedTerm>();
-
-/** Re-apply the current theme tokens to every live xterm. Called by main.tsx
- * when the user toggles light/dark; without this, terminals mounted before
- * the flip stay on the old palette until next attach. */
-export function refreshAllXtermThemes(): void {
-  for (const t of liveTerms) {
-    try {
-      t.refreshTheme();
-    } catch {
-      /* per-term failure shouldn't take down the rest */
-    }
-  }
-}
+// The live-terminal registry + refreshAllXtermThemes live in the leaf module
+// `xterm-registry.ts` (no `@xterm/*` import) so use-theme can repaint terminals
+// without pulling xterm into the boot chunk. mountXterm registers each term in
+// `liveTerms` (added on mount, pruned on dispose).
 
 export function themeFromCss(): { background: string; foreground: string } {
   const css = getComputedStyle(document.documentElement);

--- a/src/renderer/xterm-registry.ts
+++ b/src/renderer/xterm-registry.ts
@@ -1,0 +1,32 @@
+// Leaf registry of live xterms — deliberately free of any `@xterm/*` import so
+// the app shell (use-theme → refreshAllXtermThemes) can repaint terminals on a
+// light/dark flip WITHOUT pulling xterm + its 9 addons into the boot chunk.
+// The heavy `mountXterm` (xterm-mount.ts) is dynamic-imported on first terminal
+// open and registers each mounted term here; this module stays tiny and eager.
+
+/** Minimal shape the registry needs from a mounted terminal: re-read the CSS
+ *  theme tokens and repaint. `MountedTerm` (xterm-mount.ts) is structurally
+ *  assignable to this. */
+export interface RefreshableXterm {
+  refreshTheme(): void;
+}
+
+// Renderer-global set of every live terminal. Populated by mountXterm on mount
+// and pruned on dispose so a light/dark flip can repaint every open terminal —
+// both bottom-pane sessions and inline Code-pane runner rows — without each call
+// site wiring its own subscription.
+export const liveTerms = new Set<RefreshableXterm>();
+
+/** Re-apply the current theme tokens to every live xterm. Called by use-theme
+ *  when the user toggles light/dark; without this, terminals mounted before the
+ *  flip stay on the old palette until next attach. No-op (and cheap) before any
+ *  terminal is opened, so it never forces the xterm chunk to load. */
+export function refreshAllXtermThemes(): void {
+  for (const t of liveTerms) {
+    try {
+      t.refreshTheme();
+    } catch {
+      /* per-term failure shouldn't take down the rest */
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Three measurement-gated structural performance wins: an in-memory search index, plus a renderer boot-bundle diet that splits xterm out of first paint and lazy-loads markdown-it + highlight.js.
- A scoped search query drops from ~1.2 s to ~45 ms; the eager renderer entry chunk shrinks 1522.6 KB → 398.9 KB (−74%).

## Changes

- **Search index** (`src/main/search/index-cache.ts`): the four markdown sources (projects incl. notes, knowledge, resources, skills) are precomputed in RAM at conception-open and queried without re-reading the tree; the chokidar watcher keeps it incrementally fresh per file. Logs stay disk-scanned (too large, rarely searched), and only when in scope. `matchFile` is split into `prepareFile` (read + precompute) and `matchPrepared` (pure); `search()` falls back to the on-disk scan only while the index is still building.
- **xterm split** (`src/renderer/xterm-mount.ts`, new `src/renderer/xterm-registry.ts`): xterm + its 9 addons are dynamic-imported on first terminal open; the live-terminal registry + theme-repaint helper moved to a leaf so `use-theme` no longer drags xterm into the boot chunk.
- **markdown lazy-load** (`src/renderer/markdown.ts`): markdown-it + highlight.js build on first render; `renderMarkdown`/`highlightCode` are async and the note/help/html modals await them via `createResource`.
- Docs updated for the new index (internals, non-goals, troubleshooting, ipc-api, AGENTS.md); 7 new unit tests cover index build, notes coverage, scope filter, and incremental add/change/unlink.

## Impact

- Search results are byte-for-byte unchanged (same matcher + scoring); only the read path changes. The IPC contract is untouched.
- ~16 MB additional resident memory for the markdown index at conception scale.
- First terminal open and first markdown render now pay a one-time dynamic-chunk load, cached thereafter.

## Watchpoints

- All-sources search is still bounded by the on-disk log scan (~1 s on a large log tree); a scoped query is the fast path, and a deferred log index is the natural next step.
- Index freshness depends on the watcher: a project-note edit updates a single entry via an FS-event hook that is independent of the renderer's tree-event classification.