### PR TITLE
Add an Export-as-PDF button to the md note viewer

### DIFF
--- a/docs/guides/deliverables.md
+++ b/docs/guides/deliverables.md
@@ -77,7 +77,9 @@ The embedded viewer is an Electron `<webview>` pointed at a `file://` URL — Ch
 
 ## Generating the PDF
 
-condash doesn't generate PDFs — you do, from whatever source lives alongside the item. The common shape:
+The quick path is built in: open any markdown note in the viewer and click **Export as PDF** in the header. condash prints the rendered note (code highlighting, task lists, Mermaid diagrams, embedded images) to a PDF via a save dialog that defaults to `<note-name>.pdf` next to the source — no external tools. The export always uses a light, print-oriented style regardless of the app theme.
+
+For finer typographic control (LaTeX-grade output, custom numbering), generate the PDF yourself from whatever source lives alongside the item. The common shape:
 
 - Write the body as Markdown under `<item>/notes/<name>.md`.
 - Convert with `~/.claude/scripts/md_to_pdf.sh` (pandoc + xelatex + mermaid-filter):

--- a/src/main/export-pdf.ts
+++ b/src/main/export-pdf.ts
@@ -1,0 +1,32 @@
+import { BrowserWindow } from 'electron';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Print a self-contained HTML document to a PDF buffer.
+ *
+ * The document renders in a hidden, sandboxed BrowserWindow so `printToPDF`
+ * captures only the exported note, never the app UI. It is loaded from a
+ * temp file rather than a `data:` URL — Chromium caps `data:` navigations
+ * well below a large note carrying inline mermaid SVGs. The window uses the
+ * default session, so `condash-file://` image URLs in the document resolve
+ * through the conception-bounded protocol handler exactly as they do in the
+ * note view.
+ */
+export async function htmlToPdf(html: string): Promise<Buffer> {
+  const dir = await fs.mkdtemp(join(tmpdir(), 'condash-pdf-'));
+  const file = join(dir, 'note.html');
+  await fs.writeFile(file, html, 'utf8');
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: { sandbox: true, contextIsolation: true, nodeIntegration: false },
+  });
+  try {
+    await win.loadFile(file);
+    return await win.webContents.printToPDF({ printBackground: true, pageSize: 'A4' });
+  } finally {
+    win.destroy();
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -304,7 +304,8 @@ function isPathUnder(child: string, parent: string): boolean {
  *   • repos — listRepos, listReposForPrimary, invalidateGitStatus,
  *     getDirtyDetails, listOpenWith, launchOpenWith, forceStopRepo.
  *   • settings — theme/layout/welcome/cardMinWidth/treeExpansion/getSettingsPath.
- *   • system — shell-out + app-info + conception path mutation.
+ *   • system — shell-out + app-info + conception path mutation + note-PDF
+ *     export.
  *   • terminal — every term.* verb.
  */
 function registerIpc(): void {

--- a/src/main/ipc/system.test.ts
+++ b/src/main/ipc/system.test.ts
@@ -26,12 +26,16 @@ vi.mock('electron', () => ({
     getVersion: () => '0.0.0-test',
     quit: vi.fn(),
   },
-  dialog: { showOpenDialog: vi.fn() },
+  dialog: { showOpenDialog: vi.fn(), showSaveDialog: vi.fn() },
   shell: {
     openPath: vi.fn(async () => ''),
     openExternal: vi.fn(async () => undefined),
     showItemInFolder: vi.fn(),
   },
+}));
+
+vi.mock('../export-pdf', () => ({
+  htmlToPdf: vi.fn(async () => Buffer.from('%PDF-fake')),
 }));
 
 vi.mock('../settings', () => ({
@@ -182,6 +186,56 @@ describe('openPath', () => {
     expect(shell.openPath).toHaveBeenCalledWith(
       await fs.realpath(testGlobals.__testSettingsPath as string),
     );
+  });
+});
+
+describe('exportNotePdf', () => {
+  it('returns null without printing when the save dialog is cancelled', async () => {
+    const { dialog } = await import('electron');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog.showSaveDialog as any).mockResolvedValue({ canceled: true });
+    const result = await handlers.exportNotePdf(trustedEvent, '/c/note.md', '<html></html>');
+    expect(result).toBeNull();
+    const { htmlToPdf } = await import('../export-pdf');
+    expect(htmlToPdf).not.toHaveBeenCalled();
+  });
+
+  it('prints and writes the PDF to the picked path', async () => {
+    const target = join(tmp, 'out.pdf');
+    const { dialog } = await import('electron');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (dialog.showSaveDialog as any).mockResolvedValue({ canceled: false, filePath: target });
+    const result = await handlers.exportNotePdf(trustedEvent, '/c/note.md', '<html></html>');
+    expect(result).toBe(target.split('\\').join('/'));
+    expect(await fs.readFile(target, 'utf8')).toBe('%PDF-fake');
+    // The dialog defaults to <note-name>.pdf next to the source note.
+    expect(dialog.showSaveDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ defaultPath: '/c/note.pdf' }),
+    );
+  });
+
+  it('rejects an oversized document before opening the dialog', async () => {
+    const huge = 'x'.repeat(8 * 1024 * 1024 + 1);
+    await expect(handlers.exportNotePdf(trustedEvent, '/c/note.md', huge)).rejects.toThrow(
+      /size cap/,
+    );
+    const { dialog } = await import('electron');
+    expect(dialog.showSaveDialog).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty arguments', async () => {
+    await expect(handlers.exportNotePdf(trustedEvent, '', '<html></html>')).rejects.toThrow(
+      /expected a non-empty string/,
+    );
+    await expect(handlers.exportNotePdf(trustedEvent, '/c/note.md', '')).rejects.toThrow(
+      /expected a non-empty string/,
+    );
+  });
+
+  it('rejects an untrusted (webview) sender', async () => {
+    await expect(
+      handlers.exportNotePdf(webviewEvent, '/c/note.md', '<html></html>'),
+    ).rejects.toThrow(/not an app window/);
   });
 });
 

