### PR TITLE
Fix mermaid node-box clipping under modal scale animation

### DIFF
--- a/src/renderer/markdown.ts
+++ b/src/renderer/markdown.ts
@@ -229,6 +229,9 @@ const HLJS_LANG_BY_EXT: Record<string, string> = {
 
 let mermaidPromise: Promise<typeof import('mermaid').default> | null = null;
 
+// Monotonic, DOM-safe id for each mermaid.render target (see runMermaidIn).
+let mermaidRenderSeq = 0;
+
 function activeMermaidTheme(): 'default' | 'dark' {
   const explicit = document.documentElement.dataset.theme;
   if (explicit === 'dark') return 'dark';
@@ -265,13 +268,27 @@ export async function runMermaidIn(container: HTMLElement): Promise<void> {
   if (blocks.length === 0) return;
 
   const mermaid = await getMermaid();
-  // mermaid.run rewrites blocks in place; mark them so it doesn't double-run.
   for (const block of blocks) {
-    if (!block.dataset.processed) {
-      block.dataset.processed = '';
+    // This effect re-runs on every html()/theme change; once a block has been
+    // turned into an SVG, skip it so we don't re-parse rendered output as source.
+    if (block.dataset.processed) continue;
+    const source = block.textContent ?? '';
+    if (!source.trim()) continue;
+    try {
+      // Render via mermaid.render, not mermaid.run. run() measures each node
+      // label inside `block` with getBoundingClientRect (screen space); the note
+      // and help modals mount mermaid while their `modal-in` scale() animation is
+      // live, so every node box is sized to the transformed (shrunken) text and
+      // then clips once the animation settles to scale(1). render() measures in a
+      // throwaway element on the untransformed <body>, so box widths are correct
+      // regardless of any ancestor transform. See issue #319.
+      const id = `condash-mermaid-${(mermaidRenderSeq += 1)}`;
+      const { svg, bindFunctions } = await mermaid.render(id, source);
+      block.innerHTML = svg;
+      block.dataset.processed = 'true';
+      bindFunctions?.(block);
+    } catch (err) {
+      console.error('[mermaid]', err);
     }
   }
-  await mermaid.run({ nodes: Array.from(blocks) }).catch((err) => {
-    console.error('[mermaid]', err);
-  });
 }


### PR DESCRIPTION
## Summary

Mermaid flowchart nodes with a long single-line label rendered at a fixed,
too-narrow box width with the label clipped at the right edge in the dashboard
note viewer (#319). The same source renders correctly on GitHub / mermaid.live.

Root cause: `runMermaidIn` used `mermaid.run({ nodes })`, which measures each
node label **inside** the `<pre class="mermaid">` element via
`getBoundingClientRect` (screen space). The note and help modals mount mermaid
while their `modal-in` `scale()` animation is live (`modal-base.css:269`), so
every box was sized to the transformed, shrunken text width and then clipped
once the animation settled to `scale(1)`.

The reporter's font-metrics hypothesis was disproved: mermaid labels use
mermaid's own font stack (not the page's Figtree), and boxes size correctly even
with a cold web font — so `document.fonts.ready` would not have helped.

## Changes

- `src/renderer/markdown.ts` — `runMermaidIn` now renders each block via
  `mermaid.render(id, source)` and injects the returned SVG, instead of
  `mermaid.run({ nodes })`. With no container argument mermaid builds its
  measurement DOM in a throwaway element on `<body>` (it does `select("body")`),
  which carries no CSS transform, so box widths are correct regardless of any
  ancestor transform or animation. Dedup via `data-processed` so the re-running
  effect doesn't re-parse already-rendered SVG as diagram source.

## Impact

- Fixes #319. Box widths now fit the label, matching GitHub / mermaid.live.
- Verified in a headless Chromium repro of the exact diagram: box width tracks
  the ancestor scale under `mermaid.run` (260 → 254 at `scale(0.97)` → 180 at
  `scale(0.6)`) but stays a correct 260 under `mermaid.render` at every scale.

## Watchpoints

- `mermaid.render` returns `bindFunctions`; it's called on the block so any node
  interactions still wire. `securityLevel: 'strict'` and the theme/reset path
  are unchanged.
