### PR TITLE
Dashboard: background-agent waits show as working; hover for full text

### DIFF
--- a/src/main/dashboard/summarizer.test.ts
+++ b/src/main/dashboard/summarizer.test.ts
@@ -5,6 +5,7 @@ import {
   buildWriterUserPrompt,
   parseCardWriter,
   parseTabSummary,
+  TAB_SYSTEM_PROMPT,
   temperatureForModel,
   withTimeout,
 } from './summarizer';
@@ -257,5 +258,23 @@ describe('withTimeout', () => {
     // withTimeout must keep this from becoming an unhandled rejection.
     rejectLater(new Error('late failure'));
     await new Promise((resolve) => setTimeout(resolve, 10));
+  });
+});
+
+describe('TAB_SYSTEM_PROMPT delegated-agent guidance', () => {
+  // Regression guard for the delegated-background-agent idle-misread: an
+  // [assistant] tail describing still-running delegated work (the "Waiting for N
+  // background agents to finish" state) is grid-only chrome, never framed into the
+  // transcript, so the classifier only ever sees the assistant's prose. The prompt
+  // must therefore carry the semantic itself. Guards both halves so neither is
+  // silently dropped.
+  it('classifies still-running background/parallel/sub-agents as working', () => {
+    expect(TAB_SYSTEM_PROMPT).toContain('Delegated work is also "working"');
+    expect(TAB_SYSTEM_PROMPT).toContain('background / parallel / sub-agents or tasks');
+    expect(TAB_SYSTEM_PROMPT).toMatch(/still running[\s\S]*classify "working"/);
+  });
+
+  it('still treats finished delegated work as idle', () => {
+    expect(TAB_SYSTEM_PROMPT).toMatch(/FINISHED or returned their results[\s\S]*that is "idle"/);
   });
 });

--- a/src/main/dashboard/summarizer.ts
+++ b/src/main/dashboard/summarizer.ts
@@ -235,7 +235,8 @@ export function parseCardWriter(reply: string): CardWriterResult {
 // request until the next `Stop` — is forced back to `working` deterministically in
 // `buildSummary` (engine.ts); the `[user]`-tail rule below reinforces the card
 // content the model writes for it.
-const TAB_SYSTEM_PROMPT = [
+// Exported for unit testing (the delegated-agent guidance is a regression guard).
+export const TAB_SYSTEM_PROMPT = [
   'You summarize a single terminal tab for a developer dashboard.',
   'You are given the tab command/cwd, a prior summary (possibly stale), and the',
   'most recent terminal output.',
@@ -274,6 +275,16 @@ const TAB_SYSTEM_PROMPT = [
   'is resting. The finished-reply-is-idle and "awaiting" judgements apply only when',
   'the last message is [assistant], and "awaiting" still requires that [assistant]',
   'message to end on a concrete blocking question.',
+  'Delegated work is also "working" even with no visible progress indicator: when',
+  'the latest [assistant] message says the agent has launched, dispatched, or is',
+  'waiting on or monitoring background / parallel / sub-agents or tasks that are',
+  'still running (for example "launched 2 agents in parallel ... while they run",',
+  '"waiting for the background agents to finish", "monitoring the parallel jobs"),',
+  'the turn is still in flight — classify "working" with the matching activity',
+  '(usually "researching", or the delegated work\'s stage), never "idle". This is',
+  'distinct from an [assistant] message reporting that those agents or tasks have',
+  'FINISHED or returned their results, where the agent is resting or asking what to',
+  'do next — that is "idle".',
   'Treat informational notices and recoverable warnings as background noise (for',
   'example "workspace not trusted", "N permissions ignored", deprecation or auth',
   'notices): never report them as the current action, a blocker, or an error.',

--- a/src/renderer/panes/dashboard.tsx
+++ b/src/renderer/panes/dashboard.tsx
@@ -407,7 +407,9 @@ export function DashboardView() {
                               <span class="dashboard-card-action-time" title={fmtTime(ev.at)}>
                                 {fmtAge(ev.at)}
                               </span>
-                              <span class="dashboard-card-action-text">{ev.text}</span>
+                              <span class="dashboard-card-action-text" title={ev.text}>
+                                {ev.text}
+                              </span>
                             </li>
                           )}
                         </For>


### PR DESCRIPTION
## Summary

- Surfaced from a live session: an agent had launched two background research agents and was waiting on them, but its dashboard card read **IDLE** — the agent was mid-turn, not resting.
- Second fix in the same card: the recent-action line silently truncates with an ellipsis; add a hover tooltip so the full text is readable.

## Changes

- `TAB_SYSTEM_PROMPT` (summarizer): teach the card model that an `[assistant]` tail describing background / parallel / sub-agents or tasks **still running** is `working` (not `idle`), while an `[assistant]` message reporting that delegated work has **finished or returned** stays `idle`. The prompt const is now exported for testing.
- `dashboard.tsx`: add `title={ev.text}` to the recent-action span so the ellipsis-cropped line shows its full text on hover (mirrors the existing timestamp span). The line stays single-line/ellipsis in the card.
- Regression test asserting both halves of the new prompt guidance survive.

## Impact

- User-visible: an agent blocked on background/parallel sub-agents now reads as `working` on its card instead of `idle`; long action lines are fully readable on hover.
- No config, schema, or API change.

## Watchpoints

- The "delegated work in flight" signal is **prose-only**. The "Waiting for N background agents to finish" indicator is terminal-grid chrome and is never framed into the neutral transcript, so nothing deterministic can key on it — this is a prompt-level classification fix, not a hard override like the `[user]`-tail case (`forceWorkingOnUserTail`). Background-agent *completions* already arrive as `[user]` frames and are forced to `working`; the gap this closes is the wait *between* launch and the next completion, where the tail is an `[assistant]` message. After deploy, watch a card for an agent waiting on background agents — it should read `working`, and return to `idle` only once the assistant reports the delegated work finished.
