### PR TITLE
Make the /knowledge skill own the full promotion gate

### DIFF
--- a/conception-template/.agents/skills/knowledge/SKILL.md
+++ b/conception-template/.agents/skills/knowledge/SKILL.md
@@ -55,9 +55,31 @@ These are the contract every `/knowledge` action enforces:
 - **New app** → add a row to `internal/index.md`. Create `internal/<app>.md` only when the first non-pointer fact surfaces.
 - **Single-app detail** → that app's own `CLAUDE.md`, not here.
 
-## Promotion check (signalled by `projects`)
+## Promotion (the three-yes gate, the check, deferred re-evaluation)
 
-`condash projects check-knowledge <slug>` and `condash audit --include knowledge-check` only **signal** that a done project may still hold un-promoted findings — they are read-only and never write the marker. Resolving the signal is this skill's job: run `condash projects scan-promotions <slug>`, walk each candidate through the three-question durability test, and **create the actual knowledge** with `/knowledge update` (stamping the origin paragraph `**Transferred:** YYYY-MM-DD → <path>`). Only once the real promotion is done — or every candidate is genuinely dropped — does the project record `- YYYY-MM-DD — Checked knowledge promotion` as its last timeline entry. The marker attests that this work happened; never append it as a substitute for doing it.
+Durable findings from project work enter `knowledge/` only through this gate — it keeps single-PR detail and app-internal trivia out of the tree.
+
+### Three-yes durability test
+
+Before promoting any finding, run it through all three conditions — promote only on three yeses:
+
+1. **Holds beyond this task** — still true even if the task were done differently; not tied to one PR's implementation detail.
+2. **Applies to more than one app, or governs the ecosystem** — single-app internals belong in that app's own `CLAUDE.md`, not here.
+3. **True regardless of the PR's outcome** — a finding made true only *by* the not-yet-merged PR fails this condition at evaluation time (see deferred re-evaluation below).
+
+Three yeses → `/knowledge update`, stamping the origin paragraph `**Transferred:** YYYY-MM-DD → <path>` (the historical promotion marker; the body file also carries the `**Verified:**` freshness stamp from Core rules).
+
+### Promotion check (signalled by `projects`)
+
+`condash projects check-knowledge <slug>` and `condash audit --include knowledge-check` only **signal** that a done project may still hold un-promoted findings — they are read-only and never write the marker. Resolving the signal is this skill's job: run `condash projects scan-promotions <slug>`, walk each candidate through the three-yes test, and **create the actual knowledge** with `/knowledge update` (stamping the origin paragraph as above). Only once the real promotion is done — or every candidate is genuinely dropped — does the project record `- YYYY-MM-DD — Checked knowledge promotion` as its last timeline entry. The marker attests that this work happened; never append it as a substitute for doing it.
+
+### Deferred re-evaluation
+
+A finding that passes conditions 1 and 2 but fails only condition 3 — because its truth is *established by* a not-yet-merged PR — would otherwise be silently stranded in project notes. Instead:
+
+1. Write an open `[knowledge-recheck:pending]` timeline marker in the project README.
+2. After the PR merges, re-run the three-yes test; on a pass, promote via `/knowledge update` and update the marker to `[knowledge-recheck:done]`.
+3. `condash audit --include knowledge-recheck` surfaces any unmatched open marker across all projects (closed ones included), so the deferral can't be buried.
 
 ## Index tree contract
 


### PR DESCRIPTION
## Summary

The knowledge-promotion conventions — the three-yes durability test, the Transferred/Verified stamps, and the deferred-recheck mechanism — are generic mechanics of the `/knowledge` skill, but they were being restated as per-conception `knowledge/` body files. That duplicated shipped-skill content and violated the skill's own core rule ("No workflow rules in `knowledge/`"). This makes the skill the single canonical source.

## Changes

- `conception-template/.agents/skills/knowledge/SKILL.md`: replace the single `## Promotion check` section with a complete `## Promotion` gate —
  - enumerate the **three-yes durability test** (holds beyond the task / applies to >1 app or the ecosystem / true regardless of PR outcome),
  - keep the **promotion check** workflow (`check-knowledge` signal → `scan-promotions` → `/knowledge update` → dated marker),
  - add the **deferred re-evaluation** mechanism (`[knowledge-recheck:pending|done]` timeline markers + `condash audit --include knowledge-recheck`).

## Impact

- Skill-markdown only — no TypeScript, no runtime change, no test touches this file's content. Shipped verbatim into each conception by `condash skills install`.
- Patch-level (doc-only).

## Watchpoints

- Follow-up lands separately in the conception tree (not this repo): the two duplicate `knowledge/` body files are deleted now that the skill is canonical.
