### PR TITLE
Add favorite agents; make Playwright tests headless on Wayland

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,15 +57,22 @@ When changing the dev port, update **every** file:
 | `make dev` / `npm run dev` | watch mode: tsc + vite + electron |
 | `make build` / `npm run build` | compile main + renderer |
 | `make package` / `npm run package` | electron-builder installers (Linux/macOS/Windows) |
-| `make test` | build, then the Playwright suite (headless via `xvfb-run` when present) |
-| `make test-headless` | build, then Playwright under `xvfb-run` (no window; errors if `xvfb-run` absent) |
-| `make test-visible` | build, then Playwright with the window visible (watch the run) |
+| `make test` / `npm run test` | build, then the Playwright suite **headless by default** (see below) |
+| `make test-headless` | alias of `make test` (headless; errors if `xvfb-run` absent) |
+| `make test-visible` | build, then Playwright with the window visible (`CONDASH_TEST_HEADED=1`) |
 | `make test-unit` / `npm run test:unit` | vitest unit suite |
 | `make deadcode` / `npm run deadcode` | knip — dead files / deps / duplicate exports |
 | `make typecheck` | tsc on both projects, no emit |
 | `make format` | prettier on `src/` |
 | `make kill` | free port 5600 |
 | `make clean` | remove `dist/`, `dist-electron/`, `release/` |
