### PR TITLE
Terminal: pool WebGL contexts to cap the many-tabs GPU cliff

### DIFF
--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -162,6 +162,10 @@ The sub-file vocabulary is fixed so a reader can predict the layout:
 
 Existing `-parts/` dirs: `panes/projects-parts/`, `panes/code-parts/`, `panes/tasks-parts/`, `settings-modal-parts/`, `note-modal-parts/`, `project-preview-parts/`. A sub-component that *is* a modal renders through the shared `<Modal>` shell (invariant 10) — it does not hand-roll a backdrop/header. `settings-modal.tsx` is the one pane still over the threshold with a richer split owed (its Esc/save contract keeps it off the shared shell); decompose it further when next substantially touched.
 
+### 13. Terminal WebGL contexts are pooled { #webgl-pool }
+
+xterm's `WebglAddon` holds one GPU context per terminal, and condash eagerly mounts every open "my terms" tab (`terminal-pane/controller.ts` mounts each session, hidden ones included). Each open tab therefore used to hold its own live WebGL context; past the browser's ~16-context ceiling the GPU force-loses contexts and the addon's context-loss retry churns — the "slow with many terminals open" cliff. A shared LRU pool (`src/renderer/webgl-pool.ts`) now caps the number of live contexts (default 8): `mountXterm` registers each terminal's context as a pool slot, the terminal pane calls `MountedTerm.setVisible()` from `focusActive()` so the currently-shown tab(s) are protected and long-hidden tabs release their context (falling back to xterm's DOM renderer — no data loss), and re-showing a tab re-attaches a fresh context. The pool module is `@xterm/*`-free so it unit-tests under the node vitest env (`webgl-pool.test.ts`), mirroring the `prompt-decorations.ts` split. The addon's own `onContextLoss` rebuild still runs for genuine GPU resets, but only if the pool still wants that terminal live — recovery can't smuggle a terminal past the cap.
+
 ## Environment hygiene { #environment-hygiene }
 
 condash spawns subprocesses (terminals, runners, `force_stop` commands, open-with launchers). The main process scrubs the environment before each spawn to avoid leaking interpreter-specific vars into unrelated child programs:

--- a/src/renderer/code-runs.tsx
+++ b/src/renderer/code-runs.tsx
@@ -144,11 +144,16 @@ function CodeRunRow(props: {
   // Re-attach the xterm element to whichever host node is currently mounted.
   // createEffect re-runs when expanded() flips back on.
   createEffect(() => {
-    if (!expanded() || !host) return;
+    if (!expanded() || !host) {
+      // Collapsed row → release the WebGL context back to the pool (F1).
+      mounted?.setVisible(false);
+      return;
+    }
     void ensureMounted().then(() => {
       if (host && xtermElement.parentElement !== host) {
         host.appendChild(xtermElement);
       }
+      mounted?.setVisible(true);
       requestAnimationFrame(() => {
         try {
           mounted?.fit.fit();

--- a/src/renderer/terminal-pane/controller.ts
+++ b/src/renderer/terminal-pane/controller.ts
@@ -248,7 +248,11 @@ export function createTerminalController(props: TerminalPaneProps) {
       const id = activeIdIn(col);
       for (const [tid, h] of xterms) {
         if (h.column !== col) continue;
-        h.element.style.display = tid === id ? 'flex' : 'none';
+        const visible = tid === id;
+        h.element.style.display = visible ? 'flex' : 'none';
+        // Keep the WebGL pool in step with real visibility so hidden background
+        // tabs release their GPU context and the visible one keeps it (F1).
+        h.mounted.setVisible(visible);
       }
     }
     const id = activeIdIn(activeColumn());

--- a/src/renderer/webgl-pool.test.ts
+++ b/src/renderer/webgl-pool.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+import { WebglContextPool, type WebglSlot } from './webgl-pool';
+
+/** A test slot that records attach/detach calls and its live state. */
+function makeSlot(name: string, log: string[]): WebglSlot & { live: boolean } {
+  const slot = {
+    name,
+    live: false,
+    attach() {
+      slot.live = true;
+      log.push(`attach:${name}`);
+    },
+    detach() {
+      slot.live = false;
+      log.push(`detach:${name}`);
+    },
+  };
+  return slot;
+}
+
+describe('WebglContextPool', () => {
+  it('attaches on touch and reports live count', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(3);
+    const a = makeSlot('a', log);
+    pool.touch(a);
+    expect(a.live).toBe(true);
+    expect(pool.liveCount).toBe(1);
+    expect(pool.has(a)).toBe(true);
+    expect(log).toEqual(['attach:a']);
+  });
+
+  it('touching an already-live slot does not re-attach', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(3);
+    const a = makeSlot('a', log);
+    pool.touch(a);
+    pool.touch(a);
+    expect(log).toEqual(['attach:a']);
+    expect(pool.liveCount).toBe(1);
+  });
+
+  it('caps live contexts and evicts the least-recently-touched', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(2);
+    const a = makeSlot('a', log);
+    const b = makeSlot('b', log);
+    const c = makeSlot('c', log);
+    pool.touch(a);
+    pool.touch(b);
+    pool.touch(c); // over cap → evict LRU (a)
+    expect(pool.liveCount).toBe(2);
+    expect(a.live).toBe(false);
+    expect(b.live).toBe(true);
+    expect(c.live).toBe(true);
+    expect(log).toEqual(['attach:a', 'attach:b', 'attach:c', 'detach:a']);
+  });
+
+  it('touch refreshes recency so the truly-oldest is evicted', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(2);
+    const a = makeSlot('a', log);
+    const b = makeSlot('b', log);
+    const c = makeSlot('c', log);
+    pool.touch(a);
+    pool.touch(b);
+    pool.touch(a); // a is now MRU
+    pool.touch(c); // over cap → evict b (now LRU), not a
+    expect(a.live).toBe(true);
+    expect(b.live).toBe(false);
+    expect(c.live).toBe(true);
+  });
+
+  it('never evicts a shown (visible) slot', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(2);
+    const a = makeSlot('a', log);
+    const b = makeSlot('b', log);
+    const c = makeSlot('c', log);
+    pool.show(a); // visible, protected
+    pool.touch(b);
+    pool.touch(c); // over cap → must evict b, not the protected a
+    expect(a.live).toBe(true);
+    expect(b.live).toBe(false);
+    expect(c.live).toBe(true);
+  });
+
+  it('may exceed cap when more slots are shown than capacity (fails safe)', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(2);
+    const slots = ['a', 'b', 'c'].map((n) => makeSlot(n, log));
+    for (const slot of slots) pool.show(slot);
+    // All three are protected: none can be evicted, so all stay live.
+    expect(pool.liveCount).toBe(3);
+    expect(slots.every((slot) => slot.live)).toBe(true);
+  });
+
+  it('hide un-protects and lets the slot be evicted on the next touch', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(2);
+    const a = makeSlot('a', log);
+    const b = makeSlot('b', log);
+    const c = makeSlot('c', log);
+    pool.show(a); // protected, MRU
+    pool.touch(b); // live {a, b}, under cap
+    expect(pool.liveCount).toBe(2);
+    pool.hide(a); // a is now evictable and the least-recently-touched
+    pool.touch(c); // over cap → evict a (LRU, no longer protected), keep b
+    expect(a.live).toBe(false);
+    expect(b.live).toBe(true);
+    expect(c.live).toBe(true);
+    expect(pool.liveCount).toBe(2);
+  });
+
+  it('a protected slot fully consuming the cap evicts a newly-touched slot (fails safe)', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(1);
+    const a = makeSlot('a', log);
+    const b = makeSlot('b', log);
+    pool.show(a); // protected, fills the single slot
+    pool.touch(b); // over cap and a can't be evicted → b is dropped again
+    expect(a.live).toBe(true);
+    expect(b.live).toBe(false);
+    expect(pool.liveCount).toBe(1);
+  });
+
+  it('remove drops a slot without calling detach', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(3);
+    const a = makeSlot('a', log);
+    pool.touch(a);
+    pool.remove(a);
+    expect(pool.has(a)).toBe(false);
+    expect(pool.liveCount).toBe(0);
+    // detach not called by remove — caller's own teardown owns disposal.
+    expect(log).toEqual(['attach:a']);
+  });
+
+  it('re-showing an evicted slot re-attaches a fresh context', () => {
+    const log: string[] = [];
+    const pool = new WebglContextPool(1);
+    const a = makeSlot('a', log);
+    const b = makeSlot('b', log);
+    pool.touch(a);
+    pool.touch(b); // evicts a
+    expect(a.live).toBe(false);
+    pool.show(a); // brings a back, evicts b
+    expect(a.live).toBe(true);
+    expect(b.live).toBe(false);
+    expect(log).toEqual(['attach:a', 'attach:b', 'detach:a', 'attach:a', 'detach:b']);
+  });
+});

--- a/src/renderer/webgl-pool.ts
+++ b/src/renderer/webgl-pool.ts
@@ -1,0 +1,124 @@
+// Caps the number of live WebGL renderer contexts across all mounted terminals.
+//
+// xterm's WebglAddon holds one GPU context per terminal, and condash eagerly
+// mounts every open "my terms" tab (terminal-pane/controller.ts) — so N tabs
+// meant N live contexts. Past the browser's ~16-context ceiling the GPU
+// force-loses contexts, triggering the WebglAddon's context-loss retry churn
+// (review finding F1 — the "slow with many terminals" cliff).
+//
+// This pool keeps at most `capacity` contexts live. Currently-visible terminals
+// are "shown" (protected) and never evicted; when a newly-touched terminal
+// pushes the live count over capacity, the least-recently-touched *unprotected*
+// terminal's context is disposed — xterm reverts to its DOM renderer with no
+// data loss. Re-showing that terminal re-attaches a fresh context.
+//
+// The module is free of any `@xterm/*` import so it unit-tests under the node
+// vitest env; the caller (xterm-mount.ts) injects the attach/detach closures
+// that build and dispose the real WebglAddon.
+
+/** The GPU-context lifecycle hooks for one terminal. `attach` builds + loads a
+ *  fresh WebglAddon; `detach` disposes it (reverting to xterm's DOM renderer).
+ *  Both must be idempotent — the pool may call `attach` on an already-live slot
+ *  or `detach` on an already-detached one. */
+export interface WebglSlot {
+  attach(): void;
+  detach(): void;
+}
+
+/** Default live-context cap. Well under the browser's ~16-context ceiling to
+ *  leave headroom for the app's other GPU canvases (mermaid, image previews). */
+export const DEFAULT_WEBGL_CAPACITY = 8;
+
+/**
+ * LRU pool bounding the number of live terminal WebGL contexts. Visible
+ * terminals are shielded from eviction; hidden ones age out least-recently-used
+ * first once the cap is exceeded.
+ */
+export class WebglContextPool {
+  private readonly capacity: number;
+  /** Slots holding a live context, least-recently-touched first (MRU at end). */
+  private readonly order: WebglSlot[] = [];
+  /** Membership mirror of `order` for O(1) liveness checks. */
+  private readonly live = new Set<WebglSlot>();
+  /** Visible slots — never evicted while present here. */
+  private readonly shown = new Set<WebglSlot>();
+
+  constructor(capacity: number = DEFAULT_WEBGL_CAPACITY) {
+    this.capacity = Math.max(1, Math.floor(capacity));
+  }
+
+  /** Ensure `slot` holds a live context and mark it most-recently-used, then
+   *  evict least-recently-used unprotected slots back down to capacity. Used on
+   *  mount and on context-loss recovery. */
+  touch(slot: WebglSlot): void {
+    this.promote(slot);
+    this.evict();
+  }
+
+  /** Mark `slot` visible: give it a context, make it MRU, and shield it from
+   *  eviction until `hide`. */
+  show(slot: WebglSlot): void {
+    this.shown.add(slot);
+    this.promote(slot);
+    this.evict();
+  }
+
+  /** Mark `slot` hidden: it keeps its context (LRU decides when to drop it) but
+   *  is no longer shielded from eviction. */
+  hide(slot: WebglSlot): void {
+    if (!this.shown.delete(slot)) return;
+    this.evict();
+  }
+
+  /** Drop `slot` from the pool entirely (terminal disposed). Does not call
+   *  `detach` — the caller's own teardown disposes the addon. */
+  remove(slot: WebglSlot): void {
+    this.shown.delete(slot);
+    if (this.live.delete(slot)) {
+      const index = this.order.indexOf(slot);
+      if (index >= 0) this.order.splice(index, 1);
+    }
+  }
+
+  /** Whether `slot` currently holds a live context (per the pool's bookkeeping;
+   *  a GPU context-loss doesn't clear this — the slot is still pool-live and
+   *  eligible to rebuild). */
+  has(slot: WebglSlot): boolean {
+    return this.live.has(slot);
+  }
+
+  /** Live-context count — for tests and diagnostics. */
+  get liveCount(): number {
+    return this.live.size;
+  }
+
+  private promote(slot: WebglSlot): void {
+    const index = this.order.indexOf(slot);
+    if (index >= 0) this.order.splice(index, 1);
+    this.order.push(slot);
+    if (!this.live.has(slot)) {
+      this.live.add(slot);
+      slot.attach();
+    }
+  }
+
+  private evict(): void {
+    let index = 0;
+    // Walk oldest→newest, disposing unprotected slots until back under cap.
+    // Protected (visible) slots are skipped, so a pathological >capacity visible
+    // count fails safe (never disposes a visible terminal's context).
+    while (this.live.size > this.capacity && index < this.order.length) {
+      const slot = this.order[index];
+      if (this.shown.has(slot)) {
+        index++;
+        continue;
+      }
+      this.order.splice(index, 1);
+      this.live.delete(slot);
+      slot.detach();
+    }
+  }
+}
+
+/** Process-wide pool shared by every mounted terminal. */
+export const webglPool = new WebglContextPool();

--- a/src/renderer/xterm-mount.ts
+++ b/src/renderer/xterm-mount.ts
@@ -18,6 +18,7 @@ import '@xterm/xterm/css/xterm.css';
 import type { TerminalXtermPrefs } from '@shared/types';
 import { liveTerms } from './xterm-registry';
 import { PromptDecorations } from './prompt-decorations';
+import { webglPool, type WebglSlot } from './webgl-pool';
 
 export type XtermPrefs = TerminalXtermPrefs;
 
@@ -53,6 +54,10 @@ export interface MountedTerm {
    * pick up the new palette without a re-attach. User color overrides from
    * `XtermPrefs` win over the CSS fallback. */
   refreshTheme(prefs?: XtermPrefs): void;
+  /** Report whether this terminal is currently visible so the shared WebGL
+   * pool keeps visible terminals GPU-rendered and evicts long-hidden ones'
+   * contexts (review F1 — the ~16-tab GPU-context cliff). Idempotent. */
+  setVisible(visible: boolean): void;
   /** Tear down the xterm. Idempotent — safe to call from both onCleanup and
    * an explicit detach (e.g. when re-siding a session). */
   dispose(): void;
@@ -219,31 +224,51 @@ export function mountXterm(
 
   term.open(hostElement);
 
-  // ---- WebGL renderer (best-effort; falls back to DOM) ----
-  // On context loss (GPU reset, tab visibility race, driver crash) the
-  // disposed-only path leaves the terminal stuck on a blank canvas — the
-  // DOM fallback never re-attaches because no addon is wired any more.
-  // Recover by remounting a fresh WebGL addon on the next frame; if that
-  // throws (driver still wedged, repeated loss), bail to the default DOM
-  // renderer for the lifetime of this terminal.
+  // ---- WebGL renderer, pooled (best-effort; falls back to DOM) ----
+  // Every mounted tab used to hold its own WebGL context; past ~16 tabs the GPU
+  // force-loses contexts and the retry churn below fires in a storm (review F1).
+  // The context now lives in the shared `webglPool`, which caps live contexts
+  // and disposes the least-recently-visible terminal's context on overflow —
+  // xterm reverts to its DOM renderer, no data loss. `attach`/`detach` build and
+  // dispose the addon; the pool decides when each runs. On GPU context loss
+  // (driver reset, not overflow) we rebuild on the next frame — but only if the
+  // pool still wants this terminal live, so recovery can't smuggle us past the
+  // cap. After two losses we give up and stay on the DOM renderer.
+  let currentWebgl: WebglAddon | null = null;
   let webglRetries = 0;
-  const attachWebgl = (): void => {
-    try {
-      const webgl = new WebglAddon();
-      webgl.onContextLoss(() => {
-        webgl.dispose();
-        if (webglRetries >= 2) return;
-        webglRetries++;
-        // Defer one frame so the GPU process has a chance to settle before
-        // we ask for a fresh context.
-        requestAnimationFrame(attachWebgl);
-      });
-      term.loadAddon(webgl);
-    } catch {
-      /* GPU unavailable; keep the default DOM renderer */
-    }
+  const webglSlot: WebglSlot = {
+    attach() {
+      if (currentWebgl) return;
+      try {
+        const webgl = new WebglAddon();
+        webgl.onContextLoss(() => {
+          webgl.dispose();
+          if (currentWebgl === webgl) currentWebgl = null;
+          if (webglRetries >= 2) return;
+          webglRetries++;
+          // Defer one frame so the GPU process can settle, then rebuild only if
+          // the pool hasn't evicted us in the meantime.
+          requestAnimationFrame(() => {
+            if (!currentWebgl && webglPool.has(webglSlot)) webglSlot.attach();
+          });
+        });
+        term.loadAddon(webgl);
+        currentWebgl = webgl;
+      } catch {
+        /* GPU unavailable; keep the default DOM renderer */
+      }
+    },
+    detach() {
+      if (!currentWebgl) return;
+      try {
+        currentWebgl.dispose();
+      } catch {
+        /* already disposed */
+      }
+      currentWebgl = null;
+    },
   };
-  attachWebgl();
+  webglPool.touch(webglSlot);
 
   // ---- ligatures (gated; loads font-ligatures behind the scenes) ----
   if (prefs.ligatures) {
@@ -430,10 +455,17 @@ export function mountXterm(
     promptLines: () => prompts.promptLines(),
     jumpToPrompt,
     refreshTheme,
+    setVisible(visible: boolean) {
+      if (disposed) return;
+      if (visible) webglPool.show(webglSlot);
+      else webglPool.hide(webglSlot);
+    },
     dispose() {
       if (disposed) return;
       disposed = true;
       liveTerms.delete(mounted);
+      // Drop our pool slot before term.dispose() (which disposes the WebglAddon).
+      webglPool.remove(webglSlot);
       prompts.dispose();
       term.dispose();
     },


### PR DESCRIPTION
## What

Cap the number of live terminal **WebGL contexts** with a shared LRU pool, so opening many terminal tabs no longer drives condash into the GPU context-loss cliff.

## Why

condash eagerly mounts every open "my terms" tab (hidden ones included), and each mounted xterm attached its own `WebglAddon` → one live GPU context per tab. Past the browser's ~16-context ceiling the GPU force-loses contexts and the addon's `onContextLoss` retry churns — the "slow when many terminals are open over a long session" symptom (perf-review finding **F1**).

## How

- New `src/renderer/webgl-pool.ts` — an LRU `WebglContextPool` (default cap **8**). Visible terminals are *protected* (never evicted); when a newly-touched terminal pushes the live count over the cap, the least-recently-touched **hidden** terminal's context is disposed and xterm reverts to its DOM renderer (no data loss). Re-showing a tab re-attaches a fresh context.
- `xterm-mount.ts` — the WebGL addon is now a pool slot (`attach`/`detach`); `mountXterm` returns a new `MountedTerm.setVisible(visible)`. The `onContextLoss` rebuild still handles genuine GPU resets, but only while the pool still wants the terminal live, so recovery can't exceed the cap.
- `terminal-pane/controller.ts` (`focusActive`) and `code-runs.tsx` (expand/collapse) drive `setVisible()` from real visibility.

## Acceptance / validation

- With ~20 tabs open, live WebGL contexts ≤ pool cap; no context-loss retry storm on focus switch; the visible terminal stays GPU-rendered; re-showing a long-hidden tab re-attaches cleanly. (Manual: `chrome://gpu` context count + console context-loss warnings while a background agent streams.)
- New `webgl-pool.test.ts` (10 cases) covers cap/eviction, LRU recency, visible-protection, hide→evict, remove, and re-show. Full `test:unit` (1360) + `typecheck` + `build` green.

## Locked-decision notes

- The pool module is `@xterm/*`-free and imported only from `xterm-mount.ts`, so it lands in the async xterm chunk — the **lazy-split** / xterm beta-pin disciplines are unchanged (xterm stays off the eager boot chunk). No addon versions touched.
- Documented as internals invariant 13.
