### PR TITLE
Add "Pull branch" action to the code-card branch menu

### DIFF
--- a/docs/reference/ipc-api.md
+++ b/docs/reference/ipc-api.md
@@ -65,6 +65,7 @@ All writes are `tmp` → `fsync` → `rename`. The per-file write queue (`mutate
 | `invalidateGitStatus()` | Drop the 3 s TTL git-status cache (used by the Refresh button). |
 | `getDirtyDetails(path, opts?)` | Detailed `git status -s` + `git diff --stat HEAD` for a worktree path. Powers the click-to-inspect popover on the per-branch `N dirty` badge. Returns `null` when the path is missing or not a git repo. |
 | `forceStopRepo(repoName)` | Run the repo's `force_stop:` shell command — escape hatch for a port held by a non-condash process. |
+| `pullBranch(path)` | Fast-forward a worktree to its upstream (`git pull --ff-only`) — the per-branch **Pull branch** menu action. Refuses on a dirty tree and returns `updated` / `up-to-date` / `diverged` / `dirty` so the caller can toast the outcome; throws on an unexpected git failure (no upstream, network, not a repo). |
 | `listOpenWith()` | Return `open_with` slots from `<conception>/.condash/settings.json` (with legacy `condash.json` / `configuration.json` as read fallbacks). Slots resolve through the conception ⊕ global precedence; the global `settings.json` provides defaults. |
 | `launchOpenWith(slot, path)` | Spawn the configured editor against `path`. |
 | `openInEditor(path)` | Resolve the user's preferred editor and open the file. |

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -4,10 +4,16 @@ import { invalidateAll } from '../git-status-cache';
 import { recomputeAllWatchedRepos, setRepoWatchers, watchTargetsFromRepos } from '../repo-watchers';
 import { getDirtyDetails } from '../git-details';
 import { forceStopRepo, launchOpenWith, listOpenWith } from '../launchers';
+import { pullBranch } from '../pull-branch';
 import { requirePathUnderWorkspace } from '../path-bounds';
 import { readSettings } from '../settings';
 import type { OpenWithSlotKey } from '../../shared/types';
-import { requireConception, requireMainWindowSender, withConception } from './utils';
+import {
+  requireConception,
+  requireMainWindowSender,
+  requireNonEmptyString,
+  withConception,
+} from './utils';
 
 /**
  * Wire repo / git-status / launcher IPC handlers. The two listRepos verbs
@@ -90,6 +96,17 @@ export function registerReposIpc(): void {
       const realPath = await requirePathUnderWorkspace(path);
       return launchOpenWith(conceptionPath, slot, realPath);
     });
+  });
+
+  // Code-pane per-branch "Pull branch": fast-forward the worktree to its
+  // upstream. Bounded to the workspace + worktrees roots so the renderer can
+  // only drive a `git pull` inside a known checkout, never an arbitrary
+  // directory on disk.
+  ipcMain.handle('pullBranch', async (event, path: string) => {
+    requireMainWindowSender(event);
+    requireNonEmptyString('pullBranch', path);
+    const realPath = await requirePathUnderWorkspace(path);
+    return pullBranch(realPath);
   });
 
   ipcMain.handle('forceStopRepo', (event, repoName: string) => {

--- a/src/main/pull-branch.test.ts
+++ b/src/main/pull-branch.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the pure pull-output classifiers plus one real-git
+ * integration of `pullBranch` end-to-end: a clone fast-forwarding to new
+ * upstream commits, the already-in-sync case, the dirty refusal, and a
+ * diverged branch that can't fast-forward.
+ */
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { exec } from './exec';
+import { invalidateAll } from './git-status-cache';
+import { classifyPullFailure, classifyPullSuccess, pullBranch } from './pull-branch';
+
+describe('classifyPullSuccess', () => {
+  it('detects an already-up-to-date pull', () => {
+    expect(classifyPullSuccess('Already up to date.\n')).toEqual({
+      status: 'up-to-date',
+      message: 'Already up to date',
+    });
+    // Older git spelling.
+    expect(classifyPullSuccess('Already up-to-date.\n').status).toBe('up-to-date');
+  });
+
+  it('reports a fast-forward with the commit range when present', () => {
+    const out = 'Updating 1a2b3c4..5d6e7f8\nFast-forward\n file.txt | 1 +\n';
+    expect(classifyPullSuccess(out)).toEqual({
+      status: 'updated',
+      message: 'Fast-forwarded (1a2b3c4..5d6e7f8)',
+    });
+  });
+
+  it('falls back to a generic updated message when no range is printed', () => {
+    expect(classifyPullSuccess('Fast-forward\n')).toEqual({
+      status: 'updated',
+      message: 'Fast-forwarded to upstream',
+    });
+  });
+});
+
+describe('classifyPullFailure', () => {
+  it('maps a non-fast-forward error to a diverged result', () => {
+    expect(classifyPullFailure('fatal: Not possible to fast-forward, aborting.')).toEqual({
+      status: 'diverged',
+      message: 'Branch has diverged from upstream — fast-forward not possible',
+    });
+  });
+
+  it('returns null for an unrecognised failure (rethrow path)', () => {
+    expect(classifyPullFailure('fatal: could not read from remote repository')).toBeNull();
+    expect(classifyPullFailure('there is no tracking information')).toBeNull();
+  });
+});
+
+describe('pullBranch against a real repo', () => {
+  let tmp: string;
+  let remote: string;
+  let work: string;
+  let local: string;
+
+  async function git(cwd: string, ...args: string[]): Promise<string> {
+    const { stdout } = await exec('git', args, {
+      cwd,
+      env: { ...process.env, GIT_CONFIG_GLOBAL: '/dev/null', GIT_CONFIG_SYSTEM: '/dev/null' },
+    });
+    return stdout;
+  }
+
+  async function commitTo(
+    repo: string,
+    file: string,
+    body: string,
+    message: string,
+  ): Promise<void> {
+    writeFileSync(join(repo, file), body);
+    await git(repo, 'add', '.');
+    await git(repo, 'commit', '-q', '-m', message);
+  }
+
+  beforeAll(async () => {
+    tmp = mkdtempSync(join(tmpdir(), 'condash-pull-'));
+    remote = join(tmp, 'remote.git');
+    work = join(tmp, 'work');
+    local = join(tmp, 'local');
+
+    // Bare remote seeded from a working clone, so `local` clones with an
+    // `origin/main` upstream already configured (what `--ff-only` needs).
+    await git(tmp, 'init', '-q', '--bare', '-b', 'main', 'remote.git');
+    await git(tmp, 'clone', '-q', remote, 'work');
+    await git(work, 'config', 'user.email', 'test@example.com');
+    await git(work, 'config', 'user.name', 'Test');
+    await commitTo(work, 'file.txt', 'one\n', 'init');
+    await git(work, 'push', '-q', '-u', 'origin', 'main');
+
+    await git(tmp, 'clone', '-q', remote, 'local');
+    await git(local, 'config', 'user.email', 'dev@example.com');
+    await git(local, 'config', 'user.name', 'Dev');
+    invalidateAll();
+  });
+
+  afterAll(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('reports up-to-date when the clone is already in sync', async () => {
+    const result = await pullBranch(local);
+    expect(result.status).toBe('up-to-date');
+  });
+
+  it('fast-forwards when upstream has new commits', async () => {
+    await commitTo(work, 'file.txt', 'one\ntwo\n', 'second');
+    await git(work, 'push', '-q', 'origin', 'main');
+    invalidateAll();
+    const result = await pullBranch(local);
+    expect(result.status).toBe('updated');
+  });
+
+  it('refuses on a dirty working tree', async () => {
+    writeFileSync(join(local, 'scratch.txt'), 'uncommitted\n');
+    invalidateAll();
+    const result = await pullBranch(local);
+    expect(result.status).toBe('dirty');
+    // Clean up so the divergence test starts from a clean tree.
+    rmSync(join(local, 'scratch.txt'));
+    invalidateAll();
+  });
+
+  it('reports a diverged branch that cannot fast-forward', async () => {
+    // Local advances on its own commit...
+    await commitTo(local, 'file.txt', 'one\ntwo\nlocal\n', 'local-only');
+    // ...while upstream advances on a different one.
+    await commitTo(work, 'file.txt', 'one\ntwo\nremote\n', 'remote-only');
+    await git(work, 'push', '-q', 'origin', 'main');
+    invalidateAll();
+    const result = await pullBranch(local);
+    expect(result.status).toBe('diverged');
+  });
+});

--- a/src/main/pull-branch.ts
+++ b/src/main/pull-branch.ts
@@ -1,0 +1,82 @@
+// "Pull branch" action behind the Code-pane per-branch actions menu.
+//
+// Runs `git pull --ff-only` in a worktree's working directory, but refuses
+// when the tree is dirty — committing or stashing is the user's call, not
+// ours. The fast-forward-only flag means a diverged branch is reported, never
+// force-merged: issue #337's "don't silently swallow a non-ff failure".
+//
+// Output classification is split into two pure helpers so the updated /
+// up-to-date / diverged decision is unit-tested without a live git (mirrors
+// the parsePorcelain / parseNumstat split in git-details.ts).
+
+import { simpleGit } from 'simple-git';
+import type { PullBranchResult } from '../shared/types';
+import { getDirtyCount } from './git-status-cache';
+
+/** Classify a *successful* `git pull --ff-only` stdout. Git prints "Already
+ *  up to date." when there was nothing to apply; any other output means
+ *  commits were fast-forwarded in. Pure; exported for tests. */
+export function classifyPullSuccess(stdout: string): PullBranchResult {
+  if (/already up[ -]to[ -]date/i.test(stdout)) {
+    return { status: 'up-to-date', message: 'Already up to date' };
+  }
+  const range = stdout.match(/Updating\s+([0-9a-f]+\.\.[0-9a-f]+)/i);
+  return {
+    status: 'updated',
+    message: range ? `Fast-forwarded (${range[1]})` : 'Fast-forwarded to upstream',
+  };
+}
+
+/** Map a *failed* `git pull --ff-only` error message to a result, or null
+ *  when the failure isn't a recognised non-fast-forward and should bubble up
+ *  as a thrown error (no upstream configured, network down, not a repo).
+ *  Pure; exported for tests. */
+export function classifyPullFailure(message: string): PullBranchResult | null {
+  if (/not possible to fast-forward|non-fast-forward|diverg/i.test(message)) {
+    return {
+      status: 'diverged',
+      message: 'Branch has diverged from upstream — fast-forward not possible',
+    };
+  }
+  return null;
+}
+
+/**
+ * Fast-forward a worktree to its upstream. Returns a `dirty` result (no git
+ * run) when the working tree has uncommitted changes; otherwise runs
+ * `git pull --ff-only` and classifies the outcome. Throws on an unexpected
+ * git failure the user can't resolve from the card (no upstream configured,
+ * network failure, path not a repo) so the renderer surfaces it as an error.
+ *
+ * @param path Absolute path to the worktree working directory.
+ * @returns The classified pull outcome.
+ */
+export async function pullBranch(path: string): Promise<PullBranchResult> {
+  const dirty = await getDirtyCount(path);
+  if (dirty && dirty > 0) {
+    return {
+      status: 'dirty',
+      message: `Worktree has ${dirty} uncommitted change${dirty === 1 ? '' : 's'} — commit or stash before pulling`,
+    };
+  }
+  const git = simpleGit({ baseDir: path });
+  try {
+    const stdout = await git.raw(['pull', '--ff-only']);
+    return classifyPullSuccess(stdout);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const classified = classifyPullFailure(message);
+    if (classified) return classified;
+    throw new Error(firstLine(message) || 'git pull failed');
+  }
+}
+
+/** First non-empty line of a multi-line error, trimmed — keeps a thrown
+ *  message toast-sized. */
+function firstLine(message: string): string {
+  for (const line of message.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed) return trimmed;
+  }
+  return '';
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -24,6 +24,7 @@ const api: CondashApi = {
   listOpenWith: () => ipcRenderer.invoke('listOpenWith'),
   launchOpenWith: (slot, path) => ipcRenderer.invoke('launchOpenWith', slot, path),
   forceStopRepo: (repoName) => ipcRenderer.invoke('forceStopRepo', repoName),
+  pullBranch: (path) => ipcRenderer.invoke('pullBranch', path),
   openInEditor: (path) => ipcRenderer.invoke('openInEditor', path),
   pickConceptionPath: () => ipcRenderer.invoke('pickConceptionPath'),
   getConceptionPath: () => ipcRenderer.invoke('getConceptionPath'),

--- a/src/renderer/hooks/use-repo-actions.ts
+++ b/src/renderer/hooks/use-repo-actions.ts
@@ -10,6 +10,10 @@ export interface UseRepoActionsDeps {
 
 export interface UseRepoActions {
   handleLaunch: (slot: OpenWithSlotKey, path: string) => Promise<void>;
+  /** Code-pane per-branch "Pull branch" — `git pull --ff-only` in the
+   *  worktree, toasting updated / up-to-date / diverged / dirty. Drops the
+   *  git-status cache after a real fast-forward so the card's badges refresh. */
+  handlePull: (path: string) => Promise<void>;
   handleForceStop: (repo: RepoEntry) => void;
   runForceStop: (repo: RepoEntry) => Promise<void>;
   /** Per-card ⏹ — close the live code-side session for this repo, which
@@ -27,6 +31,20 @@ export function useRepoActions(deps: UseRepoActionsDeps): UseRepoActions {
       await window.condash.launchOpenWith(slot, path);
     } catch (err) {
       deps.flashToast(`Launch failed: ${(err as Error).message}`, 'error');
+    }
+  };
+
+  const handlePull = async (path: string): Promise<void> => {
+    try {
+      const result = await window.condash.pullBranch(path);
+      const kind =
+        result.status === 'updated' ? 'success' : result.status === 'up-to-date' ? 'info' : 'error';
+      deps.flashToast(result.message, kind);
+      // Only a real fast-forward moves HEAD / dirty / ahead — drop the git
+      // status cache so the card's badges reflect the new tip right away.
+      if (result.status === 'updated') await window.condash.invalidateGitStatus();
+    } catch (err) {
+      deps.flashToast(`Pull failed: ${(err as Error).message}`, 'error');
     }
   };
 
@@ -75,5 +93,5 @@ export function useRepoActions(deps: UseRepoActionsDeps): UseRepoActions {
     }
   };
 
-  return { handleLaunch, handleForceStop, runForceStop, handleStopRepo, handleRunRepo };
+  return { handleLaunch, handlePull, handleForceStop, runForceStop, handleStopRepo, handleRunRepo };
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -264,7 +264,7 @@ function App() {
   });
 
   // --- Repo actions (Code-pane row callbacks) ---------------------------
-  const { handleLaunch, handleForceStop, runForceStop, handleStopRepo, handleRunRepo } =
+  const { handleLaunch, handlePull, handleForceStop, runForceStop, handleStopRepo, handleRunRepo } =
     useRepoActions({
       allSessions,
       getTerminalHandle: () => terminalHandle,
@@ -689,6 +689,7 @@ function App() {
                         onSetAllSticky={branchFilter.setAllSticky}
                         onSetNoneBranches={branchFilter.setNone}
                         onOpen={handleOpenInEditor}
+                        onPull={(path) => void handlePull(path)}
                         onLaunch={(slot, path) => void handleLaunch(slot, path)}
                         onForceStop={(r) => void handleForceStop(r)}
                         onStop={handleStopRepo}

--- a/src/renderer/panes/code-parts/branch-actions.tsx
+++ b/src/renderer/panes/code-parts/branch-actions.tsx
@@ -23,6 +23,7 @@ export function BranchActions(props: {
    * the row that actually represents it. */
   running: boolean;
   onOpen: (path: string) => void;
+  onPull: (path: string) => void;
   onLaunch: (slot: OpenWithSlotKey, path: string) => void;
   onRun: (repo: RepoEntry, worktree?: Worktree) => void;
   onStop: (repo: RepoEntry) => void;
@@ -32,6 +33,12 @@ export function BranchActions(props: {
 
   const launcherEntries = (): OpenWithSlotKey[] =>
     LAUNCHER_SLOTS.filter((slot) => !!props.slots[slot]);
+
+  // "Pull branch" only makes sense for a real git checkout sitting on a
+  // branch — hidden for a missing path, a plain (non-git) directory, or a
+  // detached HEAD (no branch to fast-forward).
+  const canPull = (): boolean =>
+    !props.repo.missing && props.repo.isGit !== false && props.worktree.branch != null;
 
   return (
     <div class="branch-actions">
@@ -123,6 +130,20 @@ export function BranchActions(props: {
             </span>
             <span>Open in file manager</span>
           </button>
+          <Show when={canPull()}>
+            <button
+              class="branch-action-menu-item"
+              role="menuitem"
+              title="Fast-forward this branch to its upstream (git pull --ff-only)"
+              onClick={() => {
+                menu.close();
+                props.onPull(props.worktree.path);
+              }}
+            >
+              <span class="glyph">↓</span>
+              <span>Pull branch</span>
+            </button>
+          </Show>
         </div>
       </Show>
     </div>

--- a/src/renderer/panes/code-parts/repo-row.tsx
+++ b/src/renderer/panes/code-parts/repo-row.tsx
@@ -23,6 +23,7 @@ export function RepoRow(props: {
    *  (the "All (sticky)" mode from issue #169). */
   stickyAllBranches: boolean;
   onOpen: (path: string) => void;
+  onPull: (path: string) => void;
   onLaunch: (slot: OpenWithSlotKey, path: string) => void;
   onForceStop: (repo: RepoEntry) => void;
   onStop: (repo: RepoEntry) => void;
@@ -137,6 +138,7 @@ export function RepoRow(props: {
                 onStop={props.onStop}
                 onOpenInTerm={props.onOpenInTerm}
                 onOpen={props.onOpen}
+                onPull={props.onPull}
               />
             </li>
           )}

--- a/src/renderer/panes/code.tsx
+++ b/src/renderer/panes/code.tsx
@@ -45,6 +45,7 @@ export function CodeView(props: {
   /** Switch the branch filter into "only main" mode. */
   onSetNoneBranches: () => void;
   onOpen: (path: string) => void;
+  onPull: (path: string) => void;
   onLaunch: (slot: OpenWithSlotKey, path: string) => void;
   onForceStop: (repo: RepoEntry) => void;
   onStop: (repo: RepoEntry) => void;
@@ -121,6 +122,7 @@ export function CodeView(props: {
                   selectedBranches={props.selectedBranches}
                   stickyAllBranches={props.stickyAllBranches}
                   onOpen={props.onOpen}
+                  onPull={props.onPull}
                   onLaunch={props.onLaunch}
                   onForceStop={props.onForceStop}
                   onStop={props.onStop}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -14,6 +14,7 @@ import type {
   ProjectCreateInput,
   ProjectCreateResult,
   ProjectFileEntry,
+  PullBranchResult,
   RepoEntry,
   RepoEvent,
   ResourceNode,
@@ -81,6 +82,12 @@ export interface CondashApi {
   listOpenWith(): Promise<OpenWithSlots>;
   launchOpenWith(slot: OpenWithSlotKey, path: string): Promise<void>;
   forceStopRepo(repoName: string): Promise<void>;
+  /** Fast-forward a worktree to its upstream — the Code-pane per-branch
+   * "Pull branch" action (`git pull --ff-only`). Refuses on a dirty tree and
+   * reports updated / up-to-date / diverged via the result so the caller can
+   * toast the outcome; throws on an unexpected git failure (no upstream,
+   * network, not a repo). */
+  pullBranch(path: string): Promise<PullBranchResult>;
   openInEditor(path: string): Promise<void>;
   pickConceptionPath(): Promise<string | null>;
   getConceptionPath(): Promise<string | null>;

--- a/src/shared/types/git.ts
+++ b/src/shared/types/git.ts
@@ -42,6 +42,19 @@ export interface UpstreamStatus {
   ahead: number;
 }
 
+/** Outcome of a per-branch `git pull --ff-only` (the Code-pane "Pull branch"
+ *  action). The renderer toasts `message`; `status` picks the toast tone.
+ *  - `updated`: the worktree fast-forwarded to new upstream commits.
+ *  - `up-to-date`: already in sync — nothing to apply.
+ *  - `diverged`: local and upstream both advanced, so a fast-forward isn't
+ *    possible; condash can't resolve it, so it's reported, not swallowed.
+ *  - `dirty`: refused because the worktree has uncommitted changes. */
+export interface PullBranchResult {
+  status: 'updated' | 'up-to-date' | 'diverged' | 'dirty';
+  /** Human-readable one-line summary for the toast. */
+  message: string;
+}
+
 /** Click-to-inspect payload for the per-branch dirty badge. One row per
  *  dirty file (capped at a fixed file limit) with totals for the footer.
  *  Also carries unpushed-commit context so the popover can list them in a


### PR DESCRIPTION
## Summary

Adds a **Pull branch** action to the Code-pane per-branch actions dropdown (issue #337). It fast-forwards the selected branch's worktree to its upstream — `git pull --ff-only` — so a branch can be updated from the dashboard without dropping to a terminal.

## Behaviour

- New **Pull branch** item in the per-branch `⌄` menu, alongside the existing open actions.
- Runs `git pull --ff-only` in the branch's working directory.
- Outcome surfaced as a toast: **updated** (success), **already up to date** (info), **diverged** / **dirty** (error). Refuses on a dirty tree rather than stashing.
- A real fast-forward drops the git-status cache so the card's dirty / ahead-behind badges refresh immediately.
- The item is hidden where a pull is meaningless: a missing path, a plain (non-git) directory, or a detached HEAD. (Every condash worktree row has a working directory, so the issue's "no checkout" case doesn't arise.)

## Implementation

- `src/main/pull-branch.ts` — `pullBranch(path)` plus two pure output classifiers (`classifyPullSuccess` / `classifyPullFailure`).
- `pullBranch` IPC verb in `src/main/ipc/repos.ts`, bounded to the workspace + worktrees roots via `requirePathUnderWorkspace`; new `PullBranchResult` shared type; `api.ts` + preload wiring.
- Renderer: menu item in `branch-actions.tsx`, `handlePull` in `use-repo-actions.ts`, threaded through `code.tsx` / `repo-row.tsx` / `main.tsx`.
- Docs: `pullBranch` row added to `docs/reference/ipc-api.md`.

## Testing

- `pull-branch.test.ts`: pure-classifier unit tests + a real-git integration covering up-to-date / fast-forward / dirty-refusal / diverged.
- Green locally: typecheck, build (main + renderer + CLI), knip, full unit suite (1191 tests), Playwright e2e (46 tests).

Closes #337
