### PR TITLE
Cleanup: --success token, drop CSS literal fallbacks, dead eslint-disable, PDF-export CSP (F15, F16, F13)

### DIFF
--- a/src/main/dashboard/clean-text.ts
+++ b/src/main/dashboard/clean-text.ts
@@ -13,17 +13,13 @@
 // Control-character ranges we drop (everything below 0x20 except \n and \t,
 // plus DEL). Declared once; the `\r` overwrite pass runs before this so lone
 // carriage returns are resolved rather than deleted.
-// eslint-disable-next-line no-control-regex
 const CONTROL_CHARS = /[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g;
 // OSC: ESC ] ... terminated by BEL or ESC \. Stripped first so the BEL
 // terminator is consumed here rather than by the control-char pass.
-// eslint-disable-next-line no-control-regex
 const OSC_SEQUENCE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 // CSI: ESC [ params intermediate final.
-// eslint-disable-next-line no-control-regex
 const CSI_SEQUENCE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 // Other two-byte escapes: ESC followed by a single byte in @-_ or \.
-// eslint-disable-next-line no-control-regex
 const SHORT_ESCAPE = /\x1b[@-Z\\-_]/g;
 
 /**

--- a/src/main/ipc/logs.test.ts
+++ b/src/main/ipc/logs.test.ts
@@ -32,7 +32,6 @@ vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/electron-app' },
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
 
 /** Minimal event shape accepted by `requireMainWindowSender`. */
@@ -44,7 +43,6 @@ const trustedEvent = {
 beforeEach(async () => {
   handlers = {};
   const { ipcMain } = await import('electron');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (ipcMain.handle as any).mockImplementation(
     (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
       handlers[channel] = fn;

--- a/src/main/ipc/settings-card-min-width.test.ts
+++ b/src/main/ipc/settings-card-min-width.test.ts
@@ -20,7 +20,6 @@ vi.mock('electron', () => ({
 }));
 
 let tmp: string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
 let settingsPathValue: string;
 
@@ -48,7 +47,6 @@ beforeEach(async () => {
 
   handlers = {};
   const { ipcMain } = await import('electron');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (ipcMain.handle as any).mockImplementation(
     (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
       handlers[channel] = fn;

--- a/src/main/ipc/settings-tree-expansion.test.ts
+++ b/src/main/ipc/settings-tree-expansion.test.ts
@@ -18,7 +18,6 @@ vi.mock('electron', () => ({
 }));
 
 let tmp: string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
 let settingsPathValue: string;
 
@@ -64,7 +63,6 @@ beforeEach(async () => {
 
   handlers = {};
   const { ipcMain } = await import('electron');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (ipcMain.handle as any).mockImplementation(
     (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
       handlers[channel] = fn;

--- a/src/main/ipc/system.test.ts
+++ b/src/main/ipc/system.test.ts
@@ -57,7 +57,6 @@ vi.mock('../effective-config', () => ({
 vi.mock('../watcher', () => ({ setWatchedConception: vi.fn(async () => undefined) }));
 vi.mock('../repo-watchers', () => ({ disposeRepoWatchers: vi.fn(async () => undefined) }));
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
 let onConceptionPicked: ReturnType<typeof vi.fn>;
 let tmp: string;
@@ -78,7 +77,6 @@ beforeEach(async () => {
   vi.clearAllMocks();
   handlers = {};
   const { ipcMain } = await import('electron');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (ipcMain.handle as any).mockImplementation(
     (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
       handlers[channel] = fn;
@@ -192,7 +190,6 @@ describe('openPath', () => {
 describe('exportNotePdf', () => {
   it('returns null without printing when the save dialog is cancelled', async () => {
     const { dialog } = await import('electron');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog.showSaveDialog as any).mockResolvedValue({ canceled: true });
     const result = await handlers.exportNotePdf(trustedEvent, '/c/note.md', '<html></html>');
     expect(result).toBeNull();
@@ -203,7 +200,6 @@ describe('exportNotePdf', () => {
   it('prints and writes the PDF to the picked path', async () => {
     const target = join(tmp, 'out.pdf');
     const { dialog } = await import('electron');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (dialog.showSaveDialog as any).mockResolvedValue({ canceled: false, filePath: target });
     const result = await handlers.exportNotePdf(trustedEvent, '/c/note.md', '<html></html>');
     expect(result).toBe(target.split('\\').join('/'));

--- a/src/main/ipc/tasks.test.ts
+++ b/src/main/ipc/tasks.test.ts
@@ -20,7 +20,6 @@ vi.mock('electron', () => ({
 }));
 
 let tmp: string;
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 let handlers: Record<string, (...args: any[]) => Promise<unknown>>;
 let settingsPathValue: string;
 let conceptionConfigPathValue: string;
@@ -52,7 +51,6 @@ beforeEach(async () => {
 
   handlers = {};
   const { ipcMain } = await import('electron');
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (ipcMain.handle as any).mockImplementation(
     (channel: string, fn: (...args: any[]) => Promise<unknown>) => {
       handlers[channel] = fn;

--- a/src/main/user-data-dir.ts
+++ b/src/main/user-data-dir.ts
@@ -20,7 +20,6 @@ export function userDataDir(): string {
   // returns the path to the binary as a *string*, not the API object, so
   // we have to probe the shape before reaching `.app.getPath()`.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
     const candidate: unknown = require('electron');
     if (
       candidate !== null &&

--- a/src/renderer/note-modal-parts/export-pdf.ts
+++ b/src/renderer/note-modal-parts/export-pdf.ts
@@ -30,6 +30,12 @@ export async function buildNotePdfHtml(
     '<html data-theme="light">',
     '<head>',
     '<meta charset="utf-8" />',
+    // Lock the print document down: it is condash-generated (rendered note
+    // body + inline app CSS) and runs no scripts, so a strict CSP costs
+    // nothing here while it neutralises any beaconing from a crafted note.
+    // Images/fonts resolve over the conception-bounded condash-file: scheme
+    // (or inline data:); the code + print stylesheets are inline.
+    '<meta http-equiv="Content-Security-Policy" content="default-src \'none\'; img-src condash-file: data:; font-src condash-file: data:; style-src \'unsafe-inline\'" />',
     `<title>${escapeHtml(opts.title)}</title>`,
     `<style>${codeThemeCss}\n${exportCss}</style>`,
     '</head>',

--- a/src/renderer/panes/dashboard-pane.css
+++ b/src/renderer/panes/dashboard-pane.css
@@ -61,10 +61,10 @@
   flex-direction: column;
   gap: 2px;
   padding: 8px 10px;
-  border: 1px solid color-mix(in srgb, var(--danger, #c0392b) 50%, var(--border));
-  border-left: 3px solid var(--danger, #c0392b);
+  border: 1px solid color-mix(in srgb, var(--danger) 50%, var(--border));
+  border-left: 3px solid var(--danger);
   border-radius: var(--radius);
-  background: color-mix(in srgb, var(--danger, #c0392b) 12%, var(--bg-elevated));
+  background: color-mix(in srgb, var(--danger) 12%, var(--bg-elevated));
 }
 
 .dashboard-error-banner-label {
@@ -72,7 +72,7 @@
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--danger, #c0392b);
+  color: var(--danger);
 }
 
 .dashboard-error-banner-msg {

--- a/src/renderer/settings-modal.css
+++ b/src/renderer/settings-modal.css
@@ -409,12 +409,12 @@
 
 .settings-dashboard-test-ok {
   font-size: var(--text-sm);
-  color: var(--success, #2e7d32);
+  color: var(--success);
 }
 
 .settings-dashboard-test-error {
   font-size: var(--text-sm);
-  color: var(--danger, #c0392b);
+  color: var(--danger);
   word-break: break-word;
 }
 
@@ -644,7 +644,7 @@
   align-items: center;
   gap: 8px;
   padding: 6px 8px;
-  border: 1px solid var(--border, #444);
+  border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg-elevated);
 }

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -97,6 +97,12 @@
   --danger: var(--warn);
   --text-dim: var(--text-faint);
 
+  /* Positive / success green. Unlike --danger (an alias onto --warn), success
+   * has no base in the palette to ride, so it carries its own value with a
+   * --dark-success mirror remapped across both dark paths below — exactly the
+   * pattern --border uses. Used by the Settings "test connection" OK state. */
+  --success: #2e7d32;
+
   /* Terminal-preview sample palette (Tokyo Night). These are intentionally
    * NOT the app palette: the Settings colour-grid preview shows a fixed
    * sample terminal theme so the user can judge contrast independently of
@@ -215,6 +221,7 @@
   --dark-col-backlog: #7d92ad;
   --dark-col-done: #7d8290;
   --dark-warn: #d6748f;
+  --dark-success: #3fb950;
   --dark-col-unknown: #d6748f;
   --dark-col-running: #5fc97f;
   --dark-col-dirty: #e8a878;
@@ -252,6 +259,7 @@
     --col-backlog: var(--dark-col-backlog);
     --col-done: var(--dark-col-done);
     --warn: var(--dark-warn);
+    --success: var(--dark-success);
     --col-unknown: var(--dark-col-unknown);
     --col-running: var(--dark-col-running);
     --col-dirty: var(--dark-col-dirty);
@@ -286,6 +294,7 @@
   --col-backlog: var(--dark-col-backlog);
   --col-done: var(--dark-col-done);
   --warn: var(--dark-warn);
+  --success: var(--dark-success);
   --col-unknown: var(--dark-col-unknown);
   --col-running: var(--dark-col-running);
   --col-dirty: var(--dark-col-dirty);


### PR DESCRIPTION
Quality + light-security cleanup from the v4.47.0 review.

## F15 — CSS design-system violations
- Stripped the six forbidden `var(--x, #literal)` fallbacks that aliased defined tokens (`--danger`, `--border`).
- Defined the one missing token: `--success` (+ `--dark-success`, remapped across both dark paths), so `settings-modal.css` no longer rendered only via a hardcoded fallback and now has a tuned dark value.
- **Correction:** the six "raw-px font-size" violations were a false positive — all are documented icon-glyph exemptions, or the self-contained PDF print stylesheet where `--text-*` is undefined (a swap would *regress*). Left unchanged.

## F16 — inert eslint-disable directives
Removed all 17 (no ESLint is configured/installed, so they suppress nothing) across 7 files. No behaviour change.

## F13 (CSP, partial)
Injected a restrictive `<meta>` CSP (`default-src 'none'; img-src/font-src condash-file: data:; style-src 'unsafe-inline'`) into the **condash-generated** PDF-export document — scoped via meta, not a session header, so the main window and the user-HTML preview webview are unaffected. PDF images/styles still render.

**Deliberately not done (watchpoints):** the `.html` preview webview is left un-CSP'd because it renders the user's own JS/CDN-driven slides/article deliverables — a script/connect-blocking CSP would break them. The Electron major-version bump (other half of F13) is also out of scope (needs a chosen target + smoke test).

## Testing
`make typecheck` clean · `make test-unit` 1286 passing · `npm run build` green.