### PR TITLE
dashboard/state: fix prettier formatting (unblock v4.52.0 release)

### DIFF
--- a/src/main/dashboard/state.ts
+++ b/src/main/dashboard/state.ts
@@ -62,13 +62,11 @@ function coerceState(parsed: unknown): DashboardState | null {
     updatedAt: typeof raw.updatedAt === 'number' ? raw.updatedAt : 0,
     overview: Array.isArray(raw.overview) ? raw.overview.filter((l) => typeof l === 'string') : [],
     history: Array.isArray(raw.history) ? raw.history.filter(isEvent) : [],
-    tabs: raw.tabs
-      .filter(isTabSummary)
-      .map((tab) => ({
-        ...tab,
-        state: coerceTabState(tab.state),
-        events: tab.events.filter(isEvent),
-      })),
+    tabs: raw.tabs.filter(isTabSummary).map((tab) => ({
+      ...tab,
+      state: coerceTabState(tab.state),
+      events: tab.events.filter(isEvent),
+    })),
     // `roster` is live data (the currently-open tabs); a persisted copy is stale
     // the moment the app reopens, so always start empty and let the first tick
     // rebuild it from the live session map.


### PR DESCRIPTION
The v4.52.0 release run failed at the `fast` job's format-check step: `coerceState`'s `.filter().map()` chain in `src/main/dashboard/state.ts` was broken across lines instead of the chain head on one line. This collapses it to the repo's canonical prettier output so the release can be re-cut.

No behaviour change — formatting only. (Root cause: the redesign branch's worktree resolved a different ancestor prettier/editorconfig than CI, so its `make format` produced output CI rejects.)