### PR TITLE
UI: migrate the .modal-button vocabulary onto <Button> (F14)

### DIFF
--- a/src/renderer/action-dropdown-button.css
+++ b/src/renderer/action-dropdown-button.css
@@ -170,17 +170,24 @@
 }
 
 /* Modal-header variant — same treatment as row-card so the trigger blends
- * into the header instead of carrying full button chrome. */
-.action-dropdown-button.modal-button.work-on-button {
-  width: auto;
-  height: auto;
+ * into the header instead of carrying full button chrome. Self-contained now
+ * that the trigger no longer composes with the removed `.modal-button`: it
+ * supplies its own 26 px head-glyph sizing (scoped to the trigger content so
+ * the caret keeps its 12 px) and 7 px head radius. */
+.action-dropdown-button.work-on-button {
   padding: 4px 6px;
   border: none;
+  border-radius: 7px;
   background: transparent;
   font-weight: 500;
 }
 
-.action-dropdown-button.modal-button.work-on-button:hover {
+.action-dropdown-button.work-on-button .action-dropdown-trigger-content svg {
+  width: 26px;
+  height: 26px;
+}
+
+.action-dropdown-button.work-on-button:hover {
   background: var(--bg-hover);
   color: var(--col-running);
   border-color: transparent;

--- a/src/renderer/actions.css
+++ b/src/renderer/actions.css
@@ -21,15 +21,13 @@
  *                      warn in every pane, not pane-by-pane.
  *   .action-bar        footer commit/cancel row (cancel left, primary right)
  *   .seg / .seg-item   segmented toggle group (scope / view switches)
+ *   .btn--modal-head   the chunky 32 px modal-head icon idiom (close, reveal,
+ *                      edit/save/pdf, …) — the former standalone .modal-button,
+ *                      now a modifier in this one vocabulary
  *
  * The <Button>/<IconButton>/<ActionBar> wrappers in actions.tsx render these
  * classes so call-sites name intent, not chrome. Built entirely on the
- * styles.css token set (colour / type / radius) — no literals, no new tokens.
- *
- * Out of scope by design: the 32 px modal-head icon button (`.modal-button`
- * in modal-base.css) stays its own idiom — it is already internally
- * consistent and is the deliberate output of the phase-4 modal shell. It is
- * the head-bar sibling of .btn--icon; the two share shape and tokens. */
+ * styles.css token set (colour / type / radius) — no literals, no new tokens. */
 
 .btn {
   display: inline-flex;
@@ -155,6 +153,44 @@
   stroke-width: 1.7;
 }
 
+/* Modal-head icon button — the chunky 32 px head idiom (close, reveal,
+ * open-in-OS, edit/save/pdf, delete-session, the note find-bar steppers).
+ * Larger box + glyph than the quiet .btn--icon row button, and prominent
+ * (text-body, inherited from .btn--default) at rest rather than muted.
+ * Rehomed verbatim from the former standalone `.modal-button`; pair it with
+ * <Button variant="default"> — NOT <IconButton>, whose `.btn--icon svg`
+ * stroke-width would thin these glyphs. `tone` still colours the hover verb
+ * cue (e.g. tone="stop" reproduces the close button's warn hover). */
+.btn--modal-head {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  gap: 0;
+  border-radius: 7px;
+  flex-shrink: 0;
+  /* Glyph buttons (×, ↑, ↓, ⤷) inherited the 14 px body size; `.btn` forces
+   * 13 px, so restore it. Harmless for the SVG-icon buttons. */
+  font-size: var(--text-md);
+}
+.btn--modal-head svg {
+  width: 26px;
+  height: 26px;
+}
+/* Reproduce the former .modal-button:disabled — explicit faint colours at
+ * full opacity, not the .btn 50 %-opacity wash. */
+.btn--modal-head:disabled,
+.btn--modal-head[aria-disabled='true'] {
+  opacity: 1;
+  color: var(--text-faint);
+  background: var(--bg-subtle);
+  border-color: var(--border);
+}
+/* Pressed toggle (the note modal's edit/view switch). */
+.btn--modal-head.active {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}
+
 /* ---- Semantic tone (the verb's colour) --------------------------------- */
 /* On an icon button: colours the hover text + border by the action's verb,
  * so the same verb reads the same in every pane (resting state stays
@@ -163,30 +199,22 @@
  * specificity. */
 /* open (navigate / reveal) and add (create / new) share the brand accent —
  * both are the positive "go forward" verb; previously add actions drifted
- * across amber / green / accent pane-by-pane. */
-/* `.modal-button` (the 32 px modal-head icon button, modal-base.css) carries
- * tones too, so a verb in a modal head — "open in OS", "work on" — reads the
- * same accent/green/warn cue as the same verb in a pane row. */
+ * across amber / green / accent pane-by-pane. A verb in a modal head ("open
+ * in OS", "work on") reads the same cue as the same verb in a pane row. */
 .btn[data-tone='open']:hover:not(:disabled),
-.btn[data-tone='add']:hover:not(:disabled),
-.modal-button[data-tone='open']:hover:not(:disabled),
-.modal-button[data-tone='add']:hover:not(:disabled) {
+.btn[data-tone='add']:hover:not(:disabled) {
   color: var(--accent);
   border-color: var(--accent);
 }
 /* work / run — start a terminal or run a command: the "go live" green. */
 .btn[data-tone='work']:hover:not(:disabled),
-.btn[data-tone='run']:hover:not(:disabled),
-.modal-button[data-tone='work']:hover:not(:disabled),
-.modal-button[data-tone='run']:hover:not(:disabled) {
+.btn[data-tone='run']:hover:not(:disabled) {
   color: var(--col-running);
   border-color: var(--col-running);
 }
 /* stop / danger — halt, kill, delete, discard. */
 .btn[data-tone='stop']:hover:not(:disabled),
-.btn[data-tone='danger']:hover:not(:disabled),
-.modal-button[data-tone='stop']:hover:not(:disabled),
-.modal-button[data-tone='danger']:hover:not(:disabled) {
+.btn[data-tone='danger']:hover:not(:disabled) {
   color: var(--warn);
   border-color: var(--warn);
 }

--- a/src/renderer/html-modal.css
+++ b/src/renderer/html-modal.css
@@ -34,3 +34,14 @@
   gap: 4px;
   flex-shrink: 0;
 }
+
+/* The tabs are <Button variant="default"> text buttons. Carry over the two
+ * deltas the former `.modal-button--text` had over `.btn--default`: the 7 px
+ * head radius, and the selected-tab accent border (formerly `.modal-button.active`). */
+.modal-seg .btn {
+  border-radius: 7px;
+}
+.modal-seg .btn.active {
+  background: var(--bg-hover);
+  border-color: var(--accent);
+}

--- a/src/renderer/html-modal.tsx
+++ b/src/renderer/html-modal.tsx
@@ -1,5 +1,6 @@
 import { createResource, createSignal, Show } from 'solid-js';
 import { Modal } from './modal';
+import { Button } from './actions';
 import { highlightCode, pathToCondashFileUrl } from './markdown';
 import './html-modal.css';
 
@@ -49,41 +50,43 @@ export function HtmlModal(props: {
       headExtra={
         <>
           <div class="modal-seg" role="tablist" aria-label="HTML view mode">
-            <button
+            <Button
               type="button"
               role="tab"
-              class="modal-button modal-button--text"
+              variant="default"
               classList={{ active: mode() === 'rendered' }}
               aria-selected={mode() === 'rendered'}
               onClick={() => setMode('rendered')}
             >
               Rendered
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               role="tab"
-              class="modal-button modal-button--text"
+              variant="default"
               classList={{ active: mode() === 'source' }}
               aria-selected={mode() === 'source'}
               onClick={() => setMode('source')}
             >
               Source
-            </button>
+            </Button>
           </div>
-          <button
-            class="modal-button"
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={() => props.onReveal(props.path)}
             title="Reveal in file manager"
           >
             ⤷
-          </button>
-          <button
-            class="modal-button"
+          </Button>
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={() => props.onOpenInOs(props.path)}
             title="Open in OS default browser"
           >
             ↗
-          </button>
+          </Button>
         </>
       }
     >

--- a/src/renderer/image-modal.tsx
+++ b/src/renderer/image-modal.tsx
@@ -1,5 +1,6 @@
 import { createSignal, Show } from 'solid-js';
 import { Modal } from './modal';
+import { Button } from './actions';
 import { pathToCondashFileUrl } from './markdown';
 import './image-modal.css';
 
@@ -32,20 +33,22 @@ export function ImageModal(props: {
       onClose={props.onClose}
       headExtra={
         <>
-          <button
-            class="modal-button"
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={() => props.onReveal(props.path)}
             title="Reveal in file manager"
           >
             ⤷
-          </button>
-          <button
-            class="modal-button"
+          </Button>
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={() => props.onOpenInOs(props.path)}
             title="Open in OS default viewer"
           >
             ↗
-          </button>
+          </Button>
         </>
       }
     >

--- a/src/renderer/logs-modal.tsx
+++ b/src/renderer/logs-modal.tsx
@@ -11,6 +11,7 @@ import {
 } from 'solid-js';
 import type { TermLogSessionMeta, TermLogSessionRead } from '@shared/types';
 import { Modal } from './modal';
+import { Button } from './actions';
 import './logs-modal.css';
 
 /**
@@ -185,9 +186,10 @@ export function LogsViewerModal(props: {
         </>
       }
       headExtra={
-        <button
+        <Button
           type="button"
-          class="modal-button"
+          variant="default"
+          class="btn--modal-head"
           title="Delete this session"
           aria-label="Delete this session"
           disabled={!sessionRead()?.meta}
@@ -197,7 +199,7 @@ export function LogsViewerModal(props: {
           }}
         >
           ⌫
-        </button>
+        </Button>
       }
     >
       <div class="logs-modal-search">

--- a/src/renderer/modal-base.css
+++ b/src/renderer/modal-base.css
@@ -190,57 +190,8 @@
   flex-shrink: 0;
 }
 
-.modal-button {
-  /* Modal-head action buttons — chunkier than the card's row-actions
-   * because the modal head needs the icons to read clearly without
-   * crowding the title. Slightly larger square + larger SVG, with a
-   * tinted hover that picks up an action-specific colour cue. */
-  background: var(--bg-subtle);
-  border: 1px solid transparent;
-  width: 32px;
-  height: 32px;
-  border-radius: 7px;
-  cursor: pointer;
-  color: var(--text-body);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition:
-    background 100ms ease,
-    color 100ms ease,
-    border-color 100ms ease;
-}
-
-.modal-button svg {
-  /* SVG is sized to fill 80% of the 32 px button so the icon content
-   * reads at full presence, not as a tiny glyph in a big box. */
-  width: 26px;
-  height: 26px;
-}
-
-.modal-button:hover {
-  background: var(--bg-hover);
-  color: var(--text);
-  border-color: var(--border-strong);
-}
-
-.modal-button:disabled {
-  color: var(--text-faint);
-  background: var(--bg-subtle);
-  border-color: var(--border);
-  cursor: not-allowed;
-}
-
-.modal-button.active {
-  background: var(--bg-hover);
-  border-color: var(--accent);
-}
-
-.modal-button.modal-close:hover {
-  color: var(--warn);
-  border-color: var(--warn);
-}
+/* The 32 px modal-head icon idiom moved into the action framework as
+ * `.btn--modal-head` (actions.css); head buttons now render through <Button>. */
 
 .modal-body {
   flex: 1;
@@ -292,14 +243,6 @@
 
 .modal-backdrop {
   animation: backdrop-in 160ms ease;
-}
-
-.modal-button--text {
-  width: auto;
-  height: auto;
-  padding: 5px 12px;
-  font-size: var(--text-sm);
-  white-space: nowrap;
 }
 
 .help-modal {

--- a/src/renderer/modal.tsx
+++ b/src/renderer/modal.tsx
@@ -1,5 +1,6 @@
 import { type JSX, Show } from 'solid-js';
 import { createBackdropClose, useModalEscHandler } from './modal-helpers';
+import { Button } from './actions';
 import { IconClose } from './icons';
 
 export interface ModalProps {
@@ -75,14 +76,16 @@ export function Modal(props: ModalProps): JSX.Element {
             {props.headLeading}
           </Show>
           {props.headExtra}
-          <button
-            class="modal-button modal-close"
+          <Button
+            variant="default"
+            tone="stop"
+            class="btn--modal-head"
             onClick={() => props.onClose()}
             title={props.closeTitle ?? 'Close (Esc)'}
             aria-label={props.closeLabel ?? 'Close'}
           >
             <IconClose />
-          </button>
+          </Button>
         </header>
         {props.children}
       </div>

--- a/src/renderer/note-modal-parts/config-summary.tsx
+++ b/src/renderer/note-modal-parts/config-summary.tsx
@@ -1,4 +1,5 @@
 import { createSignal } from 'solid-js';
+import { Button } from '../actions';
 
 /**
  * Reference panel surfaced above the rendered body when the open file is
@@ -36,8 +37,9 @@ export function ConfigSummaryPanel(props: { onOpenFullDoc: () => void }) {
     >
       <summary>
         Reference — top-level keys
-        <button
-          class="modal-button config-summary-link"
+        <Button
+          variant="default"
+          class="config-summary-link"
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
@@ -46,7 +48,7 @@ export function ConfigSummaryPanel(props: { onOpenFullDoc: () => void }) {
           title="Open the full configuration reference"
         >
           Full reference →
-        </button>
+        </Button>
       </summary>
       <ul class="config-summary-list">
         {CONFIG_SUMMARY.map((row) => (

--- a/src/renderer/note-modal.css
+++ b/src/renderer/note-modal.css
@@ -10,11 +10,6 @@
   max-height: calc(100% - 48px);
 }
 
-.modal-button.work-on-button:hover {
-  color: var(--col-now);
-  border-color: var(--col-now);
-}
-
 .md-rendered {
   font-size: var(--text-md);
   line-height: 1.6;

--- a/src/renderer/note-modal.tsx
+++ b/src/renderer/note-modal.tsx
@@ -14,6 +14,7 @@ import type { MountedEditor } from './editor';
 import type { Deliverable } from '@shared/types';
 import type { ModalState } from './modal-types';
 import { ConfirmModal } from './confirm-modal';
+import { Button } from './actions';
 import { IconClose, IconExternal } from './icons';
 import { IconEdit, IconPdf, IconSave, IconView } from './note-modal-parts/icons';
 import { clearFindHighlights, focusFindMatch, highlightFindMatches } from './note-modal-parts/find';
@@ -573,55 +574,60 @@ export function NoteModal(props: {
             </span>
           </Show>
           <Show when={!props.state?.readOnly}>
-            <button
-              class="modal-button"
+            <Button
+              variant="default"
+              class="btn--modal-head"
               classList={{ active: mode() === 'edit' }}
               onClick={requestViewMode}
               title={mode() === 'edit' ? 'View (Ctrl+E)' : 'Edit (Ctrl+E)'}
               aria-label={mode() === 'edit' ? 'Switch to view mode' : 'Switch to edit mode'}
             >
               {mode() === 'edit' ? <IconView /> : <IconEdit />}
-            </button>
+            </Button>
           </Show>
           <Show when={mode() === 'edit' && !props.state?.readOnly}>
-            <button
-              class="modal-button"
+            <Button
+              variant="default"
+              class="btn--modal-head"
               onClick={() => void save()}
               disabled={!dirty()}
               title="Save (Ctrl+S)"
               aria-label="Save"
             >
               <IconSave />
-            </button>
+            </Button>
           </Show>
           <Show when={mode() === 'view' && props.state && isMarkdown(props.state.path)}>
-            <button
-              class="modal-button"
+            <Button
+              variant="default"
+              class="btn--modal-head"
               onClick={() => void exportPdf()}
               disabled={exporting()}
               title="Export as PDF"
               aria-label="Export as PDF"
             >
               <IconPdf />
-            </button>
+            </Button>
           </Show>
-          <button
-            class="modal-button"
-            data-tone="open"
+          <Button
+            variant="default"
+            tone="open"
+            class="btn--modal-head"
             onClick={() => props.state && props.onOpenInEditor(props.state.path)}
             title="Open in $EDITOR"
             aria-label="Open in external editor"
           >
             <IconExternal />
-          </button>
-          <button
-            class="modal-button"
+          </Button>
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={handleBackdropClose}
             title="Close (Esc)"
             aria-label="Close"
           >
             <IconClose />
-          </button>
+          </Button>
         </header>
 
         <Show when={findOpen() && mode() === 'view'}>
@@ -641,18 +647,25 @@ export function NoteModal(props: {
                   : `${findMatch()!.index + 1} / ${findMatch()!.total}`}
               </span>
             </Show>
-            <button
-              class="modal-button"
+            <Button
+              variant="default"
+              class="btn--modal-head"
               onClick={() => stepFind(-1)}
               title="Previous (Shift+Enter)"
             >
               ↑
-            </button>
-            <button class="modal-button" onClick={() => stepFind(1)} title="Next (Enter)">
+            </Button>
+            <Button
+              variant="default"
+              class="btn--modal-head"
+              onClick={() => stepFind(1)}
+              title="Next (Enter)"
+            >
               ↓
-            </button>
-            <button
-              class="modal-button"
+            </Button>
+            <Button
+              variant="default"
+              class="btn--modal-head"
               onClick={() => {
                 setFindOpen(false);
                 setFindQuery('');
@@ -660,7 +673,7 @@ export function NoteModal(props: {
               title="Close (Esc)"
             >
               ×
-            </button>
+            </Button>
           </div>
         </Show>
 
@@ -684,23 +697,23 @@ export function NoteModal(props: {
         <Show when={pendingViewSwitch()}>
           <div class="modal-confirm" role="alertdialog" aria-label="Unsaved changes">
             <span class="modal-confirm-message">Unsaved changes — switch to view mode?</span>
-            <button
-              class="modal-button"
+            <Button
+              variant="default"
               onClick={() => void confirmSaveAndSwitch()}
               title="Save and switch to view"
             >
               Save
-            </button>
-            <button
-              class="modal-button"
+            </Button>
+            <Button
+              variant="default"
               onClick={confirmDiscardAndSwitch}
               title="Discard changes and switch to view"
             >
               Discard
-            </button>
-            <button class="modal-button" onClick={cancelViewSwitch} title="Stay in edit mode">
+            </Button>
+            <Button variant="default" onClick={cancelViewSwitch} title="Stay in edit mode">
               Cancel
-            </button>
+            </Button>
           </div>
         </Show>
 
@@ -719,9 +732,9 @@ export function NoteModal(props: {
           <Show when={content.error}>
             <div class="empty warn">
               Failed to read: {(content.error as Error).message}
-              <button class="modal-button" onClick={() => void reload()}>
+              <Button variant="default" onClick={() => void reload()}>
                 Reload
-              </button>
+              </Button>
             </div>
           </Show>
           <Show

--- a/src/renderer/panes/code-pane.css
+++ b/src/renderer/panes/code-pane.css
@@ -506,15 +506,6 @@
   border-color: var(--warn);
 }
 
-.modal-button.warn {
-  border-color: var(--warn);
-  color: var(--warn);
-}
-
-.modal-button.warn:hover {
-  background: color-mix(in srgb, var(--warn) 14%, var(--bg-elevated));
-}
-
 .branches {
   list-style: none;
   margin: 6px 0 0;

--- a/src/renderer/pdf-modal.tsx
+++ b/src/renderer/pdf-modal.tsx
@@ -1,5 +1,6 @@
 import { createResource, Show } from 'solid-js';
 import { Modal } from './modal';
+import { Button } from './actions';
 import './pdf-modal.css';
 
 export function PdfModal(props: {
@@ -27,20 +28,22 @@ export function PdfModal(props: {
       onClose={props.onClose}
       headExtra={
         <>
-          <button
-            class="modal-button"
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={() => props.onReveal(props.path)}
             title="Reveal in file manager"
           >
             ⤷
-          </button>
-          <button
-            class="modal-button"
+          </Button>
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={() => props.onOpenInOs(props.path)}
             title="Open in OS default viewer"
           >
             ↗
-          </button>
+          </Button>
         </>
       }
     >

--- a/src/renderer/project-preview.tsx
+++ b/src/renderer/project-preview.tsx
@@ -274,25 +274,28 @@ export function ProjectPreview(props: {
                     if (action) props.onProjectAction?.(project(), action);
                   }
                 }}
-                class="modal-button work-on-button"
+                class="work-on-button"
               />
-              <button
-                class="modal-button"
-                data-tone="open"
+              <Button
+                variant="default"
+                tone="open"
+                class="btn--modal-head"
                 onClick={() => props.onOpenInEditor(projectDir(project().path))}
                 title="Open folder in OS"
                 aria-label="Open folder in OS"
               >
                 <IconExternal />
-              </button>
-              <button
-                class="modal-button modal-close"
+              </Button>
+              <Button
+                variant="default"
+                tone="stop"
+                class="btn--modal-head"
                 onClick={props.onClose}
                 title="Close (Esc)"
                 aria-label="Close"
               >
                 <IconClose />
-              </button>
+              </Button>
             </header>
 
             <div class="preview-body">

--- a/src/renderer/settings-modal-parts/repo-row.tsx
+++ b/src/renderer/settings-modal-parts/repo-row.tsx
@@ -1,6 +1,7 @@
 import { createSignal, For, Show } from 'solid-js';
 import type { RawRepo, RawSubmoduleRepo } from '@shared/config-types';
 import { type BindTextFn, type DndHandlers, moveItem } from './data';
+import { Button } from '../actions';
 import { Caret } from '../icons';
 
 const REPO_ROW_OPEN_KEY = 'condash:settings-modal:repo-row-open';
@@ -165,25 +166,32 @@ export function RepoRow(props: {
             {summary()}
           </span>
         </Show>
-        <button
-          class="modal-button"
+        <Button
+          variant="default"
+          class="btn--modal-head"
           title="Move up"
           disabled={props.index === 0}
           onClick={() => props.onMove(-1)}
         >
           ↑
-        </button>
-        <button
-          class="modal-button"
+        </Button>
+        <Button
+          variant="default"
+          class="btn--modal-head"
           title="Move down"
           disabled={props.index === props.total - 1}
           onClick={() => props.onMove(1)}
         >
           ↓
-        </button>
-        <button class="modal-button" title="Remove" onClick={() => props.onRemove()}>
+        </Button>
+        <Button
+          variant="default"
+          class="btn--modal-head"
+          title="Remove"
+          onClick={() => props.onRemove()}
+        >
           ×
-        </button>
+        </Button>
       </div>
       <Show when={nameMissing()}>
         <p class="settings-repo-name-error">
@@ -319,12 +327,12 @@ export function RepoRow(props: {
           </div>
         </Show>
         <div class="settings-list-actions">
-          <button
-            class="modal-button"
+          <Button
+            variant="default"
             onClick={() => void updateSubmodules((all) => [...all, { name: '' }])}
           >
             + Add sub repo
-          </button>
+          </Button>
         </div>
       </Show>
     </div>

--- a/src/renderer/settings-modal-parts/section-recent-conceptions.tsx
+++ b/src/renderer/settings-modal-parts/section-recent-conceptions.tsx
@@ -1,6 +1,7 @@
 import { createResource, createSignal, For, Show } from 'solid-js';
 import type { JSX } from 'solid-js';
 import { SectionShell } from './section-shell';
+import { Button } from '../actions';
 
 /**
  * Per-machine list of recently-opened conception paths (Personal group). Each
@@ -61,23 +62,24 @@ export function RecentConceptionsSection(): JSX.Element {
                 >
                   <code class="settings-recents-path">{path}</code>
                 </button>
-                <button
+                <Button
                   type="button"
-                  class="modal-button settings-recents-remove"
+                  variant="default"
+                  class="settings-recents-remove"
                   onClick={() => void handleRemove(path)}
                   title="Remove from recents"
                   aria-label={`Remove ${path} from recents`}
                 >
                   ×
-                </button>
+                </Button>
               </li>
             )}
           </For>
         </ul>
         <div class="settings-recents-actions">
-          <button type="button" class="modal-button" onClick={() => void handleClear()}>
+          <Button type="button" variant="default" onClick={() => void handleClear()}>
             Clear all
-          </button>
+          </Button>
         </div>
       </Show>
     </SectionShell>

--- a/src/renderer/settings-modal-parts/section-row.tsx
+++ b/src/renderer/settings-modal-parts/section-row.tsx
@@ -1,6 +1,7 @@
 import { Show, type JSX } from 'solid-js';
 import type { RawRepo } from '@shared/config-types';
 import type { BindTextFn, DndHandlers } from './data';
+import { Button } from '../actions';
 
 /**
  * One row in the repositories list that is a `{ section: "…" }` marker — a
@@ -65,25 +66,32 @@ export function SectionRow(props: {
             (v) => props.onPatch({ section: v }),
           )}
         />
-        <button
-          class="modal-button"
+        <Button
+          variant="default"
+          class="btn--modal-head"
           title="Move up"
           disabled={props.index === 0}
           onClick={() => props.onMove(-1)}
         >
           ↑
-        </button>
-        <button
-          class="modal-button"
+        </Button>
+        <Button
+          variant="default"
+          class="btn--modal-head"
           title="Move down"
           disabled={props.index === props.total - 1}
           onClick={() => props.onMove(1)}
         >
           ↓
-        </button>
-        <button class="modal-button" title="Remove section" onClick={() => props.onRemove()}>
+        </Button>
+        <Button
+          variant="default"
+          class="btn--modal-head"
+          title="Remove section"
+          onClick={() => props.onRemove()}
+        >
           ×
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/renderer/settings-modal-parts/sections-agents.tsx
+++ b/src/renderer/settings-modal-parts/sections-agents.tsx
@@ -10,6 +10,7 @@ import { For, Show, type JSX } from 'solid-js';
 import type { Agent } from '@shared/types';
 import { type BindTextFn, type RawConfig } from './data';
 import { SectionShell } from './section-shell';
+import { Button } from '../actions';
 
 interface AgentsSectionProps {
   /** Draft-aware config getter for the global file. */
@@ -87,30 +88,33 @@ export function AgentsSection(props: AgentsSectionProps): JSX.Element {
                   {entry.label.trim() || `Agent ${index() + 1}`}
                 </span>
                 <span class="settings-agent-row-actions">
-                  <button
-                    class="modal-button"
+                  <Button
+                    variant="default"
+                    class="btn--modal-head"
                     title="Move up"
                     disabled={index() === 0}
                     onClick={() => void moveAgent(index(), -1)}
                   >
                     ↑
-                  </button>
-                  <button
-                    class="modal-button"
+                  </Button>
+                  <Button
+                    variant="default"
+                    class="btn--modal-head"
                     title="Move down"
                     disabled={index() === agents().length - 1}
                     onClick={() => void moveAgent(index(), 1)}
                   >
                     ↓
-                  </button>
-                  <button
-                    class="modal-button"
+                  </Button>
+                  <Button
+                    variant="default"
+                    class="btn--modal-head"
                     title="Remove agent"
                     aria-label="Remove agent"
                     onClick={() => void removeAgent(index())}
                   >
                     ×
-                  </button>
+                  </Button>
                 </span>
               </div>
               <div class="settings-agent-card-fields">
@@ -190,9 +194,9 @@ export function AgentsSection(props: AgentsSectionProps): JSX.Element {
           )}
         </For>
         <div class="settings-list-actions">
-          <button class="modal-button" onClick={() => void addAgent()}>
+          <Button variant="default" onClick={() => void addAgent()}>
             + Add agent
-          </button>
+          </Button>
         </div>
       </div>
     </SectionShell>

--- a/src/renderer/settings-modal-parts/sections-dashboard.tsx
+++ b/src/renderer/settings-modal-parts/sections-dashboard.tsx
@@ -11,6 +11,7 @@ import { createSignal, Show, type JSX } from 'solid-js';
 import type { DashboardSettings } from '@shared/types';
 import { type RawConfig } from './data';
 import { SectionShell } from './section-shell';
+import { Button } from '../actions';
 
 /** Inline result of the "Test connection" probe. */
 type TestState =
@@ -155,14 +156,14 @@ export function DashboardSection(props: DashboardSectionProps): JSX.Element {
       </div>
 
       <div class="settings-dashboard-test">
-        <button
+        <Button
           type="button"
-          class="modal-button"
+          variant="default"
           disabled={!dashboard().apiKey || test().status === 'testing'}
           onClick={() => void runTest()}
         >
           {test().status === 'testing' ? 'Testing…' : 'Test connection'}
-        </button>
+        </Button>
         <Show when={test().status === 'ok'}>
           <span class="settings-dashboard-test-ok">✓ Connection OK</span>
         </Show>

--- a/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
+++ b/src/renderer/settings-modal-parts/sections-repos-and-open-with.tsx
@@ -12,6 +12,7 @@ import { type BindTextFn, OPEN_WITH_SLOTS, type RawConfig } from './data';
 import { RepoRow } from './repo-row';
 import { SectionRow } from './section-row';
 import { SectionShell } from './section-shell';
+import { Button } from '../actions';
 
 interface RepositoriesSectionProps {
   parsed: () => RawConfig;
@@ -143,12 +144,12 @@ export function RepositoriesSection(props: RepositoriesSectionProps): JSX.Elemen
           )}
         </For>
         <div class="settings-list-actions">
-          <button class="modal-button" onClick={() => void addRepo()}>
+          <Button variant="default" onClick={() => void addRepo()}>
             + Add repo
-          </button>
-          <button class="modal-button" onClick={() => void addSection()}>
+          </Button>
+          <Button variant="default" onClick={() => void addSection()}>
             + Add section
-          </button>
+          </Button>
         </div>
       </div>
     </SectionShell>

--- a/src/renderer/settings-modal.css
+++ b/src/renderer/settings-modal.css
@@ -545,24 +545,10 @@
   margin-top: 4px;
 }
 
-/* Text-bearing buttons inside the settings modal need the natural-width
- * variant — `.modal-button` defaults to a 32 × 32 icon square (note-modal
- * head action), which clips multi-word labels like "+ with run / label". */
-.settings-modal--full .settings-list-actions .modal-button,
-.settings-modal--full .settings-rail-actions .modal-button,
-.settings-modal--full .settings-recents-row .modal-button,
-.settings-modal--full .settings-recents-actions .modal-button,
-.settings-modal--full .settings-conception-path .modal-button {
-  width: auto;
-  height: auto;
-  padding: 5px 12px;
-  border-radius: 6px;
-  font: inherit;
-  font-size: var(--text-sm);
-  font-weight: 500;
-  white-space: nowrap;
-  line-height: 1.2;
-}
+/* The settings text actions now render through <Button variant="default">,
+ * whose `.btn--default` already supplies this natural-width chrome (5/12
+ * padding, 6 px radius, 13 px / 500 label) — so the former `.modal-button`
+ * un-square override here is no longer needed. */
 
 /* Compact override for the per-field "Reset to global" / "Remove
  * override" button — sits next to a small badge and shouldn't dwarf it. */
@@ -1246,16 +1232,12 @@
   white-space: nowrap;
 }
 
+/* The remove (×) is now a <Button variant="default">; it already carries the
+ * default chrome the former `.modal-button` text-override gave it. Only the
+ * row-shrink guard remains live (the 26 px-square props were always clobbered
+ * by that higher-specificity override, so they never rendered). */
 .settings-recents-remove {
   flex-shrink: 0;
-  width: 26px;
-  height: 26px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  font-size: var(--text-lg);
-  line-height: 1;
 }
 
 .settings-empty-hint {

--- a/src/renderer/settings-modal.tsx
+++ b/src/renderer/settings-modal.tsx
@@ -583,14 +583,15 @@ export function SettingsModal(props: {
           >
             Discard
           </Button>
-          <button
-            class="modal-button"
+          <Button
+            variant="default"
+            class="btn--modal-head"
             onClick={attemptClose}
             title="Close (Esc)"
             aria-label="Close settings"
           >
             <IconClose />
-          </button>
+          </Button>
         </header>
 
         <div class="settings-search-bar">
@@ -663,20 +664,20 @@ export function SettingsModal(props: {
               )}
             </For>
             <div class="settings-rail-actions">
-              <button
-                class="modal-button"
+              <Button
+                variant="default"
                 onClick={openSettingsExternally}
                 title={`Open ${SCOPE_FILE.global} with the OS default editor`}
               >
                 Open {SCOPE_FILE.global}
-              </button>
-              <button
-                class="modal-button"
+              </Button>
+              <Button
+                variant="default"
                 onClick={openConfigExternally}
                 title={`Open ${SCOPE_FILE.conception} with the OS default editor`}
               >
                 Open .condash/settings.json
-              </button>
+              </Button>
             </div>
           </nav>
 

--- a/tests/file-preview.spec.ts
+++ b/tests/file-preview.spec.ts
@@ -78,7 +78,7 @@ test('Resources viewers: image, highlighted code, HTML rendered/source, reveal',
     await expect(window.locator('.html-modal')).toBeVisible();
     await expect(window.locator('.html-modal .html-webview')).toBeVisible();
     // Flip to Source → highlighted markup.
-    await window.locator('.html-modal .modal-button--text', { hasText: 'Source' }).click();
+    await window.locator('.html-modal .modal-seg .btn', { hasText: 'Source' }).click();
     await expect(window.locator('.html-modal .html-source .hljs')).toBeVisible();
     await window.screenshot({ path: join(SHOTS, 'html-source.png') }).catch(() => undefined);
     await window.keyboard.press('Escape');

--- a/tests/repo-sections.spec.ts
+++ b/tests/repo-sections.spec.ts
@@ -37,7 +37,7 @@ test('Settings: + Add section appends a section marker to condash.json', async (
     // id; scroll it into view before driving its controls.
     const reposSection = modal.locator('section#settings-section-repositories');
     await reposSection.scrollIntoViewIfNeeded();
-    const addSectionBtn = reposSection.locator('button.modal-button', {
+    const addSectionBtn = reposSection.locator('button.btn', {
       hasText: '+ Add section',
     });
     await addSectionBtn.click();

--- a/tests/settings-modal-audit.spec.ts
+++ b/tests/settings-modal-audit.spec.ts
@@ -558,7 +558,7 @@ test('settings modal: representative fields render and round-trip to the right f
     {
       const reposSection = modal.locator('#settings-section-repositories');
       await safeScroll(reposSection);
-      await reposSection.locator('button.modal-button', { hasText: '+ Add repo' }).click();
+      await reposSection.locator('button.btn', { hasText: '+ Add repo' }).click();
       await booted.window.waitForTimeout(150);
       const nameInput = reposSection.locator('.settings-repo-row input.settings-repo-name').first();
       await auditText({


### PR DESCRIPTION
condash had two parallel button vocabularies — the canonical `<Button>`/`<IconButton>` (role class + `data-tone`) and the legacy `.modal-button` class (47 sites, 6 CSS files) bridged by `actions.css`. This migrates every `.modal-button` call-site onto `<Button>` and deletes the legacy CSS + the bridge, leaving **one** vocabulary.

## Appearance preserved
A single carry-over modifier, `.btn--modal-head`, reproduces the 32px modal-head icon idiom exactly (32px box, 26px glyph, 7px radius, faint full-opacity disabled) on top of `.btn`/`.btn--default`; close uses `tone="stop"`, open-in-OS `tone="open"`. Box geometry is identical under the global `box-sizing:border-box`. The `.modal-button--text` sites (already auto-width) became plain text `<Button variant="default">`.

## One intentional improvement
Four text-bearing buttons that used bare `.modal-button` (`width:32px`) were clipping their labels as 32px squares (note-modal confirm Save/Discard/Cancel + Reload, dashboard Test-connection, config-summary link) — now proper auto-width text buttons. Three primitives are left as their own idiom (`ActionDropdownButton`, `.modal-back-button`, the deliverables-pane button) to avoid changing their look.

## Testing
`grep modal-button` clean (only comments). `make typecheck` clean · `make test-unit` 1286 passing · `npm run build` green · **Playwright e2e 48 passing** (3 specs updated for the new markup) · `knip` 0.

Visually verified the migrated icon buttons (spawn-dropdown / open-external / close) in the project-preview modal head (light + dark). Note: the screenshot spec only captures that one modal — the other button-bearing surfaces (note-modal head, settings modal, confirm dialogs, viewers, new-project) are covered functionally by the behavioural e2e but not pixel-captured; worth an eyeball.