### PR TITLE
dashboard: colour tabs by agent state (live-state cockpit)

### DIFF
--- a/src/main/dashboard/engine-status.test.ts
+++ b/src/main/dashboard/engine-status.test.ts
@@ -107,7 +107,12 @@ describe('dashboard engine status', () => {
     h.tabs = [{ sid: 'a', cwd: '/w', cmd: 'sh' }];
     h.bytes = new Map([['a', 12]]);
     h.recent = 'real transcript output';
-    h.summary = { title: 'Build', contextLines: ['compiling'], currentAction: 'compiling' };
+    h.summary = {
+      title: 'Build',
+      contextLines: ['compiling'],
+      currentAction: 'compiling',
+      state: 'working',
+    };
     h.overview = { overview: ['Tab a is compiling'], events: [] };
     await setDashboardConception(CONCEPTION);
     await vi.waitFor(() => {
@@ -126,7 +131,12 @@ describe('dashboard engine status', () => {
     h.tabs = [{ sid: 'a', cwd: '/w', cmd: 'sh' }];
     h.bytes = new Map([['a', 12]]);
     h.recent = 'real transcript output';
-    h.summary = { title: 'Build', contextLines: ['compiling'], currentAction: 'compiling' };
+    h.summary = {
+      title: 'Build',
+      contextLines: ['compiling'],
+      currentAction: 'compiling',
+      state: 'working',
+    };
     h.overview = { overview: ['Tab a is compiling'], events: [] };
     await setDashboardConception(CONCEPTION);
     // The renderer must still receive the post-cycle state — summarized tab,

--- a/src/main/dashboard/engine.ts
+++ b/src/main/dashboard/engine.ts
@@ -228,6 +228,8 @@ export async function tick(conceptionPath: string): Promise<void> {
         title: result.title,
         contextLines: result.contextLines,
         currentAction: result.currentAction,
+        state: result.state,
+        ...(result.awaitingPrompt ? { awaitingPrompt: result.awaitingPrompt } : {}),
         updatedAt: now,
         events,
       };

--- a/src/main/dashboard/state.test.ts
+++ b/src/main/dashboard/state.test.ts
@@ -24,6 +24,7 @@ function stateWith(eventCount: number): DashboardState {
         title: 'build',
         contextLines: ['ctx'],
         currentAction: 'compiling',
+        state: 'idle',
         updatedAt: 100,
         events,
       },
@@ -109,5 +110,7 @@ describe('loadDashboardState', () => {
     expect(loaded?.roster).toEqual([]);
     expect(loaded?.engine).toBeUndefined();
     expect(loaded?.tabs.map((tab) => tab.sid)).toEqual(['t-1']);
+    // A pre-`state` persisted summary backfills to 'idle' on load.
+    expect(loaded?.tabs[0]?.state).toBe('idle');
   });
 });

--- a/src/main/dashboard/state.ts
+++ b/src/main/dashboard/state.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { condashDir } from '../condash-dir';
 import { atomicWrite } from '../atomic-write';
-import type { DashboardEvent, DashboardState, TabSummary } from '../../shared/types';
+import type { DashboardEvent, DashboardState, TabState, TabSummary } from '../../shared/types';
 
 /** Subdirectory under `.condash/` that holds the dashboard's persisted state. */
 const DASHBOARD_SUBDIR = 'dashboard';
@@ -16,6 +16,17 @@ export function dashboardStatePath(conceptionPath: string): string {
 /** A fresh, empty dashboard state. */
 export function emptyDashboardState(updatedAt: number): DashboardState {
   return { updatedAt, overview: [], tabs: [], roster: [], history: [] };
+}
+
+const TAB_STATES: readonly TabState[] = ['working', 'awaiting', 'idle', 'error'];
+
+/** Backfill `state` for a persisted summary written before the field existed
+ *  (or with a garbled value): default to `idle` so an old `state.json` loads
+ *  cleanly instead of yielding an undefined state the renderer can't colour. */
+function coerceTabState(value: unknown): TabState {
+  return typeof value === 'string' && (TAB_STATES as readonly string[]).includes(value)
+    ? (value as TabState)
+    : 'idle';
 }
 
 function isEvent(value: unknown): value is DashboardEvent {
@@ -53,7 +64,11 @@ function coerceState(parsed: unknown): DashboardState | null {
     history: Array.isArray(raw.history) ? raw.history.filter(isEvent) : [],
     tabs: raw.tabs
       .filter(isTabSummary)
-      .map((tab) => ({ ...tab, events: tab.events.filter(isEvent) })),
+      .map((tab) => ({
+        ...tab,
+        state: coerceTabState(tab.state),
+        events: tab.events.filter(isEvent),
+      })),
     // `roster` is live data (the currently-open tabs); a persisted copy is stale
     // the moment the app reopens, so always start empty and let the first tick
     // rebuild it from the live session map.

--- a/src/main/dashboard/summarizer.test.ts
+++ b/src/main/dashboard/summarizer.test.ts
@@ -8,7 +8,7 @@ import {
 } from './summarizer';
 
 describe('parseTabSummary', () => {
-  it('parses a clean JSON object', () => {
+  it('parses a clean JSON object and defaults a missing state to idle', () => {
     const reply = JSON.stringify({
       title: 'running tests',
       contextLines: ['vitest watch in condash', 'all green so far'],
@@ -18,13 +18,41 @@ describe('parseTabSummary', () => {
       title: 'running tests',
       contextLines: ['vitest watch in condash', 'all green so far'],
       currentAction: 'waiting for file changes',
+      state: 'idle',
     });
+  });
+
+  it('keeps a valid state and the awaiting question', () => {
+    const reply = JSON.stringify({
+      title: 'auth refactor',
+      contextLines: [],
+      currentAction: 'asking to overwrite',
+      state: 'awaiting',
+      awaitingPrompt: 'Overwrite state.json? (y/n)',
+    });
+    const parsed = parseTabSummary(reply);
+    expect(parsed?.state).toBe('awaiting');
+    expect(parsed?.awaitingPrompt).toBe('Overwrite state.json? (y/n)');
+  });
+
+  it('defaults an unrecognised state to idle and drops a non-awaiting awaitingPrompt', () => {
+    const reply = JSON.stringify({
+      title: 'building',
+      contextLines: [],
+      currentAction: 'compiling',
+      state: 'on-fire',
+      awaitingPrompt: 'this should be ignored',
+    });
+    const parsed = parseTabSummary(reply);
+    expect(parsed?.state).toBe('idle');
+    expect(parsed?.awaitingPrompt).toBeUndefined();
   });
 
   it('recovers JSON wrapped in prose / a markdown fence', () => {
     const reply =
-      'Sure!\n```json\n{"title":"build","contextLines":[],"currentAction":"compiling"}\n```';
+      'Sure!\n```json\n{"title":"build","contextLines":[],"currentAction":"compiling","state":"working"}\n```';
     expect(parseTabSummary(reply)?.title).toBe('build');
+    expect(parseTabSummary(reply)?.state).toBe('working');
   });
 
   it('clamps an overlong title to a few words and drops blank context lines', () => {
@@ -102,6 +130,7 @@ describe('buildTabUserPrompt redacts secrets before they reach the prompt', () =
         title: 'deploy',
         contextLines: ['key sk-AbCdEf0123456789ZyXwVuTs leaked earlier'],
         currentAction: 'waiting',
+        state: 'idle',
         updatedAt: 0,
         events: [],
       },
@@ -119,6 +148,7 @@ describe('buildOverviewUserPrompt redacts secrets in tab summaries', () => {
         title: 'using sk-AbCdEf0123456789ZyXwVuTs',
         contextLines: [],
         currentAction: 'idle',
+        state: 'idle',
         updatedAt: 0,
         events: [],
       },

--- a/src/main/dashboard/summarizer.ts
+++ b/src/main/dashboard/summarizer.ts
@@ -3,7 +3,7 @@ import { mkdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { redactSecrets } from '../logs-redact';
-import type { DashboardConfig, DashboardEvent, TabSummary } from '../../shared/types';
+import type { DashboardConfig, DashboardEvent, TabState, TabSummary } from '../../shared/types';
 
 let undiciShimInstalled = false;
 /**
@@ -45,6 +45,11 @@ export interface TabSummaryResult {
   title: string;
   contextLines: string[];
   currentAction: string;
+  /** Coarse state used to colour the card; defaulted to `idle` when the reply
+   *  omits or garbles it. */
+  state: TabState;
+  /** The one-line question the tab is blocking on when `state === 'awaiting'`. */
+  awaitingPrompt?: string;
 }
 
 /** The fields the model is asked to produce for the cross-tab overview. */
@@ -114,6 +119,17 @@ function clampWords(text: string, maxWords: number): string {
   return words.slice(0, maxWords).join(' ');
 }
 
+const TAB_STATES: readonly TabState[] = ['working', 'awaiting', 'idle', 'error'];
+
+/** Coerce a model-supplied `state` value to a known `TabState`, defaulting to
+ *  `idle` for anything missing or unrecognised — so an old reply or a flaky
+ *  model can never break the colour rendering. */
+function coerceTabState(value: unknown): TabState {
+  return typeof value === 'string' && (TAB_STATES as readonly string[]).includes(value)
+    ? (value as TabState)
+    : 'idle';
+}
+
 /** Parse the model reply for a single tab into a `TabSummaryResult`, or null if
  *  it lacks a usable title. Exported for unit testing without a live model. */
 export function parseTabSummary(reply: string): TabSummaryResult | null {
@@ -122,10 +138,17 @@ export function parseTabSummary(reply: string): TabSummaryResult | null {
   const record = obj as Record<string, unknown>;
   const title = typeof record.title === 'string' ? clampWords(record.title, MAX_TITLE_WORDS) : '';
   if (!title) return null;
+  const state = coerceTabState(record.state);
+  const awaitingPrompt =
+    state === 'awaiting' && typeof record.awaitingPrompt === 'string'
+      ? record.awaitingPrompt.trim()
+      : '';
   return {
     title,
     contextLines: asStringArray(record.contextLines, MAX_CONTEXT_LINES),
     currentAction: typeof record.currentAction === 'string' ? record.currentAction.trim() : '',
+    state,
+    ...(awaitingPrompt ? { awaitingPrompt } : {}),
   };
 }
 
@@ -141,8 +164,9 @@ export function parseOverview(reply: string): OverviewResult | null {
 
 // Guardrails below were tuned against an eval of a week of real terminal logs on
 // deepseek-v4-flash: name the tool from cmd/status (never invent one), don't read
-// the user's draft prompt line as an action, distinguish working/awaiting/idle,
-// and title the work rather than the tool.
+// the user's draft prompt line as an action, classify the tab into one structured
+// `state` (working/awaiting/idle/error) the dashboard colours on, and title the
+// work rather than the tool.
 const TAB_SYSTEM_PROMPT = [
   'You summarize a single terminal tab for a developer dashboard.',
   'You are given the tab command/cwd, a prior summary (possibly stale), and the',
@@ -156,22 +180,27 @@ const TAB_SYSTEM_PROMPT = [
   'A line after a "❯" or ">" prompt marker is text the user is typing or about to',
   'send. It is not something the tab is doing or has done — never report it as the',
   'current action or as an event.',
-  'Distinguish three states. (1) Working: output is still progressing — say what',
-  'it is doing. (2) Awaiting the user: the program asked a specific question or',
-  'shows an interactive menu/prompt that needs an answer — say what answer it',
-  'awaits. (3) Idle: the work finished or nothing is pending — say so, and you may',
-  'add the last meaningful thing it did. An agent resting at an empty prompt after',
-  'finishing is idle, not blocked on you.',
+  'Classify the tab into exactly one state. "working": output is still',
+  'progressing — say what it is doing. "awaiting": the program asked a specific',
+  'question or shows an interactive menu/prompt that needs an answer — say what',
+  'answer it awaits. "idle": the work finished or nothing is pending — say so, and',
+  'you may add the last meaningful thing it did; an agent resting at an empty',
+  'prompt after finishing is idle, not blocked on you. "error": a command crashed',
+  'or a process exited non-zero and is NOT recovering — a recoverable warning is',
+  'not an error, it stays "working" or "idle".',
   'Treat informational notices and recoverable warnings as background noise (for',
   'example "workspace not trusted", "N permissions ignored", deprecation or auth',
-  'notices): never report them as the current action or a blocker.',
+  'notices): never report them as the current action, a blocker, or an error.',
   'Reply with ONLY a JSON object, no markdown fence:',
   '{"title": string (<=5 words naming the work, project, or subject the tab is',
-  ' about — not the program; use the program or directory name as the title only',
-  ' when the tab has done no real work yet),',
+  ' about — not the program; e.g. good "Auth refactor", bad "claude"; use the',
+  ' program or directory name as the title only when the tab has done no real work yet),',
   ' "contextLines": string[] (1-4 short factual lines: what this tab is for and recent progress),',
-  ' "currentAction": string (one short line for the state above: what is happening',
-  ' now, the answer it awaits, or the final/idle state)}.',
+  ' "currentAction": string (one short line for the state: what is happening now,',
+  ' the answer it awaits, or the final/idle state),',
+  ' "state": one of "working" | "awaiting" | "idle" | "error" (judged from the latest output),',
+  ' "awaitingPrompt": string (ONLY when state is "awaiting": the one-line question',
+  ' or selection it is blocking on, e.g. "Overwrite file? (y/n)"; omit otherwise)}.',
 ].join(' ');
 
 const OVERVIEW_SYSTEM_PROMPT = [

--- a/src/renderer/panes/dashboard-pane.css
+++ b/src/renderer/panes/dashboard-pane.css
@@ -90,12 +90,26 @@
   flex-wrap: wrap;
   align-items: baseline;
   row-gap: 4px;
-  padding: 8px 10px;
+  padding: 8px 12px;
   border: 1px solid var(--border);
-  border-left: 3px solid var(--accent);
+  border-left: 3px solid var(--state-color, var(--accent));
   border-radius: var(--radius);
-  background: var(--bg-subtle);
+  background: color-mix(in srgb, var(--state-color, var(--accent)) 7%, var(--bg-subtle));
   font-size: var(--text-sm);
+}
+
+/* Phase → accent colour for the strip's bar, wash, live dot, and countdown. */
+.dashboard-status[data-phase='summarizing'] {
+  --state-color: var(--accent);
+}
+.dashboard-status[data-phase='waiting'] {
+  --state-color: var(--col-running);
+}
+.dashboard-status[data-phase='idle'] {
+  --state-color: var(--text-faint);
+}
+.dashboard-status[data-phase='no-api-key'] {
+  --state-color: var(--warn);
 }
 
 .dashboard-status-item {
@@ -120,10 +134,36 @@
   color: var(--text-muted);
 }
 
+/* Live dot in the Status segment — pulses while a cycle is in flight, steady
+ * otherwise, so the strip reads as a heartbeat. */
+.dashboard-status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  align-self: center;
+  background: var(--state-color, var(--accent));
+}
+.dashboard-status[data-phase='summarizing'] .dashboard-status-dot {
+  animation: dashboard-ping 1.6s ease-out infinite;
+}
+@keyframes dashboard-ping {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--state-color) 60%, transparent);
+  }
+  70% {
+    box-shadow: 0 0 0 7px transparent;
+  }
+  100% {
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+
 /* The live countdown — tinted + tabular figures so it doesn't jitter as it ticks. */
 .dashboard-status-next {
-  color: var(--accent);
+  color: var(--state-color, var(--accent));
   font-variant-numeric: tabular-nums;
+  font-weight: 600;
 }
 
 /* Two-column key/value grid for the active summarizer settings. */
@@ -164,6 +204,45 @@
   color: var(--text);
 }
 
+/* "Open tabs" header row: section title on the left, the cross-tab state tally
+ * on the right. The tally is the cockpit's at-a-glance triage readout. */
+.dashboard-tab-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+.dashboard-tab-head h3 {
+  margin: 0;
+}
+
+.dashboard-tally {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+/* One chip per non-empty state — count + label, tinted in the state colour. */
+.dashboard-tally-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--state-color, var(--text-muted));
+  background: color-mix(in srgb, var(--state-color, var(--text-muted)) 13%, var(--bg-elevated));
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--state-color, var(--text-muted)) 26%, transparent);
+}
+.dashboard-tally-chip b {
+  font-weight: 800;
+  font-size: var(--text-sm);
+}
+
 /* Responsive card grid: as many ~240px columns as fit, so the cards spread
  * across the wide main column instead of one full-width card per row. */
 .dashboard-tab-list {
@@ -176,36 +255,141 @@
   align-items: start;
 }
 
+/* Per-state accent colour, mapped onto the app's existing palette tokens and
+ * shared by the card bar/wash, the state pill, and the tally chips. Scoped to
+ * the pane so it can't leak onto other `data-state` users elsewhere. */
+.dashboard-pane [data-state='working'] {
+  --state-color: var(--col-running);
+}
+.dashboard-pane [data-state='awaiting'] {
+  --state-color: var(--col-review);
+}
+.dashboard-pane [data-state='idle'] {
+  --state-color: var(--col-done);
+}
+.dashboard-pane [data-state='error'] {
+  --state-color: var(--warn);
+}
+.dashboard-pane [data-state='pending'] {
+  --state-color: var(--text-faint);
+}
+
+/* The state-coloured card. A left bar (::before) + a faint wash carry the
+ * state; the pill names it in words so colour is never the only signal. */
 .dashboard-tab-card {
-  border: 1px solid var(--border);
+  position: relative;
+  border: 1px solid color-mix(in srgb, var(--state-color, var(--border)) 30%, var(--border));
   border-radius: var(--radius);
-  background: var(--bg-elevated);
-  padding: 10px 12px;
+  background: color-mix(in srgb, var(--state-color, transparent) 8%, var(--bg-elevated));
+  padding: 11px 13px 11px 15px;
   box-shadow: var(--shadow-card);
   min-width: 0;
   overflow-wrap: anywhere;
 }
 
+/* The left state bar. */
+.dashboard-tab-card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 4px;
+  border-radius: var(--radius) 0 0 var(--radius);
+  background: var(--state-color, var(--border));
+}
+
+/* Awaiting-you is the one card that should pull the eye across a full grid:
+ * a coloured ring + a soft glow. */
+.dashboard-tab-card[data-state='awaiting'] {
+  border-color: color-mix(in srgb, var(--state-color) 55%, var(--border));
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--state-color) 35%, transparent),
+    0 6px 18px color-mix(in srgb, var(--state-color) 20%, transparent);
+}
+
 /* A tab with no summary yet (no readable output, or before the first cycle).
- * Dimmed and dashed so it reads as "present but not yet summarized" rather than
- * a full summary card — the point is only that the tab is never invisible. */
+ * Dashed + dimmed so it reads as "present but not yet summarized" — the point
+ * is only that the tab is never invisible. */
 .dashboard-tab-card-pending {
   border-style: dashed;
   background: transparent;
   box-shadow: none;
-  opacity: 0.85;
+  opacity: 0.9;
+}
+.dashboard-tab-card-pending::before {
+  opacity: 0.5;
 }
 
 .dashboard-tab-card-head {
   display: flex;
-  align-items: baseline;
+  align-items: center;
   justify-content: space-between;
   gap: 8px;
 }
 
+/* The state pill — tinted in the state colour with a coloured-ink label, so it
+ * stays legible (AA) in both the light and dark themes. */
+.dashboard-tab-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+  font-size: var(--text-3xs);
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  color: var(--state-color, var(--text-muted));
+  background: color-mix(in srgb, var(--state-color, var(--text-muted)) 16%, transparent);
+}
+.dashboard-tab-state-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  background: currentColor;
+}
+
+/* Right side of the head: the #repo pill, the driving program, and relative time. */
+.dashboard-tab-card-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+/* #handle pill — reuses the per-app hash palette (--app-pill-bg/fg set by the
+ * appColorClass `app-pill-N` class) so a tab's repo reads with the same colour
+ * it has in the Projects and Code panes. */
+.dashboard-repo-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 7px;
+  border-radius: 4px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  white-space: nowrap;
+  background: var(--app-pill-bg, var(--bg-subtle));
+  color: var(--app-pill-fg, var(--text));
+}
+.dashboard-tab-agent {
+  font-family: var(--font-mono);
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+
+/* Title is now the card's heading, on its own line below the state row. */
 .dashboard-tab-card-title {
-  font-size: var(--text-sm);
-  font-weight: 600;
+  margin: 7px 0 0;
+  font-size: var(--text-base);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.25;
   color: var(--text);
 }
 
@@ -268,4 +452,28 @@
   margin-top: auto;
   font-size: var(--text-xs);
   color: var(--text-muted);
+}
+
+/* Dark "control room": the live-state bars glow, so a working / awaiting / error
+ * card reads as a lit indicator on the dark surface — the cockpit-at-night feel.
+ * Mirrors the two dark activation paths used app-wide (explicit toggle + OS
+ * preference with no light override). */
+[data-theme='dark'] .dashboard-tab-card[data-state='working']::before,
+[data-theme='dark'] .dashboard-tab-card[data-state='awaiting']::before,
+[data-theme='dark'] .dashboard-tab-card[data-state='error']::before {
+  box-shadow: 0 0 12px color-mix(in srgb, var(--state-color) 75%, transparent);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) .dashboard-tab-card[data-state='working']::before,
+  :root:not([data-theme='light']) .dashboard-tab-card[data-state='awaiting']::before,
+  :root:not([data-theme='light']) .dashboard-tab-card[data-state='error']::before {
+    box-shadow: 0 0 12px color-mix(in srgb, var(--state-color) 75%, transparent);
+  }
+}
+
+/* Honour reduced-motion: drop the pulsing status dot. */
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-status[data-phase='summarizing'] .dashboard-status-dot {
+    animation: none;
+  }
 }

--- a/src/renderer/panes/dashboard.tsx
+++ b/src/renderer/panes/dashboard.tsx
@@ -1,6 +1,22 @@
 import { createSignal, For, onCleanup, onMount, Show } from 'solid-js';
-import type { DashboardConfigView, DashboardState, TabInfo, TabSummary } from '@shared/types';
+import type {
+  DashboardConfigView,
+  DashboardState,
+  TabInfo,
+  TabState,
+  TabSummary,
+} from '@shared/types';
+import { appColorClass, appPillText } from '@shared/app-color';
+import './app-pill.css';
 import './dashboard-pane.css';
+
+/** Human label for the state pill, by state. */
+const STATE_LABEL: Record<TabState, string> = {
+  working: 'Working',
+  awaiting: 'Awaiting you',
+  idle: 'Idle',
+  error: 'Error',
+};
 
 /**
  * The Dashboard working surface: a detailed, always-current view of what the
@@ -118,6 +134,32 @@ export function DashboardView() {
   const tabLabel = (tab: TabInfo): string =>
     tab.cmd?.trim() || tab.cwd.split('/').filter(Boolean).pop() || tab.sid;
 
+  // The app a tab belongs to: its launched repo if known, else the cwd's last
+  // path segment. Rendered as a hash-coloured `#handle` pill so a busy grid is
+  // scannable by project.
+  const repoRef = (tab: TabInfo): string =>
+    tab.repo?.trim() || tab.cwd.split('/').filter(Boolean).pop() || '';
+  // The program driving the tab — the first token of the command (basename), so
+  // a card shows "claude" / "pi" / "make" next to the repo. Empty cmd → shell.
+  const agentName = (tab: TabInfo): string => {
+    const first = tab.cmd?.trim().split(/\s+/)[0] ?? '';
+    return first.split('/').pop() || 'shell';
+  };
+  // For an awaiting tab, the blocking question is the headline; otherwise the
+  // model's one-line current action.
+  const cardAction = (summary: TabSummary): string =>
+    summary.state === 'awaiting' && summary.awaitingPrompt
+      ? summary.awaitingPrompt
+      : summary.currentAction;
+
+  // Cross-tab state tally for the chip row above the grid — counted over the
+  // live summarized tabs (state().tabs holds only still-open ones).
+  const tally = (): Record<TabState, number> => {
+    const counts: Record<TabState, number> = { working: 0, awaiting: 0, idle: 0, error: 0 };
+    for (const tab of state()?.tabs ?? []) counts[tab.state] += 1;
+    return counts;
+  };
+
   const fmtTime = (ms: number): string => new Date(ms).toLocaleTimeString();
   const fmtRelative = (ms: number): string => {
     const seconds = Math.max(0, Math.round((Date.now() - ms) / 1000));
@@ -173,8 +215,9 @@ export function DashboardView() {
           A single horizontal line — three labelled segments separated by hairline
           dividers — so it stays compact above the working surface. */}
       <Show when={config()?.enabled}>
-        <section class="dashboard-status">
+        <section class="dashboard-status" data-phase={engine()?.phase ?? 'idle'}>
           <span class="dashboard-status-item">
+            <span class="dashboard-status-dot" />
             <span class="dashboard-status-label">Status</span>
             <span>
               {statusLabel(config()!)}
@@ -246,7 +289,30 @@ export function DashboardView() {
 
         <main class="dashboard-main">
           <section class="dashboard-section">
-            <h3>Open tabs</h3>
+            {/* Header row: title + the cross-tab state tally — the cockpit's
+                at-a-glance triage readout. A chip per non-empty state. */}
+            <div class="dashboard-tab-head">
+              <h3>Open tabs{cards().length > 0 ? ` · ${cards().length}` : ''}</h3>
+              <Show
+                when={(['working', 'awaiting', 'idle', 'error'] as const).some(
+                  (s) => tally()[s] > 0,
+                )}
+              >
+                <div class="dashboard-tally">
+                  <For
+                    each={(['working', 'awaiting', 'idle', 'error'] as const).filter(
+                      (s) => tally()[s] > 0,
+                    )}
+                  >
+                    {(s) => (
+                      <span class="dashboard-tally-chip" data-state={s}>
+                        <b>{tally()[s]}</b> {STATE_LABEL[s].toLowerCase()}
+                      </span>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </div>
             <Show
               when={cards().length > 0}
               fallback={<p class="dashboard-pane-hint">No open terminal tabs.</p>}
@@ -259,15 +325,29 @@ export function DashboardView() {
                       fallback={
                         // No summary yet: the tab is still visible, drawn from
                         // its command/cwd, so the user always sees every tab.
-                        <li class="dashboard-tab-card dashboard-tab-card-pending">
+                        <li
+                          class="dashboard-tab-card dashboard-tab-card-pending"
+                          data-state="pending"
+                        >
                           <div class="dashboard-tab-card-head">
-                            <span class="dashboard-tab-card-title">{tabLabel(card.tab)}</span>
-                            <span class="dashboard-tab-card-time">{pendingTimeText()}</span>
+                            <span class="dashboard-tab-state" data-state="pending">
+                              <span class="dashboard-tab-state-dot" />
+                              Starting
+                            </span>
+                            <span class="dashboard-tab-card-meta">
+                              <Show when={repoRef(card.tab)}>
+                                <span
+                                  class={`dashboard-repo-pill ${appColorClass(repoRef(card.tab))}`}
+                                >
+                                  {appPillText(repoRef(card.tab))}
+                                </span>
+                              </Show>
+                              <span class="dashboard-tab-agent">{agentName(card.tab)}</span>
+                              <span class="dashboard-tab-card-time">{pendingTimeText()}</span>
+                            </span>
                           </div>
+                          <div class="dashboard-tab-card-title">{tabLabel(card.tab)}</div>
                           <ul class="dashboard-tab-card-context">
-                            <Show when={card.tab.cmd}>
-                              <li>Command: {card.tab.cmd}</li>
-                            </Show>
                             <li>Directory: {card.tab.cwd}</li>
                             <li>
                               Waiting for first agent output (a submitted prompt or finished turn).
@@ -277,18 +357,32 @@ export function DashboardView() {
                       }
                     >
                       {(summary) => (
-                        <li class="dashboard-tab-card">
+                        <li class="dashboard-tab-card" data-state={summary().state}>
                           <div class="dashboard-tab-card-head">
-                            <span class="dashboard-tab-card-title">{summary().title}</span>
-                            <span
-                              class="dashboard-tab-card-time"
-                              title={fmtTime(summary().updatedAt)}
-                            >
-                              {fmtRelative(summary().updatedAt)}
+                            <span class="dashboard-tab-state" data-state={summary().state}>
+                              <span class="dashboard-tab-state-dot" />
+                              {STATE_LABEL[summary().state]}
+                            </span>
+                            <span class="dashboard-tab-card-meta">
+                              <Show when={repoRef(card.tab)}>
+                                <span
+                                  class={`dashboard-repo-pill ${appColorClass(repoRef(card.tab))}`}
+                                >
+                                  {appPillText(repoRef(card.tab))}
+                                </span>
+                              </Show>
+                              <span class="dashboard-tab-agent">{agentName(card.tab)}</span>
+                              <span
+                                class="dashboard-tab-card-time"
+                                title={fmtTime(summary().updatedAt)}
+                              >
+                                {fmtRelative(summary().updatedAt)}
+                              </span>
                             </span>
                           </div>
-                          <Show when={summary().currentAction}>
-                            <p class="dashboard-tab-card-action">{summary().currentAction}</p>
+                          <div class="dashboard-tab-card-title">{summary().title}</div>
+                          <Show when={cardAction(summary())}>
+                            <p class="dashboard-tab-card-action">{cardAction(summary())}</p>
                           </Show>
                           <Show when={summary().contextLines.length > 0}>
                             <ul class="dashboard-tab-card-context">

--- a/src/shared/types/dashboard.ts
+++ b/src/shared/types/dashboard.ts
@@ -15,6 +15,17 @@ export interface DashboardEvent {
   text: string;
 }
 
+/** Coarse machine-readable state of a tab, derived by the summarizer from the
+ *  latest output. Drives the colour a card is rendered with.
+ *  - `working` — output is still progressing.
+ *  - `awaiting` — the program asked a question or shows a menu/prompt that needs
+ *    the user to answer (the question itself is in `TabSummary.awaitingPrompt`).
+ *  - `idle` — the work finished or nothing is pending (an agent resting at an
+ *    empty prompt is idle, not blocked). The default when the model omits it.
+ *  - `error` — a command crashed or failed and is not recovering. Distinct from
+ *    `DashboardState.lastError`, which is the engine's own summarization failure. */
+export type TabState = 'working' | 'awaiting' | 'idle' | 'error';
+
 /** Live summary for a single terminal tab. */
 export interface TabSummary {
   /** Terminal session id — matches `TermSession.id` / `TabInfo.sid`. */
@@ -25,6 +36,12 @@ export interface TabSummary {
   contextLines: string[];
   /** One-line "what is happening now". */
   currentAction: string;
+  /** Coarse state used to colour the card. Always present — the parser defaults
+   *  it to `idle` when the model reply omits or garbles it. */
+  state: TabState;
+  /** When `state === 'awaiting'`, the one-line question or selection the tab is
+   *  blocked on (e.g. "overwrite state.json? (y/n)"). Absent otherwise. */
+  awaitingPrompt?: string;
   /** Epoch ms of the last update. */
   updatedAt: number;
   /** Bounded history of notable events for this tab, oldest first. */


### PR DESCRIPTION
## Summary

The Dashboard pane read as a wall of text because the per-tab summary carried no state to colour on. This adds a structured tab `state` and rebuilds the pane around it — working / awaiting-you / idle / error — so a multi-tab workspace is triaged at a glance. Prompt, content, and UX move together because one unlocks the next.

## Changes

- **Summarizer** (`summarizer.ts`): the model now returns `state` (`working|awaiting|idle|error`, judged from the latest output) and, when awaiting, the one-line `awaitingPrompt` it is blocking on. `parseTabSummary` defaults a missing/garbled state to `idle` (back-compat with old replies) and drops `awaitingPrompt` unless awaiting.
- **Engine + persistence**: `state`/`awaitingPrompt` thread into the built `TabSummary`; `loadDashboardState` backfills `state` to `idle` for pre-existing `state.json` files.
- **Pane** (`dashboard.tsx` + `dashboard-pane.css`): colour-by-state cards (left bar + tinted state pill + faint wash), an awaiting-you glow ring, a cross-tab tally chip row, a `#repo` pill (reusing the per-handle hash palette) + driving-program meta row, the blocking question as the awaiting headline, and a phase-driven live dot on the status strip. Dark mode glows the bars (control-room feel). State is never colour-only — the pill text and bar carry it — and the pulse honours `prefers-reduced-motion`. Every colour reuses an existing token, so light and dark both work.

## Testing

- `make typecheck` clean; `make test-unit` **1302 passed** (new parser cases + a persistence-backfill assertion); `make build` clean; `npm run test -- dashboard-roster` (live-Electron dashboard e2e) passes.
- Shipped CSS rendered against the real DOM in both light and dark themes.