### PR TITLE
Fix dashboard never persisting state — create state dir + push before save

### DIFF
--- a/src/main/dashboard/engine-status.test.ts
+++ b/src/main/dashboard/engine-status.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { DashboardConfig, TabInfo } from '../../shared/types';
+import { EVENT_CHANNELS } from '../../shared/ipc-channels';
+import type { DashboardConfig, DashboardState, TabInfo } from '../../shared/types';
 import type { OverviewResult, TabSummaryResult } from './summarizer';
 
 // Mutable fixtures the mocks read, so each case can shape the engine's inputs.
@@ -10,10 +11,29 @@ const h = vi.hoisted(() => ({
   recent: '',
   summary: null as TabSummaryResult | null,
   overview: null as OverviewResult | null,
+  // Every `dashboardState` payload the engine broadcasts, in order — lets a test
+  // assert what actually reached the renderer (not just the in-memory state).
+  pushed: [] as DashboardState[],
 }));
 
-// The engine imports electron + broadcasts via getAllWindows(); stub to no-op.
-vi.mock('electron', () => ({ BrowserWindow: { getAllWindows: () => [] } }));
+// The engine broadcasts via getAllWindows().webContents.send. A single fake
+// window records every `dashboardState` push so a test can assert the renderer
+// saw the final post-cycle state even when persistence fails.
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [
+      {
+        isDestroyed: () => false,
+        webContents: {
+          isDestroyed: () => false,
+          send: (channel: string, payload: unknown) => {
+            if (channel === EVENT_CHANNELS.dashboardState) h.pushed.push(payload as DashboardState);
+          },
+        },
+      },
+    ],
+  },
+}));
 vi.mock('./config', async (importOriginal) => {
   const actual = await importOriginal<typeof import('./config')>();
   return { ...actual, readDashboardConfig: vi.fn(async () => h.config) };
@@ -58,6 +78,7 @@ beforeEach(() => {
   h.recent = '';
   h.summary = null;
   h.overview = null;
+  h.pushed = [];
 });
 
 afterEach(async () => {
@@ -97,5 +118,25 @@ describe('dashboard engine status', () => {
     });
     // The tab was actually summarized this cycle.
     expect(getDashboardState()?.tabs.map((tab) => tab.sid)).toEqual(['a']);
+  });
+
+  it('still pushes the final state to the renderer when persistence fails', async () => {
+    const { saveDashboardState } = await import('./state');
+    vi.mocked(saveDashboardState).mockRejectedValue(new Error('ENOENT: state dir missing'));
+    h.tabs = [{ sid: 'a', cwd: '/w', cmd: 'sh' }];
+    h.bytes = new Map([['a', 12]]);
+    h.recent = 'real transcript output';
+    h.summary = { title: 'Build', contextLines: ['compiling'], currentAction: 'compiling' };
+    h.overview = { overview: ['Tab a is compiling'], events: [] };
+    await setDashboardConception(CONCEPTION);
+    // The renderer must still receive the post-cycle state — summarized tab,
+    // resting `waiting` phase — even though the save threw. The old order (save
+    // then push) skipped the push on a throwing save, so every summary and the
+    // phase reset never reached the pane (it stayed stuck on "summarizing").
+    await vi.waitFor(() => {
+      const last = h.pushed.at(-1);
+      expect(last?.engine?.phase).toBe('waiting');
+      expect(last?.tabs.map((tab) => tab.sid)).toEqual(['a']);
+    });
   });
 });

--- a/src/main/dashboard/engine.ts
+++ b/src/main/dashboard/engine.ts
@@ -261,8 +261,17 @@ export async function tick(conceptionPath: string): Promise<void> {
       },
       config.historyLimit,
     );
-    await saveDashboardState(conceptionPath, state);
+    // Push the freshly computed state to the renderer FIRST, then persist.
+    // Persistence is a best-effort next-launch seed; a save failure must never
+    // suppress the live UI update. The previous order (save, then push) meant a
+    // throwing save skipped the push entirely — so every summary, overview and
+    // resting-phase reset was computed but never reached the pane.
     pushState();
