### PR TITLE
Projects: drop timeline[] from the resident list, lazy-load it in the preview

### DIFF
--- a/docs/explanation/internals.md
+++ b/docs/explanation/internals.md
@@ -98,7 +98,7 @@ When a Run button fires for a repo on the code side, any prior code-side session
 
 A single watcher rooted at `<conception>/`, debounced 250 ms. Events are classified into:
 
-- `project` — `projects/<month>/<slug>/README.md` add/change/unlink. Renderer patches the project list in place via `getProject`.
+- `project` — `projects/<month>/<slug>/README.md` add/change/unlink. Renderer patches the project list in place via `getProject` (timeline-stripped to match the list projection — see §7).
 - `knowledge` — any `.md` under `knowledge/`. Coarse — the renderer just bumps `refreshKey`.
 - `config` — the canonical `.condash/settings.json` (that single file — the rest of `.condash/` is never watched), or a legacy `condash.json` / `configuration.json` at the conception root. Same coarse handling; a `config` event also triggers a watcher rebuild in case `skills_path` changed.
 - `unknown` — any classification failure. Forces a full re-render.
@@ -117,6 +117,8 @@ F5 / View → Refresh fans out across **every working surface** (`reloadAll` in 
 ### 7. IPC contract
 
 `CondashApi` in `src/shared/api.ts` is the *whole* IPC surface. The preload (`src/preload/index.ts`) implements every verb as a one-line `ipcRenderer.invoke`; the main process registers one handler per verb. `src/main/index.ts:registerIpc` is a thin dispatcher that calls each per-domain module under `src/main/ipc/` (`projects.ts`, `trees.ts`, `repos.ts`, `settings.ts`, `system.ts`, `terminal.ts`). No string-mux'd actions, no implicit channels.
+
+**`listProjects` projection.** `listProjects` returns the same `Project[]` shape as `getProject`, but with the potentially large `timeline[]` **emptied** on every row (`toListProjection` in `ipc/projects.ts`) — the array grows with a project's age, and multiplied across hundreds of resident projects + every reload's structured-clone it was a real long-session cost (review G1). The single timeline datum the card needs — the most recent entry's date — is precomputed at parse time as `Project.lastActivity` (kept on the row). The **preview** is the only surface that renders the full `timeline[]`, and it lazy-fetches the full project via `getProject` (a parse-cache hit, so effectively free) when it opens. The tree-events single-card patch strips the timeline the same way so the resident list stays uniformly timeline-free.
 
 Subscriptions (`onTreeEvents`, `onTermData`, `onTermExit`, `onTermSessions`) return an unsubscribe function; the renderer holds it and calls it from `onCleanup`.
 

--- a/src/main/ipc/projects.ts
+++ b/src/main/ipc/projects.ts
@@ -34,6 +34,19 @@ async function assertUnderConception(path: string): Promise<void> {
   await requirePathUnder(path, conceptionPath);
 }
 
+/**
+ * Slim a parsed project for the resident list: drop the unbounded `timeline[]`
+ * (it grows with a project's age — G1) while keeping the precomputed
+ * `lastActivity` scalar the card needs. The preview lazy-fetches the full
+ * project (with `timeline`) via `getProject`. Returns the cached object
+ * untouched when there's nothing to trim; otherwise a shallow copy so the
+ * parse-cache entry keeps its full timeline.
+ */
+function toListProjection(project: Project): Project {
+  if (project.timeline.length === 0) return project;
+  return { ...project, timeline: [] };
+}
+
 async function listProjects(): Promise<Project[]> {
   const { lastConceptionPath: conceptionPath } = await readSettings();
   if (!conceptionPath) return [];
@@ -41,7 +54,7 @@ async function listProjects(): Promise<Project[]> {
   const readmes = await findProjectReadmes(conceptionPath);
   // parseReadmeCached memoises on path + mtime, so a reload with no file changes
   // re-parses nothing — the R2 fix for the whole-tree re-parse on every reload.
-  const projects = await Promise.all(readmes.map(parseReadmeCached));
+  const projects = (await Promise.all(readmes.map(parseReadmeCached))).map(toListProjection);
 
   return projects.sort(compareByStatusThenSlug);
 }

--- a/src/main/parse.test.ts
+++ b/src/main/parse.test.ts
@@ -366,3 +366,33 @@ apps: []
     expect(project.deliverables.map((d) => d.label)).toEqual(['Yes']);
   });
 });
+
+describe('lastActivity (timeline projection scalar)', () => {
+  const header = `---
+date: 2026-05-19
+kind: project
+status: now
+---
+
+# X
+`;
+
+  it('is the most recent ## Timeline date, regardless of source order', async () => {
+    const body = `${header}
+## Timeline
+
+- 2026-05-19 — opened
+- 2026-05-25 — shipped
+- 2026-05-21 — reviewed
+`;
+    const path = await writeReadme('2026-05-19-la', body);
+    const project = await parseReadme(path);
+    expect(project.lastActivity).toBe('2026-05-25');
+  });
+
+  it('is null when the README has no ## Timeline entries', async () => {
+    const path = await writeReadme('2026-05-19-none', `${header}\n## Goal\n\nNo timeline.\n`);
+    const project = await parseReadme(path);
+    expect(project.lastActivity).toBeNull();
+  });
+});

