### PR TITLE
Unify config-type triplet into shared/config-types

### DIFF
--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
 import type { CardMinWidthPrefs } from '../shared/types';
+import { isSectionMarker, type RawRepo, type RawSubmoduleRepo } from '../shared/config-types';
+
+// The raw repo-entry contract is process-agnostic and lives in shared/ so the
+// renderer can reference it without importing this zod-based module. Re-export
+// it here so existing main-process and CLI imports keep resolving.
+export { isSectionMarker, type RawRepo, type RawSubmoduleRepo };
 
 /**
  * Schemas for the two condash settings files. The unified shape lives here
@@ -135,48 +141,11 @@ const retiredAppEntry = z
   })
   .strict();
 
-export type RawSubmoduleRepo =
-  | string
-  | {
-      handle?: string;
-      name?: string;
-      path?: string;
-      label?: string;
-      aliases?: string[];
-      run?: string;
-      force_stop?: string;
-      install?: string;
-      pinned_branch?: string;
-      env?: string[];
-    };
-
-export type RawRepo =
-  | string
-  | {
-      handle?: string;
-      name?: string;
-      path?: string;
-      label?: string;
-      aliases?: string[];
-      run?: string;
-      force_stop?: string;
-      install?: string;
-      pinned_branch?: string;
-      env?: string[];
-      submodules?: RawSubmoduleRepo[];
-    }
-  | { section: string };
-
 /** A retired (defunct) app handle — see {@link retiredAppEntry}. */
 export interface RetiredApp {
   handle: string;
   label?: string;
   aliases?: string[];
-}
-
-/** True when `entry` is the section-marker variant of `RawRepo`. */
-export function isSectionMarker(entry: RawRepo): entry is { section: string } {
-  return typeof entry === 'object' && entry !== null && 'section' in entry;
 }
 
 const openWithSlot = z

--- a/src/main/config-walk.ts
+++ b/src/main/config-walk.ts
@@ -1,6 +1,7 @@
 import { basename, isAbsolute, join } from 'node:path';
 import type { TerminalPrefs } from '../shared/types';
 import { appHandle } from '../shared/app-color';
+import { isSectionMarker, type RawRepo, type RawSubmoduleRepo } from '../shared/config-types';
 
 /**
  * Shared configuration-walk helpers. Both `repos.ts` (for the flat repo list
@@ -8,43 +9,17 @@ import { appHandle } from '../shared/app-color';
  * lookup the Run / force_stop pipelines need) walk the same `repositories`
  * tree. This module owns the recursion + cwd-resolution rules so the rest of
  * the main process doesn't re-implement them.
+ *
+ * The raw entry types and the section-marker discriminator are re-exported
+ * from `shared/config-types` so existing `config-walk` importers keep working.
  */
 
