### PR TITLE
Fix garbage dashboard tab summaries and put status strip on one line

### DIFF
--- a/src/main/dashboard/clean-text.test.ts
+++ b/src/main/dashboard/clean-text.test.ts
@@ -30,4 +30,20 @@ describe('cleanTerminalText', () => {
   it('returns empty string for escape-only input', () => {
     expect(cleanTerminalText('\x1b[2J\x1b[H')).toBe('');
   });
+
+  it('consumes nF charset-designation escapes instead of leaking "(B"', () => {
+    // ESC ( B = "designate G0 = US-ASCII"; the printable "(B" tail must not survive.
+    expect(cleanTerminalText('\x1b(Bhello')).toBe('hello');
+    expect(cleanTerminalText('\x1b(B\x1b)0\x1b*B\x1b+B')).toBe('');
+    expect(cleanTerminalText('\x1b#8aligned')).toBe('aligned');
+  });
+
+  it('cleans an alternate-screen repaint frame to empty (no "(B" residue)', () => {
+    // Regression: a TUI repainting via cursor addressing emits ESC ( B every
+    // frame; the cleaned text must not read as a tab printing "(B" repeatedly.
+    const frame = '\x1b[H\x1b(B\x1b[2K\x1b(B'.repeat(6);
+    const cleaned = cleanTerminalText(frame);
+    expect(cleaned).not.toContain('(B');
+    expect(cleaned).toBe('');
+  });
 });

--- a/src/main/dashboard/clean-text.ts
+++ b/src/main/dashboard/clean-text.ts
@@ -21,6 +21,14 @@ const OSC_SEQUENCE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
 const CSI_SEQUENCE = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 // Other two-byte escapes: ESC followed by a single byte in @-_ or \.
 const SHORT_ESCAPE = /\x1b[@-Z\\-_]/g;
+// ECMA-48 "nF" escapes: ESC + one-or-more intermediate bytes (0x20-0x2F) + a
+// final byte (0x30-0x7E). Covers charset designation (ESC ( B, ESC ) 0), DEC
+// line alignment (ESC # 8), UTF-8 select (ESC % G), etc. Without this the lone
+// ESC is later removed by the CONTROL_CHARS pass and the intermediate+final
+// bytes (e.g. "(B") leak into the cleaned text as repeated literal residue —
+// an alternate-screen TUI emits ESC ( B on every repaint, so the summarizer
+// would otherwise "see" a tab printing "(B" over and over.
+const NF_ESCAPE = /\x1b[\x20-\x2f]+[\x30-\x7e]/g;
 
 /**
  * Clean raw terminal output into plain text.
@@ -34,6 +42,9 @@ export function cleanTerminalText(raw: string): string {
   let text = raw.replace(/\r\n/g, '\n');
   text = text.replace(OSC_SEQUENCE, '');
   text = text.replace(CSI_SEQUENCE, '');
+  // Strip nF escapes before the CONTROL_CHARS pass below, which would otherwise
+  // delete only the lone ESC and leave the printable "(B" tail behind.
+  text = text.replace(NF_ESCAPE, '');
   text = text.replace(SHORT_ESCAPE, '');
   // Resolve carriage-return overwrites per line: a `\r` rewinds to column 0, so
   // the visible result of "10%\r50%\rdone" is "done". Keep the last segment.

--- a/src/renderer/panes/dashboard-pane.css
+++ b/src/renderer/panes/dashboard-pane.css
@@ -83,31 +83,41 @@
 
 /* Always-on liveness strip above the two-column body: next-update ETA, current
  * loop phase, and last-run time. Visible whenever the engine is enabled, so an
- * idle-but-running summarizer is never mistaken for a dead one. */
+ * idle-but-running summarizer is never mistaken for a dead one. Laid out as a
+ * single horizontal line; segments wrap only when the pane is too narrow. */
 .dashboard-status {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  row-gap: 4px;
   padding: 8px 10px;
   border: 1px solid var(--border);
   border-left: 3px solid var(--accent);
   border-radius: var(--radius);
   background: var(--bg-subtle);
-}
-
-.dashboard-status-list {
-  margin: 0;
-  display: grid;
-  grid-template-columns: max-content 1fr;
-  gap: 4px 12px;
   font-size: var(--text-sm);
 }
 