+    try {
+      await saveDashboardState(conceptionPath, state);
+    } catch (err) {
+      process.stderr.write(`condash dashboard: state persist failed: ${(err as Error).message}\n`);
+    }
   } catch (err) {
     process.stderr.write(`condash dashboard: tick failed: ${(err as Error).message}\n`);
   } finally {

--- a/src/main/dashboard/state.test.ts
+++ b/src/main/dashboard/state.test.ts
@@ -7,6 +7,7 @@ import {
   emptyDashboardState,
   loadDashboardState,
   pruneDashboardState,
+  saveDashboardState,
 } from './state';
 import type { DashboardState } from '../../shared/types';
 
@@ -59,6 +60,20 @@ describe('emptyDashboardState', () => {
       roster: [],
       history: [],
     });
+  });
+});
+
+describe('saveDashboardState', () => {
+  it('creates the .condash/dashboard dir on a fresh conception and round-trips', async () => {
+    // A fresh conception has no `.condash/dashboard/` — the dir is created
+    // lazily on first save and scaffolded nowhere else. Deliberately do NOT
+    // mkdir it here: without the save's own mkdir, `atomicWrite` throws ENOENT
+    // and every persist silently fails (the bug this guards against). Note the
+    // sibling load test mkdir's the dir itself, which is exactly what masked it.
+    const dir = await mkdtemp(join(tmpdir(), 'condash-dash-save-'));
+    await expect(saveDashboardState(dir, emptyDashboardState(7))).resolves.toBeUndefined();
+    const loaded = await loadDashboardState(dir);
+    expect(loaded?.updatedAt).toBe(7);
   });
 });
 

--- a/src/main/dashboard/state.ts
+++ b/src/main/dashboard/state.ts
@@ -1,5 +1,5 @@
-import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 import { condashDir } from '../condash-dir';
 import { atomicWrite } from '../atomic-write';
 import type { DashboardEvent, DashboardState, TabSummary } from '../../shared/types';
@@ -82,7 +82,14 @@ export async function saveDashboardState(
   conceptionPath: string,
   state: DashboardState,
 ): Promise<void> {
-  await atomicWrite(dashboardStatePath(conceptionPath), JSON.stringify(state, null, 2) + '\n');
+  const path = dashboardStatePath(conceptionPath);
+  // `.condash/dashboard/` is created lazily on the first save and never
+  // scaffolded elsewhere, so on a fresh conception it doesn't exist yet.
+  // `atomicWrite` needs the parent dir present (same convention as the config
+  // writers) — without this mkdir every save throws ENOENT, which the engine's
+  // catch swallows, so the dashboard never persists and never pushes a summary.
+  await mkdir(dirname(path), { recursive: true });
+  await atomicWrite(path, JSON.stringify(state, null, 2) + '\n');
 }
 
 /** Clamp every bounded array (global history + each tab's events) to the last


### PR DESCRIPTION
## What

The Dashboard could never display a summary or overview and never persisted
state, because **every state save threw and the renderer push was sequenced
behind that throwing save**.

- `saveDashboardState` writes `<conception>/.condash/dashboard/state.json` via
  `atomicWrite`, which — by the codebase's documented convention — needs its
  parent dir to already exist (the config writers `mkdir -p` first, e.g.
  `cli/commands/config.ts:283`, `main/write-config.ts:57`). `.condash/dashboard/`
  is scaffolded nowhere, so on a fresh conception **every save threw `ENOENT`**.
- In the engine cycle, `pushState()` ran *after* `await saveDashboardState()`
  inside one `try`. When the save threw, the push never fired — so the summarized
  tab, cross-tab overview, history, and the resting-phase reset (from
  `summarizing` back to `waiting`) were computed in memory but **never reached the
  renderer**. The strip stuck on "Summarizing 1 tab…" while the tab itself showed
  "no transcript captured yet".

Net: the pane could only ever show pre-summary liveness chrome — the recurring
"I never see what's going on" report, one layer below the prior #357/#358 work.

## Fix

- `state.ts` — `mkdir(dirname(path), {recursive:true})` before `atomicWrite`,
  matching the config-writer convention. Saves succeed; state persists.
- `engine.ts` — push to the renderer first, then persist best-effort in its own
  `try/catch`. A persistence failure is logged but can never suppress the live UI.

## Why it shipped

- No test covered `saveDashboardState`; the `loadDashboardState` test `mkdir`s
  `.condash/dashboard/` itself — masking the missing production mkdir.
- `engine-status.test.ts` mocked `saveDashboardState` to a no-op, so the engine
  path never exercised the real (throwing) save.

## Tests

- New `saveDashboardState` test that does **not** pre-create the dir — verified it
  **fails on the old code** (`ENOENT … open '…/.condash/dashboard/.<tmp>'`) and
  passes with the fix.
- New engine test: a fake Electron window captures broadcasts; with
  `saveDashboardState` rejecting, the renderer still receives the final
  post-cycle state (`phase:'waiting'`, tab summarized).

## Verification

- Confirmed **live** on the running, unmodified v4.50.0: creating
  `.condash/dashboard/` by hand made the dashboard persist `state.json` and reset
  `engine.phase` to `waiting` within ~24s.
- `make format`, `npm run typecheck`, `npm run deadcode` clean; full `vitest run`
  1292 passed (one unrelated pre-existing flaky test, `search/index-cache.test.ts`,
  green in isolation); e2e `dashboard-roster.spec.ts` green under Xvfb.