-export type RawSubmoduleRepo =
-  | string
-  | {
-      handle?: string;
-      name?: string;
-      path?: string;
-      label?: string;
-      aliases?: string[];
-      run?: string;
-      force_stop?: string;
-    };
-
-export type RawRepo =
-  | string
-  | {
-      handle?: string;
-      name?: string;
-      path?: string;
-      label?: string;
-      aliases?: string[];
-      run?: string;
-      force_stop?: string;
-      submodules?: RawSubmoduleRepo[];
-    }
-  | { section: string };
+export { isSectionMarker, type RawRepo, type RawSubmoduleRepo };
 
 export interface ConfigShape {
   workspace_path?: string;
   repositories?: RawRepo[];
   terminal?: TerminalPrefs;
-}
-
-/** True when `entry` is a section-marker variant of `RawRepo`. */
-export function isSectionMarker(entry: RawRepo): entry is { section: string } {
-  return typeof entry === 'object' && entry !== null && 'section' in entry;
 }
 
 export interface RepoLookup {

--- a/src/main/worktree/shared.ts
+++ b/src/main/worktree/shared.ts
@@ -16,16 +16,6 @@ export interface ConfigWithPaths extends ConfigShape {
   worktrees_path?: string;
 }
 
-export interface RawRepoExtended {
-  name: string;
-  pinned_branch?: string;
-  install?: string;
-  /** Files to copy from the primary into a new worktree on setup. Applied
-   *  unconditionally when present (no CLI flag needed). */
-  env?: string[];
-  submodules?: { name: string }[];
-}
-
 export interface RepoLookupExtended {
   name: string;
   cwd: string;
@@ -61,11 +51,10 @@ export function repoLookupMap(config: ConfigWithPaths): Map<string, RepoLookupEx
     const dirName = raw.name ?? basename(raw.path ?? '');
     const lookup = map.get(dirName);
     if (!lookup) continue;
-    const ext = raw as unknown as RawRepoExtended;
-    if (typeof ext.pinned_branch === 'string') lookup.pinnedBranch = ext.pinned_branch;
-    if (typeof ext.install === 'string') lookup.install = ext.install;
-    if (Array.isArray(ext.env) && ext.env.length > 0) {
-      lookup.env = ext.env.filter((s) => typeof s === 'string' && s.length > 0);
+    if (typeof raw.pinned_branch === 'string') lookup.pinnedBranch = raw.pinned_branch;
+    if (typeof raw.install === 'string') lookup.install = raw.install;
+    if (Array.isArray(raw.env) && raw.env.length > 0) {
+      lookup.env = raw.env.filter((s) => typeof s === 'string' && s.length > 0);
     }
   }
   return map;

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -7,7 +7,7 @@ import type {
   TerminalXtermPrefs,
   Theme,
 } from '@shared/types';
-import { isSectionMarker, type RawRepo, type RawSubmoduleRepo } from '../../main/config-schema';
+import { isSectionMarker, type RawRepo, type RawSubmoduleRepo } from '@shared/config-types';
 
 export type SettingsTab = 'global' | 'conception';
 

--- a/src/renderer/settings-modal-parts/repo-row.tsx
+++ b/src/renderer/settings-modal-parts/repo-row.tsx
@@ -1,5 +1,5 @@
 import { createSignal, For, Show } from 'solid-js';
-import type { RawRepo, RawSubmoduleRepo } from '../../main/config-schema';
+import type { RawRepo, RawSubmoduleRepo } from '@shared/config-types';
 import { type BindTextFn, type DndHandlers, moveItem } from './data';
 
 const REPO_ROW_OPEN_KEY = 'condash:settings-modal:repo-row-open';

--- a/src/renderer/settings-modal-parts/section-row.tsx
+++ b/src/renderer/settings-modal-parts/section-row.tsx
@@ -1,5 +1,5 @@
 import { Show, type JSX } from 'solid-js';
-import type { RawRepo } from '../../main/config-schema';
+import type { RawRepo } from '@shared/config-types';
 import type { BindTextFn, DndHandlers } from './data';
 
 /**

--- a/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
+++ b/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
@@ -7,7 +7,7 @@
  */
 
 import { createSignal, For, Show, type JSX } from 'solid-js';
-import { isSectionMarker, type RawRepo } from '../../main/config-schema';
+import { isSectionMarker, type RawRepo } from '@shared/config-types';
 import { type BindTextFn, OPEN_WITH_SLOTS, type RawConfig } from './data';
 import { FieldBadgeRow, type InheritanceState } from './badges';
 import { RepoRow } from './repo-row';

--- a/src/shared/config-types.ts
+++ b/src/shared/config-types.ts
@@ -1,0 +1,61 @@
+/**
+ * Process-agnostic config contract for the `repositories` list in the two
+ * settings files (`settings.json` / `condash.json`).
+ *
+ * These are the raw, pre-validation shapes a user can write by hand, plus the
+ * pure `isSectionMarker` discriminator. They live in `shared/` so both the main
+ * process (zod schemas, the config walker, worktree plumbing) and the renderer
+ * (the Settings modal) reference one definition without the renderer pulling
+ * the zod-based schema layer in `main/config-schema.ts` into its bundle. The
+ * zod schemas, migrations, and canonicalisers stay in `main/config-schema.ts`
+ * and validate against these types.
+ */
+
+/**
+ * A submodule entry: the same shape as a top-level repo, minus the recursive
+ * `submodules` (no nested submodules) and the section-marker variant
+ * (sections are top-level only).
+ */
+export type RawSubmoduleRepo =
+  | string
+  | {
+      handle?: string;
+      name?: string;
+      path?: string;
+      label?: string;
+      aliases?: string[];
+      run?: string;
+      force_stop?: string;
+      install?: string;
+      pinned_branch?: string;
+      env?: string[];
+    };
+
+/**
+ * A top-level entry: a name string, a full repo object (with optional
+ * `submodules`), or a section marker that groups everything until the next
+ * marker into a labelled bucket. Section markers carry no behaviour — they only
+ * steer the Settings UI and the Code pane's card grouping; the walker in
+ * `main/config-walk.ts` strips them out before any consumer sees the list.
+ */
+export type RawRepo =
+  | string
+  | {
+      handle?: string;
+      name?: string;
+      path?: string;
+      label?: string;
+      aliases?: string[];
+      run?: string;
+      force_stop?: string;
+      install?: string;
+      pinned_branch?: string;
+      env?: string[];
+      submodules?: RawSubmoduleRepo[];
+    }
+  | { section: string };
+
+/** True when `entry` is the section-marker variant of `RawRepo`. */
+export function isSectionMarker(entry: RawRepo): entry is { section: string } {
+  return typeof entry === 'object' && entry !== null && 'section' in entry;
+}


### PR DESCRIPTION
## Summary

Phase 1 of the condash coherence roadmap. Unifies the `RawRepo` / `RawSubmoduleRepo` / `isSectionMarker` config-type triplet into one process-agnostic location, sealing the last renderer→main runtime back-edge and keeping zod out of the renderer bundle. Addresses review findings D1-1, D2-1, and D6-1 (one root cause surfacing across three dimensions).

## Changes

- Add `src/shared/config-types.ts` holding the canonical `RawRepo`, `RawSubmoduleRepo`, and the pure `isSectionMarker` discriminator — process-agnostic, zod-free.
- `config-schema.ts` and `config-walk.ts` now import + re-export these from the shared module instead of declaring their own copies, so every existing importer keeps resolving. The zod schemas, migrations, and canonicalisers stay in `src/main`.
- Delete the stale duplicate type subset in `config-walk.ts` (it omitted `install` / `pinned_branch` / `env`) that caused silent drift.
- Delete `RawRepoExtended` and the `as unknown as` double-cast in `worktree/shared.ts` — the canonical `RawRepo` already models those fields, so the cast is no longer needed.
- Re-point the four renderer Settings-modal files at `@shared/config-types`.

## Impact

- The shipped renderer code no longer imports runtime code from `src/main` (verified: only the test file `data.test.ts` still references the main zod schema, by design, and it is excluded from the build).
- zod no longer ships in the renderer/SPA bundle (verified: no zod signature strings in `dist/assets`).
- The stale duplicate type and its unsafe cast are gone. Net -67 lines of duplication.

## Watchpoints

- `data.test.ts` still imports the runtime `conceptionConfigSchema` from main to assert that save payloads validate against the real schema. This is intentional and test-only — moving the zod schema out of main is out of scope for this phase.