+
+### Tests are headless by default — never open windows on the dev's screen
+
+A Playwright run launches the **real Electron app**, which on a Wayland desktop renders to the live compositor (or XWayland) and **steals focus mid-run**. The headless guarantee lives in `npm run test` → `scripts/run-playwright.mjs`, which wraps the whole run in a throwaway **Xvfb** display with `WAYLAND_DISPLAY` dropped and the **X11 Ozone backend pinned** (`--ozone-platform=headless` is not usable — Electron can't attach Playwright to it). A *direct* `npx playwright test` that skips the wrapper is **aborted by the globalSetup guard** (`tests/fixtures/headless-guard.ts`) before any window opens.
+
+- **Always run the suite via `npm run test` / `make test`** (or `npm run test -- <spec>` for one file). Never `npx playwright test` / `xvfb-run npx playwright test` directly — the first aborts, the second double-wraps.
+- A visible run (to watch it) is the explicit opt-in `CONDASH_TEST_HEADED=1` (`make test-visible`).
 
 ## Configuration
 

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,17 @@
 DEV_PORT     ?= 5600
 PREVIEW_PORT ?= 5601
 
-# Electron opens an on-screen window unless it runs against a virtual display.
-# Prefer xvfb-run for the Playwright suite when it's installed (the Linux dev
-# norm — mirrors CI) so the window never appears or steals focus; fall back to
-# a visible run where xvfb-run is absent (macOS/Windows). `make test-visible`
-# always shows the window; `make test-headless` always wraps and errors out if
-# xvfb-run is missing.
-#
-# On a Wayland session the dev shell exports ELECTRON_OZONE_PLATFORM_HINT=wayland
-# and WAYLAND_DISPLAY; Electron honours those over xvfb's virtual X DISPLAY and
-# opens the window on the real compositor — stealing focus despite the wrap. For
-# the wrapped run, drop the Wayland socket and pin the X11 Ozone backend so
-# Electron renders into Xvfb only. (test-visible deliberately keeps Wayland.)
-XVFB_RUN  := $(shell command -v xvfb-run 2>/dev/null)
-XVFB_X11  := env -u WAYLAND_DISPLAY ELECTRON_OZONE_PLATFORM_HINT=x11
-TEST_WRAP := $(if $(XVFB_RUN),xvfb-run -a $(XVFB_X11),)
+# Tests are HEADLESS BY DEFAULT — a run must never pop an Electron window onto
+# the developer's screen and steal focus. The guarantee lives in `npm run test`
+# (scripts/run-playwright.mjs), which wraps the whole suite in a throwaway Xvfb
+# display with the Wayland socket dropped and the X11 Ozone backend pinned, so
+# Electron renders into the virtual display, never the live compositor — no
+# matter how the suite is launched. A direct `npx playwright test` that skips
+# that wrapper is aborted by the globalSetup guard (tests/fixtures/headless-
+# guard.ts) before any window opens. Opt into a visible run with
+# CONDASH_TEST_HEADED=1 (`make test-visible`). This is the durable fix for the
+# recurring "a window popped up mid-run" problem — wrapping only the Makefile in
+# xvfb left every direct/ad-hoc invocation exposed.
 
 help:
 	@echo "Targets:"
@@ -29,9 +25,9 @@ help:
 	@echo "  typecheck    run tsc on both main and renderer"
 	@echo "  format       run prettier on src/"
 	@echo "  format-check check prettier formatting without writing"
-	@echo "  test          build then run the Playwright suite (headless when xvfb-run is present)"
-	@echo "  test-headless build then run the suite under xvfb-run (no window; errors if xvfb-run absent)"
-	@echo "  test-visible  build then run the suite with the window visible (watch the run)"
+	@echo "  test          build then run the Playwright suite (headless by default — no window)"
+	@echo "  test-headless build then run the suite (headless; xvfb wrap as defence in depth)"
+	@echo "  test-visible  build then run the suite with the window visible (CONDASH_TEST_HEADED=1)"
 	@echo "  test-unit    run vitest unit suite"
 	@echo "  deadcode     run knip — fail on dead files / deps / duplicate exports"
 	@echo "  kill         free dev port $(DEV_PORT)"
@@ -63,15 +59,15 @@ format-check:
 
 test:
 	npm run build
-	$(TEST_WRAP) npm run test
+	npm run test
 
 test-headless:
 	npm run build
-	xvfb-run -a $(XVFB_X11) npm run test
+	npm run test
 
 test-visible:
 	npm run build
-	npm run test
+	CONDASH_TEST_HEADED=1 npm run test
 
 test-unit:
 	npx vitest run

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -240,11 +240,13 @@ Embedded-terminal preferences. All keys are optional; an empty string means "fal
 
 **Agents** are a flat list of terminal launchers under the top-level `agents` key. The tab-strip spawn dropdown lists them (it always offers `New shell` first, then each agent by `label`). Picking one opens a new terminal tab running its `command` — that's the whole model. An agent is a **top-level** config key (like `repositories`), so it resolves global-default ← per-conception override like every other workspace key: define machine-wide defaults in `settings.json`, override or extend per tree in `.condash/settings.json`.
 
+**Favourites.** Mark agents with `"favorite": true` to keep the dropdown short: it then shows `New shell` + the favourites (each prefixed with a ★) directly, and tucks every non-favourite under a `More ▸` fly-out submenu. With **no** agent marked favourite, the dropdown lists every agent inline — so the split only takes effect once at least one agent opts in. Order within each group follows config order.
+
 ```json
 {
   "agents": [
-    { "id": "claude", "label": "Claude", "command": "claude" },
-    { "id": "claude-kimi", "label": "Claude · Kimi", "command": "claude-kimi" },
+    { "id": "claude", "label": "Claude", "command": "claude", "favorite": true },
+    { "id": "claude-kimi", "label": "Claude · Kimi", "command": "claude-kimi", "favorite": true },
     { "id": "opencode-kimi", "label": "OpenCode · Kimi", "command": "opencode-kimi" }
   ]
 }
@@ -256,6 +258,7 @@ Embedded-terminal preferences. All keys are optional; an empty string means "fal
 | `label`   | string | yes      | Display name shown in the spawn dropdown and as the pinned tab title.                                                                                            |
 | `command` | string | yes      | Shell command run on launch, in a fresh tab with the terminal's ambient environment. Point it at a wrapper on `PATH` or inline the invocation. Blank → skipped.  |
 | `promptFlags` | bool | no | Default `false`. Set `true` when `command` understands [agedum](../guides/agent-clis-and-models.md)'s `--prompt` / `--run` flags. [Tasks](#tasks) and agent-bound [actions](#terminalprojectactions) then pass the prompt in argv — `<command> --run "<prompt>"` when submitting (non-interactive, exits) or `<command> --prompt "<prompt>"` otherwise (interactive, seeded) — instead of spawning the bare command and typing the prompt into the live TUI. Leave off for an opaque command (e.g. a raw `claude`). |
+| `favorite` | bool | no | Default `false`. Surface this agent directly in the spawn dropdown (prefixed with a ★); non-favourites move under a `More ▸` fly-out. When no agent is marked, every agent is listed inline. |
 
 condash builds **no** provider environment and stores **no** secrets — model/provider wiring and any API token live entirely in `command` (usually a `~/bin` wrapper script). See the [Agent CLIs and model providers guide](../guides/agent-clis-and-models.md) for wrapper recipes. Edit the list in the Settings modal's **Agents** section (on both the Global and This-conception tabs — agents inherit global → conception like other keys) or in the config file directly. **Migration:** condash ≤ 3.25 had `terminal.launchers` + the scalar `terminal.launcher_command`; both are dropped on read. (A later per-file `<conception>/agents/<slug>.json` harness store was also replaced by this `agents` list.)
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "package": "npm run build && electron-builder",
     "typecheck": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit",
     "format": "prettier --write \"src/**/*.{ts,tsx,css,html,json}\"",
-    "test": "playwright test",
+    "test": "node scripts/run-playwright.mjs",
     "test:unit": "vitest run",
     "deadcode": "knip",
     "postinstall": "electron-rebuild"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from '@playwright/test';
 export default defineConfig({
   testDir: './tests',
   testMatch: /.*\.spec\.ts$/,
+  // Aborts a direct `npx playwright test` on a Wayland desktop before any window
+  // can open — the headless wrap lives in scripts/run-playwright.mjs (npm run
+  // test), and this catches invocations that skip it. See the guard for detail.
+  globalSetup: './tests/fixtures/headless-guard.ts',
   fullyParallel: false,
   workers: 1,
   reporter: [['list']],

--- a/scripts/run-playwright.mjs
+++ b/scripts/run-playwright.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Headless-by-default Playwright runner — the canonical way to run the suite.
+ *
+ * A test run must NEVER open Electron windows onto the developer's screen. On a
+ * Wayland desktop Electron renders to the live compositor (WAYLAND_DISPLAY) — or
+ * to XWayland via DISPLAY — and steals focus mid-run. Electron also cannot
+ * attach to Playwright under a true offscreen backend (`--ozone-platform=
+ * headless`), so the reliable recipe is a throwaway Xvfb display with the
+ * Wayland socket dropped and the X11 Ozone backend pinned. This wrapper applies
+ * that recipe to the whole run, so `npm run test` / `make test` stay headless
+ * regardless of how they were invoked. (The globalSetup guard in
+ * tests/fixtures/headless-guard.ts catches a *direct* `npx playwright test`
+ * that skips this wrapper.)
+ *
+ * Opt into a visible, on-screen run with CONDASH_TEST_HEADED=1. Extra args are
+ * forwarded to `playwright test` (e.g. `npm run test -- spawn-dropdown`).
+ */
+import { spawnSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const npx = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+
+const run = (cmd, cmdArgs, env) =>
+  spawnSync(cmd, cmdArgs, { stdio: 'inherit', env: env ?? process.env });
+
+let result;
+if (process.env.CONDASH_TEST_HEADED === '1' || process.platform !== 'linux') {
+  // Visible run, or a platform without the Wayland-window problem (macOS /
+  // Windows). Run Playwright directly.
+  result = run(npx, ['playwright', 'test', ...args]);
+} else {
+  // Headless on Linux: render into a throwaway Xvfb display, never the live
+  // compositor. `env -u WAYLAND_DISPLAY ELECTRON_OZONE_PLATFORM_HINT=x11` stops
+  // Electron falling back onto Wayland; CONDASH_TEST_XVFB tells the globalSetup
+  // guard this run is safely wrapped.
+  result = run(
+    'xvfb-run',
+    [
+      '-a',
+      'env',
+      '-u',
+      'WAYLAND_DISPLAY',
+      'ELECTRON_OZONE_PLATFORM_HINT=x11',
+      npx,
+      'playwright',
+      'test',
+      ...args,
+    ],
+    { ...process.env, CONDASH_TEST_XVFB: '1' },
+  );
+  if (result.error && result.error.code === 'ENOENT') {
+    console.error(
+      '\nrun-playwright: `xvfb-run` not found — cannot run headless.\n' +
+        'Install it (e.g. `sudo apt install xvfb`) or run a visible suite with\n' +
+        '`CONDASH_TEST_HEADED=1 npm run test`. Refusing to open windows on your screen.\n',
+    );
+    process.exit(1);
+  }
+}
+process.exit(result.status ?? 1);

--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -99,6 +99,39 @@ describe('configSchema repoEntry', () => {
   });
 });
 
+describe('configSchema agents', () => {
+  it('accepts the optional favorite + promptFlags flags', () => {
+    const result = configSchema.safeParse({
+      agents: [
+        { id: 'claude', label: 'Claude', command: 'claude', favorite: true },
+        { id: 'kimi', label: 'Kimi', command: 'claude-kimi', promptFlags: true },
+        { id: 'plain', label: 'Plain', command: 'opencode' },
+      ],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agents?.[0].favorite).toBe(true);
+      expect(result.data.agents?.[1].favorite).toBeUndefined();
+    }
+  });
+
+  it('rejects an unknown agent field (strict)', () => {
+    const result = configSchema.safeParse({
+      agents: [{ id: 'claude', label: 'Claude', command: 'claude', favourite: true }],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('round-trips favorite through the conception canonicaliser', () => {
+    const canon = validateAndCanonicaliseConceptionConfig(
+      JSON.stringify({
+        agents: [{ id: 'claude', label: 'Claude', command: 'claude', favorite: true }],
+      }),
+    );
+    expect(JSON.parse(canon).agents[0].favorite).toBe(true);
+  });
+});
+
 describe('configSchema taskConfig (capability 1)', () => {
   it('accepts a per-task schedule + timeout + excludeFromLogs map', () => {
     const result = configSchema.safeParse({

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -263,13 +263,15 @@ const actionTemplateSchema = z
  *  round-trip to disk and stays visible for the user to fill in; `listAgents`
  *  skips entries whose `id` or `command` is blank. Optional `promptFlags` opts
  *  the agent into argv prompt-seeding (`--prompt`) instead of the keystroke
- *  path — see the `Agent` type. */
+ *  path; optional `favorite` surfaces it directly in the spawn dropdown (the
+ *  rest move under `More ▸`) — see the `Agent` type. */
 const agentSchema = z
   .object({
     id: z.string(),
     label: z.string(),
     command: z.string(),
     promptFlags: z.boolean().optional(),
+    favorite: z.boolean().optional(),
   })
   .strict();
 

--- a/src/renderer/settings-modal-parts/sections-agents.tsx
+++ b/src/renderer/settings-modal-parts/sections-agents.tsx
@@ -82,9 +82,11 @@ export function AgentsSection(props: AgentsSectionProps): JSX.Element {
         stable identity referenced by tasks and project actions. Point <code>command</code> at a
         wrapper on your <code>PATH</code> (e.g. <code>claude-kimi</code>) or inline it (e.g.{' '}
         <code>claude</code>). The command inherits the terminal's environment — condash injects no
-        provider env or tokens. Enable <em>Seed prompt via flags</em> when the command speaks
-        agedum's <code>--run</code> / <code>--prompt</code> so tasks pass the prompt in argv instead
-        of typing it into the live TUI.
+        provider env or tokens. Mark agents <em>Favourite</em> to show them directly in the new-tab
+        menu; the rest move under a <code>More ▸</code> fly-out (with none marked, every agent is
+        listed inline). Enable <em>Seed prompt via flags</em> when the command speaks agedum's{' '}
+        <code>--run</code> / <code>--prompt</code> so tasks pass the prompt in argv instead of
+        typing it into the live TUI.
       </p>
       <div class="settings-bucket">
         <For each={agents()}>
@@ -162,6 +164,19 @@ export function AgentsSection(props: AgentsSectionProps): JSX.Element {
               <Show when={idMissing(entry)}>
                 <p class="settings-repo-name-error">Id is required to launch this agent.</p>
               </Show>
+              <label class="settings-checkbox">
+                <input
+                  type="checkbox"
+                  checked={entry.favorite === true}
+                  onChange={(e) =>
+                    void updateField(index(), { favorite: e.currentTarget.checked || undefined })
+                  }
+                />
+                <span>
+                  Favourite — show directly in the new-tab menu (non-favourites move under{' '}
+                  <code>More ▸</code>)
+                </span>
+              </label>
               <label class="settings-checkbox">
                 <input
                   type="checkbox"

--- a/src/renderer/terminal-pane.css
+++ b/src/renderer/terminal-pane.css
@@ -412,6 +412,41 @@
   background: var(--bg-hover);
 }
 
+/* Leading ★ on a favourite agent, shown only when the favourites split is
+ * active (i.e. at least one agent opted in). */
+.terminal-tab-dropdown-star {
+  margin-right: 6px;
+  color: var(--col-review);
+}
+
+/* The `More ▸` row: chevron pushed to the right, `position: relative` so the
+ * fly-out submenu can anchor to it. */
+.terminal-tab-dropdown-more {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  position: relative;
+}
+
+/* Overflow submenu — nested inside the portal'd menu, so it inherits the
+ * `.terminal-tab-dropdown-menu li` row styling via the descendant combinator
+ * and only needs its own box + placement here. Opens to the right of the
+ * `More ▸` row. */
+.terminal-tab-dropdown-submenu {
+  position: absolute;
+  top: -5px;
+  left: 100%;
+  margin-left: 2px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-strong);
+  border-radius: 4px;
+  min-width: 140px;
+  list-style: none;
+  padding: 4px 0;
+  box-shadow: var(--shadow-lift);
+}
+
 /* ── Tab right-click context menu ─────────────────────────────────── */
 
 /* Same `position: fixed` portal treatment as the spawn dropdown so it

--- a/src/renderer/terminal-pane/column.tsx
+++ b/src/renderer/terminal-pane/column.tsx
@@ -1,4 +1,4 @@
-import { createSignal, For, Show } from 'solid-js';
+import { createEffect, createSignal, For, Show } from 'solid-js';
 import { Portal } from 'solid-js/web';
 import type { Agent } from '@shared/types';
 import { createDropdownMenu } from '../dropdown-menu';
@@ -36,13 +36,33 @@ export interface TerminalColumnProps {
   onTogglePane: () => void;
 }
 
+/** One row of the primary spawn menu: the plain shell, a launchable agent, or
+ *  the `More ▸` toggle that owns the overflow submenu. */
+interface SpawnRow {
+  label: string;
+  /** Agent id to launch, or null for the plain shell. Unused for the More row. */
+  value: string | null;
+  /** Marks the `More ▸` toggle row (opens the overflow submenu, never spawns). */
+  isMore?: boolean;
+  /** Render a leading ★ — only when the favourites split is active. */
+  isFavorite?: boolean;
+}
+
 /** Dropdown button + menu for spawning tabs. Replaces the fixed `+` / μ / λ
- *  button row with a single control that lists all configured launchers.
+ *  button row with a single control that lists configured launchers.
+ *
+ *  When at least one agent is marked `favorite`, the menu lists `New shell` +
+ *  the favourites (starred) directly and tucks the rest behind a `More ▸`
+ *  fly-out submenu. With no favourites it lists every agent inline (the
+ *  pre-favourites behaviour).
  *
  *  The menu is rendered with `position: fixed` (the `.portal` class via
  *  `createDropdownMenu`) so it escapes the strip's `overflow: auto` —
  *  otherwise the menu's full height gets clipped down to the strip's 32px
- *  box and the user sees only fragments of the menu items.
+ *  box and the user sees only fragments of the menu items. The submenu is a
+ *  nested `<ul>` *inside* that portal'd menu (not a second portal) so a click
+ *  on it counts as inside `menuEl` and createDropdownMenu's outside-click
+ *  dismissal leaves it open.
  */
 function SpawnDropdown(props: {
   agents: readonly Agent[];
@@ -50,16 +70,44 @@ function SpawnDropdown(props: {
 }) {
   const menu = createDropdownMenu({ align: 'left' });
   const [highlighted, setHighlighted] = createSignal(0);
+  const [submenuOpen, setSubmenuOpen] = createSignal(false);
+  const [subHighlighted, setSubHighlighted] = createSignal(0);
 
-  const items = () => [
-    { label: 'New shell', value: null as string | null },
-    ...props.agents.map((a) => ({ label: a.label, value: a.id as string | null })),
-  ];
+  const favorites = () => props.agents.filter((a) => a.favorite);
+  const others = () => props.agents.filter((a) => !a.favorite);
+  // No favourite designated → list every agent inline, no split (back-compat).
+  const usesFavorites = () => favorites().length > 0;
+  const primaryAgents = () => (usesFavorites() ? favorites() : props.agents);
+  const hasMore = () => usesFavorites() && others().length > 0;
+
+  const rows = (): SpawnRow[] => {
+    const list: SpawnRow[] = [{ label: 'New shell', value: null }];
+    for (const agent of primaryAgents()) {
+      list.push({ label: agent.label, value: agent.id, isFavorite: usesFavorites() });
+    }
+    if (hasMore()) list.push({ label: 'More', value: null, isMore: true });
+    return list;
+  };
+
+  // Reset transient menu state whenever the menu closes (select, outside click,
+  // or the global Escape handler in createDropdownMenu) so a re-open starts at
+  // the top with the submenu collapsed.
+  createEffect(() => {
+    if (!menu.isOpen()) {
+      setSubmenuOpen(false);
+      setHighlighted(0);
+      setSubHighlighted(0);
+    }
+  });
+
+  const openSubmenu = () => {
+    setSubHighlighted(0);
+    setSubmenuOpen(true);
+  };
 
   const select = (value: string | null) => {
     props.onSpawn(value);
     menu.close();
-    setHighlighted(0);
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
@@ -71,18 +119,45 @@ function SpawnDropdown(props: {
       }
       return;
     }
-    const count = items().length;
+    // Submenu has keyboard focus: cycle the overflow agents; ArrowLeft returns
+    // to the primary menu. (Escape closes everything via createDropdownMenu.)
+    if (submenuOpen()) {
+      const subCount = others().length;
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setSubHighlighted((h) => (h + 1) % subCount);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setSubHighlighted((h) => (h - 1 + subCount) % subCount);
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        select(others()[subHighlighted()].id);
+      } else if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        // Right is a no-op here; Left collapses back to the primary menu.
+        if (e.key === 'ArrowLeft') {
+          e.preventDefault();
+          setSubmenuOpen(false);
+        }
+      }
+      return;
+    }
+    const list = rows();
+    const count = list.length;
+    const current = list[highlighted()];
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       setHighlighted((h) => (h + 1) % count);
     } else if (e.key === 'ArrowUp') {
       e.preventDefault();
       setHighlighted((h) => (h - 1 + count) % count);
+    } else if (e.key === 'ArrowRight' && current?.isMore) {
+      e.preventDefault();
+      openSubmenu();
     } else if (e.key === 'Enter') {
       e.preventDefault();
-      select(items()[highlighted()].value);
+      if (current?.isMore) openSubmenu();
+      else select(current?.value ?? null);
     }
-    // Escape is handled by createDropdownMenu globally.
   };
 
   return (
@@ -118,19 +193,73 @@ function SpawnDropdown(props: {
               left: `${menu.anchor()!.left}px`,
             }}
           >
-            <For each={items()}>
-              {(item, idx) => (
+            <For each={rows()}>
+              {(row, idx) => (
                 <li
                   role="option"
+                  class={row.isMore ? 'terminal-tab-dropdown-more' : undefined}
+                  aria-haspopup={row.isMore ? 'true' : undefined}
+                  aria-expanded={row.isMore ? submenuOpen() : undefined}
                   aria-selected={highlighted() === idx()}
                   classList={{ highlighted: highlighted() === idx() }}
-                  onMouseEnter={() => setHighlighted(idx())}
+                  onMouseEnter={() => {
+                    setHighlighted(idx());
+                    if (row.isMore) openSubmenu();
+                    else setSubmenuOpen(false);
+                  }}
                   onClick={(e) => {
                     e.stopPropagation();
-                    select(item.value);
+                    if (row.isMore) {
+                      // Idempotent open — hover already opens it, so a click
+                      // (hover + press) must not toggle it back shut. Collapse
+                      // via leaving the row, Escape, or ArrowLeft.
+                      setHighlighted(idx());
+                      openSubmenu();
+                    } else {
+                      select(row.value);
+                    }
                   }}
                 >
-                  {item.label}
+                  <Show
+                    when={row.isMore}
+                    fallback={
+                      <>
+                        <Show when={row.isFavorite}>
+                          <span class="terminal-tab-dropdown-star" aria-hidden="true">
+                            ★
+                          </span>
+                        </Show>
+                        {row.label}
+                      </>
+                    }
+                  >
+                    <span>{row.label}</span>
+                    <span aria-hidden="true">▸</span>
+                    <Show when={submenuOpen()}>
+                      <ul
+                        class="terminal-tab-dropdown-submenu"
+                        role="listbox"
+                        aria-label="More agents"
+                      >
+                        <For each={others()}>
+                          {(agent, subIdx) => (
+                            <li
+                              role="option"
+                              aria-selected={subHighlighted() === subIdx()}
+                              classList={{ highlighted: subHighlighted() === subIdx() }}
+                              onMouseEnter={() => setSubHighlighted(subIdx())}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                select(agent.id);
+                              }}
+                            >
+                              {agent.label}
+                            </li>
+                          )}
+                        </For>
+                      </ul>
+                    </Show>
+                  </Show>
                 </li>
               )}
             </For>

--- a/src/shared/types/terminal.ts
+++ b/src/shared/types/terminal.ts
@@ -79,6 +79,11 @@ export interface Agent {
    *  TUI. Omit for an opaque agent: the default keystroke path works for any
    *  harness but races the TUI's boot. */
   promptFlags?: boolean;
+  /** When true, the agent is surfaced directly in the tab-strip spawn dropdown;
+   *  non-favourite agents are tucked behind a `More ▸` fly-out. When NO agent is
+   *  marked favourite, the dropdown lists every agent inline (the pre-favourites
+   *  behaviour) — so this only takes effect once at least one agent opts in. */
+  favorite?: boolean;
 }
 
 export interface TerminalPrefs {

--- a/tests/fixtures/electron-app.ts
+++ b/tests/fixtures/electron-app.ts
@@ -68,7 +68,11 @@ export async function bootApp(
   await writeFile(
     join(userDataDir, 'condash', 'settings.json'),
     JSON.stringify(
-      { lastConceptionPath: conceptionDir, recentConceptionPaths: [conceptionDir], theme: 'system' },
+      {
+        lastConceptionPath: conceptionDir,
+        recentConceptionPaths: [conceptionDir],
+        theme: 'system',
+      },
       null,
       2,
     ) + '\n',
@@ -81,6 +85,14 @@ export async function bootApp(
     await options.prepare(conceptionDir);
   }
 
+  // The suite runs headless by default — but the guarantee lives OUTSIDE this
+  // fixture, because Electron can't attach Playwright under a true offscreen
+  // (`--ozone-platform=headless`) backend. Instead `npm run test`
+  // (scripts/run-playwright.mjs) wraps the whole run in Xvfb with the Wayland
+  // socket dropped and the X11 Ozone backend pinned, so Electron renders into a
+  // throwaway virtual display and never the live compositor; the globalSetup
+  // guard (tests/fixtures/headless-guard.ts) aborts any un-wrapped Wayland run
+  // before a window can open. We just inherit that prepared environment here.
   const app = await electron.launch({
     args: ['.', '--no-sandbox'],
     cwd: repoRoot,

--- a/tests/fixtures/headless-guard.ts
+++ b/tests/fixtures/headless-guard.ts
@@ -1,0 +1,23 @@
+/**
+ * Playwright globalSetup — refuse to open real windows on a Wayland desktop.
+ *
+ * The headless guarantee is applied by `scripts/run-playwright.mjs` (run via
+ * `npm run test` / `make test`), which wraps the run in Xvfb and sets
+ * CONDASH_TEST_XVFB. A *direct* `npx playwright test` skips that wrapper, so on
+ * Wayland it would render Electron onto the live compositor and steal focus.
+ * Abort here — before any worker launches Electron — with guidance instead of
+ * popping windows. Visible runs opt in with CONDASH_TEST_HEADED=1.
+ */
+export default function headlessGuard(): void {
+  const headed = process.env.CONDASH_TEST_HEADED === '1';
+  const wrapped = process.env.CONDASH_TEST_XVFB === '1';
+  const onWayland = process.platform === 'linux' && Boolean(process.env.WAYLAND_DISPLAY);
+  if (onWayland && !headed && !wrapped) {
+    throw new Error(
+      'Refusing to launch Electron onto your live Wayland session — it would open ' +
+        'windows and steal focus.\n' +
+        'Run the suite headless with `npm run test` or `make test` (both wrap it in ' +
+        'Xvfb), or do a visible run with `CONDASH_TEST_HEADED=1 npx playwright test`.',
+    );
+  }
+}

--- a/tests/spawn-dropdown-favorites.spec.ts
+++ b/tests/spawn-dropdown-favorites.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from '@playwright/test';
+import { bootApp } from './fixtures/electron-app';
+
+/** Two favourite agents + two non-favourites. The dropdown should show
+ *  `New shell` + the two favourites (starred) + a `More ▸` row, and hide the
+ *  non-favourites until `More ▸` is opened. */
+const MIXED_AGENTS = [
+  { id: 'fav-alpha', label: 'fav-alpha', command: 'true', favorite: true },
+  { id: 'fav-beta', label: 'fav-beta', command: 'true', favorite: true },
+  { id: 'other-gamma', label: 'other-gamma', command: 'true' },
+  { id: 'other-delta', label: 'other-delta', command: 'true' },
+];
+
+/** No favourite marked → the dropdown lists every agent inline (back-compat),
+ *  with no star and no `More ▸`. */
+const PLAIN_AGENTS = [
+  { id: 'one', label: 'one', command: 'true' },
+  { id: 'two', label: 'two', command: 'true' },
+];
+
+test('favourites show inline + starred; the rest hide behind More ▸', async ({}, testInfo) => {
+  testInfo.setTimeout(60_000);
+
+  const booted = await bootApp({ extraConfig: { agents: MIXED_AGENTS } });
+  try {
+    const win = booted.window;
+
+    const dropdown = win.locator('.terminal-tab-dropdown').first();
+    await dropdown.waitFor({ state: 'visible' });
+    await dropdown.click();
+
+    const menu = win.locator('.terminal-tab-dropdown-menu');
+    await expect(menu).toBeVisible();
+
+    // Primary rows = New shell + 2 favourites + More (direct children only, so
+    // the submenu's <li> don't inflate the count once it opens).
+    await expect(menu.locator(':scope > li')).toHaveCount(4);
+    // A ★ on each favourite, none elsewhere.
+    await expect(menu.locator('.terminal-tab-dropdown-star')).toHaveCount(2);
+    await expect(menu.getByText('fav-alpha')).toBeVisible();
+    await expect(menu.getByText('fav-beta')).toBeVisible();
+    await expect(menu.locator('.terminal-tab-dropdown-more')).toBeVisible();
+
+    // Non-favourites are not rendered until the submenu opens.
+    await expect(win.getByText('other-gamma')).toHaveCount(0);
+
+    await win.screenshot({ path: testInfo.outputPath('favorites-menu.png'), fullPage: false });
+    await testInfo.attach('favorites-menu', {
+      path: testInfo.outputPath('favorites-menu.png'),
+      contentType: 'image/png',
+    });
+
+    // Open the fly-out — the non-favourites appear inside it.
+    await win.locator('.terminal-tab-dropdown-more').click();
+    const submenu = win.locator('.terminal-tab-dropdown-submenu');
+    await expect(submenu).toBeVisible();
+    await expect(submenu.locator('li')).toHaveCount(2);
+    await expect(submenu.getByText('other-gamma')).toBeVisible();
+    await expect(submenu.getByText('other-delta')).toBeVisible();
+
+    await win.screenshot({ path: testInfo.outputPath('favorites-submenu.png'), fullPage: false });
+    await testInfo.attach('favorites-submenu', {
+      path: testInfo.outputPath('favorites-submenu.png'),
+      contentType: 'image/png',
+    });
+
+    // Picking an overflow agent spawns it and dismisses the whole menu.
+    await submenu.getByText('other-gamma').click();
+    await expect(menu).toBeHidden();
+  } finally {
+    await booted.cleanup();
+  }
+});
+
+test('with no favourites, every agent lists inline with no More ▸', async ({}, testInfo) => {
+  testInfo.setTimeout(60_000);
+
+  const booted = await bootApp({ extraConfig: { agents: PLAIN_AGENTS } });
+  try {
+    const win = booted.window;
+
+    const dropdown = win.locator('.terminal-tab-dropdown').first();
+    await dropdown.waitFor({ state: 'visible' });
+    await dropdown.click();
+
+    const menu = win.locator('.terminal-tab-dropdown-menu');
+    await expect(menu).toBeVisible();
+
+    // New shell + both agents inline; no More row, no stars.
+    await expect(menu.locator(':scope > li')).toHaveCount(3);
+    await expect(menu.locator('.terminal-tab-dropdown-more')).toHaveCount(0);
+    await expect(menu.locator('.terminal-tab-dropdown-star')).toHaveCount(0);
+    await expect(menu.getByText('one')).toBeVisible();
+    await expect(menu.getByText('two')).toBeVisible();
+  } finally {
+    await booted.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- The new-terminal-tab spawn dropdown listed every configured agent inline, which gets unwieldy with many agents. Agents can now be marked `favorite`: the dropdown shows favourites directly and tucks the rest behind a `More ▸` fly-out.
- Bundles an unrelated test-infra fix: the Playwright suite popped real Electron windows onto the developer's screen on Wayland and stole focus mid-run. It is now headless by default and bypass-proof.
- The two concerns land as two separate commits.

## Changes

**Favorite agents**
- `favorite?: boolean` added to the `Agent` type and the zod `agentSchema` (optional, default off).
- `SpawnDropdown` splits agents into favourites (listed inline, starred) and the rest (under a `More ▸` submenu nested inside the portal'd menu so outside-click dismissal still works). With no agent marked favourite, every agent lists inline as before. Keyboard nav: Up/Down/Enter, Right opens the submenu, Left collapses it.
- A favourite star toggle per agent row in Settings → Agents (both Global and This-conception tabs).
- Config reference docs updated; a schema unit test; two Playwright specs (favourites split + no-favourites back-compat).

**Headless Playwright on Wayland**
- `scripts/run-playwright.mjs` is now the target of `npm run test`: it wraps the whole run in `xvfb-run` with `WAYLAND_DISPLAY` dropped and the X11 Ozone backend pinned, so Electron renders into a throwaway virtual display, never the live compositor.
- A Playwright `globalSetup` guard (`tests/fixtures/headless-guard.ts`) aborts an un-wrapped run on Wayland before any window can open. A visible run is the explicit opt-in `CONDASH_TEST_HEADED=1`.
- `package.json` (`test` script), `Makefile` (targets simplified, no double-wrap; `test-visible` opts in), and `AGENTS.md` updated to document the headless-by-default contract.

## Impact

- New optional `favorite` key on `agents[]`; existing configs are unaffected — with none marked, the dropdown behaves exactly as before.
- `npm run test` / `make test` are now headless on every invocation. A direct `npx playwright test` on Wayland is intentionally aborted with guidance instead of opening windows; `CONDASH_TEST_HEADED=1` produces a visible run.

## Watchpoints

- The headless wrapper requires `xvfb-run` on Linux; it errors clearly if absent rather than silently falling back to a visible run. CI Linux runners must have it installed.
