### PR TITLE
Fix Agents settings: persist favorite/promptFlags on Save + per-agent cards

### DIFF
--- a/src/renderer/settings-modal-parts/data.test.ts
+++ b/src/renderer/settings-modal-parts/data.test.ts
@@ -76,6 +76,39 @@ describe('buildSavePayload — agents', () => {
     ]);
     expect(conceptionConfigSchema.safeParse(payload).success).toBe(true);
   });
+
+  it('preserves favorite + promptFlags through Save (regression: the toggles were stripped)', () => {
+    const payload = buildSavePayload({
+      agents: [
+        {
+          id: 'claude',
+          label: 'Claude',
+          command: 'agedum claude',
+          favorite: true,
+          promptFlags: true,
+        },
+      ],
+    });
+    expect(payload.agents).toEqual([
+      {
+        id: 'claude',
+        label: 'Claude',
+        command: 'agedum claude',
+        favorite: true,
+        promptFlags: true,
+      },
+    ]);
+    expect(conceptionConfigSchema.safeParse(payload).success).toBe(true);
+  });
+
+  it('omits favorite + promptFlags when not set rather than writing false', () => {
+    const payload = buildSavePayload({
+      agents: [
+        { id: 'kimi', label: 'Kimi', command: 'agedum kimi', favorite: false, promptFlags: false },
+      ],
+    });
+    expect(payload.agents).toEqual([{ id: 'kimi', label: 'Kimi', command: 'agedum kimi' }]);
+  });
 });
 
 describe('compactRepos — invariants', () => {

--- a/src/renderer/settings-modal-parts/data.ts
+++ b/src/renderer/settings-modal-parts/data.ts
@@ -357,13 +357,23 @@ export function buildSavePayload(config: RawConfig): RawConfig {
  * the save round-trip and stays visible for the user to fill in. Routing them
  * through `pruneEmpty` would strip the empty-string fields and leave `{}` rows
  * the schema can't round-trip cleanly.
+ *
+ * The boolean flags (`favorite`, `promptFlags`) are carried through only when
+ * explicitly `true`, mirroring how the checkboxes write them (`true | undefined`).
+ * Omitting this is what dropped a user's Favourite / Seed-prompt toggles on every
+ * Save — they round-trip now.
  */
 export function compactAgents(agents: Agent[]): Agent[] {
-  return agents.map((a) => ({
-    id: a.id ?? '',
-    label: a.label ?? '',
-    command: a.command ?? '',
-  }));
+  return agents.map((a) => {
+    const compacted: Agent = {
+      id: a.id ?? '',
+      label: a.label ?? '',
+      command: a.command ?? '',
+    };
+    if (a.favorite === true) compacted.favorite = true;
+    if (a.promptFlags === true) compacted.promptFlags = true;
+    return compacted;
+  });
 }
 
 type RawTerminal = {

--- a/src/renderer/settings-modal-parts/sections-agents.tsx
+++ b/src/renderer/settings-modal-parts/sections-agents.tsx
@@ -91,9 +91,14 @@ export function AgentsSection(props: AgentsSectionProps): JSX.Element {
       <div class="settings-bucket">
         <For each={agents()}>
           {(entry, index) => (
-            <div class="settings-open-with" data-invalid={idMissing(entry) ? 'true' : undefined}>
-              <div class="settings-open-with-head">
-                <span class="settings-field-label">
+            <div class="settings-agent-card" data-invalid={idMissing(entry) ? 'true' : undefined}>
+              <div class="settings-agent-card-head">
+                <span class="settings-agent-card-title">
+                  <Show when={entry.favorite === true}>
+                    <span class="settings-agent-card-star" title="Favourite" aria-hidden="true">
+                      ★
+                    </span>
+                  </Show>
                   {entry.label.trim() || `Agent ${index() + 1}`}
                 </span>
                 <span class="settings-agent-row-actions">
@@ -123,73 +128,79 @@ export function AgentsSection(props: AgentsSectionProps): JSX.Element {
                   </button>
                 </span>
               </div>
-              <label>
-                <span>Label</span>
-                <input
-                  type="text"
-                  placeholder="Claude · Kimi"
-                  {...props.bindText(
-                    `${props.target}.agents[${index()}].label`,
-                    () => entry.label,
-                    (v) => updateField(index(), { label: v }),
-                  )}
-                />
-              </label>
-              <label>
-                <span>Command</span>
-                <input
-                  type="text"
-                  placeholder="claude-kimi"
-                  {...props.bindText(
-                    `${props.target}.agents[${index()}].command`,
-                    () => entry.command,
-                    (v) => updateField(index(), { command: v }),
-                  )}
-                />
-              </label>
-              <label>
-                <span>Id</span>
-                <input
-                  type="text"
-                  placeholder="claude-kimi"
-                  classList={{ 'settings-input--invalid': idMissing(entry) }}
-                  aria-invalid={idMissing(entry)}
-                  {...props.bindText(
-                    `${props.target}.agents[${index()}].id`,
-                    () => entry.id,
-                    (v) => updateField(index(), { id: v }),
-                  )}
-                />
-              </label>
-              <Show when={idMissing(entry)}>
-                <p class="settings-repo-name-error">Id is required to launch this agent.</p>
-              </Show>
-              <label class="settings-checkbox">
-                <input
-                  type="checkbox"
-                  checked={entry.favorite === true}
-                  onChange={(e) =>
-                    void updateField(index(), { favorite: e.currentTarget.checked || undefined })
-                  }
-                />
-                <span>
-                  Favourite — show directly in the new-tab menu (non-favourites move under{' '}
-                  <code>More ▸</code>)
-                </span>
-              </label>
-              <label class="settings-checkbox">
-                <input
-                  type="checkbox"
-                  checked={entry.promptFlags === true}
-                  onChange={(e) =>
-                    void updateField(index(), { promptFlags: e.currentTarget.checked || undefined })
-                  }
-                />
-                <span>
-                  Seed prompt via <code>--run</code> / <code>--prompt</code> (command must accept
-                  them, e.g. agedum)
-                </span>
-              </label>
+              <div class="settings-agent-card-fields">
+                <label>
+                  <span>Label</span>
+                  <input
+                    type="text"
+                    placeholder="Claude · Kimi"
+                    {...props.bindText(
+                      `${props.target}.agents[${index()}].label`,
+                      () => entry.label,
+                      (v) => updateField(index(), { label: v }),
+                    )}
+                  />
+                </label>
+                <label>
+                  <span>Command</span>
+                  <input
+                    type="text"
+                    placeholder="claude-kimi"
+                    {...props.bindText(
+                      `${props.target}.agents[${index()}].command`,
+                      () => entry.command,
+                      (v) => updateField(index(), { command: v }),
+                    )}
+                  />
+                </label>
+                <label>
+                  <span>Id</span>
+                  <input
+                    type="text"
+                    placeholder="claude-kimi"
+                    classList={{ 'settings-input--invalid': idMissing(entry) }}
+                    aria-invalid={idMissing(entry)}
+                    {...props.bindText(
+                      `${props.target}.agents[${index()}].id`,
+                      () => entry.id,
+                      (v) => updateField(index(), { id: v }),
+                    )}
+                  />
+                </label>
+                <Show when={idMissing(entry)}>
+                  <p class="settings-repo-name-error">Id is required to launch this agent.</p>
+                </Show>
+              </div>
+              <div class="settings-agent-card-flags">
+                <label class="settings-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={entry.favorite === true}
+                    onChange={(e) =>
+                      void updateField(index(), { favorite: e.currentTarget.checked || undefined })
+                    }
+                  />
+                  <span>
+                    Favourite — show directly in the new-tab menu (non-favourites move under{' '}
+                    <code>More ▸</code>)
+                  </span>
+                </label>
+                <label class="settings-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={entry.promptFlags === true}
+                    onChange={(e) =>
+                      void updateField(index(), {
+                        promptFlags: e.currentTarget.checked || undefined,
+                      })
+                    }
+                  />
+                  <span>
+                    Seed prompt via <code>--run</code> / <code>--prompt</code> (command must accept
+                    them, e.g. agedum)
+                  </span>
+                </label>
+              </div>
             </div>
           )}
         </For>

--- a/src/renderer/settings-modal.css
+++ b/src/renderer/settings-modal.css
@@ -480,6 +480,7 @@
 .settings-color input,
 .settings-open-with input,
 .settings-list-row input,
+.settings-agent-card-fields input,
 .settings-repo-row input {
   background: var(--bg-elevated);
   border: 1px solid var(--border);
@@ -496,6 +497,7 @@
 .settings-color input:focus,
 .settings-open-with input:focus,
 .settings-list-row input:focus,
+.settings-agent-card-fields input:focus,
 .settings-repo-row input:focus {
   outline: none;
   border-color: var(--accent);
@@ -1200,6 +1202,86 @@
   background: var(--bg-hover);
   color: var(--text);
   border-color: var(--border);
+}
+
+/* ---- Agents (per-agent cards) --------------------------------------- */
+
+.settings-agent-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-elevated);
+  padding: 10px 12px 12px;
+  margin-bottom: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* A card missing its id reads as invalid — tint the whole border like the
+   inline-invalid inputs so the broken card is scannable at the card level. */
+.settings-agent-card[data-invalid='true'] {
+  border-color: var(--danger);
+}
+
+.settings-agent-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.settings-agent-card-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.settings-agent-card-star {
+  flex-shrink: 0;
+  color: var(--accent);
+  font-size: var(--text-sm);
+  line-height: 1;
+}
+
+.settings-agent-row-actions {
+  display: inline-flex;
+  flex-shrink: 0;
+  gap: 4px;
+}
+
+.settings-agent-card-fields {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 8px 12px;
+}
+
+.settings-agent-card-fields label {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+
+/* Validation message spans the full grid width rather than sitting in a column. */
+.settings-agent-card-fields .settings-repo-name-error {
+  grid-column: 1 / -1;
+}
+
+.settings-agent-card-flags {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
 }
 
 /* ---- Inline validation (D3) + required (D2) -------------------------- */


### PR DESCRIPTION
## Summary

The favorite-agents feature (v4.35.0) looked broken: the spawn dropdown listed every agent inline. Root cause wasn't the dropdown — it was the Settings save path silently dropping the flag.

`compactAgents` (the save normaliser) rebuilt every agent as `{id, label, command}`, so ticking **Favourite** (or **Seed prompt via flags**) in Settings → Agents never reached disk — the toggle reverted on the next load. With no agent ever persisting `favorite: true`, the dropdown always fell back to the inline list. Same reason `promptFlags` never stuck either.

This fixes the persistence bug and reworks the section into a proper per-agent card.

## Changes

- **Fix:** `compactAgents` now carries `favorite` / `promptFlags` through Save when explicitly `true` (omitted otherwise, never written as `false`). Two regression tests in `data.test.ts`.
- **UI:** Settings → Agents renders each agent as a bordered card — title with a `★` on favourites, move/remove actions, Label/Command/Id in a responsive grid, and the flag checkboxes in a divided footer. An invalid card (missing id) tints its whole border. Layout only; bindings/validation/move-add-remove unchanged.

## Validation

- Typecheck + prettier clean.
- Unit: 846 pass (incl. the 2 new tests).
- Playwright: full suite 43 pass headless. The only `.settings-open-with` test ref is Open-with-scoped; `.settings-checkbox` assertions are terminal-only — the rename is safe.

## Watchpoints

- Persisting a favourite now actually sticks, but the agentsconf `conception-agents-sync.sh` regenerates `agents[]` from the provider configs and would still overwrite a UI-set favourite — that side is fixed in the parallel agentsconf PR (carries `favorite` from the provider JSON).
