### PR TITLE
Config: route setTaskConfig to the conception file; guard scope drift (F1, F2)

### DIFF
--- a/src/main/config-schema.test.ts
+++ b/src/main/config-schema.test.ts
@@ -497,83 +497,134 @@ describe('every settings key the IPC layer can write survives the canonicaliser'
   // A new IPC setter whose key (or sub-key) is missing from the schema fails
   // here instead of bricking every subsequent Settings save in production. With
   // disjoint schemas the keys are split by their owning file.
+  // Lifted to describe scope so the coverage test below can assert these two
+  // literals exercise every key SCOPE_OF owns. A literal omitting a newly-owned
+  // key fails the coverage test, not silently in production on the next save.
+  const everyGlobalSetterKey = {
+    // pickConceptionPath / openConception / removeRecentConceptionPath
+    lastConceptionPath: '/home/me/src/conception',
+    recentConceptionPaths: ['/home/me/src/conception', '/home/me/src/other'],
+    // setTheme
+    theme: 'dark',
+    // setLayout
+    layout: {
+      projects: true,
+      leftView: 'deliverables',
+      working: 'logs',
+      terminal: true,
+      projectsWidth: 320,
+    },
+    // setWelcomeDismissed
+    welcome: { dismissed: true },
+    // setCardMinWidth — every pane key
+    cardMinWidth: Object.fromEntries(CARD_MIN_WIDTH_KEYS.map((key) => [key, 500])),
+    // setTreeExpansion — every tree key
+    treeExpansion: {
+      knowledge: ['topics'],
+      resources: ['renders'],
+      skills: ['pr'],
+      skillsUser: ['git'],
+    },
+    // setSelectedBranches / setBranchFilterStickyAll
+    selectedBranches: ['main', 'feature-x'],
+    branchFilterStickyAll: false,
+    // setSkillsActiveScope
+    skillsActiveScope: 'user',
+    // termSetPrefs
+    terminal: {
+      shell: '/bin/zsh',
+      shortcut: 'Ctrl+T',
+      screenshot_dir: '/home/me/Pictures',
+      xterm: { font_size: 13, cursor_blink: true },
+      logging: { enabled: true, retentionDays: 14, maxDirMb: 500, scrollback: 10000 },
+    },
+    // setDashboardConfig (Settings → Dashboard) — every field
+    dashboard: {
+      enabled: true,
+      provider: 'deepseek',
+      apiKey: 'sk-deepseek-xxx',
+      baseUrl: 'https://api.deepseek.com',
+      model: 'deepseek-v4-flash',
+      intervalSec: 120,
+      gateOnActivity: true,
+      historyLimit: 20,
+    },
+    // agents / open_with / pdf_viewer have no narrow IPC setter — they are
+    // edited through the Settings modal's raw save (writeNote →
+    // validateAndCanonicaliseGlobalSettings), the same canonicaliser asserted
+    // here. Covered so the coverage test sees the whole global schema exercised.
+    agents: [
+      { id: 'claude', label: 'Claude', command: 'claude', promptFlags: true, favorite: true },
+    ],
+    open_with: {
+      main_ide: { label: 'VS Code', command: 'code -g {file}:{line}' },
+      secondary_ide: { command: 'subl {file}' },
+      terminal: { command: 'kitty' },
+    },
+    pdf_viewer: ['zathura', '{file}'],
+  };
+
+  const everyConceptionSetterKey = {
+    // tree-owned location + repo list
+    workspace_path: '/home/me/src',
+    worktrees_path: '/home/me/src/worktrees',
+    repositories: [{ section: 'Apps' }, 'condash', { name: 'frontend', run: 'make dev' }],
+    retired_apps: [{ handle: 'oldapp', aliases: ['legacy-name'] }],
+    // setTaskConfig (Tasks editor) — every TaskConfigEntry field
+    taskConfig: {
+      'sample-task': {
+        schedule: '5m',
+        timeout: '1m',
+        excludeFromLogs: true,
+        runMode: 'oneshot',
+        gateOnUpdatedTabs: true,
+      },
+    },
+  };
+
   it('round-trips every global IPC setter through the global canonicaliser', () => {
-    const everyGlobalSetterKey = {
-      // pickConceptionPath / openConception / removeRecentConceptionPath
-      lastConceptionPath: '/home/me/src/conception',
-      recentConceptionPaths: ['/home/me/src/conception', '/home/me/src/other'],
-      // setTheme
-      theme: 'dark',
-      // setLayout
-      layout: {
-        projects: true,
-        leftView: 'deliverables',
-        working: 'logs',
-        terminal: true,
-        projectsWidth: 320,
-      },
-      // setWelcomeDismissed
-      welcome: { dismissed: true },
-      // setCardMinWidth — every pane key
-      cardMinWidth: Object.fromEntries(CARD_MIN_WIDTH_KEYS.map((key) => [key, 500])),
-      // setTreeExpansion — every tree key
-      treeExpansion: {
-        knowledge: ['topics'],
-        resources: ['renders'],
-        skills: ['pr'],
-        skillsUser: ['git'],
-      },
-      // setSelectedBranches / setBranchFilterStickyAll
-      selectedBranches: ['main', 'feature-x'],
-      branchFilterStickyAll: false,
-      // setSkillsActiveScope
-      skillsActiveScope: 'user',
-      // termSetPrefs
-      terminal: {
-        shell: '/bin/zsh',
-        shortcut: 'Ctrl+T',
-        screenshot_dir: '/home/me/Pictures',
-        xterm: { font_size: 13, cursor_blink: true },
-        logging: { enabled: true, retentionDays: 14, maxDirMb: 500, scrollback: 10000 },
-      },
-      // setDashboardConfig (Settings → Dashboard) — every field
-      dashboard: {
-        enabled: true,
-        provider: 'deepseek',
-        apiKey: 'sk-deepseek-xxx',
-        baseUrl: 'https://api.deepseek.com',
-        model: 'deepseek-v4-flash',
-        intervalSec: 120,
-        gateOnActivity: true,
-        historyLimit: 20,
-      },
-    };
     expect(() =>
       validateAndCanonicaliseGlobalSettings(JSON.stringify(everyGlobalSetterKey)),
     ).not.toThrow();
   });
 
   it('round-trips every conception IPC setter through the conception canonicaliser', () => {
-    const everyConceptionSetterKey = {
-      // tree-owned location + repo list
-      workspace_path: '/home/me/src',
-      worktrees_path: '/home/me/src/worktrees',
-      repositories: [{ section: 'Apps' }, 'condash', { name: 'frontend', run: 'make dev' }],
-      retired_apps: [{ handle: 'oldapp', aliases: ['legacy-name'] }],
-      // writeTaskConfig (Tasks editor) — every TaskConfigEntry field
-      taskConfig: {
-        'sample-task': {
-          schedule: '5m',
-          timeout: '1m',
-          excludeFromLogs: true,
-          runMode: 'oneshot',
-          gateOnUpdatedTabs: true,
-        },
-      },
-    };
     expect(() =>
       validateAndCanonicaliseConceptionConfig(JSON.stringify(everyConceptionSetterKey)),
     ).not.toThrow();
+  });
+
+  // SCOPE_OF is derived from the two field groups, so it cannot silently drift
+  // from the schemas — assert it anyway to lock the invariant against a future
+  // hand-edit that re-encodes the split, and to anchor the coverage test below.
+  it('SCOPE_OF owns exactly the keys of the two strict schemas', () => {
+    const schemaKeys = new Set<string>([
+      ...Object.keys(globalSettingsSchema.shape),
+      ...Object.keys(configSchema.shape),
+    ]);
+    // `$schema_doc` is a doc pointer allowed in either file — intentionally not
+    // a SCOPE_OF entry.
+    schemaKeys.delete('$schema_doc');
+    expect(new Set(Object.keys(SCOPE_OF))).toEqual(schemaKeys);
+  });
+
+  // The trap this whole describe guards against: a new IPC-writable key that no
+  // test exercises ships and bricks the next save. A new owned key lands in
+  // SCOPE_OF automatically (it is derived from the field groups), so requiring
+  // the round-trip literals to cover every SCOPE_OF key forces a literal update
+  // — and with it a canonicaliser round-trip — before the key can merge.
+  it('the round-trip literals exercise every key SCOPE_OF owns', () => {
+    const covered = new Set<string>([
+      ...Object.keys(everyGlobalSetterKey),
+      ...Object.keys(everyConceptionSetterKey),
+    ]);
+    for (const key of Object.keys(SCOPE_OF)) {
+      expect(
+        covered.has(key),
+        `SCOPE_OF owns "${key}" but no round-trip literal exercises it — add it to ` +
+          `everyGlobalSetterKey / everyConceptionSetterKey so the canonicaliser is tested against it`,
+      ).toBe(true);
+    }
   });
 });
 

