### PR TITLE
Fix user-scope skills path in Skills pane

### DIFF
--- a/docs/guides/skills-pane.md
+++ b/docs/guides/skills-pane.md
@@ -21,7 +21,7 @@ The header carries a segmented control with two scopes (and a **refresh** button
 | Scope | `AGENTS.md` pinned at top | Skills tree |
 |-------|---------------------------|-------------|
 | **Conception** (default) | `<conception>/AGENTS.md` | `<conception>/.agents/skills/` |
-| **User** | `~/.config/agents/AGENTS.md` | `~/.agents/skills/` |
+| **User** | `~/.config/agents/AGENTS.md` | `~/.config/agents/skills/` |
 
 Both are **agedum sources**. condash never reads the compiled per-harness outputs (`.claude/`, `.kimi/`, `.opencode/`, …) — only the agent-neutral source tree. Each scope pins its `AGENTS.md` as a read-only callout at the top of the tree, then lists the skills below.
 
@@ -39,7 +39,7 @@ These sources are placed verbatim by `condash skills install`; condash does not 
 If a scope has no skills yet, the pane shows an empty state:
 
 - **Conception** — *"Run `condash skills install` to lay down the shipped skills under `.agents/skills/`,"* with a **Copy install command** button.
-- **User** — *"User-scope skills live at `~/.agents/skills/`. Edit them via your agedum sources."*
+- **User** — *"User-scope skills live at `~/.config/agents/skills/`. Edit them via your agedum sources."*
 
 ## Viewing files
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -132,7 +132,7 @@ Legacy formats — JSONL event streams from condash ≤ 2.22, compressed `.txt.g
 
 Since the reframe, two panes read **hard-coded** directories — no config key controls either:
 
-- The **Skills** pane reads the agedum sources at `<conception_path>/.agents/skills/` (and `~/.agents/skills/` for the User scope). The former `skills_path` key was dropped; condash never reads compiled per-harness outputs (`.claude/`, `.kimi/`, …). See the [Skills pane guide](../guides/skills-pane.md).
+- The **Skills** pane reads the agedum sources at `<conception_path>/.agents/skills/` (and `~/.config/agents/skills/` for the User scope). The former `skills_path` key was dropped; condash never reads compiled per-harness outputs (`.claude/`, `.kimi/`, …). See the [Skills pane guide](../guides/skills-pane.md).
 - The **Resources** pane reads `<conception_path>/resources/`.
 
 ### `repositories`

--- a/src/main/skills.test.ts
+++ b/src/main/skills.test.ts
@@ -123,7 +123,7 @@ describe('readSkillsTree (conception scope, default)', () => {
 
 describe('readSkillsTreeForScope (user scope)', () => {
   it('reads agedum sources from CONDASH_USER_SKILLS_ROOT + CONDASH_USER_AGENTS_MD', async () => {
-    const userSkills = join(userHome, '.agents', 'skills');
+    const userSkills = join(userHome, '.config', 'agents', 'skills');
     mkdirSync(join(userSkills, 'mything'), { recursive: true });
     writeFileSync(join(userSkills, 'mything', 'SKILL.md'), '# My thing\n\nUser skill.\n');
     const userAgents = join(userHome, '.config', 'agents', 'AGENTS.md');

--- a/src/main/skills.ts
+++ b/src/main/skills.ts
@@ -17,7 +17,7 @@ const HIDDEN_PREFIX = /^\./;
  *     of the tree as a read-only callout, then `<conception>/.agents/skills/`
  *     as the tree itself.
  *   - **User scope** — `~/.config/agents/AGENTS.md` pinned at the top,
- *     then `~/.agents/skills/` as the tree.
+ *     then `~/.config/agents/skills/` as the tree.
  *
  * Both are agedum sources; condash never reads the compiled outputs
  * (`~/.claude/`, `<conception>/.claude/`, …). The pane is read-only in

--- a/src/main/user-scope-paths.ts
+++ b/src/main/user-scope-paths.ts
@@ -8,13 +8,13 @@ import { join } from 'node:path';
  * harness compiled outputs (`~/.claude/`, `~/.kimi/`, …).
  *
  * Env overrides (used by tests):
- *   CONDASH_USER_SKILLS_ROOT       ~/.agents/skills
+ *   CONDASH_USER_SKILLS_ROOT       ~/.config/agents/skills
  *   CONDASH_USER_AGENTS_MD         ~/.config/agents/AGENTS.md
  */
 
 /** Root of the user-scope skills tree (agedum source). */
 export function userSkillsRoot(): string {
-  return process.env.CONDASH_USER_SKILLS_ROOT ?? join(homedir(), '.agents', 'skills');
+  return process.env.CONDASH_USER_SKILLS_ROOT ?? join(homedir(), '.config', 'agents', 'skills');
 }
 
 /** Path of the user-scope AGENTS.md file (agedum source). */

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -129,8 +129,8 @@ export function SkillsView(props: {
         when={props.scope === 'conception'}
         fallback={
           <p>
-            User-scope skills live at <code>~/.config/agents/skills/</code>. Edit them via your agedum
-            sources.
+            User-scope skills live at <code>~/.config/agents/skills/</code>. Edit them via your
+            agedum sources.
           </p>
         }
       >

--- a/src/renderer/panes/skills.tsx
+++ b/src/renderer/panes/skills.tsx
@@ -129,7 +129,7 @@ export function SkillsView(props: {
         when={props.scope === 'conception'}
         fallback={
           <p>
-            User-scope skills live at <code>~/.agents/skills/</code>. Edit them via your agedum
+            User-scope skills live at <code>~/.config/agents/skills/</code>. Edit them via your agedum
             sources.
           </p>
         }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -50,7 +50,7 @@ export interface CondashApi {
   /** Tree of the scope's skills directory plus the scope's AGENTS.md pinned
    *  at the top:
    *  - `conception` → `<conception>/AGENTS.md` + `<conception>/.agents/skills/`
-   *  - `user`       → `~/.config/agents/AGENTS.md` + `~/.agents/skills/`
+   *  - `user`       → `~/.config/agents/AGENTS.md` + `~/.config/agents/skills/`
    *  Both surfaces are agedum sources, never compiled outputs. Shipped-SHA
    *  stamps are populated from `.condash-skills.json` when present. Resolves
    *  to null when neither the skills directory nor the AGENTS.md exists. */

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -10,7 +10,7 @@ import type { TaskConfigEntry } from './task-runs';
 /** Scope toggle in the Skills pane. `conception` reads the active
  *  conception's `AGENTS.md` + `.agents/skills/` tree; `user` reads the
  *  per-machine agedum sources at `~/.config/agents/AGENTS.md` +
- *  `~/.agents/skills/`. The pane is read-only in both scopes; condash
+ *  `~/.config/agents/skills/`. The pane is read-only in both scopes; condash
  *  surfaces the agedum source-of-truth and never edits it. */
 export type SkillScope = 'conception' | 'user';
 
@@ -89,7 +89,7 @@ export interface TreeExpansionPrefs {
    *  the Skills pane switched to agedum sources. The legacy `skills` key
    *  is read for back-compat but never written. */
   skills?: string[];
-  /** User-scope skills tree (`~/.agents/skills/`). */
+  /** User-scope skills tree (`~/.config/agents/skills/`). */
   skillsUser?: string[];
 }
 

--- a/src/shared/types/tree.ts
+++ b/src/shared/types/tree.ts
@@ -104,7 +104,7 @@ export interface SkillShippedInfo {
  */
 export interface SkillNode {
   /** Path relative to the scope's skills root (`<conception>/.agents/skills/`
-   *  for conception scope, `~/.agents/skills/` for user scope). Empty string
+   *  for conception scope, `~/.config/agents/skills/` for user scope). Empty string
    *  for the root. */
   relPath: string;
   /** Absolute path on disk. */


### PR DESCRIPTION
## Summary

- User-scope skills from agentsconf were not appearing in the condash Skills pane User scope
- `userSkillsRoot()` defaulted to `~/.agents/skills/` which does not exist — agentsconf syncs user skills to `~/.config/agents/skills/`
- The path was correct before the reframe (commit `4394cee`) and was changed to the wrong value during that simplification

## Changes

- Fix `userSkillsRoot()` default path in `src/main/user-scope-paths.ts`
- Update test fixture path in `src/main/skills.test.ts`
- Update comments in `src/main/skills.ts`, `src/shared/api.ts`, `src/shared/types/settings.ts`, `src/shared/types/tree.ts`
- Update user-facing message in `src/renderer/panes/skills.tsx`
- Update docs in `docs/guides/skills-pane.md` and `docs/reference/config.md`