--- a/src/main/ipc/system.ts
+++ b/src/main/ipc/system.ts
@@ -12,11 +12,15 @@ import {
 } from '../settings';
 import { resolveConceptionConfigPath } from '../effective-config';
 import { detectConceptionState, initConception } from '../conception-init';
+import { htmlToPdf } from '../export-pdf';
 import { requirePathUnder, requirePathUnderWorkspace } from '../path-bounds';
 import { setWatchedConception } from '../watcher';
 import { disposeRepoWatchers } from '../repo-watchers';
 import { readHelpDoc } from '../help';
 import { requireMainWindowSender, requireNonEmptyString } from './utils';
+
+/** Backstop cap on the renderer-built export document handed to `exportNotePdf`. */
+const MAX_EXPORT_HTML_CHARS = 8 * 1024 * 1024;
 
 /**
  * Bound a renderer-supplied path for `openPath` / `showInFolder`: it must
@@ -109,6 +113,31 @@ export function registerSystemIpc(opts: {
       url: pathToFileURL(real).href,
       filename: basename(real),
     };
+  });
+
+  ipcMain.handle('exportNotePdf', async (event, path: string, html: string) => {
+    requireMainWindowSender(event);
+    requireNonEmptyString('exportNotePdf', path);
+    requireNonEmptyString('exportNotePdf', html);
+    // Backstop against a runaway payload — a real note (mermaid SVGs
+    // included) stays far below this.
+    if (html.length > MAX_EXPORT_HTML_CHARS) {
+      throw new Error('exportNotePdf: document exceeds the export size cap');
+    }
+    // `path` only seeds the save dialog's default name/location — it is
+    // never read or written, and the write target is whatever the user picks
+    // in the dialog. So no workspace bound, mirroring openInEditor's
+    // documented trust boundary above.
+    const defaultPath = path.replace(/\.[^./\\]*$/, '') + '.pdf';
+    const result = await dialog.showSaveDialog({
+      title: 'Export as PDF',
+      defaultPath,
+      filters: [{ name: 'PDF', extensions: ['pdf'] }],
+    });
+    if (result.canceled || !result.filePath) return null;
+    const pdf = await htmlToPdf(html);
+    await fs.writeFile(result.filePath, pdf);
+    return toPosix(result.filePath);
   });
 
   ipcMain.handle('detectConceptionState', (event, path: string) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -73,6 +73,7 @@ const api: CondashApi = {
   writeNote: (path, expectedContent, newContent) =>
     ipcRenderer.invoke('writeNote', path, expectedContent, newContent),
   readHelpDoc: (name) => ipcRenderer.invoke('readHelpDoc', name),
+  exportNotePdf: (path, html) => ipcRenderer.invoke('exportNotePdf', path, html),
   onTreeEvents: (callback) => {
     const handler = (_: unknown, events: TreeEvent[]): void => callback(events);
     ipcRenderer.on(EVENT_CHANNELS.treeEvents, handler);

--- a/src/renderer/markdown.ts
+++ b/src/renderer/markdown.ts
@@ -268,6 +268,44 @@ export async function runMermaidIn(container: HTMLElement): Promise<void> {
   if (blocks.length === 0) return;
 
   const mermaid = await getMermaid();
+  await renderMermaidBlocks(container, mermaid);
+}
+
+/**
+ * Render markdown into a print-ready HTML body for PDF export. A fresh render
+ * (so view-mode DOM state like find-bar highlights never leaks in) with
+ * mermaid diagrams forced to the light theme — a dark-themed SVG would be
+ * unreadable on a white page. The shared mermaid singleton is re-initialised
+ * back to the live app theme afterwards.
+ */
+export async function renderMarkdownForExport(
+  input: string,
+  options: RenderMarkdownOptions = {},
+): Promise<string> {
+  const html = await renderMarkdown(input, options);
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  if (container.querySelector('pre.mermaid')) {
+    const mermaid = await getMermaid();
+    mermaid.initialize({ startOnLoad: false, theme: 'default', securityLevel: 'strict' });
+    try {
+      await renderMermaidBlocks(container, mermaid);
+    } finally {
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: activeMermaidTheme(),
+        securityLevel: 'strict',
+      });
+    }
+  }
+  return container.innerHTML;
+}
+
+async function renderMermaidBlocks(
+  container: HTMLElement,
+  mermaid: Awaited<ReturnType<typeof getMermaid>>,
+): Promise<void> {
+  const blocks = container.querySelectorAll<HTMLElement>('pre.mermaid');
   for (const block of blocks) {
     // This effect re-runs on every html()/theme change; once a block has been
     // turned into an SVG, skip it so we don't re-parse rendered output as source.

--- a/src/renderer/note-modal-parts/export-pdf.css
+++ b/src/renderer/note-modal-parts/export-pdf.css
@@ -1,0 +1,153 @@
+/* Print stylesheet for the note-PDF export (see export-pdf.ts). The exported
+ * document renders in a bare hidden window with none of the app's stylesheets,
+ * so this file is self-contained on purpose: literal light colours (GitHub
+ * light palette, matching code-theme.css's light arm), no app var() tokens.
+ * Typography mirrors `.md-rendered` in note-modal.css. */
+
+body {
+  margin: 0;
+  background: #ffffff;
+  color: #1f2328;
+  font-family:
+    system-ui,
+    -apple-system,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+}
+
+.md-rendered {
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.md-rendered h1,
+.md-rendered h2,
+.md-rendered h3 {
+  margin-top: 1.6em;
+  margin-bottom: 0.4em;
+  line-height: 1.25;
+  break-after: avoid-page;
+}
+
+.md-rendered h1:first-child,
+.md-rendered h2:first-child,
+.md-rendered h3:first-child {
+  margin-top: 0;
+}
+
+.md-rendered h1 {
+  font-size: 1.6em;
+}
+.md-rendered h2 {
+  font-size: 1.3em;
+  border-bottom: 1px solid #d0d7de;
+  padding-bottom: 0.2em;
+}
+.md-rendered h3 {
+  font-size: 1.1em;
+}
+
+.md-rendered p {
+  margin: 0.6em 0;
+}
+
+.md-rendered a {
+  color: #0969da;
+  text-decoration: none;
+}
+
+.md-rendered a.wikilink {
+  color: #0969da;
+  border-bottom: 1px dashed #0969da;
+}
+
+.md-rendered code {
+  background: #f6f8fa;
+  border-radius: 3px;
+  padding: 1px 4px;
+  font-family: ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+  font-size: 0.9em;
+}
+
+.md-rendered pre {
+  background: #f6f8fa;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  padding: 12px;
+  margin: 0.8em 0;
+  line-height: 1.45;
+  /* No horizontal scroll on paper — wrap long code lines instead. */
+  white-space: pre-wrap;
+  word-break: break-word;
+  break-inside: avoid-page;
+}
+
+.md-rendered pre code {
+  background: transparent;
+  padding: 0;
+  font-size: 0.92em;
+}
+
+.md-rendered table {
+  border-collapse: collapse;
+  margin: 0.8em 0;
+}
+
+.md-rendered th,
+.md-rendered td {
+  border: 1px solid #d0d7de;
+  padding: 4px 8px;
+  text-align: left;
+}
+
+.md-rendered th {
+  background: #f6f8fa;
+}
+
+.md-rendered blockquote {
+  border-left: 3px solid #0969da;
+  margin: 0.8em 0;
+  padding: 0.2em 12px;
+  color: #57606a;
+}
+
+.md-rendered ul,
+.md-rendered ol {
+  padding-left: 1.6em;
+  margin: 0.5em 0;
+}
+
+.md-rendered li {
+  margin: 0.2em 0;
+}
+
+.md-rendered .task-list-item {
+  list-style: none;
+  margin-left: -1.2em;
+}
+
+.md-rendered .task-list-item input {
+  margin-right: 6px;
+}
+
+.md-rendered hr {
+  border: none;
+  border-top: 1px solid #d0d7de;
+  margin: 1.2em 0;
+}
+
+.md-rendered img {
+  max-width: 100%;
+  height: auto;
+}
+
+.md-rendered .mermaid {
+  background: #ffffff;
+  border: 1px solid #d0d7de;
+  border-radius: 6px;
+  padding: 12px;
+  text-align: center;
+  white-space: normal;
+  break-inside: avoid-page;
+}

--- a/src/renderer/note-modal-parts/export-pdf.ts
+++ b/src/renderer/note-modal-parts/export-pdf.ts
@@ -1,0 +1,41 @@
+import codeThemeCss from '../code-theme.css?inline';
+import { renderMarkdownForExport } from '../markdown';
+import exportCss from './export-pdf.css?inline';
+
+/** Minimal escape for text dropped into the export document's <title>. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Build the self-contained HTML document `exportNotePdf` prints in a hidden
+ * window. Carries everything inline: the freshly-rendered note body (mermaid
+ * pre-rendered to SVG — the hidden window runs no scripts), the code-fence
+ * palette, and the print stylesheet. `data-theme="light"` pins the bundled
+ * code-theme palette to its light arm regardless of OS dark preference (its
+ * dark arms key on `[data-theme='dark']` or `prefers-color-scheme: dark`
+ * without a `light` override).
+ */
+export async function buildNotePdfHtml(
+  markdown: string,
+  opts: { baseDir?: string; title: string },
+): Promise<string> {
+  const body = await renderMarkdownForExport(markdown, { baseDir: opts.baseDir });
+  return [
+    '<!doctype html>',
+    '<html data-theme="light">',
+    '<head>',
+    '<meta charset="utf-8" />',
+    `<title>${escapeHtml(opts.title)}</title>`,
+    `<style>${codeThemeCss}\n${exportCss}</style>`,
+    '</head>',
+    '<body>',
+    `<article class="md-rendered">${body}</article>`,
+    '</body>',
+    '</html>',
+  ].join('\n');
+}

--- a/src/renderer/note-modal-parts/icons.tsx
+++ b/src/renderer/note-modal-parts/icons.tsx
@@ -39,6 +39,25 @@ export function IconView() {
   );
 }
 
+export function IconPdf() {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3.5 1.5h6l3 3v10h-9z" />
+      <path d="M9.5 1.5v3h3" />
+      <path d="M8 6.5v4" />
+      <path d="M6 8.8l2 2 2-2" />
+    </svg>
+  );
+}
+
 export function IconSave() {
   return (
     <svg

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -15,9 +15,10 @@ import type { Deliverable } from '@shared/types';
 import type { ModalState } from './modal-types';
 import { ConfirmModal } from './confirm-modal';
 import { IconClose, IconExternal } from './icons';
-import { IconEdit, IconSave, IconView } from './note-modal-parts/icons';
+import { IconEdit, IconPdf, IconSave, IconView } from './note-modal-parts/icons';
 import { clearFindHighlights, focusFindMatch, highlightFindMatches } from './note-modal-parts/find';
 import { ConfigSummaryPanel } from './note-modal-parts/config-summary';
+import { buildNotePdfHtml } from './note-modal-parts/export-pdf';
 import './note-modal.css';
 import './code-theme.css';
 
@@ -136,6 +137,22 @@ export function NoteModal(props: {
     if (savedAtTimer !== null) clearTimeout(savedAtTimer);
   });
 
+  // PDF export: busy flag (debounces the button) + a transient exported-✓
+  // pill mirroring the saved-✓ one.
+  const [exporting, setExporting] = createSignal(false);
+  const [exportedAt, setExportedAt] = createSignal<number | null>(null);
+  let exportedAtTimer: ReturnType<typeof setTimeout> | null = null;
+  const scheduleExportedAtClear = (): void => {
+    if (exportedAtTimer !== null) clearTimeout(exportedAtTimer);
+    exportedAtTimer = setTimeout(() => {
+      setExportedAt(null);
+      exportedAtTimer = null;
+    }, 1500);
+  };
+  onCleanup(() => {
+    if (exportedAtTimer !== null) clearTimeout(exportedAtTimer);
+  });
+
   // Mirror the dirty flag out to the host. createEffect, not a wrapped
   // setDirty: covers every flip including the resets fired below on path
   // change, so the host's "unsaved" view never lags the modal's.
@@ -164,6 +181,7 @@ export function NoteModal(props: {
     setDirty(false);
     setError(null);
     setSavedAt(null);
+    setExportedAt(null);
     setFindOpen(false);
     setFindQuery('');
     setFindMatch(null);
@@ -361,6 +379,32 @@ export function NoteModal(props: {
     }
   };
 
+  // Export the current note as a PDF: build the self-contained document
+  // (fresh render + inline print CSS) and hand it to the main process, which
+  // owns the save dialog and the hidden print window. A `null` result means
+  // the user cancelled the dialog — only a real save shows the ✓ pill.
+  const exportPdf = async (): Promise<void> => {
+    const state = props.state;
+    const text = content();
+    if (!state || text == null || exporting()) return;
+    setError(null);
+    setExporting(true);
+    try {
+      const baseDir = state.path.replace(/\/[^/]*$/, '');
+      const title = state.title ?? state.path.split('/').pop() ?? 'note';
+      const doc = await buildNotePdfHtml(text, { baseDir, title });
+      const saved = await window.condash.exportNotePdf(state.path, doc);
+      if (saved) {
+        setExportedAt(Date.now());
+        scheduleExportedAtClear();
+      }
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setExporting(false);
+    }
+  };
+
   // Request a switch to view mode. If the editor is dirty, defer until the
   // user resolves the Save / Discard / Cancel dialog so edits aren't silently
   // lost when CodeMirror unmounts.
@@ -523,6 +567,11 @@ export function NoteModal(props: {
               ✓
             </span>
           </Show>
+          <Show when={exportedAt() !== null}>
+            <span class="modal-saved" title="PDF exported" aria-label="PDF exported">
+              ✓
+            </span>
+          </Show>
           <Show when={!props.state?.readOnly}>
             <button
               class="modal-button"
@@ -543,6 +592,17 @@ export function NoteModal(props: {
               aria-label="Save"
             >
               <IconSave />
+            </button>
+          </Show>
+          <Show when={mode() === 'view' && props.state && isMarkdown(props.state.path)}>
+            <button
+              class="modal-button"
+              onClick={() => void exportPdf()}
+              disabled={exporting()}
+              title="Export as PDF"
+              aria-label="Export as PDF"
+            >
+              <IconPdf />
             </button>
           </Show>
           <button

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -379,6 +379,13 @@ export interface CondashApi {
    *  and percent-encoding). Returns the URL plus the basename so the
    *  renderer can render it without doing its own POSIX-only path split. */
   pdfToFileUrl(path: string): Promise<{ url: string; filename: string }>;
+  /** Export a rendered note as a PDF. `html` is the self-contained document
+   *  the renderer built (see `note-modal-parts/export-pdf.ts`); `path` is the
+   *  source note, used only to seed the save dialog's default `<name>.pdf`
+   *  target. The main process pops the save dialog, prints the document in a
+   *  hidden window via `printToPDF`, and writes the result. Resolves to the
+   *  saved file's path, or `null` when the user cancels the dialog. */
+  exportNotePdf(path: string, html: string): Promise<string | null>;
   /**
    * Subscribe to commands sent by the application menu (File → Search,
    * File → Open conception directory, File → Quit). Returns an unsubscribe.

--- a/tests/note-export-pdf.spec.ts
+++ b/tests/note-export-pdf.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { bootApp } from './fixtures/electron-app';
+
+/**
+ * End-to-end export pipeline: open a markdown note in the viewer, click
+ * "Export as PDF", and assert a real PDF lands at the picked path. The OS
+ * save dialog is stubbed in the main process so the run stays headless; the
+ * rest — renderer-built HTML document, hidden print window, `printToPDF`,
+ * file write — runs for real.
+ */
+test('Export as PDF prints the open note to the picked path', async () => {
+  const booted = await bootApp();
+  try {
+    const win = booted.window;
+    const target = join(booted.conceptionDir, 'exported.pdf');
+    await booted.app.evaluate(({ dialog }, filePath) => {
+      dialog.showSaveDialog = async () => ({ canceled: false, filePath });
+    }, target);
+
+    await win.waitForSelector('.row', { state: 'visible', timeout: 5000 });
+    await win.click('.row .title');
+    await win.waitForSelector('.modal.project-preview', { state: 'visible' });
+    await win.click('button[title="Open README"]');
+    await win.waitForSelector('.modal.note-modal', { state: 'visible' });
+
+    await win.click('.modal.note-modal button[aria-label="Export as PDF"]');
+    // The transient exported-✓ pill appears once the main process reports
+    // the written file.
+    await win.waitForSelector('.modal.note-modal .modal-saved[title="PDF exported"]', {
+      timeout: 15000,
+    });
+
+    const pdf = await readFile(target);
+    expect(pdf.subarray(0, 5).toString()).toBe('%PDF-');
+  } finally {
+    await booted.cleanup();
+  }
+});
+
+test('the export button is absent in edit mode', async () => {
+  const booted = await bootApp();
+  try {
+    const win = booted.window;
+    await win.waitForSelector('.row', { state: 'visible', timeout: 5000 });
+    await win.click('.row .title');
+    await win.waitForSelector('.modal.project-preview', { state: 'visible' });
+    await win.click('button[title="Open README"]');
+    await win.waitForSelector('.modal.note-modal', { state: 'visible' });
+
+    await expect(win.locator('.modal.note-modal button[aria-label="Export as PDF"]')).toBeVisible();
+    // Switch to edit mode — the affordance only applies to the rendered view.
+    await win.click('.modal.note-modal button[aria-label="Switch to edit mode"]');
+    await expect(win.locator('.modal.note-modal button[aria-label="Export as PDF"]')).toHaveCount(
+      0,
+    );
+  } finally {
+    await booted.cleanup();
+  }
+});


### PR DESCRIPTION
## Summary

- Viewing a markdown note now offers a one-click **Export as PDF** from the note modal header — no external tools, output matches the in-app rendering.
- Chosen design: Electron `printToPDF` on a renderer-built, self-contained light-theme document, behind an OS save dialog defaulting to `<note-name>.pdf` next to the source note.

## Changes

- `src/shared/api.ts` + `src/preload/index.ts` — new `exportNotePdf(path, html): Promise<string | null>` IPC verb (null on dialog cancel).
- `src/main/ipc/system.ts` — handler: sender/arg validation, 8M-char payload cap, save dialog seeded from the source note's name; the source path is never read or written (trust boundary documented inline, mirroring `openInEditor`).
- `src/main/export-pdf.ts` (new) — loads the document from a temp file into a hidden sandboxed `BrowserWindow` and prints via `printToPDF({ printBackground: true, pageSize: 'A4' })`.
- `src/renderer/markdown.ts` — `renderMarkdownForExport`: fresh render with mermaid forced to the light theme (singleton re-initialised back to the app theme after); mermaid block loop extracted to a shared helper.
- `src/renderer/note-modal-parts/export-pdf.ts` / `.css` (new) — builds the self-contained HTML document: inlined `code-theme.css` pinned to its light arm via `data-theme="light"`, plus a self-contained print stylesheet (literal light palette, wrapped `pre`, page-break hints).
- `src/renderer/note-modal.tsx` + `note-modal-parts/icons.tsx` — header button (view mode, `.md` only), busy/disabled state, transient "PDF exported" pill, errors surface in the existing modal error banner.
- `src/main/ipc/system.test.ts` — 5 new cases (cancel, write + default path, size cap, empty args, webview sender).
- `tests/note-export-pdf.spec.ts` (new) — e2e: save dialog stubbed in the main process, real `%PDF-` file asserted on disk; button absent in edit mode.
- `docs/guides/deliverables.md` — built-in export documented as the quick path; the pandoc recipe kept for typographic control.

## Impact

- Relative note images keep working in exports: they are rewritten to `condash-file://` at render time and the hidden window shares the default session, so the conception-bounded protocol handler serves them.
- Exports are always light-themed regardless of app/OS theme — deliberate, for print readability.