--- a/src/main/config-schema.ts
+++ b/src/main/config-schema.ts
@@ -1,5 +1,17 @@
 import { z } from 'zod';
-import type { CardMinWidthPrefs, TreeExpansionPrefs } from '../shared/types';
+import type {
+  ActionTemplate,
+  Agent,
+  CardMinWidthPrefs,
+  DashboardSettings,
+  LayoutState,
+  TaskConfigEntry,
+  TerminalLoggingPrefs,
+  TerminalPrefs,
+  TerminalXtermColors,
+  TerminalXtermPrefs,
+  TreeExpansionPrefs,
+} from '../shared/types';
 import { isSectionMarker, type RawRepo, type RawSubmoduleRepo } from '../shared/config-types';
 import { migrateRawSettings } from './config-migrate';
 
@@ -206,7 +218,7 @@ const xtermColors = z
     bright_magenta: z.string().optional(),
     bright_cyan: z.string().optional(),
     bright_white: z.string().optional(),
-  })
+  } satisfies Record<keyof TerminalXtermColors, z.ZodTypeAny>)
   .strict();
 
 const xtermSettings = z
@@ -222,7 +234,7 @@ const xtermSettings = z
     scrollback: z.number().int().nonnegative().optional(),
     ligatures: z.boolean().optional(),
     colors: xtermColors.optional(),
