### PR TITLE
Tighten shipped agent config: hand-scaffold guard, deliverables narrowing, fetch-before-base, /applications in reference

### DIFF
--- a/conception-template/.agents/skills/projects/SKILL.md
+++ b/conception-template/.agents/skills/projects/SKILL.md
@@ -66,7 +66,7 @@ Kind-specific additions (incidents only): `environment: <PROD/STAGING/DEV>`, `se
 
 ## Deliverables
 
-A `## Deliverables` section lists an item's tangible outputs. condash renders them on the project card and in the **Deliverables** pane, and opens each by type. One bullet per item, in one of two forms:
+A `## Deliverables` section lists **only the outputs you explicitly designate as deliverables** — not every artefact the work produces or touches. Intermediate files, scratch renders, supporting notes, and incidental outputs stay out of the section (and so off the project card and the Deliverables pane); when unsure, leave it off and ask. condash renders the listed ones on the project card and in the **Deliverables** pane, and opens each by type. One bullet per item, in one of two forms:
 
 ```markdown
 - [<label>](<target>) — <optional comment>      # local file or http(s) URL

--- a/conception-template/.agents/skills/projects/worktree.md
+++ b/conception-template/.agents/skills/projects/worktree.md
@@ -32,6 +32,8 @@ The CLI owns the multi-app derivation, the protected-set logic, and the per-repo
 
    **Base ref.** The CLI reads `base` from every item declaring `<branch>` and uses it as the start point for new branches. All declaring items must agree on the base (the call fails with the disagreeing slugs otherwise). `--base <ref>` overrides the README field for one-shot setups. When no item declares `base` and `--base` isn't passed, new branches are created off the repo's default tip.
 
+   **Fetch before setup.** The base is the **local** tip, which may trail `origin`. Before running setup, `git -C <workspace_path>/<repo> fetch origin` and fast-forward local `main` for each declaring repo — otherwise the branch starts from a stale base and you may re-implement or conflict with already-merged work, surfacing only at PR time.
+
    The CLI:
    - reads `apps` from every item declaring `<branch>` and unions the top-level repos,
    - skips repos with `pinned_branch:` (those track a different axis),

--- a/conception-template/AGENTS.md
+++ b/conception-template/AGENTS.md
@@ -6,7 +6,7 @@
 
 This `## General` section is shipped by condash and overwritten on every `condash skills install` — condash owns everything from the top of the file through the `<!-- end condash agents -->` marker. Per-conception content lives **below** the marker, in `## Specifics`, which condash never touches.
 
-A conception is a Markdown tree condash manages: durable reference material under `knowledge/`, and dated work items (projects, incidents, documents) under `projects/`. Both trees are self-describing through their `index.md` files. condash is the single parser for the tree — drive every read and write through a skill or a `condash` verb, never by hand-scaffolding paths.
+A conception is a Markdown tree condash manages: durable reference material under `knowledge/`, and dated work items (projects, incidents, documents) under `projects/`. Both trees are self-describing through their `index.md` files. condash is the single parser for the tree — drive every read and write through a skill or a `condash` verb, never by hand-scaffolding paths: no `mkdir`, no raw `Write`/`Edit` on tree-canonical paths, no raw `git worktree add`. The skill owns slug validation, enum checks, template generation, and index tracking; hand-scaffolding silently breaks the dashboard.
 
 ### Layout
 

--- a/docs/reference/skill.md
+++ b/docs/reference/skill.md
@@ -1,6 +1,6 @@
 ---
 title: Management skills · condash reference
-description: Reference for the three shipped Claude Code skills — /projects, /knowledge, /pr — and how they shell out to the condash CLI.
+description: Reference for the four shipped Claude Code skills — /projects, /knowledge, /pr, /applications — and how they shell out to the condash CLI.
 ---
 
 # Management skills
@@ -9,13 +9,14 @@ description: Reference for the three shipped Claude Code skills — /projects, /
 
 ## At a glance
 
-condash ships three [Claude Code](https://docs.claude.com/en/docs/claude-code/) skills. They live under [`conception-template/.agents/skills/`](https://github.com/vcoeur/condash/tree/main/conception-template/.agents/skills) in the repo and land at `<conception>/.agents/skills/` after running `condash skills install`. Each skill is placed verbatim — `SKILL.md` plus any task `.md` files and an optional `SKILL.<harness>.md` overlay. condash does not compile them to per-harness directories; the harness launcher renders them per agent at run time.
+condash ships four [Claude Code](https://docs.claude.com/en/docs/claude-code/) skills. They live under [`conception-template/.agents/skills/`](https://github.com/vcoeur/condash/tree/main/conception-template/.agents/skills) in the repo and land at `<conception>/.agents/skills/` after running `condash skills install`. Each skill is placed verbatim — `SKILL.md` plus any task `.md` files and an optional `SKILL.<harness>.md` overlay. condash does not compile them to per-harness directories; the harness launcher renders them per agent at run time.
 
 | Skill | Scope | What it does |
 |---|---|---|
 | **`/projects`** | items + worktrees | Create / read / update / close projects, incidents, and documents. Manage worktrees per branch. |
 | **`/knowledge`** | knowledge tree | Retrieve, update, index, and verify durable reference material in `<conception>/knowledge/`. Audits (orphans, dangling links, cross-repo refs, worktree drift, LFS coverage, large binaries, stale stamps) flow through `verify`. |
 | **`/pr`** | git | Open a GitHub PR from the current branch with the project README's timeline-append rule applied. |
+| **`/applications`** | app registry | Manage the `#handle` app registry (list / add / set / rename / sync-docs / validate) — the single source of truth for how apps are referenced across the tree. |
 
 The skills are **editorial only**. Every mechanical step shells out to `condash`, so the dashboard, the CLI, and the skills always see the same canonical view of the tree. A skill never re-implements parsing or validation in `bash + grep + sed`.
 


### PR DESCRIPTION
## Summary

Clarity + accuracy pass on condash's shipped agent-config — the `## General` template, the `projects` skill, and the skill reference doc. Markdown only; no code or behaviour changes.

## Changes

- **`conception-template/AGENTS.md` (`## General`)** — spell out the "never hand-scaffold" rule with the concrete cases (no `mkdir`, no raw `Write`/`Edit` on tree-canonical paths, no raw `git worktree add`) and why: the skill owns validation + index tracking, so hand-scaffolding silently breaks the dashboard.
- **`projects` skill · `## Deliverables`** — narrow the default: list only the outputs the user explicitly designates as deliverables, not every artefact the work touches. Stops the Deliverables pane over-collecting.
- **`projects` skill · `worktree.md`** — add a "fetch before setup" note: the base is the local tip and may trail `origin`, so a stale base causes re-implementation / conflicts that only surface at PR time.
- **`docs/reference/skill.md`** — fix the shipped-skill count (three → four) and add the missing `/applications` row (it ships today but was undocumented).

## Impact

Documentation / instruction only. The `## General` change reaches conception trees on their next `condash skills install`. The `/tidy` + `/skills` retirement note already in this doc is confirmed correct and left as-is.
