### PR TITLE
Add `condash projects activity` verb (generic project-tree activity data)

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,6 +91,7 @@ Item lifecycle and reads.
 |---|---|
 | `list` | List items, optionally filtered by `--status`, `--kind`, `--apps`, `--branch`, `--sort` |
 | `read <slug>` | Read one item by slug or path |
+| `activity [--begin <YYYY-MM-DD>] [--end <YYYY-MM-DD>] [--format md]` | Generic project-tree activity over a date range (default: last 7 days): every `## Timeline` beat parsed into items + dated events + day/week/month/app indices. `--json` is the reusable data layer for digest tooling and dashboards; plain output is a one-look summary; `--format md` emits a no-frills markdown digest |
 | `resolve <slug>` | Resolve a slug to its absolute path |
 | `search <query>` | Full-text search across items, optional `--status` / `--kind` / `--limit` |
 | `validate [<slug>]` | Validate header fields against the schema; pass `--all` for the whole tree, or `--path <readme>` to check one file outside the resolved conception |

--- a/src/cli/commands/projects-activity.test.ts
+++ b/src/cli/commands/projects-activity.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { activityCommand } from './projects-activity';
+import {
+  makeTmpConception,
+  rmConception,
+  writeProjectReadme,
+  captureStdout,
+  jsonCtx,
+  humanCtx,
+  parseJsonEnvelope,
+} from './test-helpers';
+
+interface ActivityData {
+  meta: { begin: string; end: string; itemCount: number; eventCount: number };
+  items: {
+    slug: string;
+    apps: string[];
+    prNums: string[];
+    versions: string[];
+    createdInRange: boolean;
+    closedInRange: boolean;
+    closedAt: string | null;
+    eventCount: number;
+  }[];
+  events: { date: string; isoWeek: string; month: string; slug: string; bookkeeping: boolean }[];
+  index: { days: string[]; weeks: string[]; months: string[]; apps: Record<string, string[]> };
+}
+
+const RANGE = { begin: '2026-06-01', end: '2026-06-07' };
+
+async function seed(conceptionPath: string): Promise<void> {
+  // alpha: real work in range; apps carry a dup (#condash + condash) to exercise
+  // normalization; a PR + version in the text.
+  await writeProjectReadme(conceptionPath, 'alpha', {
+    date: '2026-06-02',
+    kind: 'project',
+    status: 'done',
+    apps: ['"#condash"', 'condash'], // quoted #-handle + bare → both canonicalize to #condash
+    body: '## Timeline\n\n- 2026-06-02 — Project created.\n- 2026-06-03 — Shipped the thing. Opened PR #42; tagged v1.2.3.\n',
+  });
+  // beta: only a bookkeeping re-stamp falls in range → must be excluded.
+  await writeProjectReadme(conceptionPath, 'beta', {
+    date: '2026-05-20',
+    kind: 'project',
+    status: 'done',
+    apps: ['agedum'],
+    body: '## Timeline\n\n- 2026-05-20 — Project created.\n- 2026-06-04 — Checked knowledge promotion\n',
+  });
+  // gamma: created in range, no timeline events, no apps → included via creation,
+  // grouped under #unscoped.
+  await writeProjectReadme(conceptionPath, 'gamma', {
+    date: '2026-06-05',
+    kind: 'incident',
+    status: 'now',
+  });
+  // delta: created out of range, closed in range → included via close.
+  await writeProjectReadme(conceptionPath, 'delta', {
+    date: '2026-04-01',
+    kind: 'project',
+    status: 'done',
+    apps: ['knoten'],
+    body: '## Timeline\n\n- 2026-04-01 — Project created.\n- 2026-06-06 — Closed. Shipped it.\n',
+  });
+}
+
+describe('projects activity', () => {
+  let conceptionPath: string;
+  beforeEach(async () => {
+    conceptionPath = await makeTmpConception();
+    await seed(conceptionPath);
+  });
+  afterEach(async () => {
+    await rmConception(conceptionPath);
+  });
+
+  it('includes substantive / created / closed items and excludes bookkeeping-only', async () => {
+    const { stdout } = await captureStdout(() =>
+      activityCommand(
+        { noun: 'projects', verb: 'activity', positional: [], flags: { ...RANGE } },
+        jsonCtx(),
+        conceptionPath,
+      ),
+    );
+    const { ok, data } = parseJsonEnvelope<ActivityData>(stdout);
+    expect(ok).toBe(true);
+    const slugs = data!.items.map((i) => i.slug).sort();
+    expect(slugs).toEqual(['2026-06-02-alpha', '2026-06-05-gamma', '2026-04-01-delta'].sort());
+    expect(slugs).not.toContain('2026-05-20-beta');
+    expect(data!.meta.itemCount).toBe(3);
+  });
+
+  it('normalizes apps, mines PR/version refs, and tags iso week + month', async () => {
+    const { stdout } = await captureStdout(() =>
+      activityCommand(
+        { noun: 'projects', verb: 'activity', positional: [], flags: { ...RANGE } },
+        jsonCtx(),
+        conceptionPath,
+      ),
+    );
+    const { data } = parseJsonEnvelope<ActivityData>(stdout);
+    const alpha = data!.items.find((i) => i.slug === '2026-06-02-alpha')!;
+    expect(alpha.apps).toEqual(['#condash']); // dup collapsed, single handle
+    expect(alpha.prNums).toEqual(['42']);
+    expect(alpha.versions).toEqual(['v1.2.3']);
+    expect(alpha.eventCount).toBe(2);
+
+    const shipped = data!.events.find((e) => e.date === '2026-06-03')!;
+    expect(shipped.isoWeek).toBe('2026-W23');
+    expect(shipped.month).toBe('2026-06');
+    expect(shipped.bookkeeping).toBe(false);
+
+    expect(data!.index.apps['#unscoped']).toContain('2026-06-05-gamma');
+    expect(data!.index.days).toContain('2026-06-03');
+    expect(data!.index.days).not.toContain('2026-06-04'); // beta excluded
+  });
+
+  it('marks created-in-range and closed-in-range membership', async () => {
+    const { stdout } = await captureStdout(() =>
+      activityCommand(
+        { noun: 'projects', verb: 'activity', positional: [], flags: { ...RANGE } },
+        jsonCtx(),
+        conceptionPath,
+      ),
+    );
+    const { data } = parseJsonEnvelope<ActivityData>(stdout);
+    const gamma = data!.items.find((i) => i.slug === '2026-06-05-gamma')!;
+    expect(gamma.createdInRange).toBe(true);
+    expect(gamma.eventCount).toBe(0);
+    const delta = data!.items.find((i) => i.slug === '2026-04-01-delta')!;
+    expect(delta.closedInRange).toBe(true);
+    expect(delta.closedAt).toBe('2026-06-06');
+  });
+
+  it('--format md emits a per-day digest with refs', async () => {
+    const { stdout } = await captureStdout(() =>
+      activityCommand(
+        { noun: 'projects', verb: 'activity', positional: [], flags: { ...RANGE, format: 'md' } },
+        humanCtx(),
+        conceptionPath,
+      ),
+    );
+    expect(stdout).toContain('## Per day');
+    expect(stdout).toContain('### 2026-06-03');
+    expect(stdout).toContain('(#42, v1.2.3)');
+    expect(stdout).toContain('**By app:**');
+  });
+});

