### PR TITLE
Terminal/logs/IPC robustness: buffer, parallel listing, arg validation, tests (F7,F9,F10,F12)

### DIFF
--- a/src/main/ipc/dashboard.ts
+++ b/src/main/ipc/dashboard.ts
@@ -3,7 +3,7 @@ import type { DashboardSettings } from '../../shared/types';
 import { getDashboardConfigView, getDashboardState } from '../dashboard/engine';
 import { resolveDashboardConfig } from '../dashboard/config';
 import { testDashboardConnection } from '../dashboard/summarizer';
-import { requireMainWindowSender } from './utils';
+import { requireMainWindowSender, requireOptionalRecord } from './utils';
 
 /** Wire the dashboard read IPC handlers. The push channels (state + per-tab
  *  summaries) are sent from the engine; these are pull accessors the Dashboard
@@ -21,8 +21,11 @@ export function registerDashboardIpc(): void {
 
   // Test the settings the user is editing (draft values, key included). The
   // summarizer's test helper never throws — it resolves { ok, error? }.
-  ipcMain.handle('dashboardTestConnection', (event, settings: DashboardSettings) => {
+  ipcMain.handle('dashboardTestConnection', (event, settings: unknown) => {
     requireMainWindowSender(event);
-    return testDashboardConnection(resolveDashboardConfig(settings ?? {}));
+    const draft = requireOptionalRecord('dashboardTestConnection', settings) as
+      | DashboardSettings
+      | undefined;
+    return testDashboardConnection(resolveDashboardConfig(draft));
   });
 }

--- a/src/main/ipc/logs.test.ts
+++ b/src/main/ipc/logs.test.ts
@@ -178,6 +178,24 @@ describe('logsListSessions', () => {
     expect(result).toEqual([]);
   });
 
+  it('lists every session most-recent-first across a busy day (bounded pool)', async () => {
+    // More files than the per-listing concurrency pool (32) so the read spans
+    // multiple waves — confirms the parallelized walk drops nothing and keeps
+    // the time-descending order.
+    const expected: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      const mm = String(i % 60).padStart(2, '0');
+      const sid = `t-${String(i).padStart(3, '0')}`;
+      writeSession('2026-05-13', `09${mm}00`, sid, 'x', {});
+      expected.push(sid);
+    }
+    expected.reverse(); // most recent (largest HHMMSS) first
+    const result = (await handlers.logsListSessions(trustedEvent, '2026-05-13')) as Array<{
+      sid: string;
+    }>;
+    expect(result.map((r) => r.sid)).toEqual(expected);
+  });
+
   it('ignores .jsonl files even when they share a directory with .txt files', async () => {
     const root = condashLogsRoot(tmp);
     mkdirSync(join(root, '2026', '05', '13'), { recursive: true });

--- a/src/main/ipc/logs.ts
+++ b/src/main/ipc/logs.ts
@@ -8,7 +8,14 @@ import { condashDir, condashLogsRoot } from '../condash-dir';
 import { requirePathUnder } from '../path-bounds';
 import { readSettings } from '../settings';
 import { isTaskRunPath, listTaskRuns } from '../task-runs';
+import { runWithConcurrency } from '../search/concurrency';
 import { requireMainWindowSender } from './utils';
+
+/** Bound on the per-file metadata reads a single listing fans out — each
+ *  session file costs a stat plus a head/tail meta read, so a busy day would
+ *  otherwise serialise hundreds of round-trips on the interaction path. Matches
+ *  the search disk-scan pool size. */
+const LISTING_CONCURRENCY = 32;
 
 // Re-exported so callers that historically imported `splitContent` from this
 // file keep working. New code should import directly from `../logs-format`.
