### PR TITLE
Fix task run-popup agent select changing while typing a variable

### DIFF
--- a/src/renderer/panes/tasks-parts/task-fill.tsx
+++ b/src/renderer/panes/tasks-parts/task-fill.tsx
@@ -47,6 +47,16 @@ export function TaskFill(props: {
 
   const close = (): void => props.setFill(null);
 
+  // The selected agent id, isolated from the rest of the fill signal. `setField`
+  // replaces the whole `fill` object on every keystroke, so reading
+  // `props.fill().agent` directly in the agent `<select>` (its options, value,
+  // and per-option `disabled`) would re-run those bindings on each character.
+  // That rebuilds the `<For>`'s freshly-allocated option objects, dropping the
+  // controlled value mid-reconciliation so the select snaps to another agent.
+  // Memoising the id stops the propagation when the agent itself is unchanged —
+  // the same discipline the `prompt` memo above applies to the param inputs.
+  const currentAgent = createMemo(() => props.fill().agent);
+
   // Run-time agent choices, keyed by id like the editor: only prompt-seedable
   // agents are selectable (a task hands its prompt via `--prompt`), with the
   // current selection kept selectable even if it dangles.
@@ -54,7 +64,7 @@ export function TaskFill(props: {
     const opts = props
       .agents()
       .map((a) => ({ id: a.id, label: a.label, promptFlags: a.promptFlags === true }));
-    const current = props.fill().agent;
+    const current = currentAgent();
     if (current && !opts.some((o) => o.id === current)) {
       return [{ id: current, label: `${current} (missing)`, promptFlags: false }, ...opts];
     }
@@ -114,7 +124,7 @@ export function TaskFill(props: {
           <label class="tasks-fill-agent">
             <span>Agent</span>
             <select
-              value={props.fill().agent}
+              value={currentAgent()}
               onChange={(e) => props.setFill({ ...props.fill(), agent: e.currentTarget.value })}
             >
               <Switch>
@@ -124,7 +134,7 @@ export function TaskFill(props: {
                 <Match when={agentOptions().length > 0}>
                   <For each={agentOptions()}>
                     {(o) => (
-                      <option value={o.id} disabled={!o.promptFlags && o.id !== props.fill().agent}>
+                      <option value={o.id} disabled={!o.promptFlags && o.id !== currentAgent()}>
                         {o.promptFlags ? o.label : `${o.label} — no prompt seeding`}
                       </option>
                     )}

--- a/tests/tasks.spec.ts
+++ b/tests/tasks.spec.ts
@@ -144,6 +144,63 @@ test('typing a multi-char value into a param field keeps focus', async () => {
   }
 });
 
+test('typing a param value does not change the selected agent', async () => {
+  // Regression (sibling of the focus-drop bug above): the run-time agent
+  // <select> read the selected id straight off the whole fill signal — for its
+  // <For> options, its value, and each option's `disabled`. setField replaces
+  // that signal on every keystroke, so typing into a param field re-ran
+  // agentOptions (fresh option objects), the <For> rebuilt every <option>, and
+  // the controlled value was lost mid-reconciliation: the select snapped to
+  // another agent. Two seedable agents with the task's agent listed *second*
+  // makes the snap observable — with the bug it jumps to the first option.
+  // pressSequentially dispatches real keystrokes (fill() sets the value
+  // atomically and would not trigger the per-keystroke rebuild).
+  const fillAgents = [
+    { id: 'aider', label: 'aider', command: 'aider', promptFlags: true },
+    {
+      id: 'claude-deepseek-v4-pro',
+      label: 'deepseek-v4-pro',
+      command: 'claude',
+      promptFlags: true,
+    },
+  ];
+  const booted = await bootApp({
+    prepare: seedTask,
+    extraConfig: {
+      agents: fillAgents,
+      repositories: [{ name: 'condash', path: '/home/alice/src/vcoeur/condash' }],
+    },
+  });
+  const { window, cleanup } = booted;
+  try {
+    await window.setViewportSize({ width: 1400, height: 900 });
+    await window.locator('.edge-strip-left').first().waitFor({ state: 'visible', timeout: 10_000 });
+    await window.locator('.edge-strip-left .edge-handle', { hasText: 'Tasks' }).click();
+
+    await window.locator('.tasks-row-actions button', { hasText: 'Run…' }).click();
+    await expect(window.locator('.modal-backdrop .tasks-fill-modal')).toBeVisible();
+
+    // The agent picker defaults to the task's stored agent (listed second).
+    const agentSelect = window.locator('.tasks-fill-agent select');
+    await expect(agentSelect).toHaveValue('claude-deepseek-v4-pro');
+
+    // Type a multi-char value into the {AREA} param field.
+    const areaField = window
+      .locator('.tasks-fill-scroll label', { hasText: '{AREA}' })
+      .locator('input[type="text"]');
+    await areaField.fill('');
+    await areaField.focus();
+    await areaField.pressSequentially('src and tests', { delay: 20 });
+
+    // The agent must stay put (with the bug it snapped to 'aider'), and the typed
+    // value still lands in full.
+    await expect(agentSelect).toHaveValue('claude-deepseek-v4-pro');
+    await expect(areaField).toHaveValue('src and tests');
+  } finally {
+    await cleanup();
+  }
+});
+
 test('new task editor creates a task end-to-end', async () => {
   const booted = await bootApp({ prepare: seedTask, extraConfig: { agents: [TASK_AGENT] } });
   const { window, cleanup } = booted;


### PR DESCRIPTION
## Summary

In the task **run popup**, typing a value into a variable text field silently reselected the **Agent** dropdown (caught on *Work digest*: typing `{DATE_END}` flipped the agent from Claude to Aider). A one-shot run could then launch under the wrong agent.

Root cause: a controlled-`<select>` thrash. The agent `<select>` derived its `<For>` options, its `value`, and each option's `disabled` straight off the whole `fill` signal — which `setField` replaces on every keystroke. Each character re-ran `agentOptions` (freshly allocated option objects), so Solid's `<For>` tore down and recreated every `<option>` and the controlled value was lost mid-reconciliation, snapping the select to the first option.

## Changes

- Memoise the selected agent id (`currentAgent`) and key the select's options, value, and per-option `disabled` off it, so editing a param field no longer invalidates the option list. Mirrors the existing `prompt`/`textMarkers` memo that already keeps the param `<input>`s from being recreated per keystroke.
- Add a Playwright regression test (sibling of the focus-retention test): two seedable agents with the task's agent listed second; the agent must not move while typing.

## Impact

- Verified both ways: with the fix stashed and rebuilt, the new test fails (`expected "claude-deepseek-v4-pro"`, received `"aider"`); with the fix, all 5 tasks specs pass, the full vitest unit suite (846 tests) passes, and `tsc` typecheck is clean.