### PR TITLE
Settings: serialise migration writers; durable atomic write (F6, F11)

### DIFF
--- a/src/main/condash-dir-migrate.ts
+++ b/src/main/condash-dir-migrate.ts
@@ -1,6 +1,7 @@
 import { existsSync, promises as fs } from 'node:fs';
 import { join } from 'node:path';
 import { atomicWrite } from './atomic-write';
+import { withFileQueue } from './mutate-shared';
 import {
   CONDASH_DIR,
   condashDir,
@@ -89,7 +90,12 @@ export async function migrateLegacyConfig(conception: string): Promise<Migration
   }
 
   await fs.mkdir(condashDir(conception), { recursive: true });
-  await atomicWrite(target, content);
+  // Each settings-file write goes through its own per-path queue so a
+  // concurrent conception-config writer (Settings-modal save / `config set`,
+  // both via `withFileQueue`) can't interleave with the migration. `target`
+  // and `source` are distinct paths and each queue is acquired-then-released
+  // before the next, so there is no nesting and no deadlock.
+  await withFileQueue(target, () => atomicWrite(target, content));
 
   const now = new Date();
   const tombstone =
@@ -102,7 +108,7 @@ export async function migrateLegacyConfig(conception: string): Promise<Migration
       null,
       2,
     ) + '\n';
-  await atomicWrite(source, tombstone);
+  await withFileQueue(source, () => atomicWrite(source, tombstone));
 
   const gitignoreUpdated = await ensureGitignoreEntry(conception);
 
@@ -127,26 +133,31 @@ export async function ensureGitignoreEntry(conception: string): Promise<boolean>
   if (!existsSync(join(conception, '.git'))) return false;
 
   const gitignorePath = join(conception, '.gitignore');
