### PR TITLE
Dashboard: show a mid-turn agent as working, not awaiting/idle

### DIFF
--- a/src/main/dashboard/engine-status.test.ts
+++ b/src/main/dashboard/engine-status.test.ts
@@ -68,6 +68,7 @@ vi.mock('./state', async (importOriginal) => {
 import {
   DECAY_INTERVALS,
   decayStaleWorkingTabs,
+  forceWorkingOnUserTail,
   getDashboardState,
   refreshTab,
   setDashboardConception,
@@ -367,5 +368,80 @@ describe('decayStaleWorkingTabs', () => {
     const out = decayStaleWorkingTabs(tabs, bytes, prev, GRACE, INTERVAL);
     expect(out.find((t) => t.sid === 'quiet')?.state).toBe('idle');
     expect(out.find((t) => t.sid === 'busy')?.state).toBe('working');
+  });
+});
+
+describe('forceWorkingOnUserTail', () => {
+  /** A minimal card-model result fixture, overridable per case. */
+  function result(over: Partial<TabSummaryResult> = {}): TabSummaryResult {
+    return {
+      title: 't',
+      contextLines: [],
+      currentAction: 'doing',
+      state: 'idle',
+      activity: 'idle',
+      ...over,
+    };
+  }
+
+  // The conception-cleanup screenshot: the model called it `awaiting` while the
+  // transcript tail was the user's just-submitted request.
+  it('forces an awaiting result to working when the transcript tail is [user]', () => {
+    const recent = [
+      '[assistant] Pushed v4.55.1 and updated the knowledge file.',
+      '[user] remove isolate-0x3b662000-2259340-v8.log, and commit all conception',
+    ].join('\n\n');
+    const out = forceWorkingOnUserTail(
+      result({ state: 'awaiting', activity: 'awaiting', awaitingPrompt: 'Confirm? (y/n)' }),
+      recent,
+    );
+    expect(out.state).toBe('working');
+    expect(out.activity).toBe('implementing');
+    expect(out.awaitingPrompt).toBe('');
+  });
+
+  // The this-session screenshot: a single [user] frame, model called it idle.
+  it('forces an idle result to working when the transcript tail is [user]', () => {
+    const out = forceWorkingOnUserTail(
+      result({ state: 'idle', activity: 'idle' }),
+      '[user] dashboard is wrong, claude was working not waiting my input',
+    );
+    expect(out.state).toBe('working');
+    expect(out.activity).toBe('implementing');
+  });
+
+  it('keeps a concrete work activity when forcing (only awaiting/idle are lifted)', () => {
+    const out = forceWorkingOnUserTail(
+      result({ state: 'awaiting', activity: 'debugging' }),
+      '[user] please fix the failing test',
+    );
+    expect(out.state).toBe('working');
+    expect(out.activity).toBe('debugging');
+  });
+
+  it('leaves an [assistant] tail untouched (a finished reply stays idle)', () => {
+    const recent = [
+      '[user] summarize the diff',
+      '[assistant] Done — the change adds one guard and a test. Anything else?',
+    ].join('\n\n');
+    const out = forceWorkingOnUserTail(result({ state: 'idle', activity: 'idle' }), recent);
+    expect(out.state).toBe('idle');
+    expect(out.activity).toBe('idle');
+  });
+
+  it('preserves an error state even with a [user] tail', () => {
+    const out = forceWorkingOnUserTail(
+      result({ state: 'error', activity: 'idle' }),
+      '[user] run the build',
+    );
+    expect(out.state).toBe('error');
+  });
+
+  it('is a no-op on markerless grid text (no transcript)', () => {
+    const out = forceWorkingOnUserTail(
+      result({ state: 'idle', activity: 'idle' }),
+      'alice@host:~/src$ ls\nfoo  bar  baz',
+    );
+    expect(out.state).toBe('idle');
   });
 });

--- a/src/main/dashboard/engine.ts
+++ b/src/main/dashboard/engine.ts
@@ -10,6 +10,7 @@ import type {
   TabSummary,
 } from '../../shared/types';
 import { dashboardRoster, tabRecentText, tabsBytes } from '../terminals';
+import { lastTranscriptRole } from '../osc-transcript';
 import { DASHBOARD_DEFAULTS, readDashboardConfig, toDashboardConfigView } from './config';
 import {
   emptyDashboardState,
@@ -22,6 +23,7 @@ import {
   getSummarizerError,
   makeEvent,
   summarizeTab,
+  type TabSummaryResult,
   writeSubtitle,
 } from './summarizer';
 import { deriveProvenance } from './provenance';
@@ -234,6 +236,40 @@ export function decayStaleWorkingTabs(
 }
 
 /**
+ * Force a mid-turn agent's card to `working` when the transcript tail is a
+ * `[user]` message. The OSC sidecar transcript only gains an assistant chunk at
+ * the agent's next `Stop`, so a long in-flight turn leaves it frozen on the
+ * user's just-submitted request; the card model — blind to the live spinner,
+ * which lives only in the grid the transcript path never reads — then misreads
+ * that `[user]` tail as `awaiting` or `idle`, showing a busy agent as resting. A
+ * `[user]` tail is an unambiguous mid-turn signal, so override to `working`,
+ * lift an `awaiting`/`idle` activity to `implementing`, and drop any stale
+ * `awaitingPrompt`. `error` is left intact — a real crash must not read as work —
+ * and `decayStaleWorkingTabs` is the backstop for the rare case the agent exited
+ * right after the prompt (no assistant frame → it goes byte-quiet and decays back
+ * to idle past the grace window). A non-transcript grid fallback has no `[user]`
+ * marker, so this is a no-op there. Mutates and returns `result`. Exported for
+ * unit testing.
+ *
+ * @param result - The card model's parsed summary for this tab (mutated in place).
+ * @param recentText - The exact text the card model was given (the transcript).
+ * @returns The same `result`, corrected when a `[user]` tail was detected.
+ */
+export function forceWorkingOnUserTail(
+  result: TabSummaryResult,
+  recentText: string,
+): TabSummaryResult {
+  if (result.state !== 'error' && lastTranscriptRole(recentText) === 'user') {
+    result.state = 'working';
+    if (result.activity === 'awaiting' || result.activity === 'idle') {
+      result.activity = 'implementing';
+    }
+    result.awaitingPrompt = '';
+  }
+  return result;
+}
+
+/**
  * Run one tab through the summarizer and fold the result into a TabSummary:
  * the cheap card model extracts the facts + activity, local provenance is
  * derived (app / worktree / projects), and the writer model composes the
@@ -267,6 +303,10 @@ async function buildSummary(
     prior,
   });
   if (!result) return null;
+  // Correct a mid-turn agent the card model misread as resting (see
+  // forceWorkingOnUserTail). Done before the writer call so the subtitle is
+  // composed from the corrected state.
+  forceWorkingOnUserTail(result, recentText);
   // Provenance is local (no LLM): config + tree reads, fed to the writer for the
   // subtitle and attached to the card for the UI pills.
   const provenance = await deriveProvenance(conceptionPath, tabMeta);

--- a/src/main/dashboard/summarizer.ts
+++ b/src/main/dashboard/summarizer.ts
@@ -220,6 +220,11 @@ export function parseSubtitle(reply: string): string {
 // over-eagerly read a long visible reply as "still generating", which the
 // activity gate then froze on the card. The engine's idle-decay is the backstop;
 // the finished-turn rule below is the fix at the source.
+// The dual failure — a MID-turn `[user]` transcript tail misread as awaiting/idle
+// because the live spinner is grid-only and the transcript freezes on the user's
+// request until the next `Stop` — is forced back to `working` deterministically in
+// `buildSummary` (engine.ts); the `[user]`-tail rule below reinforces the card
+// content the model writes for it.
 const TAB_SYSTEM_PROMPT = [
   'You summarize a single terminal tab for a developer dashboard.',
   'You are given the tab command/cwd, a prior summary (possibly stale), and the',
@@ -250,6 +255,15 @@ const TAB_SYSTEM_PROMPT = [
   '"thinking" hint, or text still actively streaming. "error": a command crashed',
   'or a process exited non-zero and is NOT recovering — a recoverable warning is',
   'not an error, it stays "working" or "idle".',
+  'The recent output may be a transcript whose messages are tagged [user],',
+  '[assistant], or [reasoning]. When the LAST tagged message is [user] — the user',
+  'just submitted a request and no [assistant] reply is framed after it — the agent',
+  'has received it and is mid-turn: classify "working" and pick the matching',
+  'activity, never "awaiting" or "idle". The reply may not have streamed into the',
+  'transcript yet, so the absence of a visible progress indicator does not mean it',
+  'is resting. The finished-reply-is-idle and "awaiting" judgements apply only when',
+  'the last message is [assistant], and "awaiting" still requires that [assistant]',
+  'message to end on a concrete blocking question.',
   'Treat informational notices and recoverable warnings as background noise (for',
   'example "workspace not trusted", "N permissions ignored", deprecation or auth',
   'notices): never report them as the current action, a blocker, or an error.',

--- a/src/main/osc-transcript.test.ts
+++ b/src/main/osc-transcript.test.ts
@@ -6,6 +6,7 @@ import {
   MAX_TRANSCRIPT_LINES,
   OscTranscriptExtractor,
   formatMinute,
+  lastTranscriptRole,
   timestampMarker,
 } from './osc-transcript';
 
@@ -191,5 +192,33 @@ describe('timestampMarker / formatMinute', () => {
   it('formats a local-time Date as a zero-padded HTML-comment marker', () => {
     expect(formatMinute(new Date(2026, 0, 3, 4, 6, 0))).toBe('2026-01-03:04:06');
     expect(timestampMarker(new Date(2026, 0, 3, 4, 6, 0))).toBe('<!-- 2026-01-03:04:06 -->');
+  });
+});
+
+describe('lastTranscriptRole', () => {
+  it('returns the role of the last message', () => {
+    const text = ['[user] do the thing', '[assistant] on it', '[reasoning] thinking…'].join('\n\n');
+    expect(lastTranscriptRole(text)).toBe('reasoning');
+  });
+
+  it('detects a [user] tail (the mid-turn signal)', () => {
+    const text = ['[assistant] previous turn done', '[user] now do the next thing'].join('\n\n');
+    expect(lastTranscriptRole(text)).toBe('user');
+  });
+
+  it('detects an [assistant] tail', () => {
+    const text = ['[user] question?', '[assistant] answer.'].join('\n\n');
+    expect(lastTranscriptRole(text)).toBe('assistant');
+  });
+
+  it('is unaffected by a multi-line message body', () => {
+    // Continuation lines of a message are not new markers; the message role wins.
+    const text = '[assistant] earlier\n\n[user] line one\nline two\nline three';
+    expect(lastTranscriptRole(text)).toBe('user');
+  });
+
+  it('returns null for markerless grid text', () => {
+    expect(lastTranscriptRole('alice@host:~/src$ ls\nfoo bar')).toBeNull();
+    expect(lastTranscriptRole('')).toBeNull();
   });
 });

--- a/src/main/osc-transcript.ts
+++ b/src/main/osc-transcript.ts
@@ -82,6 +82,28 @@ export function transcriptLine(role: string | undefined, text: string): string {
   return `[${who}] ${text}`;
 }
 
+/** Role tag of the LAST message in rendered transcript text, or null when the
+ * text carries no `[role]` markers (e.g. a plain-shell grid fallback, where the
+ * summarizer reads cleaned buffer rather than a transcript). Reads back the
+ * `[user]`/`[assistant]`/`[reasoning]` shape {@link transcriptLine} writes.
+ *
+ * The dashboard uses this to detect a mid-turn agent: the OSC emitter frames a
+ * chunk only on `UserPromptSubmit` and each assistant `Stop`, so a `[user]` tail
+ * means the user's request was the last framed message and no assistant turn has
+ * completed since — the agent is working on it, not waiting on the user.
+ *
+ * @param text - Rendered transcript text (one `[role] …` line per message start).
+ * @returns The last message's role, or null when no marker is present.
+ */
+export function lastTranscriptRole(text: string): 'user' | 'assistant' | 'reasoning' | null {
+  const marker = /^\[(user|assistant|reasoning)\] /gm;
+  let role: 'user' | 'assistant' | 'reasoning' | null = null;
+  for (const match of text.matchAll(marker)) {
+    role = match[1] as 'user' | 'assistant' | 'reasoning';
+  }
+  return role;
+}
+
 export class OscTranscriptExtractor {
   /** Unconsumed tail — holds an incomplete sequence (or a partial PREFIX) that
    * spans feed boundaries. */


### PR DESCRIPTION
## Summary

- The Dashboard mislabels a coding-agent tab that is actively mid-turn as `awaiting` or `idle` — the opposite of reality. Two live captures hit it: one tab badged AWAITING ("waiting for the user to confirm"), another badged IDLE, both while their agents were busy.
- Root cause: a claude/opencode tab is summarized from its OSC transcript, which only gains an assistant chunk at the agent's next `Stop`. During a long in-flight turn the transcript freezes on the user's just-submitted request, and the live spinner the prompt looks for lives only in the grid (never the transcript) — so a busy agent reads as resting.

## Changes

- `osc-transcript.ts`: new `lastTranscriptRole(text)` — role of the last `[user]`/`[assistant]`/`[reasoning]` message (null for a markerless grid fallback).
- `dashboard/engine.ts`: new `forceWorkingOnUserTail`, called in `buildSummary` before the writer call — when the transcript tail is `[user]` and the model didn't return `error`, force `state = working`, lift an `awaiting`/`idle` activity to `implementing`, and clear `awaitingPrompt`.
- `dashboard/summarizer.ts`: reinforce `TAB_SYSTEM_PROMPT` — a `[user]` tail means the agent is working on that request; the finished-reply/awaiting judgements apply only to an `[assistant]` tail.
- Unit tests for the helper and the override.

## Impact

- A `[user]` transcript tail now always renders the tab `working`, so the top-line working/awaiting/idle tallies reflect in-flight agents. The determinism sits above the cheap card model, so the badge is right regardless of what it returns.

## Watchpoints

- On the live dashboard, a tab should flip to `working` the instant a prompt is submitted and settle back to `idle` after the reply lands; the rare "agent exits right after the prompt" case relies on `decayStaleWorkingTabs` to retire the forced-working badge.