### PR TITLE
Dashboard: redact transmitted output; bound LLM call; quit teardown (F3, F4, F5)

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -144,7 +144,7 @@ Edit it once in **Settings → Dashboard** (under **Personal · this machine**).
 | `gateOnActivity` | boolean     | `true`           | Skip a cycle when no open tab produced new output since the last run (reuses the scheduler's growth gate). Off → summarize every interval regardless.                                  |
 | `historyLimit`   | integer     | `20`             | Maximum retained events per tab and in the global history; older events roll off.                                                                                                       |
 
-> **Privacy:** enabling the dashboard transmits recent on-screen terminal output (which may include secrets) to the configured API endpoint — the DeepSeek API by default, or whatever `baseUrl` points at. Leave it off for tabs that display credentials you don't want sent off-machine.
+> **Privacy:** enabling the dashboard transmits recent on-screen terminal output to the configured API endpoint — the DeepSeek API by default, or whatever `baseUrl` points at. Before any text leaves the machine it is run through the same secret redactor as `condash logs --redact` (provider key prefixes, bearer tokens, JWTs, secret-named assignments, PEM private-key blocks → `«redacted:…»`). That redactor is conservative by design and recognises only high-precision secret shapes, so it is a backstop, not a guarantee: leave the dashboard off for tabs that display credentials you don't want sent off-machine.
 
 ### Workspace keys
 

--- a/src/main/dashboard/engine.test.ts
+++ b/src/main/dashboard/engine.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The engine imports electron (BrowserWindow) at module load and broadcasts via
+// getAllWindows(); stub it to an empty window list so the import resolves and
+// pushState is a no-op under the node test environment.
+vi.mock('electron', () => ({
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+// Make the per-tick config read throw, simulating a malformed
+// `.condash/settings.json`, while keeping the rest of ./config real.
+vi.mock('./config', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./config')>();
+  return {
+    ...actual,
+    readDashboardConfig: vi.fn(async () => {
+      throw new Error('malformed settings.json');
+    }),
+  };
+});
+
+import { setDashboardConception, tick } from './engine';
+
+const CONCEPTION = '/tmp/condash-engine-test-conception';
+
+afterEach(async () => {
+  // Clear the live interval the engine arms so the test process doesn't retain
+  // a timer between cases.
+  await setDashboardConception(null);
+  vi.clearAllMocks();
+});
+
+describe('dashboard engine tick', () => {
+  it('no-ops instead of rejecting when the config read throws', async () => {
+    await setDashboardConception(CONCEPTION);
+    // Before the config read moved inside the try/catch this rejected, which —
+    // fired as `void tick(...)` from a bare interval — surfaced as an unhandled
+    // rejection every interval. The guard must now make the tick a no-op.
+    await expect(tick(CONCEPTION)).resolves.toBeUndefined();
+  });
+});

--- a/src/main/dashboard/engine.ts
+++ b/src/main/dashboard/engine.ts
@@ -1,6 +1,12 @@
 import { BrowserWindow } from 'electron';
 import { EVENT_CHANNELS } from '../../shared/ipc-channels';
-import type { DashboardConfigView, DashboardState, TabInfo, TabSummary } from '../../shared/types';
+import type {
+  DashboardConfig,
+  DashboardConfigView,
+  DashboardState,
+  TabInfo,
+  TabSummary,
+} from '../../shared/types';
 import { tabRecentText, tabsBytes, tabsContext } from '../terminals';
 import { DASHBOARD_DEFAULTS, readDashboardConfig, toDashboardConfigView } from './config';
 import {
@@ -102,9 +108,23 @@ function rosterChanged(before: TabInfo[], after: TabInfo[]): boolean {
   return after.some((tab) => !sids.has(tab.sid));
 }
 
-async function tick(conceptionPath: string): Promise<void> {
+/** One dashboard cycle: refresh the open-tab roster, then (when enabled, keyed,
+ *  and due) summarize the changed tabs and synthesize the cross-tab overview.
+ *  A no-op when not armed for `conceptionPath`, already in flight, disabled, or
+ *  the config read throws. Exported for unit testing. */
+export async function tick(conceptionPath: string): Promise<void> {
   if (current?.path !== conceptionPath || inFlight) return;
-  const config = await readDashboardConfig(conceptionPath);
+  // Read config inside a guard: a malformed `.condash/settings.json` makes the
+  // effective-config read throw, and the tick is fired as `void tick(...)` from
+  // a bare interval with no global rejection handler — so a bad config must make
+  // the tick a no-op rather than an unhandled rejection every interval. Mirrors
+  // the task scheduler's tick.
+  let config: DashboardConfig;
+  try {
+    config = await readDashboardConfig(conceptionPath);
+  } catch {
+    return;
+  }
   if (!config.enabled) return;
 
   // Refresh the open-tab roster every tick — cheap, no LLM — so a newly opened

--- a/src/main/dashboard/summarizer.test.ts
+++ b/src/main/dashboard/summarizer.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { parseOverview, parseTabSummary } from './summarizer';
+import {
+  buildOverviewUserPrompt,
+  buildTabUserPrompt,
+  parseOverview,
+  parseTabSummary,
+  withTimeout,
+} from './summarizer';
 
 describe('parseTabSummary', () => {
   it('parses a clean JSON object', () => {
@@ -61,5 +67,89 @@ describe('parseOverview', () => {
   it('returns null when overview is empty or missing', () => {
     expect(parseOverview('{"overview":[]}')).toBeNull();
     expect(parseOverview('garbage')).toBeNull();
+  });
+});
+
+describe('buildTabUserPrompt redacts secrets before they reach the prompt', () => {
+  it('masks a secret planted in the recent output', () => {
+    const prompt = buildTabUserPrompt({
+      sid: 's1',
+      cmd: 'bash',
+      cwd: '/home/dev/app',
+      recentText: 'export GITHUB_TOKEN=ghp_0123456789abcdefABCDEF0123456789abcd\nok',
+    });
+    expect(prompt).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
+    expect(prompt).toContain('«redacted:');
+  });
+
+  it('masks a bare token in the command with its kind label', () => {
+    const prompt = buildTabUserPrompt({
+      sid: 's1',
+      cmd: 'deploy ghp_0123456789abcdefABCDEF0123456789abcd',
+      recentText: 'idle',
+    });
+    expect(prompt).not.toContain('ghp_0123456789abcdefABCDEF0123456789abcd');
+    expect(prompt).toContain('«redacted:github-token»');
+  });
+
+  it('masks a secret carried over in the prior summary', () => {
+    const prompt = buildTabUserPrompt({
+      sid: 's1',
+      cmd: 'deploy',
+      recentText: 'idle',
+      prior: {
+        sid: 's1',
+        title: 'deploy',
+        contextLines: ['key sk-AbCdEf0123456789ZyXwVuTs leaked earlier'],
+        currentAction: 'waiting',
+        updatedAt: 0,
+        events: [],
+      },
+    });
+    expect(prompt).not.toContain('sk-AbCdEf0123456789ZyXwVuTs');
+    expect(prompt).toContain('«redacted:api-key»');
+  });
+});
+
+describe('buildOverviewUserPrompt redacts secrets in tab summaries', () => {
+  it('masks a secret in a tab title or current action', () => {
+    const prompt = buildOverviewUserPrompt([
+      {
+        sid: 's1',
+        title: 'using sk-AbCdEf0123456789ZyXwVuTs',
+        contextLines: [],
+        currentAction: 'idle',
+        updatedAt: 0,
+        events: [],
+      },
+    ]);
+    expect(prompt).not.toContain('sk-AbCdEf0123456789ZyXwVuTs');
+    expect(prompt).toContain('«redacted:api-key»');
+  });
+});
+
+describe('withTimeout', () => {
+  it('passes through a value that resolves before the deadline', async () => {
+    await expect(withTimeout(Promise.resolve('ok'), 1000, 'test')).resolves.toBe('ok');
+  });
+
+  it('rejects with a labelled message when the deadline elapses first', async () => {
+    // A promise that never settles — only the timeout can win.
+    const pending = new Promise<string>(() => {});
+    await expect(withTimeout(pending, 5, 'dashboard: completion')).rejects.toThrow(
+      /dashboard: completion timed out/,
+    );
+  });
+
+  it('does not leave a late rejection unhandled when the timeout wins', async () => {
+    let rejectLater: (reason: Error) => void = () => {};
+    const losing = new Promise<string>((_resolve, reject) => {
+      rejectLater = reject;
+    });
+    await expect(withTimeout(losing, 5, 'test')).rejects.toThrow(/timed out/);
+    // Reject the racing promise after it already lost — the no-op catch inside
+    // withTimeout must keep this from becoming an unhandled rejection.
+    rejectLater(new Error('late failure'));
+    await new Promise((resolve) => setTimeout(resolve, 10));
   });
 });

--- a/src/main/dashboard/summarizer.ts
+++ b/src/main/dashboard/summarizer.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module';
 import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { redactSecrets } from '../logs-redact';
 import type { DashboardConfig, DashboardEvent, TabSummary } from '../../shared/types';
 
 let undiciShimInstalled = false;
@@ -64,6 +65,13 @@ export interface TabInput {
 const MAX_RECENT_CHARS = 6000;
 const MAX_TITLE_WORDS = 6;
 const MAX_CONTEXT_LINES = 4;
+
+/** Hard ceiling on a single pi completion. The dashboard makes a tool-free
+ *  summarization call, so a slow but live model finishes well inside this; the
+ *  cap exists so a black-holed connection can't wedge the engine's `inFlight`
+ *  guard forever (it is only cleared once the await settles). Mirrors the task
+ *  scheduler bounding its headless runs with a timeout. */
+const COMPLETION_TIMEOUT_MS = 60_000;
 
 /** Last pi-completion failure within the current cycle, surfaced to the renderer
  *  so a silent no-op (bad key, unknown model, network) is explainable. The
@@ -181,33 +189,45 @@ const OVERVIEW_SYSTEM_PROMPT = [
   ' "events": string[] (0-3 short notable cross-tab events worth remembering, else [])}.',
 ].join(' ');
 
-function buildTabUserPrompt(input: TabInput): string {
+/** Assemble the per-tab user prompt. Every field that carries captured terminal
+ *  content — the command, cwd, the prior summary, and the recent output — is run
+ *  through `redactSecrets` here, the single chokepoint before the text is POSTed
+ *  to the LLM, so a secret printed in a watched tab never leaves the machine in
+ *  clear text. Locally stored/displayed data (titles, state.json) is untouched.
+ *  Exported for unit testing. */
+export function buildTabUserPrompt(input: TabInput): string {
   const lines: string[] = [];
-  lines.push(`Tab command: ${input.cmd ?? '(shell)'}`);
-  if (input.cwd) lines.push(`Working directory: ${input.cwd}`);
+  lines.push(`Tab command: ${input.cmd ? redactSecrets(input.cmd) : '(shell)'}`);
+  if (input.cwd) lines.push(`Working directory: ${redactSecrets(input.cwd)}`);
   if (input.prior) {
     lines.push('');
     lines.push('Prior summary:');
     lines.push(
-      JSON.stringify({
-        title: input.prior.title,
-        contextLines: input.prior.contextLines,
-        currentAction: input.prior.currentAction,
-      }),
+      redactSecrets(
+        JSON.stringify({
+          title: input.prior.title,
+          contextLines: input.prior.contextLines,
+          currentAction: input.prior.currentAction,
+        }),
+      ),
     );
   }
   lines.push('');
   lines.push('Most recent terminal output:');
   lines.push('"""');
-  lines.push(input.recentText.slice(-MAX_RECENT_CHARS));
+  lines.push(redactSecrets(input.recentText.slice(-MAX_RECENT_CHARS)));
   lines.push('"""');
   return lines.join('\n');
 }
 
-function buildOverviewUserPrompt(tabs: TabSummary[]): string {
+/** Assemble the cross-tab overview user prompt. The per-tab title/currentAction
+ *  it embeds are model-derived (already from redacted input going forward), but
+ *  redact them here too so this prompt is uniformly secret-free at the wire.
+ *  Exported for unit testing. */
+export function buildOverviewUserPrompt(tabs: TabSummary[]): string {
   const lines = ['Open tabs and their current summaries:', ''];
   for (const tab of tabs) {
-    lines.push(`- [${tab.sid}] ${tab.title}: ${tab.currentAction}`);
+    lines.push(`- [${tab.sid}] ${redactSecrets(tab.title)}: ${redactSecrets(tab.currentAction)}`);
   }
   return lines.join('\n');
 }
@@ -228,6 +248,37 @@ function agentMessageText(message: unknown): string {
     )
     .map((part) => part.text)
     .join('');
+}
+
+/**
+ * Reject if `promise` does not settle within `ms`, otherwise pass its result
+ * through. The timer is always cleared so a fast resolve never leaks a pending
+ * timeout, and a late rejection from the racing promise (after the timeout has
+ * already won) is swallowed so it can't surface as an unhandled rejection.
+ * Exported for unit testing.
+ *
+ * @param promise - The work to bound.
+ * @param ms - Deadline in milliseconds.
+ * @param label - Prefix for the timeout error message.
+ * @returns The resolved value of `promise` when it wins the race.
+ * @throws when the deadline elapses first.
+ */
+export async function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s`)),
+      ms,
+    );
+  });
+  // The original promise stays pending when the timeout wins; attach a no-op
+  // catch so a later rejection of it is not flagged as unhandled.
+  promise.catch(() => {});
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**
@@ -317,7 +368,10 @@ async function runPiCompletion(
     if (event.type === 'turn_end') text += agentMessageText(event.message);
   });
   try {
-    await session.prompt(userPrompt);
+    // Bound the completion: a black-holed network connection must not hang the
+    // await forever (the engine's single-flight guard only clears once it
+    // settles). `dispose()` below tears down the session's HTTP client.
+    await withTimeout(session.prompt(userPrompt), COMPLETION_TIMEOUT_MS, 'dashboard: completion');
   } finally {
     unsubscribe();
     session.dispose();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -488,10 +488,19 @@ app.on('before-quit', (event) => {
   if (quitFlushStarted) return; // re-entrant Cmd-Q while the flush runs
   quitFlushStarted = true;
   void disposeRepoWatchers();
-  void killAll().finally(() => {
-    quitFlushDone = true;
-    app.quit();
-  });
+  // Tear down the scheduler + dashboard alongside the terminal sessions. An
+  // in-flight scheduled headless run is a separate `setsid` pty whose
+  // kill-timeout is a main-process timer that dies with the app, so without this
+  // an `interactive`-mode run reparents to init and survives the quit.
+  // setScheduledConception(null) SIGKILLs every live task run;
+  // setDashboardConception(null) clears the engine interval. Their pty sets are
+  // disjoint from killAll's interactive sessions, so the three don't race.
+  void Promise.all([setScheduledConception(null), setDashboardConception(null), killAll()]).finally(
+    () => {
+      quitFlushDone = true;
+      app.quit();
+    },
+  );
 });
 
 /** Run the terminal-logs janitor for `conceptionPath`. Pulls the


### PR DESCRIPTION
Hardens the opt-in Dashboard subsystem (re-verified against the current code, post-#349).

## F3 — transmitted terminal output was unredacted
The summarizer embedded each tab's command, cwd, prior summary, and recent output/transcript verbatim into the LLM prompt POSTed to the configured endpoint — so a secret printed in a watched tab (`export GITHUB_TOKEN=…`, `cat .env`) left the machine in clear text. Every transmitted field now passes through the existing `redactSecrets()` at the prompt-builder chokepoint. Locally stored titles/state.json are untouched. `docs/reference/config.md` privacy note updated.

## F4 — engine missing the scheduler's safeguards
- Config read moved inside the tick's try/catch-and-return, so a malformed `.condash/settings.json` makes the tick a no-op instead of an unhandled rejection every interval (mirrors `task-scheduler.ts`).
- `session.prompt()` is now bounded by a 60s `withTimeout`; a black-holed connection releases the `inFlight` guard and surfaces `lastError` instead of wedging the dashboard until restart.

## F5 — quit leaked in-flight scheduled ptys
`before-quit` tore down terminal sessions but not the scheduler/dashboard, so an in-flight interactive scheduled run (a `setsid` pty whose kill-timer dies with the app) reparented to init and survived quit. It now tears down `setScheduledConception(null)` + `setDashboardConception(null)` alongside `killAll()` (disjoint pty sets, no race).

## Testing
`make typecheck` clean · `make test-unit` 1261 passing (incl. new redaction + engine-no-op + timeout tests) · `npm run build` green.