### PR TITLE
Pin the release build's Windows runner to windows-2025

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -28,7 +28,13 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          - windows-latest
+          # Pinned (2026-06-10): `windows-latest` now redirects to the
+          # windows-2025-vs2026 image, where node-gyp's Visual Studio finder
+          # dies on ERR_CHILD_PROCESS_STDIO_MAXBUFFER (Get-VSSetupInstance
+          # output too large) and electron-rebuild can't build node-pty —
+          # killed the v4.38.0 release build. Re-point to windows-latest once
+          # @electron/node-gyp handles the VS2026 image.
+          - windows-2025
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- The v4.38.0 release build failed on its Windows leg: `windows-latest` now resolves to the new `windows-2025-vs2026` runner image, where node-gyp's Visual Studio finder dies with `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` (the image's `Get-VSSetupInstance` JSON exceeds the finder's buffer) and `electron-rebuild` cannot rebuild node-pty. v4.37.1 built fine on `windows-2025` two days earlier.

## Changes

- `.github/workflows/_build.yml`: pin the matrix's Windows entry to `windows-2025` with a dated comment explaining when to un-pin (once @electron/node-gyp handles the VS2026 image).

## Watchpoints

- The `windows-2025` image label itself will eventually retire — re-point to `windows-latest` after a node-gyp/electron-rebuild bump that survives the VS2026 image.