### PR TITLE
Fix terminal runtime slowdowns: OSC 133 decoration leak + logger fsync

### DIFF
--- a/src/main/terminal-logger.test.ts
+++ b/src/main/terminal-logger.test.ts
@@ -404,6 +404,33 @@ describe('SessionLogger', () => {
     expect(footer?.exitCode).toBe(0);
   });
 
+  it('close() persists the final buffer even when exit() never ran (kill path)', async () => {
+    // The quit / SIGKILL path closes a logger without an exit() — the forced
+    // final flush in doClose() must still land the output (with no footer,
+    // since the session never reported an exit code).
+    const logger = makeLogger(
+      tmp,
+      {
+        sid: 't-killpath',
+        side: 'my',
+        cwd: '/x',
+        spawn: { cmd: 'bash', argv: [] },
+      },
+      {},
+      // Large debounce so no periodic flush fires — only doClose's flush writes.
+      60_000,
+    );
+    logger.spawn();
+    logger.output('output never explicitly flushed\r\n');
+    await logger.close();
+
+    const txt = logger.filePath();
+    if (!txt) throw new Error('no path');
+    const { body, footer } = parseFile(txt);
+    expect(body).toContain('output never explicitly flushed');
+    expect(footer).toBeNull();
+  });
+
   it('rendered file size is bounded by scrollback × line width', async () => {
     const logger = makeLogger(
       tmp,

--- a/src/main/terminal-logger.ts
+++ b/src/main/terminal-logger.ts
@@ -33,7 +33,10 @@ import { rotateTaskRuns, taskRunDir, taskRunLogPath } from './task-runs';
  * Bytes flow: pty `output(data)` → `term.write(data)`. A debounced timer
  * (default 5 s) re-renders the buffer + header (+ footer if exited) and
  * atomically renames a temp file onto the `.txt` path. `exit()` and
- * `close()` force an immediate flush.
+ * `close()` force an immediate flush. The periodic flushes do NOT `fsync` —
+ * only the terminal flushes (exit / close) do; the atomic rename already keeps
+ * the file from ever being torn, and fsync-ing every few-second re-snapshot
+ * stalls the main process for durability a log viewer doesn't need.
  *
  * `input(data)` is intentionally a no-op — the pty echoes typed bytes
  * back through stdout, so feeding `in` into the headless xterm would
@@ -244,7 +247,8 @@ export class SessionLogger {
     this.exitCode = exitCode;
     this.finishedTs = new Date().toISOString();
     this.dirty = true;
-    this.flushNowFireAndForget();
+    // Terminal flush — fsync the final footer state to disk.
+    this.flushNowFireAndForget(true);
   }
 
   /** Idempotent — concurrent and repeated calls share one close pass.
@@ -266,6 +270,15 @@ export class SessionLogger {
       await this.flushChain;
     }
     await this.flushChain;
+    // Terminal flush: fsync the final state once. The periodic flushes above
+    // wrote it unsynced, and a session killed without exit() (quit / SIGKILL)
+    // never hit exit()'s sync — so force one durable write here. Gated on
+    // `enabled` so a logging-off session still writes nothing.
+    if (this.prefs.enabled) {
+      this.dirty = true;
+      this.flushNowFireAndForget(true);
+      await this.flushChain;
+    }
     this.cancelFlush();
     this.closed = true;
     this.term.dispose();
@@ -298,17 +311,20 @@ export class SessionLogger {
     }
   }
 
-  private flushNowFireAndForget(): void {
+  private flushNowFireAndForget(sync = false): void {
     // Append onto the serialised chain — never run two flushes
     // concurrently against the same `.txt.tmp`.
     this.flushChain = this.flushChain
-      .then(() => this.flushNow())
+      .then(() => this.flushNow(sync))
       .catch((err: Error) => {
         process.stderr.write(`condash terminal-logger: flush failed: ${err.message}\n`);
       });
   }
 
-  private async flushNow(): Promise<void> {
+  /** Render the buffer and atomically write it to the `.txt`. `sync` forces an
+   *  fsync before the rename for durability — set only on the terminal flushes
+   *  (exit / close), not the periodic ones (see the class doc). */
+  private async flushNow(sync = false): Promise<void> {
     if (!this.dirty || this.closed) return;
     this.dirty = false;
     // Wait for any queued xterm parse to complete before rendering —
@@ -322,14 +338,17 @@ export class SessionLogger {
     const text = this.composeFileContent(body, isTranscript ? 'transcript' : 'grid');
     try {
       await mkdir(dirname(this.txtPath), { recursive: true });
-      // tmp → fsync → rename, matching the atomic-write invariant
-      // (atomic-write.ts): an unsynced rename can surface a zero-length
-      // file after power loss.
+      // tmp → (fsync) → rename. The atomic rename keeps the file from ever
+      // being torn / zero-length; fsync makes the content itself durable across
+      // power loss. Periodic flushes skip the fsync (a live session re-snapshots
+      // its whole buffer every few seconds — fsync-ing each one stalls the main
+      // process's libuv threadpool for durability the log viewer doesn't need);
+      // the exit / close flushes pass `sync: true`.
       const tmp = `${this.txtPath}.tmp`;
       const fh = await open(tmp, 'w');
       try {
         await fh.writeFile(text, 'utf8');
-        await fh.sync();
+        if (sync) await fh.sync();
       } finally {
         await fh.close();
       }

--- a/src/renderer/prompt-decorations.test.ts
+++ b/src/renderer/prompt-decorations.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { PromptDecorations } from './prompt-decorations';
+
+/** Minimal stand-in for an xterm decoration: records its own disposal. */
+class FakeDecoration {
+  disposed = false;
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+/** A factory that hands out FakeDecorations and keeps every one it made, so a
+ *  test can assert which were disposed. */
+function trackingFactory() {
+  const made: FakeDecoration[] = [];
+  const make = (): FakeDecoration => {
+    const dec = new FakeDecoration();
+    made.push(dec);
+    return dec;
+  };
+  return { made, make };
+}
+
+describe('PromptDecorations', () => {
+  it('keeps the decoration list aligned with prompt lines across A/D cycles', () => {
+    const { make } = trackingFactory();
+    const prompts = new PromptDecorations<FakeDecoration>(make);
+    // 500 command cycles, baseY pinned at 0 so nothing scrolls out — this is the
+    // regression: the old code grew the decoration list by 2 per command.
+    for (let i = 0; i < 500; i++) {
+      prompts.start(i, null, 0); // OSC 133 A
+      prompts.end(0); // OSC 133 D
+    }
+    expect(prompts.size).toBe(prompts.promptLines().length);
+    expect(prompts.size).toBe(500);
+  });
+
+  it('disposes the replaced decoration on prompt-end — no orphaned decoration', () => {
+    const { made, make } = trackingFactory();
+    const prompts = new PromptDecorations<FakeDecoration>(make);
+    prompts.start(0, null, 0); // creates made[0]
+    prompts.end(0); // disposes made[0], creates made[1] in its place
+    expect(made[0].disposed).toBe(true);
+    expect(made[1].disposed).toBe(false);
+    expect(prompts.size).toBe(1);
+  });
+
+  it('trims prompts that scroll out of scrollback and disposes their decorations', () => {
+    const { made, make } = trackingFactory();
+    const prompts = new PromptDecorations<FakeDecoration>(make);
+    prompts.start(0, null, 0);
+    prompts.start(1, null, 0);
+    prompts.start(2, null, 0);
+    expect(prompts.size).toBe(3);
+    // baseY advances to 2 → prompts on lines 0 and 1 are gone.
+    prompts.trim(2);
+    expect(prompts.promptLines()).toEqual([2]);
+    expect(prompts.size).toBe(1);
+    expect(made[0].disposed).toBe(true);
+    expect(made[1].disposed).toBe(true);
+    expect(made[2].disposed).toBe(false);
+  });
+
+  it('stays aligned when the factory returns null (decoration registration failed)', () => {
+    const prompts = new PromptDecorations<FakeDecoration>(() => null);
+    prompts.start(0, null, 0);
+    prompts.end(0);
+    prompts.start(1, null, 0);
+    expect(prompts.size).toBe(prompts.promptLines().length);
+    expect(prompts.size).toBe(2);
+  });
+
+  it('end() is a no-op before any prompt-start', () => {
+    const { made, make } = trackingFactory();
+    const prompts = new PromptDecorations<FakeDecoration>(make);
+    expect(() => prompts.end(0)).not.toThrow();
+    expect(prompts.size).toBe(0);
+    expect(made).toHaveLength(0);
+  });
+
+  it('dispose() releases every decoration and clears both lists', () => {
+    const { made, make } = trackingFactory();
+    const prompts = new PromptDecorations<FakeDecoration>(make);
+    prompts.start(0, null, 0);
+    prompts.start(1, null, 0);
+    prompts.dispose();
+    expect(prompts.size).toBe(0);
+    expect(prompts.promptLines()).toEqual([]);
+    expect(made.every((d) => d.disposed)).toBe(true);
+  });
+});

--- a/src/renderer/prompt-decorations.ts
+++ b/src/renderer/prompt-decorations.ts
@@ -1,0 +1,89 @@
+// Bookkeeping for OSC 133 prompt-boundary decorations.
+//
+// xterm-mount.ts marks each shell prompt (OSC 133 `A`) with a coloured
+// decoration and recolours it with the command's exit code on prompt-end
+// (`D`). Two parallel lists track that state: the absolute buffer line of each
+// prompt, and the decoration sitting on it. They must stay index-aligned and
+// bounded to the scrollback window, or the lists grow for the life of the tab
+// (one stale entry per command) — a renderer memory leak that scales with how
+// long a terminal has been running.
+//
+// The logic lives here, free of any `@xterm/*` import, so it is unit-testable
+// under the node vitest env (xterm-mount itself needs a DOM + WebGL and can't
+// be). mountXterm injects the decoration factory; this module owns the two
+// lists and keeps them aligned.
+
+/** The slice of an xterm decoration this tracker needs — just teardown. xterm's
+ *  `IDecoration` is structurally assignable. */
+export interface PromptDecoration {
+  dispose(): void;
+}
+
+/**
+ * Tracks OSC 133 prompt decorations for one terminal, keeping the prompt-line
+ * list and the decoration list strictly index-aligned and trimmed to the
+ * scrollback window.
+ */
+export class PromptDecorations<D extends PromptDecoration> {
+  /** Absolute buffer rows where prompts begin, ascending (oldest first). */
+  private readonly lines: number[] = [];
+  /** Decoration sitting on `lines[i]`, or null when creation failed — the slot
+   *  is still kept so the two lists never drift out of alignment. */
+  private readonly decorations: (D | null)[] = [];
+
+  /**
+   * @param make Factory building a decoration for an absolute buffer `line`
+   *   coloured for `exit` (null = no exit code yet). Returns null when the
+   *   decoration could not be registered; the slot is preserved regardless.
+   */
+  constructor(private readonly make: (line: number, exit: number | null) => D | null) {}
+
+  /**
+   * Record a prompt-start (OSC 133 `A`) at absolute buffer `line`, coloured for
+   * the previous command's `exit` code, then trim prompts scrolled past `baseY`.
+   */
+  start(line: number, exit: number | null, baseY: number): void {
+    this.lines.push(line);
+    this.decorations.push(this.make(line, exit));
+    this.trim(baseY);
+  }
+
+  /**
+   * Record a prompt-end (OSC 133 `D`): recolour the most recent prompt's
+   * decoration with the resolved `exit` code, replacing it **in place** (the
+   * leak fix — the old code pushed a second entry per command).
+   */
+  end(exit: number | null): void {
+    const last = this.lines.length - 1;
+    if (last < 0) return;
+    this.decorations[last]?.dispose();
+    this.decorations[last] = this.make(this.lines[last], exit);
+  }
+
+  /** Drop prompts that have scrolled out of the scrollback window
+   *  (`line < baseY`), disposing their decorations. */
+  trim(baseY: number): void {
+    while (this.lines.length > 0 && this.lines[0] < baseY) {
+      this.lines.shift();
+      this.decorations.shift()?.dispose();
+    }
+  }
+
+  /** Absolute buffer rows of the tracked prompts, ascending. */
+  promptLines(): readonly number[] {
+    return this.lines;
+  }
+
+  /** Number of tracked decorations — always equal to `promptLines().length`.
+   *  Exposed for the alignment regression test. */
+  get size(): number {
+    return this.decorations.length;
+  }
+
+  /** Dispose every decoration and clear both lists (terminal teardown). */
+  dispose(): void {
+    for (const dec of this.decorations) dec?.dispose();
+    this.decorations.length = 0;
+    this.lines.length = 0;
+  }
+}

--- a/src/renderer/xterm-mount.ts
+++ b/src/renderer/xterm-mount.ts
@@ -17,6 +17,7 @@ import '@xterm/xterm/css/xterm.css';
 
 import type { TerminalXtermPrefs } from '@shared/types';
 import { liveTerms } from './xterm-registry';
+import { PromptDecorations } from './prompt-decorations';
 
 export type XtermPrefs = TerminalXtermPrefs;
 
@@ -322,26 +323,19 @@ export function mountXterm(
   // ---- OSC 133 prompt boundary tracking ----
   // A = prompt-start, B = prompt-end (input begins), C = command-start (output
   // begins), D = command-end + optional exit code: "133;D;<exit>".
-  const promptLines: number[] = [];
-  const promptDecorations: IDecoration[] = [];
+  // The prompt-line + decoration bookkeeping lives in PromptDecorations
+  // (prompt-decorations.ts) so it stays index-aligned and scrollback-bounded —
+  // the previous inline version pushed a second decoration entry per command,
+  // growing the list for the life of the tab.
   let lastExitCode: number | null = null;
-  const trimPromptHistory = (): void => {
-    // Keep the list bounded to what's still in the scrollback.
-    const minLine = term.buffer.active.baseY;
-    while (promptLines.length > 0 && promptLines[0] < minLine) {
-      promptLines.shift();
-      const dec = promptDecorations.shift();
-      dec?.dispose();
-    }
-  };
-  const markPromptDecoration = (line: number, exit: number | null): void => {
+  const makePromptDecoration = (line: number, exit: number | null): IDecoration | null => {
     try {
       const marker = term.registerMarker(
         line - (term.buffer.active.baseY + term.buffer.active.cursorY),
       );
-      if (!marker) return;
+      if (!marker) return null;
       const dec = term.registerDecoration({ marker, x: 0, width: 1, layer: 'top' });
-      if (!dec) return;
+      if (!dec) return null;
       dec.onRender((el) => {
         // CSS tokens, not hex literals, so the marker colours flip with the
         // theme (the decoration element lives in the document, so `var()`
@@ -353,29 +347,25 @@ export function mountXterm(
         el.style.opacity = '0.85';
         el.style.borderRadius = '1px';
       });
-      promptDecorations.push(dec);
+      return dec;
     } catch {
       /* decoration failures are non-fatal */
+      return null;
     }
   };
+  const prompts = new PromptDecorations<IDecoration>(makePromptDecoration);
   term.parser.registerOscHandler(133, (data) => {
     const parts = data.split(';');
     const kind = parts[0];
     const buf = term.buffer.active;
     const line = buf.baseY + buf.cursorY;
     if (kind === 'A') {
-      promptLines.push(line);
-      markPromptDecoration(line, lastExitCode);
-      trimPromptHistory();
+      prompts.start(line, lastExitCode, buf.baseY);
     } else if (kind === 'D') {
       const code = parts[1] !== undefined ? Number(parts[1]) : null;
       lastExitCode = Number.isFinite(code) ? (code as number) : null;
-      // Decorate the most recent prompt with the resolved exit code.
-      const lastIdx = promptLines.length - 1;
-      if (lastIdx >= 0) {
-        promptDecorations[lastIdx]?.dispose();
-        markPromptDecoration(promptLines[lastIdx], lastExitCode);
-      }
+      // Recolour the most recent prompt with the resolved exit code.
+      prompts.end(lastExitCode);
     }
     // 'B' (prompt-end) and 'C' (command-start) currently only used as data
     // boundaries; no decoration needed.
@@ -385,7 +375,7 @@ export function mountXterm(
   const jumpToPrompt = (direction: -1 | 1): void => {
     const buf = term.buffer.active;
     const cursorAbs = buf.baseY + buf.cursorY;
-    const sorted = [...promptLines].sort((a, b) => a - b);
+    const sorted = [...prompts.promptLines()].sort((a, b) => a - b);
     let target: number | null = null;
     if (direction < 0) {
       for (let i = sorted.length - 1; i >= 0; i--) {
@@ -437,14 +427,14 @@ export function mountXterm(
       return () => busyHandlers.delete(handler);
     },
     lastExitCode: () => lastExitCode,
-    promptLines: () => promptLines,
+    promptLines: () => prompts.promptLines(),
     jumpToPrompt,
     refreshTheme,
     dispose() {
       if (disposed) return;
       disposed = true;
       liveTerms.delete(mounted);
-      for (const d of promptDecorations) d.dispose();
+      prompts.dispose();
       term.dispose();
     },
   };


### PR DESCRIPTION
## Summary

- Two slowdowns that worsen the longer a terminal has been running, both surfaced by a code-reading investigation of the dashboard's terminal path.
- Fixes an unbounded renderer memory growth and removes a recurring main-process fsync stall during terminal logging.

## Changes

- **OSC 133 prompt decorations no longer leak.** The prompt-end (`D`) handler recoloured the latest prompt's marker by *pushing* a new decoration instead of replacing it in place, so the decoration list grew ~2 entries per command while the prompt-line list grew 1 — the array (and the retained decoration objects) grew for the life of the tab, proportional to commands run. The prompt-line/decoration bookkeeping moves into a new `PromptDecorations` helper that keeps the two lists index-aligned and bounded to the scrollback window.
- **`SessionLogger` stops `fsync`-ing on every periodic flush.** A logged session re-rendered and `fsync`ed its whole `.txt` on every debounced (5 s) flush; the `fsync` stalls the main process's libuv threadpool for durability a log viewer does not need. `fsync` now runs only on the terminal flushes (`exit` / `close`); the atomic `tmp`->`rename` still prevents a torn/zero-length file, and `close()` forces one final durable flush so a session killed without `exit()` (quit / SIGKILL) still persists its output.
- New `prompt-decorations.test.ts` (alignment across A/D cycles, replace-disposes-old, scrollback trim, null factory, dispose) plus a kill-path persistence case in `terminal-logger.test.ts`.

## Impact

- Renderer heap no longer grows with prompt count over a long-lived terminal tab; main-process disk I/O during active logging drops to one `fsync` per session end instead of one every 5 s.
- Terminal-log file *content* is unchanged — only `fsync` frequency. A power loss mid-session may now lose the last unsynced periodic snapshot (the live terminal still holds the data; logging is best-effort), but the state at `exit`/`close` is `fsync`ed.
- `PromptDecorations` lands in the lazily-imported xterm chunk, not the eager boot chunk.

## Watchpoints

- Logged terminals on the quit/SIGKILL path: the `.txt` should still carry the full buffer after an abrupt close (covered by a new unit test, but worth an eyeball on the Logs pane).
- OSC 133 prompt markers and Ctrl+Up/Down prompt-jump still behave — their colours and jump targets are driven by the refactored helper.