@@ -120,14 +127,15 @@ async function listSessionsForDay(day: string): Promise<TermLogSessionMeta[]> {
   const [y, m, d] = day.split('-');
   const dayPath = join(condashLogsRoot(conception), y, m, d);
 
-  const files = await readDirSafe(dayPath);
-  const metas: TermLogSessionMeta[] = [];
-  for (const name of files) {
-    if (!isSessionFile(name)) continue;
-    const fullPath = join(dayPath, name);
-    const meta = await readSessionMetaSummary(fullPath, day, name);
-    if (meta) metas.push(meta);
-  }
+  const sessionFiles = (await readDirSafe(dayPath)).filter(isSessionFile);
+  // Fan the per-file meta reads out under a bounded pool rather than awaiting
+  // each in series. `readSessionMetaSummary` already swallows its own per-file
+  // errors (returns null), so one unreadable file can't kill the listing.
+  const built = await runWithConcurrency(
+    sessionFiles.map((name) => () => readSessionMetaSummary(join(dayPath, name), day, name)),
+    LISTING_CONCURRENCY,
+  );
+  const metas: TermLogSessionMeta[] = built.filter((m): m is TermLogSessionMeta => m !== null);
   // Sort by HHMMSS descending — most recent first within a day.
   metas.sort((a, b) => (a.time < b.time ? 1 : -1));
   return metas;

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -15,8 +15,17 @@ import { latestScreenshot } from '../screenshot';
 import { requireScreenshotDir } from '../path-bounds';
 import { readSettings } from '../settings';
 import { globalSettingsSchema } from '../config-schema';
-import type { TermSpawnRequest } from '../../shared/types';
-import { requireMainWindowSender } from './utils';
+import type { TermSide, TermSpawnRequest } from '../../shared/types';
+import {
+  requireEnum,
+  requireMainWindowSender,
+  requireNonEmptyString,
+  requireRecord,
+} from './utils';
+
+/** The two terminal sides a session can live on — the allow-set for the
+ *  `termSetSide` enum decoder. */
+const TERM_SIDES: ReadonlySet<TermSide> = new Set(['my', 'code']);
 
 // The `terminal` block of the config schema — the same zod shape
 // `settings.json` is validated with, reused here so a renderer-supplied
@@ -27,15 +36,16 @@ const terminalPrefsSchema = globalSettingsSchema.shape.terminal;
 
 /** Wire every term.* IPC handler. Called once from main entry. */
 export function registerTerminalIpc(): void {
-  ipcMain.handle('termSpawn', async (event, request: TermSpawnRequest) => {
+  ipcMain.handle('termSpawn', async (event, request: unknown) => {
     requireMainWindowSender(event);
+    const spawnRequest = requireRecord('termSpawn', request) as unknown as TermSpawnRequest;
     const { lastConceptionPath: conceptionPath } = await readSettings();
-    return spawnTerminal(conceptionPath, event.sender, request);
+    return spawnTerminal(conceptionPath, event.sender, spawnRequest);
   });
 
-  ipcMain.handle('termWrite', (event, id: string, data: string) => {
+  ipcMain.handle('termWrite', (event, id: unknown, data: string) => {
     requireMainWindowSender(event);
-    writeTerminal(id, data);
+    writeTerminal(requireNonEmptyString('termWrite', id), data);
   });
 
   // Read the system clipboard from the main process. The renderer's
@@ -47,14 +57,14 @@ export function registerTerminalIpc(): void {
     return clipboard.readText();
   });
 
-  ipcMain.handle('termResize', (event, id: string, cols: number, rows: number) => {
+  ipcMain.handle('termResize', (event, id: unknown, cols: number, rows: number) => {
     requireMainWindowSender(event);
-    resizeTerminal(id, cols, rows);
+    resizeTerminal(requireNonEmptyString('termResize', id), cols, rows);
   });
 
-  ipcMain.handle('termClose', (event, id: string) => {
+  ipcMain.handle('termClose', (event, id: unknown) => {
     requireMainWindowSender(event);
-    closeSession(id);
+    closeSession(requireNonEmptyString('termClose', id));
   });
 
   ipcMain.handle('termList', (event) => {
@@ -67,17 +77,17 @@ export function registerTerminalIpc(): void {
     return tabsContext();
   });
 
-  ipcMain.handle('termAttach', (event, id: string) => {
+  ipcMain.handle('termAttach', (event, id: unknown) => {
     requireMainWindowSender(event);
-    return attachTerminal(id, event.sender);
+    return attachTerminal(requireNonEmptyString('termAttach', id), event.sender);
   });
 
-  ipcMain.handle('termSetSide', (event, id: string, side: 'my' | 'code') => {
+  ipcMain.handle('termSetSide', (event, id: unknown, side: unknown) => {
     requireMainWindowSender(event);
-    if (side !== 'my' && side !== 'code') {
-      throw new Error(`termSetSide: invalid side ${JSON.stringify(side)}`);
-    }
-    return setSessionSide(id, side);
+    return setSessionSide(
+      requireNonEmptyString('termSetSide', id),
+      requireEnum('termSetSide', side, TERM_SIDES),
+    );
   });
 
   ipcMain.handle('termGetPrefs', async (event) => {

--- a/src/main/ipc/utils.test.ts
+++ b/src/main/ipc/utils.test.ts
@@ -5,7 +5,12 @@
  * no Electron runtime needed.
  */
 import { describe, expect, it } from 'vitest';
-import { requireMainWindowSender, requireOptionalStringArray } from './utils';
+import {
+  requireMainWindowSender,
+  requireOptionalRecord,
+  requireOptionalStringArray,
+  requireRecord,
+} from './utils';
 
 function makeEvent(overrides: {
   senderType?: string;
@@ -91,6 +96,43 @@ describe('requireOptionalStringArray', () => {
     );
     expect(() => requireOptionalStringArray('search', ['a', 1])).toThrow(
       /search: expected an array of strings/,
+    );
+  });
+});
+
+describe('requireRecord', () => {
+  it('returns a plain object unchanged', () => {
+    const obj = { side: 'my', cols: 80 };
+    expect(requireRecord('termSpawn', obj)).toBe(obj);
+    expect(requireRecord('termSpawn', {})).toEqual({});
+  });
+
+  it('throws the typed error for non-objects, null, and arrays', () => {
+    expect(() => requireRecord('termSpawn', null)).toThrow(/termSpawn: expected an object/);
+    expect(() => requireRecord('termSpawn', undefined)).toThrow(/termSpawn: expected an object/);
+    expect(() => requireRecord('termSpawn', 'nope')).toThrow(/termSpawn: expected an object/);
+    expect(() => requireRecord('termSpawn', 42)).toThrow(/termSpawn: expected an object/);
+    expect(() => requireRecord('termSpawn', ['a'])).toThrow(/termSpawn: expected an object/);
+  });
+});
+
+describe('requireOptionalRecord', () => {
+  it('passes undefined and null through as undefined', () => {
+    expect(requireOptionalRecord('dashboardTestConnection', undefined)).toBeUndefined();
+    expect(requireOptionalRecord('dashboardTestConnection', null)).toBeUndefined();
+  });
+
+  it('returns a present object unchanged', () => {
+    const obj = { apiKey: 'k', enabled: true };
+    expect(requireOptionalRecord('dashboardTestConnection', obj)).toBe(obj);
+  });
+
+  it('throws the typed error for present non-objects', () => {
+    expect(() => requireOptionalRecord('dashboardTestConnection', 'nope')).toThrow(
+      /dashboardTestConnection: expected an object/,
+    );
+    expect(() => requireOptionalRecord('dashboardTestConnection', ['a'])).toThrow(
+      /dashboardTestConnection: expected an object/,
     );
   });
 });

--- a/src/main/ipc/utils.ts
+++ b/src/main/ipc/utils.ts
@@ -50,6 +50,31 @@ export function requireOptionalStringArray(channel: string, value: unknown): str
 }
 
 /**
+ * Require a plain object (non-null, non-array) — a structured IPC request
+ * payload the handler then reads fields off. Returns it as a string-keyed
+ * record; the handler casts to the concrete request type it expects.
+ */
+export function requireRecord(channel: string, value: unknown): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new Error(`${channel}: expected an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Like `requireRecord` but tolerates an absent argument (`undefined` / `null` →
+ * `undefined`), for optional object payloads such as the dashboard settings
+ * patch a handler defaults to `{}`.
+ */
+export function requireOptionalRecord(
+  channel: string,
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (value === undefined || value === null) return undefined;
+  return requireRecord(channel, value);
+}
+
+/**
  * Minimal structural slice of Electron's `IpcMainInvokeEvent` used by the
  * sender guard. Kept structural (no `electron` import) so unit tests can pass
  * a plain object without an Electron runtime.

--- a/src/main/logs-query.test.ts
+++ b/src/main/logs-query.test.ts
@@ -202,6 +202,38 @@ describe('listSessions — enumerate + filter', () => {
   });
 });
 
+describe('parallelized listing (bounded concurrency pool)', () => {
+  // More files than the pool size (32) so the listing spans multiple waves —
+  // guards that the parallelized walk still returns every row in the same
+  // sorted order the old serial loop produced.
+  it('listSessions returns all rows newest-first across a busy day', async () => {
+    const expected: string[] = [];
+    for (let i = 0; i < 40; i++) {
+      const hh = String(8 + Math.floor(i / 60)).padStart(2, '0');
+      const mm = String(i % 60).padStart(2, '0');
+      const sid = `t-${String(i).padStart(3, '0')}`;
+      await makeLog({ day: '2026-05-30', time: `${hh}${mm}00`, sid, exitCode: 0 });
+      expected.push(sid);
+    }
+    expected.reverse(); // newest spawn-time first
+    const rows = await listSessions(tmp, { day: '2026-05-30' });
+    expect(rows.map((r) => r.sid)).toEqual(expected);
+  });
+
+  it('listDays counts every session and sums sizes across many files', async () => {
+    for (let i = 0; i < 40; i++) {
+      const mm = String(i % 60).padStart(2, '0');
+      await makeLog({ day: '2026-05-30', time: `09${mm}00`, sid: `t-d${i}`, exitCode: 0 });
+    }
+    await makeLog({ day: '2026-05-29', time: '120000', sid: 't-prev', exitCode: 0 });
+    const days = await listDays(tmp);
+    expect(days.map((d) => d.day)).toEqual(['2026-05-30', '2026-05-29']);
+    expect(days[0].sessions).toBe(40);
+    expect(days[1].sessions).toBe(1);
+    expect(days[0].bytes).toBeGreaterThan(0);
+  });
+});
+
 describe('long headers (> 4 KB)', () => {
   it('parses a header line larger than the old fixed 4 KB head read', async () => {
     // A promptFlags run rides its full prompt in argv — easily over 4 KB.

--- a/src/main/logs-query.ts
+++ b/src/main/logs-query.ts
@@ -24,6 +24,12 @@ import {
 } from './logs-format';
 import { redactSecrets } from './logs-redact';
 import { condashLogsRoot } from './condash-dir';
+import { runWithConcurrency } from './search/concurrency';
+
+/** Bound on the per-file stat / meta reads a single listing fans out — a busy
+ *  conception holds hundreds of session files, so a serial walk would stack up
+ *  that many round-trips. Matches the search disk-scan pool size. */
+const LISTING_CONCURRENCY = 32;
 
 /** One enumerated session file, before any metadata is read off disk. */
 export interface SessionRef {
@@ -191,8 +197,21 @@ async function enumerateSessions(conception: string, monthPrefix?: string): Prom
 /** Enumerate days that hold at least one session, newest first. */
 export async function listDays(conception: string, monthPrefix?: string): Promise<DayRow[]> {
   const refs = await enumerateSessions(conception, monthPrefix);
+  // Stat the files under a bounded pool rather than one-at-a-time; a vanished
+  // file contributes 0 bytes but the ref is still counted, matching the prior
+  // (stat-in-try/catch-after-increment) behaviour.
+  const sizes = await runWithConcurrency(
+    refs.map((ref) => async () => {
+      try {
+        return (await fs.stat(ref.path)).size;
+      } catch {
+        return 0;
+      }
+    }),
+    LISTING_CONCURRENCY,
+  );
   const byDay = new Map<string, { path: string; sessions: number; bytes: number }>();
-  for (const ref of refs) {
+  refs.forEach((ref, i) => {
     let entry = byDay.get(ref.day);
     if (!entry) {
       // The day directory is the parent of the session file.
@@ -200,12 +219,8 @@ export async function listDays(conception: string, monthPrefix?: string): Promis
       byDay.set(ref.day, entry);
     }
     entry.sessions += 1;
-    try {
-      entry.bytes += (await fs.stat(ref.path)).size;
-    } catch {
-      /* vanished between readdir and stat — ignore */
-    }
-  }
+    entry.bytes += sizes[i];
+  });
   return [...byDay.entries()]
     .map(([day, e]) => ({ day, path: e.path, sessions: e.sessions, bytes: e.bytes }))
     .sort((a, b) => (a.day < b.day ? 1 : -1));
@@ -339,11 +354,22 @@ export async function listSessions(
 ): Promise<SessionRow[]> {
   const monthPrefix = filters.day ? filters.day.slice(0, 7) : undefined;
   const refs = await enumerateSessions(conception, monthPrefix);
+  // Apply the cheap ref-level predicates (day / sid) before touching disk, then
+  // build the surviving rows under a bounded pool. `runWithConcurrency`
+  // preserves input order, and the post-build filters + final sort run over the
+  // result exactly as the serial loop did — so the output is identical, only
+  // the I/O is parallel. `buildRow` returns null on a vanished file (skipped).
+  const candidates = refs.filter(
+    (ref) =>
+      (!filters.day || ref.day === filters.day) &&
+      (!filters.sid || ref.sid.startsWith(filters.sid)),
+  );
+  const built = await runWithConcurrency(
+    candidates.map((ref) => () => buildRow(ref)),
+    LISTING_CONCURRENCY,
+  );
   const rows: SessionRow[] = [];
-  for (const ref of refs) {
-    if (filters.day && ref.day !== filters.day) continue;
-    if (filters.sid && !ref.sid.startsWith(filters.sid)) continue;
-    const row = await buildRow(ref);
+  for (const row of built) {
     if (!row) continue;
     if (filters.repo && row.repo !== filters.repo) continue;
     if (filters.active && !row.active) continue;

--- a/src/main/task-scheduler.test.ts
+++ b/src/main/task-scheduler.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { resolveGate, resolveRunMode, resolveRunTimeout } from './task-scheduler';
+import type { TabInfo } from '../shared/types';
+import {
+  isTaskDue,
+  resolveGate,
+  resolveRunMode,
+  resolveRunTimeout,
+  selectUpdatedTabs,
+} from './task-scheduler';
 
 const DEFAULT_MS = 10 * 60_000;
 
@@ -39,5 +46,65 @@ describe('resolveGate', () => {
     expect(resolveGate(undefined)).toBe(false);
     expect(resolveGate({})).toBe(false);
     expect(resolveGate({ gateOnUpdatedTabs: false })).toBe(false);
+  });
+});
+
+describe('isTaskDue', () => {
+  it('is due once at least the cadence has elapsed since the last check', () => {
+    expect(isTaskDue(10_000, 0, 5_000)).toBe(true);
+    expect(isTaskDue(5_000, 0, 5_000)).toBe(true); // exactly the cadence
+  });
+
+  it('is not due before the cadence has elapsed', () => {
+    expect(isTaskDue(4_999, 0, 5_000)).toBe(false);
+    expect(isTaskDue(10_000, 8_000, 5_000)).toBe(false);
+  });
+
+  it('a never-checked task (lastCheckedAt 0) is due on the first non-trivial now', () => {
+    expect(isTaskDue(20_000, 0, 20_000)).toBe(true);
+  });
+});
+
+describe('selectUpdatedTabs', () => {
+  const tab = (sid: string): TabInfo => ({ sid, cwd: `/w/${sid}` });
+
+  it('returns every tab on the first run (empty previous snapshot)', () => {
+    const tabs = [tab('a'), tab('b')];
+    const current = new Map([
+      ['a', 10],
+      ['b', 20],
+    ]);
+    expect(selectUpdatedTabs(tabs, current, new Map()).map((t) => t.sid)).toEqual(['a', 'b']);
+  });
+
+  it('returns only tabs whose byte count moved since the previous snapshot', () => {
+    const tabs = [tab('a'), tab('b'), tab('c')];
+    const current = new Map([
+      ['a', 10],
+      ['b', 25],
+      ['c', 30],
+    ]);
+    const previous = new Map([
+      ['a', 10], // unchanged
+      ['b', 20], // grew
+      ['c', 30], // unchanged
+    ]);
+    expect(selectUpdatedTabs(tabs, current, previous).map((t) => t.sid)).toEqual(['b']);
+  });
+
+  it('treats a newly-opened tab (absent from previous) as updated', () => {
+    const tabs = [tab('a'), tab('new')];
+    const current = new Map([
+      ['a', 10],
+      ['new', 5],
+    ]);
+    const previous = new Map([['a', 10]]);
+    expect(selectUpdatedTabs(tabs, current, previous).map((t) => t.sid)).toEqual(['new']);
+  });
+
+  it('is empty when nothing changed', () => {
+    const tabs = [tab('a')];
+    const counts = new Map([['a', 10]]);
+    expect(selectUpdatedTabs(tabs, counts, new Map(counts))).toEqual([]);
   });
 });

--- a/src/main/task-scheduler.ts
+++ b/src/main/task-scheduler.ts
@@ -64,6 +64,35 @@ export function resolveGate(entry: TaskConfigEntry | undefined): boolean {
   return entry?.gateOnUpdatedTabs === true;
 }
 
+/** Whether a task is due to run this tick: at least `cadence` ms have elapsed
+ *  since it was last launched (or deliberately skipped). Pure, for unit testing
+ *  without a real timer. Exported for unit testing.
+ *
+ *  @param now Current epoch-ms.
+ *  @param lastCheckedAt Epoch-ms of the last launch/skip (0 before the first).
+ *  @param cadence The task's schedule interval in ms.
+ *  @returns True when the task should be considered this tick. */
+export function isTaskDue(now: number, lastCheckedAt: number, cadence: number): boolean {
+  return now - lastCheckedAt >= cadence;
+}
+
+/** The open tabs whose cumulative byte count moved since a task's last run —
+ *  the `{UPDATED_TABS}` subset and the input to the per-tab growth gate. On the
+ *  first run `previous` is empty, so every open tab reads as updated. Pure, for
+ *  unit testing without live ptys. Exported for unit testing.
+ *
+ *  @param tabs The currently-open tabs (`tabsContext()` at tick time).
+ *  @param current Per-sid live byte counts (`tabsBytes()` at tick time).
+ *  @param previous Per-sid byte counts captured at the task's last launch.
+ *  @returns The subset of `tabs` whose byte count differs from `previous`. */
+export function selectUpdatedTabs(
+  tabs: TabInfo[],
+  current: Map<string, number>,
+  previous: Map<string, number>,
+): TabInfo[] {
+  return tabs.filter((tab) => current.get(tab.sid) !== previous.get(tab.sid));
+}
+
 /** The agedum prompt-seeding flag for a run mode: `--run` runs the prompt once
  *  and exits; `--prompt` seeds it and stays interactive. */
 function promptFlag(mode: RunMode): string {
@@ -268,14 +297,13 @@ async function tick(conceptionPath: string): Promise<void> {
       states.set(slug, state);
     }
     if (state.inFlight) continue;
-    if (now - state.lastCheckedAt < cadence) continue;
+    if (!isTaskDue(now, state.lastCheckedAt, cadence)) continue;
 
     // Per-tab growth: the open tabs whose byte count moved since the last run.
     // On the first run every tab reads as updated (no prior snapshot). The run
     // is always handed exactly this subset via `{UPDATED_TABS}`.
     const bytes = tabsBytes();
-    const prevBytes = state.bytesPerSid;
-    const updated = tabsContext().filter((tab) => bytes.get(tab.sid) !== prevBytes.get(tab.sid));
+    const updated = selectUpdatedTabs(tabsContext(), bytes, state.bytesPerSid);
     // Growth gate, opt-in per task: a gated task skips a tick when nothing
     // changed (or nothing is open) rather than spend the agent. An ungated task
     // runs on every interval regardless — it may not act on `{UPDATED_TABS}`.

--- a/src/main/terminals.test.ts
+++ b/src/main/terminals.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for the pure helpers in `terminals.ts` — the cross-OS shell
+ * wrapping (`wrapForShell` / `defaultShell`) and the rolling-buffer cap
+ * (`appendRecentTail` / `recentTail`, the F10 hysteresis). The live pty path is
+ * deliberately out of scope: `electron` and `node-pty` are mocked so importing
+ * the module doesn't pull in the native / Electron runtime, and only the pure
+ * functions are exercised.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+vi.mock('node-pty', () => ({ spawn: () => ({}) }));
+
+import { appendRecentTail, defaultShell, recentTail, wrapForShell } from './terminals';
+
+/** Mirror of the module-internal cap + hysteresis so the assertions can pin the
+ *  exact thresholds the readers depend on. */
+const MAX_BUFFER = 64_000;
+const BUFFER_SLACK = 16_000;
+
+describe('wrapForShell', () => {
+  // The test host is POSIX, so the win32-only fallback branch never fires; the
+  // family is picked purely from the shell basename, which is platform-free.
+  it('wraps a POSIX shell with -c', () => {
+    expect(wrapForShell('/bin/bash', 'echo hi')).toEqual(['-c', 'echo hi']);
+    expect(wrapForShell('/usr/bin/zsh', 'ls -la')).toEqual(['-c', 'ls -la']);
+  });
+
+  it('wraps PowerShell with -NoLogo -NonInteractive -Command', () => {
+    expect(wrapForShell('pwsh', 'Get-ChildItem')).toEqual([
+      '-NoLogo',
+      '-NonInteractive',
+      '-Command',
+      'Get-ChildItem',
+    ]);
+  });
+
+  it('wraps cmd.exe with /d /s /c', () => {
+    expect(wrapForShell('cmd.exe', 'dir')).toEqual(['/d', '/s', '/c', 'dir']);
+  });
+});
+
+describe('defaultShell', () => {
+  const savedShell = process.env.SHELL;
+
+  afterEach(() => {
+    if (savedShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = savedShell;
+  });
+
+  it('returns the configured shell verbatim when non-blank', () => {
+    expect(defaultShell('/usr/bin/fish')).toBe('/usr/bin/fish');
+  });
+
+  it('falls through a blank/whitespace configured value to $SHELL on POSIX', () => {
+    process.env.SHELL = '/bin/zsh';
+    expect(defaultShell('')).toBe('/bin/zsh');
+    expect(defaultShell('   ')).toBe('/bin/zsh');
+    expect(defaultShell(undefined)).toBe('/bin/zsh');
+  });
+
+  it('falls back to /bin/bash on POSIX when $SHELL is unset', () => {
+    delete process.env.SHELL;
+    expect(defaultShell(undefined)).toBe('/bin/bash');
+  });
+});
+
+describe('appendRecentTail / recentTail — F10 rolling-buffer cap', () => {
+  it('appends without reslicing while under MAX_BUFFER + BUFFER_SLACK', () => {
+    expect(appendRecentTail('', 'abc')).toBe('abc');
+    // A tail well under the reslice threshold is allowed to grow past
+    // MAX_BUFFER — proof the hot path does NOT reslice on every chunk.
+    const tail = 'a'.repeat(MAX_BUFFER + 5_000);
+    const grown = appendRecentTail(tail, 'b');
+    expect(grown.length).toBe(MAX_BUFFER + 5_001);
+    expect(grown).toBe(tail + 'b');
+  });
+
+  it('reslices to the last MAX_BUFFER chars once the overrun exceeds the slack', () => {
+    const tail = 'a'.repeat(MAX_BUFFER + BUFFER_SLACK);
+    const trimmed = appendRecentTail(tail, 'b');
+    expect(trimmed.length).toBe(MAX_BUFFER);
+    expect(trimmed).toBe((tail + 'b').slice(-MAX_BUFFER));
+    expect(trimmed.endsWith('b')).toBe(true);
+  });
+
+  it('recentTail exposes only the last MAX_BUFFER chars', () => {
+    expect(recentTail('short')).toBe('short');
+    const over = 'x'.repeat(MAX_BUFFER + 100);
+    expect(recentTail(over).length).toBe(MAX_BUFFER);
+    expect(recentTail(over)).toBe(over.slice(-MAX_BUFFER));
+  });
+
+  it('reader output is byte-identical to a naive per-chunk cap over a stream', () => {
+    // Feed many chunks through the hysteresis append and confirm the reader's
+    // view always equals the old "(buffer + data).slice(-MAX_BUFFER)" each step.
+    let viaHelper = '';
+    let naive = '';
+    for (let i = 0; i < 400; i++) {
+      const chunk = String.fromCharCode(65 + (i % 26)).repeat(500);
+      viaHelper = appendRecentTail(viaHelper, chunk);
+      naive = (naive + chunk).slice(-MAX_BUFFER);
+      expect(recentTail(viaHelper)).toBe(naive);
+    }
+    // The total stream (200_000 chars) far exceeds the cap, so the final tail
+    // is exactly MAX_BUFFER.
+    expect(recentTail(viaHelper).length).toBe(MAX_BUFFER);
+  });
+});

--- a/src/main/terminals.ts
+++ b/src/main/terminals.ts
@@ -44,7 +44,9 @@ interface Session {
   /** Captured at spawn time so Stop doesn't need conceptionPath at kill time. */
   forceStop?: string;
   /** Rolling tail of stdout/stderr — replayed when a freshly-loaded renderer
-   * re-attaches via termAttach. Capped at MAX_BUFFER bytes. */
+   * re-attaches via termAttach. Readers expose only the last ≤ MAX_BUFFER
+   * chars (`recentTail`); the stored string may overrun the cap by up to
+   * BUFFER_SLACK between reslices (see `appendRecentTail`). */
   buffer: string;
   /** Process exit code; undefined while live. */
   exited?: number;
@@ -68,10 +70,44 @@ interface Session {
 }
 
 const MAX_BUFFER = 64_000;
+/** Reslice hysteresis: the rolling buffer is allowed to overrun MAX_BUFFER by
+ *  up to this many chars before the hot append path trims it back to the last
+ *  MAX_BUFFER. Without the slack, a high-throughput pty reallocated the whole
+ *  (up-to-64 KB) string on every output chunk; with it the reslice happens at
+ *  most once per BUFFER_SLACK chars. Readers still expose only the last
+ *  ≤ MAX_BUFFER chars via `recentTail`, so observable output is unchanged. */
+const BUFFER_SLACK = 16_000;
 const sessions = new Map<string, Session>();
 
+/**
+ * Append `data` to a rolling-tail buffer, reslicing to the last MAX_BUFFER
+ * chars only once the tail overruns MAX_BUFFER + BUFFER_SLACK. Pure (no session
+ * state) so the cap behaviour is unit-testable without a live pty.
+ *
+ * @param tail The current rolling tail.
+ * @param data The newly-emitted chunk to append.
+ * @returns The new tail — at most MAX_BUFFER + BUFFER_SLACK chars long.
+ */
+export function appendRecentTail(tail: string, data: string): string {
+  const next = tail + data;
+  return next.length > MAX_BUFFER + BUFFER_SLACK ? next.slice(-MAX_BUFFER) : next;
+}
+
+/**
+ * The last ≤ MAX_BUFFER chars of a rolling-tail buffer — what every reader
+ * replays. Trims any hysteresis overrun left by `appendRecentTail`, so the
+ * exposed tail is identical to the pre-hysteresis "always exactly capped"
+ * buffer. Pure, for unit testing alongside `appendRecentTail`.
+ *
+ * @param tail The rolling tail (possibly overrun past MAX_BUFFER).
+ * @returns The last MAX_BUFFER chars, or the whole tail when shorter.
+ */
+export function recentTail(tail: string): string {
+  return tail.length > MAX_BUFFER ? tail.slice(-MAX_BUFFER) : tail;
+}
+
 function appendBuffer(session: Session, data: string): void {
-  session.buffer = (session.buffer + data).slice(-MAX_BUFFER);
+  session.buffer = appendRecentTail(session.buffer, data);
 }
 
 function snapshot(): TermSession[] {
@@ -141,7 +177,9 @@ export function tabsBytes(): Map<string, number> {
 export function tabRecentText(sid: string, maxChars = 8000): string {
   const s = sessions.get(sid);
   if (!s || s.exited !== undefined) return '';
-  const text = s.transcript.hasTranscript() ? s.transcript.render() : cleanTerminalText(s.buffer);
+  const text = s.transcript.hasTranscript()
+    ? s.transcript.render()
+    : cleanTerminalText(recentTail(s.buffer));
   return text.length > maxChars ? text.slice(-maxChars) : text;
 }
 
@@ -157,7 +195,7 @@ export function attachTerminal(
   // but no live output arrives — `webContents.send` keeps targeting the
   // destroyed original WebContents and silently bails.
   if (!s.webContents.isDestroyed() && s.webContents.id === sender.id) {
-    return { output: s.buffer, exited: s.exited };
+    return { output: recentTail(s.buffer), exited: s.exited };
   }
   if (s.onWebContentsDestroyed) {
     try {
@@ -172,7 +210,7 @@ export function attachTerminal(
   };
   s.onWebContentsDestroyed = onDestroyed;
   sender.once('destroyed', onDestroyed);
-  return { output: s.buffer, exited: s.exited };
+  return { output: recentTail(s.buffer), exited: s.exited };
 }
 
 /** Move a session between the "my" and "code" sides. Used by the Code pane's
@@ -210,8 +248,9 @@ export function defaultShell(configured?: string): string {
  *  quoting agree with the spawn path. Detection is by shell-binary basename,
  *  so a user-configured `pwsh.exe` or `git-bash.exe` is routed correctly; the
  *  POSIX branch deliberately stays a non-login shell (rationale in the shared
- *  module — the login-shell PATH is injected via spawnEnv() instead). */
-function wrapForShell(shell: string, command: string): string[] {
+ *  module — the login-shell PATH is injected via spawnEnv() instead). Exported
+ *  for unit testing of the cross-OS family routing. */
+export function wrapForShell(shell: string, command: string): string[] {
   return shellCommandArgv(shellFamily(shell, process.platform === 'win32'), command);
 }
 


### PR DESCRIPTION
Robustness, performance, and test-coverage fixes from the v4.47.0 review.

## F10 — per-pty buffer resliced on every chunk
The recent-output buffer did `(buffer + data).slice(-MAX_BUFFER)` on every `onData` chunk — a full-string realloc per chunk on a high-throughput tab. Now appends into a rolling tail and reslices only when it overruns `MAX_BUFFER + 16KB` slack; readers expose the last `MAX_BUFFER` chars via `recentTail`, so output is byte-identical (locked by a 400-chunk test). Reslice cost is amortized to once per 16KB.

## F9 — serial FS round-trips when listing logs
`listSessionsForDay` / `listSessions` / `listDays` did ~4 serial syscalls per file in a `for…of await` loop. All three now run the per-file work through the search path's `runWithConcurrency` (limit 32); post-sort ordering and per-file error skipping preserved.

## F12 — IPC handlers diverged from the shared-decoder convention
`termSpawn`/`termWrite`/`termResize`/`termClose`/`termAttach`/`termSetSide` and `dashboardTestConnection` now validate args through the `ipc/utils` decoders (new `requireRecord`/`requireOptionalRecord`, `requireNonEmptyString` for ids, `requireEnum` for side) — junk throws a typed `<channel>: expected …` instead of a raw TypeError. `requireMainWindowSender` stays first.

## F7 — thin coverage on the terminal/scheduler stack
Added unit tests for the terminal pure helpers (`wrapForShell`, `defaultShell`, the F10 cap), extracted + tested scheduler decision helpers (`isTaskDue`, `selectUpdatedTabs`), the new IPC decoders, and the parallelized log listings (+25 tests). Live-pty/signal and the scheduler timer loop are left as a noted gap (need a heavy fake-pty harness).

## Testing
`make typecheck` clean · `make test-unit` 1286 passing · `npm run build` green.