--- a/src/main/parse.ts
+++ b/src/main/parse.ts
@@ -55,6 +55,12 @@ function parseReadmeFromRaw(raw: string, path: string, preparsedHeader?: HeaderF
   const deliverables = extractDeliverables(lines, dirname(path));
   const closedAt = extractClosedAt(lines);
   const timeline = parseTimelineEntries(raw);
+  // Precompute the most-recent timeline date so the list projection can drop
+  // the full `timeline[]` yet still drive the card's last-activity label (G1).
+  let lastActivity: string | null = null;
+  for (const entry of timeline) {
+    if (lastActivity === null || entry.date > lastActivity) lastActivity = entry.date;
+  }
 
   const slug = basename(dirname(path));
 
@@ -74,6 +80,7 @@ function parseReadmeFromRaw(raw: string, path: string, preparsedHeader?: HeaderF
     deliverableCount: deliverables.length,
     closedAt,
     timeline,
+    lastActivity,
   };
 }
 

--- a/src/renderer/panes/projects-parts/data.test.ts
+++ b/src/renderer/panes/projects-parts/data.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import type { Project, Step, StepMarker } from '../../../shared/types';
-import { nextOpenStep } from './data';
+import type { Project, Step, StepMarker, TimelineEntry } from '../../../shared/types';
+import { lastDate, nextOpenStep } from './data';
 
 function step(marker: StepMarker, text: string, lineIndex = 0): Step {
   return { lineIndex, marker, text, section: 'Steps' };
@@ -58,5 +58,26 @@ describe('nextOpenStep', () => {
 
   it('still surfaces a blocked [!] step', () => {
     expect(nextOpenStep(project([step('-', 'a', 0), step('!', 'b', 1)]))?.text).toBe('b');
+  });
+});
+
+describe('lastDate (timeline projection)', () => {
+  const withDates = (over: Partial<Project>): Project => ({ ...project([]), ...over });
+  const entry = (date: string): TimelineEntry => ({ date, text: 'x' });
+
+  it('prefers the precomputed lastActivity scalar (resident list row)', () => {
+    // The row carries lastActivity but an emptied timeline — the card still
+    // shows the right date without holding the full timeline[].
+    expect(lastDate(withDates({ lastActivity: '2026-06-30', timeline: [] }))).toBe('2026-06-30');
+  });
+
+  it('falls back to scanning timeline for a full project without the scalar', () => {
+    expect(lastDate(withDates({ timeline: [entry('2026-06-01'), entry('2026-06-10')] }))).toBe(
+      '2026-06-10',
+    );
+  });
+
+  it('falls back to the slug date when there is no timeline at all', () => {
+    expect(lastDate(withDates({ slug: '2026-05-28-x', timeline: [] }))).toBe('2026-05-28');
   });
 });

--- a/src/renderer/panes/projects-parts/data.ts
+++ b/src/renderer/panes/projects-parts/data.ts
@@ -82,16 +82,21 @@ export function firstDate(p: Project): string {
   return slugDate(p.slug);
 }
 
-/** Last date for the card / popup timeline header. Most recent entry's
- * date in `## Timeline`; falls back to the slug date when the timeline
- * is empty (legacy items pre-template). */
+/** Last date for the card / popup timeline header. Prefers the precomputed
+ * `lastActivity` scalar — the resident list carries it but not the full
+ * `timeline[]` (G1 projection). Falls back to scanning `timeline` for a full
+ * project that predates the scalar (e.g. a hand-built object), then to the slug
+ * date when there's no timeline at all (legacy items pre-template). */
 export function lastDate(p: Project): string {
-  if (!p.timeline || p.timeline.length === 0) return slugDate(p.slug);
-  let max = p.timeline[0].date;
-  for (const e of p.timeline) {
-    if (e.date > max) max = e.date;
+  if (p.lastActivity) return p.lastActivity;
+  if (p.timeline && p.timeline.length > 0) {
+    let max = p.timeline[0].date;
+    for (const e of p.timeline) {
+      if (e.date > max) max = e.date;
+    }
+    return max;
   }
-  return max;
+  return slugDate(p.slug);
 }
 
 /** Render the first/last range as a single date when they coincide, an

--- a/src/renderer/project-preview.tsx
+++ b/src/renderer/project-preview.tsx
@@ -85,6 +85,14 @@ export function ProjectPreview(props: {
     async (path) => (path ? await window.condash.listProjectFiles(path) : []),
   );
 
+  // The resident list drops `timeline[]` (G1 projection), so fetch the full
+  // project for the Timeline pane. Cheap — `getProject` is served from the
+  // main-process parse-cache (a hit right after `listProjects` populated it).
+  const [fullProject] = createResource(
+    () => props.project?.path ?? null,
+    async (path) => (path ? await window.condash.getProject(path) : null),
+  );
+
   const handleKey = (event: KeyboardEvent): void => {
     if (event.key === 'Escape') {
       // Let the local edit/add inputs swallow Escape themselves.
@@ -507,7 +515,7 @@ export function ProjectPreview(props: {
               </main>
             </div>
 
-            <TimelinePane project={project()} />
+            <TimelinePane project={fullProject() ?? project()} />
           </div>
         </div>
       )}

--- a/src/renderer/tree-events.ts
+++ b/src/renderer/tree-events.ts
@@ -79,11 +79,15 @@ export async function applyTreeEvents(events: TreeEvent[], deps: TreeEventsDeps)
         deps.mutateProjects((items) => items.filter((p) => p.path !== event.path));
         continue;
       }
+      // `getProject` returns the full project (with `timeline[]`); the resident
+      // list keeps timelines out (G1 — matches the `listProjects` projection),
+      // so patch with a timeline-stripped copy. The card reads `lastActivity`.
+      const row = project.timeline.length === 0 ? project : { ...project, timeline: [] };
       deps.mutateProjects((items) => {
-        const idx = items.findIndex((p) => p.path === project.path);
-        if (idx === -1) return [...items, project];
+        const idx = items.findIndex((p) => p.path === row.path);
+        if (idx === -1) return [...items, row];
         const next = items.slice();
-        next[idx] = project;
+        next[idx] = row;
         return next;
       });
     } catch {

--- a/src/shared/types/project.ts
+++ b/src/shared/types/project.ts
@@ -84,9 +84,19 @@ export interface Project {
    * item retains the date the latest close left behind. */
   closedAt: string | null;
   /** Parsed `## Timeline` entries in source order. Empty when the section
-   * is absent. Powers the popup's collapsed-by-default Timeline pane and
-   * the card's first/last-date display. */
+   * is absent. Powers the popup's collapsed-by-default Timeline pane.
+   *
+   * The `listProjects` projection **empties this array** in the resident
+   * renderer list + every IPC clone (it grows unbounded with a project's age —
+   * G1): cards read `lastActivity` instead, and the preview lazy-fetches the
+   * full project (with `timeline`) via `getProject`. `getProject` and the CLI
+   * paths keep it populated. */
   timeline: TimelineEntry[];
+  /** Date (`YYYY-MM-DD`) of the most recent `## Timeline` entry, or null when
+   * the section is empty — precomputed so the card's last-activity label needn't
+   * carry the whole `timeline[]`. `parseReadme` always sets it; only hand-built
+   * fixtures omit it (hence optional). */
+  lastActivity?: string | null;
 }
 
 export interface ProjectFileEntry {


### PR DESCRIPTION
## What

Drop the unbounded `timeline[]` from the resident project list (and every `listProjects` IPC clone), lazy-loading it only in the preview. Decouples resident renderer memory + per-reload clone size from how much history each project has accumulated.

## Why

The renderer holds the full `Project[]` resident and re-receives a structured-clone of it on every reload. Each project carries its full `## Timeline`, which grows unbounded with the project's **age** — across hundreds of resident projects that's a real long-session memory + IPC cost (perf-review finding **G1**).

## How

- `Project.lastActivity` — the most-recent `## Timeline` date, precomputed at parse time (`parse.ts`). This is the only timeline datum the card needs.
- `listProjects` empties `timeline[]` on every row (`toListProjection` in `ipc/projects.ts`). `lastDate()` now prefers `lastActivity`, falling back to a `timeline` scan (full project) then the slug date.
- The **preview** is the only surface that renders the full `timeline[]`; it lazy-fetches the full project via `getProject` when it opens — a parse-cache hit (after the mtime-memo PR), so effectively free.
- The `tree-events` single-card patch strips the timeline the same way, so the resident list stays uniformly timeline-free.

## Design note (deviation from the plan's literal row spec)

The plan sketched a distinct slim `ProjectListRow = {slug,title,status,date,closedAt,stepCounts,apps,branch}`. Building that faithfully turned out to be **infeasible without breaking or slowing the kanban**: the card renders `steps[]` inline (next-step, expandable list, per-step toggle) and the **Deliverables pane** reads `deliverables[]` across the whole list — dropping those would either remove features or force **N** `getProject` fetches on list render (the opposite of the goal). `timeline[]` is the *only* unbounded, growth-with-age field and is read by *just* the preview, so projecting it out (and precomputing `lastActivity`) captures the entire G1 win at a fraction of the risk, with **no IPC-shape change** (still `Project[]`). The residual — a distinct slim row type — is logged as a watchpoint; it would need a card/pane rearchitecture for no additional memory benefit.

## Acceptance / validation

- Resident `projects-store` + each `listProjects` clone no longer carry any timelines; the preview still shows full timeline detail (lazy). Card date labels unchanged (driven by `lastActivity`). No consumer reads `timeline` off a list row (the preview lazy-fetches; `lastDate` uses the scalar).
- New tests: `parse.test.ts` (`lastActivity` = most-recent timeline date; null when empty), `data.test.ts` (`lastDate` prefers `lastActivity`, falls back to scan, then slug). Full `test:unit` (1371) + `typecheck` + `build` green.

## Docs

`docs/explanation/internals.md` §6 (project-event patch) + §7 (IPC contract — the `listProjects` projection).
