### PR TITLE
Point projects/close.md at the /knowledge skill for the durability test

### DIFF
--- a/conception-template/.agents/skills/projects/close.md
+++ b/conception-template/.agents/skills/projects/close.md
@@ -18,7 +18,7 @@ Trigger: `/projects close <slug>`.
 
 4. **Knowledge promotion review.** Editorial step — Claude reads, the CLI is a backstop.
 
-   a. **Read the README and every `notes/*.md` body** returned by step 2's `read --with-notes`, and apply the three-question durability test from `knowledge/conventions.md` to each candidate paragraph:
+   a. **Read the README and every `notes/*.md` body** returned by step 2's `read --with-notes`, and apply the three-question durability test (canonical definition in the `/knowledge` skill) to each candidate paragraph:
 
       1. Holds beyond this task? (Not specific to the in-flight work.)
       2. Applies to more than one app, or to the ecosystem?


### PR DESCRIPTION
## Summary

Follow-up to #323. The three-question durability test's canonical definition now lives in the `/knowledge` `SKILL.md` (shipped alongside `close.md`). `projects/close.md` still attributed it to the per-conception `knowledge/conventions.md`, a body file a conception is free to repurpose. Repoint the attribution so the shipped skill no longer depends on a per-conception knowledge file's content.

## Changes

- `conception-template/.agents/skills/projects/close.md`: "the three-question durability test from `knowledge/conventions.md`" → "the three-question durability test (canonical definition in the `/knowledge` skill)". The inline three-question checklist is unchanged.

## Impact

- Skill-markdown only — no TypeScript, no runtime change, no test touches this file's content.
- Patch-level (doc-only).