-  let existing = '';
-  try {
-    existing = await fs.readFile(gitignorePath, 'utf8');
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-  }
+  // Read-modify-write under the file's own queue so the read of the existing
+  // contents and the write-back stay atomic against any concurrent writer of
+  // the same `.gitignore`.
+  return withFileQueue(gitignorePath, async () => {
+    let existing = '';
+    try {
+      existing = await fs.readFile(gitignorePath, 'utf8');
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
 
-  if (GITIGNORE_PATTERN_RE.test(existing)) return false;
+    if (GITIGNORE_PATTERN_RE.test(existing)) return false;
 
-  let updated: string;
-  if (existing.length === 0) {
-    updated = GITIGNORE_BLOCK;
-  } else if (existing.endsWith('\n')) {
-    updated = existing + '\n' + GITIGNORE_BLOCK;
-  } else {
-    updated = existing + '\n\n' + GITIGNORE_BLOCK;
-  }
+    let updated: string;
+    if (existing.length === 0) {
+      updated = GITIGNORE_BLOCK;
+    } else if (existing.endsWith('\n')) {
+      updated = existing + '\n' + GITIGNORE_BLOCK;
+    } else {
+      updated = existing + '\n\n' + GITIGNORE_BLOCK;
+    }
 
-  await atomicWrite(gitignorePath, updated);
-  return true;
+    await atomicWrite(gitignorePath, updated);
+    return true;
+  });
 }
 
 async function pathExists(path: string): Promise<boolean> {

--- a/src/main/scope-partition-migrate.ts
+++ b/src/main/scope-partition-migrate.ts
@@ -14,7 +14,8 @@ import { promises as fs } from 'node:fs';
 import { dirname } from 'node:path';
 import { atomicWrite } from './atomic-write';
 import { condashSettingsPath } from './condash-dir';
-import { settingsPath } from './settings';
+import { settingsPath, withSettingsQueue } from './settings';
+import { withFileQueue } from './mutate-shared';
 import { SCOPE_OF, type SettingsScope } from './config-schema';
 import { migrateRawSettings } from './config-migrate';
 
@@ -79,6 +80,29 @@ export async function partitionSettingsScopes(
   globalFile: string = settingsPath(),
 ): Promise<ScopeMigrationResult> {
   const conceptionFile = condashSettingsPath(conception);
+  // Hold both write queues across the whole read→compute→write. The global
+  // read+write must sit inside `withSettingsQueue` so a concurrent
+  // `updateSettings` (e.g. setTheme) can't land between this migrator's read of
+  // the global file and its write-back and be silently dropped; likewise the
+  // conception read+write must sit inside `withFileQueue(conceptionFile)`
+  // against a concurrent `mutateConceptionConfig` / Settings-modal save. The
+  // conception-file queue is the outer lock and the settings queue the inner
+  // one — matching write-config's ordering (file queue outside, settings queue
+  // inside) so the settings queue is always the innermost lock and the two can
+  // never deadlock.
+  return withFileQueue(conceptionFile, () =>
+    withSettingsQueue(() => partitionUnlocked(conception, globalFile, conceptionFile)),
+  );
+}
+
+/** Body of `partitionSettingsScopes`, run with both file queues already held.
+ *  Reads both files, computes the partition, and writes back any file that
+ *  changed. */
+async function partitionUnlocked(
+  conception: string,
+  globalFile: string,
+  conceptionFile: string,
+): Promise<ScopeMigrationResult> {
   const [globalRaw, conceptionRaw] = await Promise.all([
     readJsonObject(globalFile),
     readJsonObject(conceptionFile),

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { LayoutState, Settings } from '../shared/types';
+import { atomicWrite } from './atomic-write';
 import { migrateRawSettings } from './config-migrate';
 import { userDataDir } from './user-data-dir';
 
@@ -183,9 +184,12 @@ export function removeRecent(recents: string[], path: string): string[] {
   return recents.filter((p) => p !== path);
 }
 
-// `tmp → fsync → rename`: a `fs.writeFile` truncate-then-write window can
-// leave settings.json zero-length on power-loss; the `welcome.dismissed`
-// flag is small but losing the lastConceptionPath bricks the next launch.
+// `tmp → fsync → rename → dir-fsync`: a `fs.writeFile` truncate-then-write
+// window can leave settings.json zero-length on power-loss, and an unsynced
+// parent directory can lose the rename even though the file data synced; the
+// `welcome.dismissed` flag is small but losing the lastConceptionPath bricks
+// the next launch. `atomicWrite` (the shared writer) covers both fsyncs plus
+// best-effort tmp cleanup on failure.
 async function writeSettingsRaw(next: Settings): Promise<void> {
   const path = settingsPath();
   await fs.mkdir(dirname(path), { recursive: true });
@@ -195,27 +199,7 @@ async function writeSettingsRaw(next: Settings): Promise<void> {
     ...next,
     recentConceptionPaths: pruneRecents(next.recentConceptionPaths ?? []),
   };
-  await writeJsonAtomic(path, JSON.stringify(persisted, null, 2) + '\n');
-}
-
-/** `tmp → fsync → rename` with best-effort tmp cleanup on failure, so a
- * throwing write/sync/rename doesn't leak `.<ts>.<pid>.tmp` files into the
- * config directory. */
-async function writeJsonAtomic(path: string, content: string): Promise<void> {
-  const tmp = join(dirname(path), `.${Date.now()}.${process.pid}.tmp`);
-  try {
-    const fh = await fs.open(tmp, 'w');
-    try {
-      await fh.writeFile(content, 'utf8');
-      await fh.sync();
-    } finally {
-      await fh.close();
-    }
-    await fs.rename(tmp, path);
-  } catch (err) {
-    await fs.unlink(tmp).catch(() => undefined);
-    throw err;
-  }
+  await atomicWrite(path, JSON.stringify(persisted, null, 2) + '\n');
 }
 
 /**
@@ -268,6 +252,6 @@ export async function mutateSettingsJson(
     }
     await mutator(current);
     await fs.mkdir(dirname(path), { recursive: true });
-    await writeJsonAtomic(path, JSON.stringify(current, null, 2) + '\n');
+    await atomicWrite(path, JSON.stringify(current, null, 2) + '\n');
   });
 }


### PR DESCRIPTION
Robustness fixes from the v4.47.0 code review.

## F6 — migration writers bypassed the settings write-queue
`partitionSettingsScopes` and `migrateLegacyConfig` (both run from `setWatchedConception` at boot / conception-switch) wrote `settings.json` and conception files with a bare `atomicWrite`, outside `withSettingsQueue`/`withFileQueue`. That window overlaps the renderer's first `set*` IPC writes, so a concurrent `setTheme` could be silently lost (last-writer-wins on disjoint read windows).

Each write now runs under the queue that owns its file — the global `settings.json` under `withSettingsQueue`, conception/legacy/`.gitignore` files under `withFileQueue(path)` — with the read+mutate+write held in one critical section. Lock order is `withFileQueue` outer, `withSettingsQueue` inner, matching `write-config.ts`, so the settings queue stays the innermost lock and the two can't form a cycle.

## F11 — settings writer omitted the parent-dir fsync
`settings.ts` carried a drifted private `writeJsonAtomic` doing `tmp → fsync → rename` without the parent-directory fsync, so a power loss after `rename` could lose the rename of the most boot-critical file. Deleted it; `writeSettingsRaw`/`mutateSettingsJson` now use the canonical `atomicWrite` (`tmp → fsync → rename → dir-fsync` + tmp cleanup), removing the fourth divergent copy of the atomic writer.

## Testing
`make typecheck` clean · `make test-unit` 1253 passing (incl. the migrator + atomic-write suites) · `npm run build` green.