--- a/src/cli/commands/projects-activity.ts
+++ b/src/cli/commands/projects-activity.ts
@@ -1,0 +1,292 @@
+import { relative } from 'node:path';
+import { findProjectReadmes } from '../../main/walk';
+import { parseReadmeWithHeader } from '../../main/parse';
+import { appPillText } from '../../shared/app-color';
+import { emit, type OutputContext } from '../output';
+import { assertNoExtraFlags, type ParsedArgs } from '../parser';
+import { NOUN_FLAGS } from './projects';
+
+/** One dated `## Timeline` beat, decorated with its item's identity + any PR /
+ *  version references mined from the text. */
+interface ActivityEvent {
+  date: string;
+  isoWeek: string;
+  month: string;
+  slug: string;
+  title: string;
+  apps: string[];
+  kind: string;
+  status: string;
+  text: string;
+  prNums: string[];
+  versions: string[];
+  /** True for routine bookkeeping beats (created / closed / re-check / worktree /
+   *  status flip) so consumers can de-emphasise them. */
+  bookkeeping: boolean;
+}
+
+/** One project that saw substantive activity in the range. */
+interface ActivityItem {
+  slug: string;
+  title: string;
+  kind: string;
+  status: string;
+  apps: string[];
+  branch: string | null;
+  date: string | null;
+  closedAt: string | null;
+  path: string;
+  stepCounts: { todo: number; doing: number; done: number; blocked: number; dropped: number };
+  createdInRange: boolean;
+  closedInRange: boolean;
+  prNums: string[];
+  versions: string[];
+  eventCount: number;
+}
+
+interface ActivityDataset {
+  meta: {
+    begin: string;
+    end: string;
+    generated: string;
+    conception: string;
+    itemCount: number;
+    eventCount: number;
+  };
+  items: ActivityItem[];
+  events: ActivityEvent[];
+  index: {
+    days: string[];
+    weeks: string[];
+    months: string[];
+    apps: Record<string, string[]>;
+  };
+}
+
+const PR_RE = /#(\d+)/g;
+const VERSION_RE = /v\d+\.\d+\.\d+/g;
+// Routine bookkeeping beats — not "work done", so membership ignores them and
+// renderers de-emphasise them. Matches the conception extractor's set.
+const BOOKKEEPING_RE =
+  /^(Project created|Incident created|Document created|Created|Closed|Checked knowledge promotion|Worktree set up|Status →)/;
+
+/** ISO-8601 week label (e.g. `2026-W23`) for a `YYYY-MM-DD` date. */
+function isoWeek(date: string): string {
+  const d = new Date(date + 'T00:00:00Z');
+  // Shift to the Thursday of this ISO week, then count weeks from the year's
+  // first Thursday. The Thursday's calendar year is the ISO week-year.
+  const dayMonZero = (d.getUTCDay() + 6) % 7;
+  d.setUTCDate(d.getUTCDate() - dayMonZero + 3);
+  const firstThursday = new Date(Date.UTC(d.getUTCFullYear(), 0, 4));
+  const firstDayMonZero = (firstThursday.getUTCDay() + 6) % 7;
+  firstThursday.setUTCDate(firstThursday.getUTCDate() - firstDayMonZero + 3);
+  const week = 1 + Math.round((d.getTime() - firstThursday.getTime()) / (7 * 86400000));
+  return `${d.getUTCFullYear()}-W${String(week).padStart(2, '0')}`;
+}
+
+/** Canonicalise an item's `apps[]` to deduped `#handle` form. condash's project
+ *  parser returns apps exactly as written (mixed `#handle` / bare / path), so a
+ *  consumer that groups by app must normalise; `#unscoped` when the item has
+ *  none. */
+function normalizeApps(apps: readonly string[]): string[] {
+  const seen: string[] = [];
+  for (const ref of apps) {
+    const handle = appPillText(ref);
+    if (handle !== '#' && !seen.includes(handle)) seen.push(handle);
+  }
+  return seen.length ? seen : ['#unscoped'];
+}
+
+/** All PR numbers + version tags referenced in a timeline line. */
+function extractRefs(text: string): { prNums: string[]; versions: string[] } {
+  return {
+    prNums: [...text.matchAll(PR_RE)].map((m) => m[1]),
+    versions: text.match(VERSION_RE) ?? [],
+  };
+}
+
+function addDays(date: string, delta: number): string {
+  const d = new Date(date + 'T00:00:00Z');
+  d.setUTCDate(d.getUTCDate() + delta);
+  return d.toISOString().slice(0, 10);
+}
+
+/** Build the activity dataset for the inclusive range [begin, end]. */
+async function buildActivity(
+  conceptionPath: string,
+  begin: string,
+  end: string,
+): Promise<ActivityDataset> {
+  const readmes = await findProjectReadmes(conceptionPath);
+  const items: ActivityItem[] = [];
+  const events: ActivityEvent[] = [];
+
+  for (const readme of readmes) {
+    const { project, header } = await parseReadmeWithHeader(readme);
+    const inRange = project.timeline.filter((entry) => entry.date >= begin && entry.date <= end);
+    const meaningful = inRange.filter((entry) => !BOOKKEEPING_RE.test(entry.text));
+    const date = header.date;
+    const createdInRange = date !== null && date >= begin && date <= end;
+    const closedAt = project.closedAt;
+    const closedInRange = closedAt !== null && closedAt >= begin && closedAt <= end;
+    // A bookkeeping-only re-stamp on an old item is not work done in the range.
+    if (meaningful.length === 0 && !createdInRange && !closedInRange) continue;
+
+    const apps = normalizeApps(project.apps);
+    const itemPrs = new Set<string>();
+    const itemVersions = new Set<string>();
+    for (const entry of inRange) {
+      const { prNums, versions } = extractRefs(entry.text);
+      prNums.forEach((n) => itemPrs.add(n));
+      versions.forEach((v) => itemVersions.add(v));
+      events.push({
+        date: entry.date,
+        isoWeek: isoWeek(entry.date),
+        month: entry.date.slice(0, 7),
+        slug: project.slug,
+        title: project.title,
+        apps,
+        kind: project.kind,
+        status: project.status,
+        text: entry.text,
+        prNums,
+        versions,
+        bookkeeping: BOOKKEEPING_RE.test(entry.text),
+      });
+    }
+
+    const itemDir = readme.replace(/\/README\.md$/, '');
+    items.push({
+      slug: project.slug,
+      title: project.title,
+      kind: project.kind,
+      status: project.status,
+      apps,
+      branch: project.branch,
+      date,
+      closedAt,
+      path: relative(conceptionPath, itemDir),
+      stepCounts: project.stepCounts,
+      createdInRange,
+      closedInRange,
+      prNums: [...itemPrs].sort((a, b) => Number(a) - Number(b)),
+      versions: [...itemVersions].sort(),
+      eventCount: inRange.length,
+    });
+  }
+
+  events.sort((a, b) => a.date.localeCompare(b.date) || a.slug.localeCompare(b.slug));
+  const appsIndex: Record<string, string[]> = {};
+  for (const item of items) {
+    for (const app of item.apps) (appsIndex[app] ??= []).push(item.slug);
+  }
+
+  return {
+    meta: {
+      begin,
+      end,
+      generated: new Date().toISOString(),
+      conception: conceptionPath,
+      itemCount: items.length,
+      eventCount: events.length,
+    },
+    items,
+    events,
+    index: {
+      days: [...new Set(events.map((e) => e.date))].sort(),
+      weeks: [...new Set(events.map((e) => e.isoWeek))].sort(),
+      months: [...new Set(events.map((e) => e.month))].sort(),
+      apps: appsIndex,
+    },
+  };
+}
+
+/**
+ * `condash projects activity` — generic project-tree activity data.
+ *
+ * Parses every project README's `## Timeline` over a date range and emits
+ * structured activity (items + dated events + day/week/month/app indices). It is
+ * the reusable data layer the work-digest task and any other consumer build on;
+ * the rich/customisable rendering stays with the consumer.
+ */
+export async function activityCommand(
+  args: ParsedArgs,
+  ctx: OutputContext,
+  conceptionPath: string,
+): Promise<void> {
+  const beginFlag = typeof args.flags.begin === 'string' ? args.flags.begin : null;
+  const endFlag = typeof args.flags.end === 'string' ? args.flags.end : null;
+  const format = typeof args.flags.format === 'string' ? args.flags.format : null;
+  for (const k of ['begin', 'end', 'format']) delete args.flags[k];
+  assertNoExtraFlags(args, NOUN_FLAGS);
+
+  const end = endFlag ?? new Date().toISOString().slice(0, 10);
+  const begin = beginFlag ?? addDays(end, -6);
+
+  const dataset = await buildActivity(conceptionPath, begin, end);
+  emit(ctx, dataset, format === 'md' ? formatActivityMarkdown : formatActivitySummary);
+}
+
+/** Default human output — a compact one-look summary. */
+function formatActivitySummary(data: ActivityDataset): string {
+  const { meta, index } = data;
+  const lines = [
+    `Activity ${meta.begin} … ${meta.end}: ${meta.itemCount} items, ${meta.eventCount} events across ${index.days.length} day(s) [${index.weeks.join(', ')}]`,
+    `By app:  ${facet(data, 'apps')}`,
+    `By kind: ${facet(data, 'kind')}`,
+  ];
+  return lines.join('\n') + '\n';
+}
+
+/** No-frills markdown convenience — per-day item bullets + facet footer. The
+ *  rich, customisable render lives with the consumer. */
+function formatActivityMarkdown(data: ActivityDataset): string {
+  const { meta, index } = data;
+  const lines = [
+    `# Activity — ${meta.begin} … ${meta.end}`,
+    `${meta.itemCount} items · ${meta.eventCount} events · ${index.weeks.join(', ')}`,
+    '',
+    '## Per day',
+  ];
+  for (const day of index.days) {
+    const dayEvents = data.events.filter((e) => e.date === day);
+    const prs = new Set(dayEvents.flatMap((e) => e.prNums));
+    const versions = new Set(dayEvents.flatMap((e) => e.versions));
+    const closed = data.items.filter((i) => i.closedAt === day).length;
+    lines.push('', `### ${day} · ${closed} closed · ${prs.size} PRs · ${versions.size} releases`);
+    const bySlug = new Map<string, ActivityEvent[]>();
+    for (const e of dayEvents) {
+      const arr = bySlug.get(e.slug);
+      if (arr) arr.push(e);
+      else bySlug.set(e.slug, [e]);
+    }
+    for (const [, slugEvents] of bySlug) {
+      const first = slugEvents[0];
+      const meaningful = slugEvents.filter((e) => !e.bookkeeping).map((e) => e.text);
+      const text = (meaningful.length ? meaningful : slugEvents.map((e) => e.text)).join(' ');
+      const refs = [
+        ...new Set(slugEvents.flatMap((e) => e.prNums.map((n) => `#${n}`))),
+        ...new Set(slugEvents.flatMap((e) => e.versions)),
+      ];
+      const suffix = refs.length ? ` (${refs.join(', ')})` : '';
+      lines.push(
+        `- **${first.apps.join(' ')}** ${first.title} — ${text} \`[${first.kind} · ${first.status}]\`${suffix}`,
+      );
+    }
+  }
+  lines.push('', `**By app:** ${facet(data, 'apps')}`, `**By kind:** ${facet(data, 'kind')}`);
+  return lines.join('\n') + '\n';
+}
+
+/** Render a faceted count line: `#condash 23 · #agedum 24` or `project 49`. */
+function facet(data: ActivityDataset, field: 'apps' | 'kind'): string {
+  const counts = new Map<string, number>();
+  for (const item of data.items) {
+    const values = field === 'apps' ? item.apps : [item.kind];
+    for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => `${value} ${count}`)
+    .join(' · ');
+}