-  })
+  } satisfies Record<keyof TerminalXtermPrefs, z.ZodTypeAny>)
   .strict();
 
 const terminalLoggingSettings = z
@@ -232,7 +244,7 @@ const terminalLoggingSettings = z
     maxDirMb: z.number().int().min(0).optional(),
     scrollback: z.number().int().min(100).optional(),
     markerIntervalSec: z.number().int().min(0).optional(),
-  })
+  } satisfies Record<keyof TerminalLoggingPrefs, z.ZodTypeAny>)
   .strict();
 
 /** Single launcher slot. `label` is the user-defined display name shown
@@ -261,7 +273,7 @@ const actionTemplateSchema = z
     template: z.string(),
     submit: z.boolean().optional(),
     agent: z.string().optional(),
-  })
+  } satisfies Record<keyof ActionTemplate, z.ZodTypeAny>)
   .strict();
 
 /** One terminal-launcher agent. `id` is the stable identity referenced by
@@ -280,7 +292,7 @@ const agentSchema = z
     command: z.string(),
     promptFlags: z.boolean().optional(),
     favorite: z.boolean().optional(),
-  })
+  } satisfies Record<keyof Agent, z.ZodTypeAny>)
   .strict();
 
 const terminalSettings = z
@@ -295,7 +307,7 @@ const terminalSettings = z
     logging: terminalLoggingSettings.optional(),
     projectActions: z.array(actionTemplateSchema).optional(),
     newProjectActions: z.array(actionTemplateSchema).optional(),
-  })
+  } satisfies Record<keyof TerminalPrefs, z.ZodTypeAny>)
   .strict();
 
 /** LayoutState validator. Exported so the `setLayout` IPC handler can apply
@@ -319,7 +331,7 @@ export const layoutSchema = z
     ]),
     terminal: z.boolean(),
     projectsWidth: z.number().int().positive(),
-  })
+  } satisfies Record<keyof LayoutState, z.ZodTypeAny>)
   .strict();
 
 // One entry per card grid. The `satisfies Record<keyof CardMinWidthPrefs, …>`
@@ -382,7 +394,7 @@ const dashboardSettings = z
     gateOnActivity: z.boolean().optional(),
     /** Max retained events per tab and globally. */
     historyLimit: z.number().int().positive().optional(),