-.dashboard-status-list dt {
-  color: var(--text-muted);
-}
-
-.dashboard-status-list dd {
-  margin: 0;
+.dashboard-status-item {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 0 14px;
   color: var(--text);
   word-break: break-word;
+}
+
+.dashboard-status-item:first-child {
+  padding-left: 0;
+}
+
+/* Hairline divider between adjacent segments on the same line. */
+.dashboard-status-item + .dashboard-status-item {
+  border-left: 1px solid var(--border);
+}
+
+.dashboard-status-label {
+  color: var(--text-muted);
 }
 
 /* The live countdown — tinted + tabular figures so it doesn't jitter as it ticks. */

--- a/src/renderer/panes/dashboard.tsx
+++ b/src/renderer/panes/dashboard.tsx
@@ -169,22 +169,28 @@ export function DashboardView() {
 
       {/* Always-on liveness strip: next-update ETA + what the loop is doing now
           + last run. Rendered whenever the engine is enabled, independent of any
-          tab summary, so an idle-but-running engine is never mistaken for dead. */}
+          tab summary, so an idle-but-running engine is never mistaken for dead.
+          A single horizontal line — three labelled segments separated by hairline
+          dividers — so it stays compact above the working surface. */}
       <Show when={config()?.enabled}>
         <section class="dashboard-status">
-          <dl class="dashboard-status-list">
-            <dt>Status</dt>
-            <dd>
+          <span class="dashboard-status-item">
+            <span class="dashboard-status-label">Status</span>
+            <span>
               {statusLabel(config()!)}
               <Show when={nextUpdateText()}>
                 <span class="dashboard-status-next"> · {nextUpdateText()}</span>
               </Show>
-            </dd>
-            <dt>Engine</dt>
-            <dd>{enginePhaseText()}</dd>
-            <dt>Last run</dt>
-            <dd>{lastRunText()}</dd>
-          </dl>
+            </span>
+          </span>
+          <span class="dashboard-status-item">
+            <span class="dashboard-status-label">Engine</span>
+            <span>{enginePhaseText()}</span>
+          </span>
+          <span class="dashboard-status-item">
+            <span class="dashboard-status-label">Last run</span>
+            <span>{lastRunText()}</span>
+          </span>
         </section>
       </Show>
 

--- a/tests/dashboard-roster.spec.ts
+++ b/tests/dashboard-roster.spec.ts
@@ -66,7 +66,7 @@ test('Dashboard lists every open tab even with no summaries', async () => {
     // summarized) the loop's liveness must be visible — this is the "I see no
     // update / what's going on" fix. With no key the phase is the paused state.
     await expect(pane.locator('.dashboard-status')).toBeVisible();
-    await expect(pane.locator('.dashboard-status-list')).toContainText('Paused');
+    await expect(pane.locator('.dashboard-status')).toContainText('Paused');
     // "What's going on" is no longer blank: it narrates the open-but-unsummarized
     // tabs instead of hiding until a summary exists.
     await expect(pane.locator('.dashboard-overview')).toContainText('no transcript captured yet');


### PR DESCRIPTION
## Summary

Two dashboard fixes, shipped together.

### 1. Garbage tab summaries ("printing '(B' repeatedly")

`cleanTerminalText` (the plaintext feed for the LLM tab summarizer) stripped OSC / CSI / short escapes but not the ECMA-48 **nF** charset-designation family (`ESC ( B`). An alternate-screen TUI emits `ESC ( B` on every repaint; the lone `ESC` was then dropped by the control-char pass, leaving the printable `(B` tail — so a fresh `agedum claude` tab with no OSC transcript yet got summarized as "a process that repeatedly prints '(B'".

Added an `NF_ESCAPE` strip pass (`ESC` + intermediate `0x20–0x2F` + final `0x30–0x7E`) applied before the control-char pass. Such repaint frames now clean to empty, so the engine's existing empty-text guard skips the tab and the renderer shows its honest "Waiting for first agent output" pending card instead. The OSC-transcript path never calls `cleanTerminalText`, so the verified capture contract is unaffected.

### 2. Status strip on one line

The always-on Status / Engine / Last run liveness strip rendered as a three-row `<dl>` grid. Converted it to a single horizontal line — a flex row of three labelled segments with hairline dividers, wrapping only when the pane is too narrow.

## Testing

- `npm run typecheck` — clean
- full `vitest run` — **1291 passed** (added nF-escape + repaint-frame regression cases in `clean-text.test.ts`)
- `make build` — main + renderer + cli build clean
- `tests/dashboard-roster.spec.ts` e2e (Xvfb) — green; the rendered strip shows `Status On — no API key | Engine Paused … | Last run —` on a single line. Spec selector updated for the new markup.