--- a/src/cli/commands/projects.ts
+++ b/src/cli/commands/projects.ts
@@ -8,6 +8,7 @@ import {
   searchProjects,
   validateCommand,
 } from './projects-read';
+import { activityCommand } from './projects-activity';
 import {
   statusCommand,
   closeProject,
@@ -37,6 +38,7 @@ export type { CreateProjectInput, CreateProjectResult };
 // of a sibling-verb flag still gets a `(did you mean --X?)` hint.
 export const KNOWN_FLAGS_LIST = ['status', 'kind', 'apps', 'branch', 'sort'] as const;
 export const KNOWN_FLAGS_READ = ['with-notes'] as const;
+export const KNOWN_FLAGS_ACTIVITY = ['begin', 'end', 'format'] as const;
 export const KNOWN_FLAGS_RESOLVE: readonly string[] = [];
 export const KNOWN_FLAGS_SEARCH = ['limit', 'status', 'kind'] as const;
 export const KNOWN_FLAGS_VALIDATE = ['all', 'path'] as const;
@@ -66,6 +68,7 @@ export const NOUN_FLAGS: readonly string[] = [
   ...new Set<string>([
     ...KNOWN_FLAGS_LIST,
     ...KNOWN_FLAGS_READ,
+    ...KNOWN_FLAGS_ACTIVITY,
     ...KNOWN_FLAGS_RESOLVE,
     ...KNOWN_FLAGS_SEARCH,
     ...KNOWN_FLAGS_VALIDATE,
@@ -95,6 +98,7 @@ export async function runProjects(
     {
       list: () => listProjects(args, ctx, conceptionPath),
       read: () => readProject(args, ctx, conceptionPath),
+      activity: () => activityCommand(args, ctx, conceptionPath),
       resolve: () => resolveCommand(args, ctx, conceptionPath),
       search: () => searchProjects(args, ctx, conceptionPath),
       validate: () => validateCommand(args, ctx, conceptionPath),
@@ -145,6 +149,24 @@ function printHelp(verb: string | null): void {
         'Examples:',
         '  condash projects read condash-cli-ux-fixes',
         '  condash projects read condash-cli-ux-fixes --with-notes --json',
+      ]);
+      return;
+    case 'activity':
+      writeBlock([
+        'condash projects activity [--begin <YYYY-MM-DD>] [--end <YYYY-MM-DD>] [--format md]',
+        '',
+        'Generic project-tree activity over a date range: every `## Timeline` beat parsed',
+        'into items + dated events + day/week/month/app indices. `--json` is the reusable',
+        'data layer (digest tooling, dashboards); plain output is a summary.',
+        '',
+        'Optional:',
+        '  --begin    Inclusive start date (default: 6 days before --end).',
+        '  --end      Inclusive end date (default: today).',
+        '  --format   md → a no-frills markdown digest instead of the summary line.',
+        '',
+        'Examples:',
+        '  condash projects activity --begin 2026-06-01 --end 2026-06-07 --json',
+        '  condash projects activity --format md',
       ]);
       return;
     case 'resolve':
@@ -348,6 +370,7 @@ function printSubHelp(): void {
       'Verbs:',
       '  list             List projects (filters: --status --kind --apps --branch).',
       '  read             Read a project README + metadata.',
+      '  activity         Range activity (timeline events + rollups); --json data layer.',
       '  resolve          Resolve a slug to its absolute path.',
       '  search           Search project READMEs and notes.',
       '  validate         Validate header(s) against canonical enums.',

--- a/src/main/mutate-status.ts
+++ b/src/main/mutate-status.ts
@@ -181,9 +181,11 @@ export async function appendTimelineEntry(readmePath: string, line: string): Pro
  * is whatever follows the em-dash separator (or the rest of the line, when
  * the entry doesn't follow the standard shape).
  *
- * Lines that don't match the expected `- <date> — <text>` shape are skipped
- * — this keeps the parser robust against hand-edited prose between bullet
- * lines.
+ * Indented, non-empty lines following an entry are its wrapped remainder (the
+ * conception hard-wraps long entries) and are folded back into that entry's
+ * text, so multi-line entries aren't truncated. Flush-left lines that aren't a
+ * dated bullet are skipped — this keeps the parser robust against hand-edited
+ * prose between bullet lines.
  */
 export function parseTimelineEntries(raw: string): { date: string; text: string }[] {
   const lines = raw.split(/\r?\n/);
@@ -202,8 +204,15 @@ export function parseTimelineEntries(raw: string): { date: string; text: string 
     // `CLOSED_LINE` in shared/header.ts — that regex anchors only on the
     // em-dash because the `close` writer never emits a hyphen.
     const m = line.match(/^\s*-\s+(\d{4}-\d{2}-\d{2})\s+(?:—|--?)\s+(.+?)\s*$/);
-    if (!m) continue;
-    out.push({ date: m[1], text: m[2] });
+    if (m) {
+      out.push({ date: m[1], text: m[2] });
+      continue;
+    }
+    // An indented, non-empty line is the wrapped continuation of the entry
+    // above — fold it back in. Flush-left prose is left skipped.
+    if (out.length > 0 && /^\s+\S/.test(line)) {
+      out[out.length - 1].text += ' ' + line.trim();
+    }
   }
   return out;
 }

--- a/src/main/mutate.test.ts
+++ b/src/main/mutate.test.ts
@@ -185,6 +185,28 @@ describe('transitionStatus', () => {
   });
 });
 
+describe('parseTimelineEntries continuation folding', () => {
+  it('folds indented wrapped lines into the entry and stops at the next heading', () => {
+    const raw = [
+      '# T',
+      '',
+      '## Timeline',
+      '',
+      '- 2026-06-01 — First line wraps',
+      '  onto a second line; mentions #42 and v1.2.3.',
+      '- 2026-06-02 — Standalone.',
+      '',
+      '## Notes',
+      '- not a timeline entry',
+    ].join('\n');
+    const entries = parseTimelineEntries(raw);
+    expect(entries).toEqual([
+      { date: '2026-06-01', text: 'First line wraps onto a second line; mentions #42 and v1.2.3.' },
+      { date: '2026-06-02', text: 'Standalone.' },
+    ]);
+  });
+});
+
 describe('parseTimelineEntries ↔ CLOSED_LINE agreement', () => {
   it('the close lines parseTimelineEntries yields all match CLOSED_LINE', () => {
     // Every close that `condash projects close --summary` writes should be


### PR DESCRIPTION
## Summary

A new `condash projects activity` verb that turns the project tree into structured **activity data** over a date range — the reusable data layer for digest tooling and dashboards. Rich/customisable rendering stays with the consumer.

## Changes

- **`projects activity [--begin <d>] [--end <d>] [--format md]`** — parses every project README `## Timeline` over the range into `items` + dated `events` + `day`/`week`/`month`/`app` indices. `--json` is the data layer; plain output is a one-look summary; `--format md` is a no-frills markdown digest.
- Reuses `appHandle` for app-handle normalization; excludes bookkeeping-only items (a `Checked knowledge promotion` re-stamp on an old item isn't "work done"); mines PR (`#NNN`) + version (`vX.Y.Z`) refs; tags ISO week.
- **`parseTimelineEntries` now folds indented continuation lines** into the entry text, so hard-wrapped multi-line timeline entries are no longer truncated — this also fixes silent truncation in the GUI Timeline popup. Flush-left prose is still skipped (robustness preserved).
- Tests: `projects-activity.test.ts` (membership incl. created/closed-in-range, normalization, bookkeeping exclusion, refs, ISO week, `--format md`) + a continuation-folding case in `mutate.test.ts`. Docs: `reference/cli.md`.

## Impact

- The Timeline popup (and anything consuming `parseTimelineEntries`) now shows full multi-line entries instead of just the first physical line — a net improvement, no API change.
- 851 unit tests green; typecheck + knip clean.

## Watchpoints

- The verb is CLI/data only — no GUI surface; a "Digest" pane would be a separate follow-up.