-  })
+  } satisfies Record<keyof DashboardSettings, z.ZodTypeAny>)
   .strict();
 
 /**
@@ -421,7 +433,7 @@ const conceptionOnlyFields = {
           excludeFromLogs: z.boolean().optional(),
           runMode: z.enum(['interactive', 'oneshot']).optional(),
           gateOnUpdatedTabs: z.boolean().optional(),
-        })
+        } satisfies Record<keyof TaskConfigEntry, z.ZodTypeAny>)
         .strict(),
     )
     .optional(),

--- a/src/main/effective-config.ts
+++ b/src/main/effective-config.ts
@@ -1,4 +1,5 @@
 import { promises as fs } from 'node:fs';
+import { dirname } from 'node:path';
 import type { ConfigShape } from './config-walk';
 import type {
   Agent,
@@ -20,6 +21,8 @@ import {
 } from './condash-dir';
 import { settingsPath } from './settings';
 import { migrateRawSettings } from './config-migrate';
+import { atomicWrite } from './atomic-write';
+import { withFileQueue } from './mutate-shared';
 
 /**
  * Single read surface over the two settings files. Reads the per-machine
@@ -101,6 +104,44 @@ export async function resolveConceptionConfigPath(conceptionPath: string): Promi
  */
 export function conceptionConfigWritePath(conceptionPath: string): string {
   return condashSettingsPath(conceptionPath);
+}
+
+/**
+ * Atomic read-modify-write of a conception's config file — the conception-side
+ * analog of `updateSettings` for the per-machine `settings.json`. Reads the
+ * canonical `.condash/settings.json` (seeding from the legacy fallbacks when the
+ * canonical primary doesn't exist yet, so the first write never drops keys the
+ * user still keeps in a legacy `condash.json`), runs `mutator` against the
+ * parsed object, then writes it back to the canonical path. Serialised per write
+ * path so two concurrent conception-config mutations can't drop one another's
+ * update.
+ *
+ * @param conceptionPath active conception root
+ * @param mutator mutates the parsed config object in place
+ */
+export async function mutateConceptionConfig(
+  conceptionPath: string,
+  mutator: (config: Record<string, unknown>) => void | Promise<void>,
+): Promise<void> {
+  const writePath = conceptionConfigWritePath(conceptionPath);
+  return withFileQueue(writePath, async () => {
+    let current: Record<string, unknown> = {};
+    try {
+      const raw = await fs.readFile(writePath, 'utf8');
+      const parsed: unknown = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        current = parsed as Record<string, unknown>;
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+    if (Object.keys(current).length === 0) {
+      current = await readConceptionConfigRaw(conceptionPath);
+    }
+    await mutator(current);
+    await fs.mkdir(dirname(writePath), { recursive: true });
+    await atomicWrite(writePath, JSON.stringify(current, null, 2) + '\n');
+  });
 }
 
 /**

--- a/src/main/ipc/tasks.test.ts
+++ b/src/main/ipc/tasks.test.ts
@@ -23,6 +23,7 @@ let tmp: string;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
 let settingsPathValue: string;
+let conceptionConfigPathValue: string;
 
 /** Minimal event shape accepted by `requireMainWindowSender`. */
 const trustedEvent = {
@@ -30,8 +31,10 @@ const trustedEvent = {
   senderFrame: { url: 'file:///app/dist/index.html', parent: null },
 };
 
-async function readSettingsFile(): Promise<Record<string, unknown>> {
-  const raw = await fs.readFile(settingsPathValue, 'utf8');
+/** Read the conception config file (`<conception>/.condash/settings.json`) —
+ *  the conception-scoped home `setTaskConfig` writes `taskConfig` into. */
+async function readConceptionConfig(): Promise<Record<string, unknown>> {
+  const raw = await fs.readFile(conceptionConfigPathValue, 'utf8');
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
@@ -43,6 +46,7 @@ beforeEach(async () => {
   vi.resetModules();
   tmp = mkdtempSync(join(tmpdir(), 'condash-task-config-'));
   settingsPathValue = join(tmp, 'settings.json');
+  conceptionConfigPathValue = join(tmp, '.condash', 'settings.json');
   const isolatedTmp = tmp;
   vi.doMock('../user-data-dir', () => ({ userDataDir: () => isolatedTmp }));
 
@@ -54,9 +58,10 @@ beforeEach(async () => {
       handlers[channel] = fn;
     },
   );
-  // getTaskConfig resolves through the active conception. Point it at the tmp
-  // dir — with no `.condash/` there, the global settings.json `taskConfig`
-  // (where setTaskConfig writes) is the layer surfaced on read.
+  // Point the active conception at the tmp dir via the global settings pointer.
+  // `taskConfig` is conception-scoped, so setTaskConfig writes it into
+  // `<tmp>/.condash/settings.json`; the global settings.json carries only the
+  // path pointer and never a `taskConfig` key.
   await fs.writeFile(
     settingsPathValue,
     JSON.stringify({ lastConceptionPath: tmp, recentConceptionPaths: [] }),
@@ -83,8 +88,14 @@ describe('setTaskConfig / getTaskConfig runMode round-trip', () => {
       runMode: 'oneshot',
     });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     expect(onDisk.taskConfig).toEqual({ 'sample-task': { schedule: '1m', runMode: 'oneshot' } });
+
+    // F1 regression: the conception-scoped key must NOT leak into the
+    // per-machine global settings.json — a write there throws `Unrecognized
+    // key` on the next Global Settings save.
+    const globalRaw = await fs.readFile(settingsPathValue, 'utf8');
+    expect((JSON.parse(globalRaw) as Record<string, unknown>).taskConfig).toBeUndefined();
 
     const effective = await getTaskConfig();
     expect(effective['sample-task'].runMode).toBe('oneshot');
@@ -96,7 +107,7 @@ describe('setTaskConfig / getTaskConfig runMode round-trip', () => {
       runMode: 'interactive',
     });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     // interactive is the implied default — only schedule survives.
     expect(onDisk.taskConfig).toEqual({ 'sample-task': { schedule: '1m' } });
 
@@ -109,7 +120,7 @@ describe('setTaskConfig / getTaskConfig runMode round-trip', () => {
     // entry as empty when schedule/timeout/excludeFromLogs are all absent.
     await handlers.setTaskConfig(trustedEvent, 'solo', { runMode: 'oneshot' });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     expect(onDisk.taskConfig).toEqual({ solo: { runMode: 'oneshot' } });
   });
 
@@ -121,7 +132,7 @@ describe('setTaskConfig / getTaskConfig runMode round-trip', () => {
       runMode: 'oneshot',
     });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     expect(onDisk.taskConfig).toEqual({
       'sample-task': { schedule: '1m', timeout: '10m', excludeFromLogs: true, runMode: 'oneshot' },
     });
@@ -135,7 +146,7 @@ describe('setTaskConfig / getTaskConfig gateOnUpdatedTabs round-trip', () => {
       gateOnUpdatedTabs: true,
     });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     expect(onDisk.taskConfig).toEqual({
       'sample-task': { schedule: '1m', gateOnUpdatedTabs: true },
     });
@@ -150,7 +161,7 @@ describe('setTaskConfig / getTaskConfig gateOnUpdatedTabs round-trip', () => {
       gateOnUpdatedTabs: false,
     });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     expect(onDisk.taskConfig).toEqual({ 'sample-task': { schedule: '1m' } });
 
     const effective = await getTaskConfig();
@@ -161,7 +172,7 @@ describe('setTaskConfig / getTaskConfig gateOnUpdatedTabs round-trip', () => {
     // The delete-guard must treat gateOnUpdatedTabs as a real setting.
     await handlers.setTaskConfig(trustedEvent, 'solo', { gateOnUpdatedTabs: true });
 
-    const onDisk = await readSettingsFile();
+    const onDisk = await readConceptionConfig();
     expect(onDisk.taskConfig).toEqual({ solo: { gateOnUpdatedTabs: true } });
   });
 });

--- a/src/main/ipc/tasks.ts
+++ b/src/main/ipc/tasks.ts
@@ -2,8 +2,7 @@ import { ipcMain } from 'electron';
 import type { TaskDef } from '../../shared/tasks';
 import type { TaskConfigEntry } from '../../shared/types';
 import { deleteTask, listTasks, readTask, writeTask } from '../tasks';
-import { getEffectiveConceptionConfig } from '../effective-config';
-import { updateSettings } from '../settings';
+import { getEffectiveConceptionConfig, mutateConceptionConfig } from '../effective-config';
 import { killTaskRun, listRunningTaskRuns } from '../task-scheduler';
 import { requireMainWindowSender, withConception } from './utils';
 
@@ -48,9 +47,10 @@ export function registerTasksIpc(): void {
   });
 
   // Per-task schedule / timeout / excludeFromLogs / runMode config
-  // (capability 1). Read merges through the effective config (condash.json over
-  // settings.json); writes always target the per-machine settings.json
-  // `taskConfig` map.
+  // (capability 1). Both read and write target the conception-owned
+  // `taskConfig` map in `<conception>/.condash/settings.json` — `taskConfig` is
+  // a conception-scoped key (`SCOPE_OF.taskConfig === 'conception'`), so it must
+  // never land in the per-machine global `settings.json`.
   ipcMain.handle('getTaskConfig', (event) => {
     requireMainWindowSender(event);
     return withConception(async (c) => {
@@ -78,26 +78,33 @@ export function registerTasksIpc(): void {
     const runMode = entry?.runMode === 'oneshot' ? 'oneshot' : undefined;
     // Opt-in growth gate — only `true` is persisted (absent = no gate).
     const gateOnUpdatedTabs = entry?.gateOnUpdatedTabs === true ? true : undefined;
-    await updateSettings((cur) => {
-      const map = { ...((cur.taskConfig ?? {}) as Record<string, TaskConfigEntry>) };
-      if (
-        schedule === undefined &&
-        timeout === undefined &&
-        excludeFromLogs === undefined &&
-        runMode === undefined &&
-        gateOnUpdatedTabs === undefined
-      ) {
-        delete map[slug];
-      } else {
-        map[slug] = {
-          ...(schedule ? { schedule } : {}),
-          ...(timeout ? { timeout } : {}),
-          ...(excludeFromLogs ? { excludeFromLogs } : {}),
-          ...(runMode ? { runMode } : {}),
-          ...(gateOnUpdatedTabs ? { gateOnUpdatedTabs } : {}),
-        };
-      }
-      return { ...cur, taskConfig: Object.keys(map).length > 0 ? map : undefined };
-    });
+    // Exhaustive projection keyed by `keyof TaskConfigEntry`: adding a field to
+    // the type without giving it a projection here is a tsc error, not a
+    // silently-dropped setting (the bug this whole entry-shape has shipped
+    // before). Build the persisted entry by stripping the absent/default
+    // fields generically so the field list lives in exactly one place.
+    const projected = {
+      schedule,
+      timeout,
+      excludeFromLogs,
+      runMode,
+      gateOnUpdatedTabs,
+    } satisfies Record<keyof TaskConfigEntry, unknown>;
+    const persisted: TaskConfigEntry = {};
+    for (const [key, value] of Object.entries(projected)) {
+      if (value !== undefined) (persisted as Record<string, unknown>)[key] = value;
+    }
+    await withConception(async (conceptionPath) => {
+      await mutateConceptionConfig(conceptionPath, (config) => {
+        const map = { ...((config.taskConfig ?? {}) as Record<string, TaskConfigEntry>) };
+        if (Object.keys(persisted).length === 0) {
+          delete map[slug];
+        } else {
+          map[slug] = persisted;
+        }
+        if (Object.keys(map).length > 0) config.taskConfig = map;
+        else delete config.taskConfig;
+      });
+    }, undefined);
   });
 }

--- a/src/shared/types/settings.ts
+++ b/src/shared/types/settings.ts
@@ -72,9 +72,12 @@ export interface Settings {
    *  to `conception`. */
   skillsActiveScope?: SkillScope;
   /** Per-task schedule / log-routing config keyed by task slug (capability
-   *  1). Shared with `condash.json` via the config schema's
-   *  `sharedSchemaFields`; the effective-config merge lets a conception
-   *  override the per-machine value. */
+   *  1). Conception-scoped (`SCOPE_OF.taskConfig === 'conception'`): the writer
+   *  (`setTaskConfig`) and reader (`getTaskConfig`) target
+   *  `<conception>/.condash/settings.json`, never this per-machine global file.
+   *  Declared here only so a global settings.json written by a pre-scope-fix
+   *  build — which misrouted the key into the global file — still type-checks
+   *  on read until the scope-partition migrator lifts it to the conception. */
   taskConfig?: Record<string, TaskConfigEntry>;
 }
 


### PR DESCRIPTION
Fixes two findings from the v4.47.0 internal code review.

## F1 (P0 — confirmed shipping bug)
`setTaskConfig` persisted the **conception-owned** `taskConfig` key into the per-machine **global** `settings.json` (via `updateSettings`). `taskConfig` lives in `conceptionOnlyFields`, so `globalSettingsSchema.strict()` rejects it — the write didn't validate and landed silently in the wrong file, then detonated on the next **Global** Settings save (`Unrecognized key`, blocking every global save) and risked dropping the user's schedules on the next scope-partition migration.

Routed `setTaskConfig` through a new `mutateConceptionConfig` primitive (conception-side analog of `updateSettings`) that targets `<conception>/.condash/settings.json`, seeds from the legacy fallback so the first write never drops keys, and serialises per write-path through the file queue.

## F2 (config-scope drift guards)
The "IPC-writable key missing/dropped from its strict schema" trap has shipped 4+ times. Hardened the guards:
- `satisfies Record<keyof T, z.ZodTypeAny>` exhaustiveness guards on every hand-maintained schema object (dashboard, terminal, xterm, logging, layout, agent, action-template, taskConfig entry, xterm colours) — a type/schema mismatch is now a `tsc` error.
- A `keyof TaskConfigEntry` guard on the `setTaskConfig` projection, so adding a field forces updating the write path.
- Round-trip tests asserting `SCOPE_OF` exactly matches the two strict schemas, and that the canonicalisation literals exercise every owned key (closed the `agents`/`open_with`/`pdf_viewer` coverage gap).

## Testing
`make typecheck` clean · `make test-unit` 1253 passing · `npm run build` green · prettier clean.

Docs already documented `taskConfig` as conception-owned — this aligns the code to the docs.